### PR TITLE
feat(video-grabber): use Prefect serve() instead of work pool + add docs/

### DIFF
--- a/packages/tools/video-grabber/Dockerfile
+++ b/packages/tools/video-grabber/Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /app
 COPY pyproject.toml .
 COPY video_grabber/ ./video_grabber/
 RUN pip install --no-cache-dir .
-CMD ["prefect", "worker", "start", "--pool", "video-grabber-pool"]
+CMD ["python", "-m", "video_grabber.serve"]

--- a/packages/tools/video-grabber/docs/README.md
+++ b/packages/tools/video-grabber/docs/README.md
@@ -1,0 +1,49 @@
+# video-grabber
+
+Internet Archive broadcast → HLS pipeline for the 911realtime.org TV recordings.
+
+This package crawls the Internet Archive's 9/11 broadcast collections, downloads the best-quality source file for each candidate item, transcodes it to 3-rendition ABR HLS (CMAF/fMP4), uploads the package to Wasabi S3, and registers the finished asset with Directus. A separate EPG assembler stitches per-channel 24-hour playlists with blue "no signal" gap fillers between programs.
+
+## When to use this package
+
+You're working with video-grabber if you need to:
+
+- Discover new IA items for the `sept_11_tv_archive` / `911` collections.
+- Reprocess a job that failed mid-pipeline.
+- Regenerate a channel's day-of EPG and HLS playlists.
+- Diagnose why an HLS stream plays incorrectly (gap encoding, master playlist, S3 cache headers).
+- Promote a `pending_review` item to `complete` after manually classifying the channel.
+
+## Quick start
+
+Local development is Python 3.12+ with ffmpeg installed system-wide.
+
+```bash
+cd packages/tools/video-grabber
+cp .env.example .env       # fill in Wasabi + Directus credentials
+pip install -e ".[dev]"
+pytest                     # all components mock IA/S3/Directus — no live deps
+```
+
+Run a Prefect worker against a deployed server:
+
+```bash
+export PREFECT_API_URL=http://localhost:4200/api
+prefect worker start --pool video-grabber-pool
+```
+
+## Document index
+
+- [Architecture overview](./architecture.md) — components, end-to-end flow, why the boundaries are where they are.
+- [Pipeline stages](./pipeline.md) — the six Prefect flows and the `pipeline_stage` state machine.
+- [Data model](./data-model.md) — Postgres tables, the `pipeline_stage` enum, and the audit log.
+- [Module guide](./modules.md) — per-package responsibilities (`ia`, `video`, `storage`, `directus`).
+- [EPG assembler](./epg.md) — 24-hour HLS day-playlists, gap inserts, EPG JSON contract.
+- [Deployment](./deployment.md) — Kubernetes manifests, Docker image, ArgoCD pre-sync.
+- [Configuration](./configuration.md) — environment variables, secrets, ConfigMap.
+- [Runbook](./runbook.md) — common ops: rescan, retry, manual review, broken playlists.
+- [Testing](./testing.md) — test layout and the mocking strategy.
+
+## Status
+
+`v0.1.0`. Schema migration `001_initial_schema` is the only revision; the pipeline writes to Directus' `media_items` collection, which already exists in the rt911 instance.

--- a/packages/tools/video-grabber/docs/architecture.md
+++ b/packages/tools/video-grabber/docs/architecture.md
@@ -1,0 +1,71 @@
+# Architecture
+
+video-grabber is a six-stage Prefect pipeline that turns raw Internet Archive broadcast items into HLS streams served from Wasabi and surfaced through Directus. State lives in Postgres; orchestration lives in Prefect; binary work (download, transcode, upload) runs inside Kubernetes pods that the Prefect worker schedules on demand.
+
+## High-level dataflow
+
+```
+┌────────────────────┐
+│ Internet Archive   │  collection: sept_11_tv_archive, 911
+│ (metadata + files) │
+└─────────┬──────────┘
+          │ scan-collections flow (rate-limited search)
+          ▼
+┌────────────────────┐      ┌────────────────────────────┐
+│ video_jobs (PG)    │◄────►│ pipeline_transitions (PG)  │ ◄── audit log
+│ stage: discovered  │      └────────────────────────────┘
+└─────────┬──────────┘
+          │ process-item flow (one row per IA identifier)
+          ▼
+   downloading ─► downloaded ─► encoding ─► encoded ─► uploading ─► complete
+          │
+          └─► failed   (any stage)
+                  │
+                  └─► pending_review  (unrecognized channel; needs human triage)
+
+complete ─► writes Directus media_items row ─► Wasabi-hosted master.m3u8
+
+EPG assembler  (separate flow, runs daily)
+   schedule_slots + channels ─► per-channel day-playlist + EPG JSON
+```
+
+## Component map
+
+| Module | Responsibility | Talks to |
+| --- | --- | --- |
+| `ia/scanner.py` | Recursively crawl IA collections, upsert candidate `video_jobs`. | Internet Archive (`internetarchive` SDK), Postgres |
+| `ia/metadata.py` | Parse air dates and timezones from title/description. | — (pure) |
+| `ia/channel_map.py` | Normalize an IA item to a canonical channel slug. | — (pure) |
+| `pipeline/flows.py` | Prefect flow definitions, stage transitions, error capture. | Postgres, all worker modules |
+| `pipeline/downloader.py` | Pick the best source file, resumable byte-range download. | Internet Archive HTTP API |
+| `video/encoder.py` | 3-rendition ABR HLS via ffmpeg/ffprobe. | local ffmpeg/ffprobe |
+| `video/gap_filler.py` | Blue (`#0000f5`) silent fMP4 segments matching encoder rungs. | local ffmpeg |
+| `storage/wasabi.py` | Upload HLS package with the right `Content-Type` and `Cache-Control`. | Wasabi S3 |
+| `directus/writer.py` | Idempotent `POST /items/media_items`, channel→source resolution. | Directus HTTP API |
+| `epg/assembler.py` | Build per-channel 24-hour master + rendition playlists with gap inserts. | Postgres |
+| `db/migrations/` | Alembic schema; `001_initial_schema` defines all tables and the stage enum. | Postgres |
+
+Everything outside `epg/` is on the IA → Wasabi → Directus path. `epg/` is the read path that the frontend consumes.
+
+## Boundaries and why
+
+**Internet Archive is treated as untrusted input.** Items can have unparseable lengths, unknown networks, or missing dates. The scanner is permissive (anything ≥12 minutes proceeds); unrecognized channels land in `pending_review` rather than being dropped (`ia/scanner.py:25-46`). The metadata parser has multiple regex strategies and falls back to EDT when no timezone is named (`ia/metadata.py:30-32`).
+
+**Stage transitions are atomic in DB.** `transition_job()` does `UPDATE video_jobs` + `INSERT pipeline_transitions` in the same SQLAlchemy connection and commits both together (`pipeline/flows.py:46-84`). The audit table is the canonical "what happened to this job" log; the `stage` column on `video_jobs` is just a cached current state.
+
+**Workers are stateless past `/tmp/vg-scratch`.** Each `process_item_flow` run reconstructs everything it needs from the DB row and the IA identifier. The 50Gi `emptyDir` is throwaway. If a worker pod dies mid-encode, the next attempt re-downloads from scratch (the resumable download in `downloader.py` covers in-process resume, not cross-pod resume).
+
+**Directus is the public catalog; Postgres is the pipeline log.** The pipeline never reads from Directus — it only writes one record per successful job into `media_items` with the Wasabi URL. If Directus is unavailable, the job sits in `uploading`/`complete` and the writer retries on the next flow run (the idempotency check makes this safe — `directus/writer.py:31-39`).
+
+**EPG assembly is decoupled from pipeline.** It reads `schedule_slots` and writes flat playlist files. It never modifies job state and can be rerun freely.
+
+## Why six stages
+
+The granularity exists so a flaky network or a corrupt source file fails at the cheapest possible step. Splitting `downloading`/`downloaded`/`encoding`/`encoded`/`uploading` lets the operator pick the right retry point: re-run encode without re-downloading 4 GB, or re-run upload without re-encoding 60 minutes of footage. The audit log in `pipeline_transitions` makes "where did this job get stuck" answerable in one query.
+
+## What lives outside this package
+
+- **The Prefect server itself** runs as a separate Deployment (`k8s/prefect-server-deployment.yaml`). It owns its own Postgres database (`prefect`); the pipeline owns `video_grabber`.
+- **The Directus instance** runs in the `rt911` namespace. video-grabber only consumes its HTTP API.
+- **Wasabi** is the long-term storage tier. Bucket `files.911realtime.org`, region `us-central-1`.
+- **The frontend** (`packages/frontend`) consumes the EPG JSON and `master.m3u8` URLs published by this package, but it has no knowledge of `video_jobs`.

--- a/packages/tools/video-grabber/docs/configuration.md
+++ b/packages/tools/video-grabber/docs/configuration.md
@@ -1,0 +1,65 @@
+# Configuration
+
+All configuration is read from environment variables by [`video_grabber/config.py`](../video_grabber/config.py). There is no config file; the `.env.example` is the canonical reference for what to set locally and what the ConfigMap + Secret should contain in-cluster.
+
+## Variables
+
+| Variable | Default | Required in prod? | Read by |
+| --- | --- | --- | --- |
+| `DATABASE_URL` | `""` | Yes (Secret) | `pipeline/flows.py` via `Config` |
+| `WASABI_ENDPOINT_URL` | `https://s3.us-central-1.wasabisys.com` | No (ConfigMap) | `storage/wasabi.py` |
+| `WASABI_BUCKET` | `files.911realtime.org` | No (ConfigMap) | `storage/wasabi.py` |
+| `WASABI_ACCESS_KEY_ID` | `""` | Yes (Secret) | `storage/wasabi.py` |
+| `WASABI_SECRET_ACCESS_KEY` | `""` | Yes (Secret) | `storage/wasabi.py` |
+| `DIRECTUS_URL` | `http://localhost:8055` | Yes (ConfigMap) | `directus/writer.py` |
+| `DIRECTUS_API_TOKEN` | `""` | **Yes (Secret)** — must be a static token | `directus/writer.py` |
+| `ADMIN_EMAIL` | `""` | No (unused by worker) | held in `Config` for manual scripts |
+| `ADMIN_PASSWORD` | `""` | No (unused by worker) | held in `Config` for manual scripts |
+| `IA_RATE_PER_SEC` | `2` | No (ConfigMap) | `pipeline/flows.py::scan_collections_flow` |
+| `MIN_DURATION_SECONDS` | `720` | No (ConfigMap) | `ia/scanner.py` |
+| `PREFECT_API_URL` | (none) | Yes (ConfigMap) | Prefect SDK (worker boot, not `Config`) |
+| `SCRATCH_DIR` | `/tmp/vg-scratch` | No | `pipeline/flows.py` (module-level `_SCRATCH`) |
+| `HOSTNAME` | (set by Kubernetes / OS) | No | `pipeline/flows.py::transition_job` |
+
+## What goes in the Secret vs the ConfigMap
+
+The worker manifest references both with `envFrom`:
+
+```yaml
+envFrom:
+  - configMapRef:
+      name: video-grabber-config
+  - secretRef:
+      name: video-grabber-secrets
+```
+
+The split is conventional:
+
+- **ConfigMap** — anything operationally interesting (URLs, rate limits, thresholds) that's safe to read from `kubectl get configmap`.
+- **Secret** — anything that grants access (credentials, API tokens, DB URLs).
+
+`DATABASE_URL` is in the Secret rather than ConfigMap because it contains the Postgres password.
+
+## Why a static Directus token, never email/password
+
+[`directus/writer.py`](../video_grabber/directus/writer.py) only reads `cfg.directus_api_token`. The `ADMIN_EMAIL` / `ADMIN_PASSWORD` fields exist on `Config` for the benefit of manual maintenance scripts that need an admin session — they are not consumed by the worker.
+
+The reason is concurrency: Directus session tokens are bound to a single login event and rotate. When two workers tried to use the same email/password they would each log in, invalidate the other's session, and one of every pair of writes would fail with 401. Static API tokens have no session state and are safe to share across N concurrent workers. The `.env.example` says so explicitly:
+
+> Directus API — use a static token (never session tokens; they race across concurrent workers)
+
+## Why `IA_RATE_PER_SEC=2`
+
+Internet Archive's bulk-access guidelines cap automated callers at ~2 concurrent requests. The scanner sleeps `1 / IA_RATE_PER_SEC` between items (`pipeline/flows.py:90-91`). Raising this past 2 risks rate-limit IP bans. Lowering it slows down recrawls — for an initial scan of a 50k-item collection at 2/s that's roughly 7 hours, which is the budget.
+
+## Why `MIN_DURATION_SECONDS=720`
+
+12 minutes. Shorter IA items in these collections are almost always clips, promos, or test patterns rather than continuous broadcast coverage. The threshold matches the cutoff used in the legacy `packages/backend/seed.mjs` importer.
+
+## Local development `.env`
+
+Copy `.env.example` to `.env` in this directory. The file is already in `.gitignore`. Fill in real Wasabi credentials (or use a moto/localstack S3 — see the test config) and either a local Directus token or the dev cluster's Directus URL with a token scoped for development.
+
+## Test environment
+
+`pytest` does not require any env vars. The test suite stubs out `Config()`, mocks the IA SDK, mocks boto3 with `moto[s3]`, and mocks Directus HTTP with `respx`. See [testing.md](./testing.md).

--- a/packages/tools/video-grabber/docs/data-model.md
+++ b/packages/tools/video-grabber/docs/data-model.md
@@ -1,0 +1,133 @@
+# Data model
+
+The pipeline database is Postgres, managed by Alembic. Migration `001_initial_schema` ([`video_grabber/db/migrations/versions/001_initial_schema.py`](../video_grabber/db/migrations/versions/001_initial_schema.py)) creates the full schema; there are no later revisions.
+
+## Tables
+
+### `channels`
+
+Catalog of broadcast networks served by the pipeline.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | UUID PK | `gen_random_uuid()` default. |
+| `slug` | text, unique | Lowercase, hyphenated (`cnn`, `abc-news`). The same slug appears in Wasabi paths and Directus' `sources.slug`. |
+| `display_name` | text | Human label used in EPG JSON. |
+| `timezone` | text | Fixed offset name (e.g. `EDT`); `directus/writer.py` and `epg/assembler.py` consume it. |
+| `created_at` | timestamptz | `now()`. |
+
+Channels are seeded separately (not by the pipeline). New channels added via DDL or admin tooling.
+
+### `programs`
+
+Per-air metadata for a single broadcast. One program per IA item (one-to-one with `video_jobs.ia_identifier`).
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | UUID PK | |
+| `channel_id` | UUID FK → `channels.id` | |
+| `title` | text | Used as Directus `media_items.full_title`. |
+| `description` | text | Optional. |
+| `air_date` | timestamptz | UTC. Parsed from title/description by `ia/metadata.py`. |
+| `duration_seconds` | integer | From IA `length`; used by Directus writer for `calc_duration` and end-time. |
+| `ia_identifier` | text | Denormalized for convenience; equal to the parent `video_jobs.ia_identifier`. |
+| `created_at` | timestamptz | |
+
+### `video_jobs`
+
+The pipeline state row. One row per IA identifier; the unique constraint on `ia_identifier` is what makes `scan-collections` idempotent.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | UUID PK | Used as `job_id` in Prefect flows. |
+| `ia_identifier` | text, **unique** | Scanner upserts with `ON CONFLICT DO NOTHING`. |
+| `stage` | `pipeline_stage` enum | Default `discovered`. Cached current state. |
+| `collection` | text | Source collection (`sept_11_tv_archive` or `911`). |
+| `channel_id` | UUID FK → `channels.id` | Set when the channel is recognized; NULL for `pending_review` rows. |
+| `program_id` | UUID FK → `programs.id` | Set when metadata extraction populates `programs`. |
+| `ia_metadata` | jsonb | Raw IA fields captured at scan time. |
+| `local_path` | text | Where the source landed on the worker filesystem (currently unused; reserved). |
+| `encoded_path` | text | Where the HLS package landed (currently unused; reserved). |
+| `wasabi_key` | text | The key of the uploaded `master.m3u8`. Set on transition to `complete`. |
+| `bytes_total` | bigint | Source file size (currently unset; downloader does not write this). |
+| `bytes_downloaded` | bigint | Updated during streaming download; default `0`. |
+| `error_message` | text | Populated on `failed`. |
+| `retry_count` | integer | Reserved; not incremented automatically. |
+| `last_transition_at` | timestamptz | Updated by `transition_job()`. |
+| `created_at` | timestamptz | |
+
+Index: `idx_jobs_stage` on `stage` so "give me everything stuck in `encoding`" is cheap.
+
+### `pipeline_transitions`
+
+Append-only audit log. The source of truth for "what happened to this job, and when."
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | bigint PK | autoincrement. |
+| `job_id` | UUID FK → `video_jobs.id` | |
+| `from_stage` | `pipeline_stage` | NULL for the initial transition and for transitions into `failed`. |
+| `to_stage` | `pipeline_stage` | Not null. |
+| `worker_id` | text | Pod name from `HOSTNAME`. |
+| `occurred_at` | timestamptz | `now()` default. |
+
+Index: `idx_transitions_job` on `job_id`.
+
+### `schedule_slots`
+
+Consumed by the EPG assembler ([`epg/assembler.py`](../video_grabber/epg/assembler.py)). One row per programmed slot on a channel/day.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | UUID PK | |
+| `channel_id` | UUID FK → `channels.id` | |
+| `program_id` | UUID FK → `programs.id` | NULL when `is_gap` is true. |
+| `starts_at` | timestamptz | |
+| `ends_at` | timestamptz | |
+| `segment_url` | text | Optional override for the slot's playlist URL. |
+| `is_gap` | boolean | `false` default; assembler does not currently use this flag (it computes gaps from time ranges). |
+
+Index: `idx_slots_channel_time` on `(channel_id, starts_at, ends_at)`.
+
+## The `pipeline_stage` enum
+
+```sql
+CREATE TYPE pipeline_stage AS ENUM (
+  'discovered', 'metadata_extracted', 'pending_review',
+  'downloading', 'downloaded', 'encoding', 'encoded',
+  'uploading', 'complete', 'failed'
+);
+```
+
+Adding a new value requires a follow-up Alembic migration. SQLAlchemy does not auto-cast strings to this enum, so every write in `flows.py` uses `CAST(:stage AS pipeline_stage)` explicitly.
+
+## Reference queries
+
+Jobs stuck for more than an hour:
+
+```sql
+SELECT id, ia_identifier, stage, error_message, last_transition_at
+FROM video_jobs
+WHERE stage NOT IN ('complete', 'pending_review')
+  AND last_transition_at < now() - interval '1 hour'
+ORDER BY last_transition_at;
+```
+
+Full history of a single job:
+
+```sql
+SELECT from_stage, to_stage, worker_id, occurred_at
+FROM pipeline_transitions
+WHERE job_id = '...'
+ORDER BY occurred_at;
+```
+
+Reset a failed job back to `discovered`:
+
+```sql
+UPDATE video_jobs
+SET stage = 'discovered', error_message = NULL, last_transition_at = now()
+WHERE id = '...';
+```
+
+(The audit log retains the failure record — only the cached `stage` column rolls back.)

--- a/packages/tools/video-grabber/docs/deployment.md
+++ b/packages/tools/video-grabber/docs/deployment.md
@@ -1,0 +1,120 @@
+# Deployment
+
+All Kubernetes manifests live under [`k8s/`](../k8s). They target the `video-grabber` namespace and are designed for ArgoCD-style GitOps deployment against the `dev.keepinghistory.org` cluster, but they will apply against any cluster with the named secrets present.
+
+## Execution model
+
+The pipeline uses Prefect's **`serve()` model**, not a Kubernetes work pool. The single worker pod is the long-lived process that registers the flow deployments with the Prefect server and executes runs in-process. Reasons:
+
+- The worker pod already has the 50 GiB `emptyDir` scratch mounted — moving to per-run Job pods would force every flow run to its own (smaller) ephemeral storage and require PVC plumbing in the base job template.
+- ffmpeg is a single-process tool; running it next to the orchestrator inside the same pod is fine and simpler.
+- `serve()` deployments don't need a work pool at all, eliminating the "wrong pool type" failure mode (see [runbook.md](./runbook.md)).
+
+The entrypoint is [`video_grabber/serve.py`](../video_grabber/serve.py):
+
+```python
+serve(
+    process_item_flow.to_deployment(name="process-item"),
+    scan_collections_flow.to_deployment(name="scan-collections"),
+)
+```
+
+This is idempotent — every pod restart re-registers the same two deployments, and Prefect deduplicates by name.
+
+## Container image
+
+[`Dockerfile`](../Dockerfile) — `python:3.12-slim`, installs `ffmpeg` and `ca-certificates`, `pip install -e .` against the package, then runs the serve entrypoint:
+
+```dockerfile
+CMD ["python", "-m", "video_grabber.serve"]
+```
+
+Build and publish (CI publishes to `ghcr.io/keeping-history/video-grabber:latest`):
+
+```bash
+cd packages/tools/video-grabber
+docker build -t ghcr.io/keeping-history/video-grabber:latest .
+docker push ghcr.io/keeping-history/video-grabber:latest
+```
+
+The worker deployment ([`k8s/worker-deployment.yaml`](../k8s/worker-deployment.yaml)) pulls this tag with no digest pinning — restarting a pod is enough to pick up a fresh image.
+
+## Manifests
+
+| File | What it creates |
+| --- | --- |
+| `namespace.yaml` | `video-grabber` namespace. |
+| `rbac.yaml` | `video-grabber-worker` ServiceAccount, namespaced Role for `batch/jobs` + `pods`/`pods/log`, and a `ClusterRole` granting `namespaces:list` (to suppress a 403 noise log on worker boot). |
+| `prefect-server-deployment.yaml` | Single-replica `prefect-server` Deployment + ClusterIP Service on port 4200. Uses the official `prefecthq/prefect:3-latest` image. |
+| `worker-deployment.yaml` | `video-grabber-worker` Deployment (1 replica, 2–4 CPU, 4–8 GiB RAM, 50 GiB `emptyDir` scratch). Pulls `envFrom` a ConfigMap + Secret. ConfigMap is defined inline. |
+| `ingress-prefect-ui.yaml` | Traefik Ingress exposing the Prefect UI at `prefect-ui.dev.keepinghistory.org` behind a BasicAuth middleware (`video-grabber-prefect-auth@kubernetescrd`) and cert-manager-issued TLS. |
+| `db-init-job.yaml` | One-shot Job that runs as an ArgoCD `PreSync` hook to create the `video_grabber` and `prefect` databases on the shared Postgres. |
+
+## Required external resources
+
+Things the manifests assume exist and reference by name:
+
+- **Secret `video-grabber-secrets`** in the `video-grabber` namespace, with at minimum:
+  - `DATABASE_URL` — Postgres URL for the pipeline database.
+  - `WASABI_ACCESS_KEY_ID`, `WASABI_SECRET_ACCESS_KEY`.
+  - `DIRECTUS_API_TOKEN` — static token, not session-issued.
+  - `PREFECT_API_DATABASE_CONNECTION_URL` — Postgres URL for the Prefect server's own state DB (must be a different database from the pipeline's).
+- **Secret `postgres-secrets`** (consumed by `db-init-job.yaml`) with `DATABASE_URL` pointing at a Postgres role that can `CREATE DATABASE`.
+- **Traefik Middleware** `video-grabber-prefect-auth` (not in this manifest set) — BasicAuth secret for the Prefect UI. Created out-of-band by the same path used for the `time-machine` namespace's bullboard ingress.
+- **No work pool needed.** `serve()` registers deployments directly against the API. If a stale `video-grabber-pool` exists from an earlier iteration of this deployment, you can leave it (harmless) or delete it:
+  ```bash
+  kubectl exec -it -n video-grabber deploy/video-grabber-worker -- \
+    prefect work-pool delete video-grabber-pool
+  ```
+
+## The ConfigMap
+
+Defined inline in `worker-deployment.yaml`:
+
+```yaml
+PREFECT_API_URL: "http://prefect-server.video-grabber.svc.cluster.local:4200/api"
+WASABI_ENDPOINT_URL: "https://s3.us-central-1.wasabisys.com"
+WASABI_BUCKET: "files.911realtime.org"
+DIRECTUS_URL: "http://directus.rt911.svc.cluster.local:8055"
+IA_RATE_PER_SEC: "2"
+MIN_DURATION_SECONDS: "720"
+SCRATCH_DIR: "/tmp/vg-scratch"
+```
+
+Note that `DIRECTUS_URL` crosses namespaces — it points at the Directus service in `rt911`. The `directus` Service in that namespace must accept traffic from the `video-grabber` namespace (no NetworkPolicy blocks).
+
+## ArgoCD application sync order
+
+1. `namespace.yaml` (no hook, ordinary sync).
+2. `db-init-job.yaml` runs as a `PreSync` hook (`argocd.argoproj.io/hook: PreSync`) and is replaced on every sync (`hook-delete-policy: BeforeHookCreation`). It is idempotent — both `CREATE DATABASE` statements use `|| true`.
+3. `rbac.yaml`, `prefect-server-deployment.yaml`, then the worker once Prefect is ready.
+
+Database schema migrations are **not** in the manifests today. Alembic must be run manually (`alembic upgrade head` from a pod with `DATABASE_URL` set) after the first deploy and after any schema-changing PR. See [data-model.md](./data-model.md) for the current revision.
+
+## Local "deployment" (development)
+
+Skip Kubernetes entirely for development:
+
+```bash
+# Terminal 1 — Prefect server
+prefect server start
+
+# Terminal 2 — serve the flows
+export PREFECT_API_URL=http://localhost:4200/api
+export DATABASE_URL=postgresql://postgres:postgres@localhost:5432/video_grabber
+# … plus Wasabi/Directus from .env
+python -m video_grabber.serve
+```
+
+`serve()` blocks the terminal and polls the API for scheduled runs. Trigger one from the Prefect UI at `http://localhost:4200` (Deployments → `process-item` → Run → Custom run, fill in `job_id`), or from the CLI:
+
+```bash
+prefect deployment run "process-item/process-item" --param 'job_id="<uuid>"'
+prefect deployment run "scan-collections/scan-collections"
+```
+
+## Resource sizing notes
+
+- **CPU**: ffmpeg with `-preset slow` is single-threaded per encode but we run three sequentially. Two cores at request, four at limit gives headroom for the OS, httpx, and boto3's parallel upload threads.
+- **Memory**: 4 GiB request comfortably covers a 90-minute source plus the three ffmpeg processes. 8 GiB limit is conservative.
+- **Scratch volume**: 50 GiB `emptyDir` is enough for one item at a time (source can be 4–8 GiB, encoded HLS ~1–2 GiB). Nothing cleans up between items — see the runbook for manual scratch eviction.

--- a/packages/tools/video-grabber/docs/epg.md
+++ b/packages/tools/video-grabber/docs/epg.md
@@ -1,0 +1,97 @@
+# EPG assembler
+
+The EPG (Electronic Program Guide) assembler builds the artifacts that the frontend consumes: a 24-hour HLS master playlist per channel per day, three rendition playlists, and a JSON document describing the schedule grid. Implementation: [`video_grabber/epg/assembler.py`](../video_grabber/epg/assembler.py).
+
+## What it produces
+
+For one call to `assemble_day(channel, day, db)`:
+
+```python
+playlists, epg_channel = assemble_day(channel, day, db)
+# playlists = {
+#   "master": "#EXTM3U\n#EXT-X-INDEPENDENT-SEGMENTS\n#EXT-X-STREAM-INF:...\n...",
+#   "full":   "#EXTM3U\n#EXT-X-VERSION:7\n...",
+#   "mid":    "...",
+#   "thumb":  "...",
+# }
+# epg_channel = {
+#   "name": "CNN",
+#   "number": "",
+#   "callSign": "CNN",
+#   "location": "",
+#   "icon": "cnn",
+#   "grid": [{"title": "...", "start": "...", "end": "..."}, ...],
+# }
+```
+
+The `epg_channel` shape matches the `EPGChannel[]` contract that `EPG.tsx` in the frontend expects. The `playlists` map is keyed by the names the upload step writes as `<key>.m3u8` files in `epg/<channel-slug>/<YYYYMMDD>/`.
+
+## The 24-hour stitch
+
+For each programmed slot in `schedule_slots` for the day:
+
+1. If there's time between the previous cursor and `slot.starts_at` → emit a gap (see below).
+2. Emit a `#EXT-X-DISCONTINUITY` plus a new `#EXT-X-MAP:URI=…/init.mp4` for the slot's rendition.
+3. Reference each 6-second segment of the slot's HLS package by absolute URL on Wasabi: `https://files.911realtime.org/hls/<slug>/<yyyymmdd>/<ia_id>/<rend>/seg0000.m4s`.
+4. If `slot.duration % 6 != 0`, emit one shorter trailing segment to absorb the remainder.
+
+After the last slot, if `cursor < window_end`, a trailing gap fills to midnight UTC. Finally, `#EXT-X-ENDLIST` closes each rendition.
+
+## Gap playlists
+
+Gaps use the same fMP4/CMAF format as content (see [`gap_filler.py`](../video_grabber/video/gap_filler.py)). Each rendition references its own gap init segment:
+
+```
+#EXT-X-DISCONTINUITY
+#EXT-X-MAP:URI="https://files.911realtime.org/hls/cnn/20010911/_gap/full/init.mp4"
+#EXTINF:6,
+https://files.911realtime.org/hls/cnn/20010911/_gap/full/seg_gap_6s.m4s
+…
+```
+
+`_append_gap()` ([`assembler.py:113-123`](../video_grabber/epg/assembler.py)) cuts the gap into N × 6s segments and one trailing remainder segment (`seg_gap_<remainder>s.m4s`). The set of gap segment durations the assembler can produce is bounded — typically `seg_gap_6s.m4s`, `seg_gap_1s.m4s` through `seg_gap_5s.m4s`, etc. The gap-filler step needs to have generated each of these once and uploaded them to `_gap/<rend>/`. Otherwise the playlist references a 404 and hls.js stalls.
+
+## Why every slot boundary has `#EXT-X-DISCONTINUITY`
+
+The slots come from different IA items, each encoded independently with its own CMAF init segment, frame numbering, and timestamps. Without a discontinuity tag, hls.js tries to splice them with continuous timestamps and the player drifts / freezes at every boundary. The tag tells the player to reset its timeline at the next segment, and the fresh `#EXT-X-MAP` gives it the right init for the new content.
+
+## Master playlist
+
+Trivial — three `EXT-X-STREAM-INF` entries referencing the three per-rendition playlists by absolute URL. Bandwidth and resolution values match `RENDITIONS` in the encoder ([`video/encoder.py:12-37`](../video_grabber/video/encoder.py)) and are duplicated as `REND_BANDWIDTHS`/`REND_RESOLUTIONS` constants in `assembler.py`. **If you change a rendition's bitrate in the encoder, update these constants too** — there is no shared source of truth.
+
+## EPG JSON grid
+
+Real content slot:
+
+```json
+{
+  "title": "ABC News Coverage of 9/11",
+  "description": "Continuous coverage…",
+  "fullTitle": "abc-news-9-11-2001-am",
+  "start": "2001-09-11T12:30:00+00:00",
+  "end":   "2001-09-11T14:00:00+00:00"
+}
+```
+
+Gap slot:
+
+```json
+{
+  "title": "[No Signal]",
+  "start": "...",
+  "end":   "..."
+}
+```
+
+`fullTitle` is the IA identifier — the frontend uses it as a stable key for clicking through to source metadata. `description` is only present on content slots; the frontend renders an empty description block for gaps.
+
+## What the assembler does **not** do
+
+- It does not upload the playlists. The caller is expected to write `playlists[*]` to `epg/<slug>/<yyyymmdd>/<*>.m3u8` on Wasabi.
+- It does not generate gap segments. Those come from `gap_filler.py` and must be uploaded to `_gap/<rend>/` before any day-playlist that references them is served.
+- It does not re-fetch from IA or re-validate URLs. It trusts the URL convention.
+- It does not write to `schedule_slots`. Slot insertion is a manual step today (or done by a future scheduler flow that does not yet exist).
+
+## Testing
+
+`tests/test_epg.py` and `tests/test_epg_json.py` exercise the assembler with mock slot lists. The unit tests pass an explicit `slots=[...]` so the DB query path is bypassed; integration coverage of `_fetch_slots()` is light.

--- a/packages/tools/video-grabber/docs/modules.md
+++ b/packages/tools/video-grabber/docs/modules.md
@@ -1,0 +1,168 @@
+# Module guide
+
+Per-subpackage responsibilities, ordered roughly by the path a job takes through the system.
+
+## `video_grabber.config`
+
+[`video_grabber/config.py`](../video_grabber/config.py)
+
+A frozen-by-convention `@dataclass` that reads env vars in `field(default_factory=...)`. Constructing `Config()` re-reads the environment each time, so tests can `monkeypatch.setenv()` and then `Config()` to assert effective values without managing module-level state. There is no validation — empty strings are valid placeholders for missing credentials, which the consumers detect at call time.
+
+| Field | Env var | Default |
+| --- | --- | --- |
+| `database_url` | `DATABASE_URL` | `""` |
+| `wasabi_endpoint` | `WASABI_ENDPOINT_URL` | `https://s3.us-central-1.wasabisys.com` |
+| `wasabi_bucket` | `WASABI_BUCKET` | `files.911realtime.org` |
+| `wasabi_key` / `wasabi_secret` | `WASABI_ACCESS_KEY_ID` / `WASABI_SECRET_ACCESS_KEY` | `""` |
+| `directus_url` | `DIRECTUS_URL` | `http://localhost:8055` |
+| `directus_api_token` | `DIRECTUS_API_TOKEN` | `""` |
+| `ia_rate_per_sec` | `IA_RATE_PER_SEC` | `2` |
+| `min_duration_seconds` | `MIN_DURATION_SECONDS` | `720` (12 min) |
+
+`directus_email` / `directus_password` are also read but **not used by the worker**. They exist only for manual admin scripts; the writer always uses the static API token. Session tokens race across concurrent workers and were the source of an early bug — see the `.env.example` warning.
+
+## `video_grabber.ia`
+
+### `scanner.py`
+
+[`ia/scanner.py`](../video_grabber/ia/scanner.py)
+
+Recursive `crawl_collection()` walks an IA collection identifier with `session.search_items()` and recurses into items whose `mediatype == "collection"`. Leaf items are passed through `is_candidate()` (duration ≥ `MIN_DURATION_SECONDS`) and then `upsert_job()`.
+
+The `visited` set is mandatory — IA collections form a DAG, not a tree, so without dedup the crawler can revisit the same sub-collection through multiple parents. `sleep_sec` between item iterations enforces the IA rate limit (calculated as `1 / IA_RATE_PER_SEC` in the calling flow).
+
+`upsert_job()` uses `INSERT … ON CONFLICT (ia_identifier) DO NOTHING`, so rescanning is a free no-op for known items. New items with a recognized channel start at `stage='discovered'`; new items with no recognizable channel start at `stage='pending_review'`.
+
+### `metadata.py`
+
+[`ia/metadata.py`](../video_grabber/ia/metadata.py)
+
+Pure date/timezone parsing. Two regex strategies tried in order: ISO 8601 then "Month Day, Year HH:MM TZ". Both return a `datetime` in UTC.
+
+Specific behaviors worth knowing:
+
+- **Default timezone is EDT (`UTC-4`)**, matching the on-air timezone of the eastern US 9/11 coverage. Items with no timezone abbreviation are interpreted in EDT, not local time, not UTC. This is intentional and ported from `packages/backend/seed.mjs`.
+- **ISO with no zone is treated as UTC**, not EDT. Mixed-mode quirk; rationale: ISO strings in our corpus came from machine-generated metadata that records in UTC.
+- BST/CEST are mapped for the small number of BBC items in the collection.
+- The patterns use `_MONTH_NAMES` with both long ("september") and short ("sept", "sep") forms.
+
+### `channel_map.py`
+
+[`ia/channel_map.py`](../video_grabber/ia/channel_map.py)
+
+`normalize_slug(item)` checks `creator`, then `subject`, then `title`. The first hit wins. `KNOWN_CHANNELS` lists the canonical major networks; the `_LOCAL_CALL_SIGN` regex catches W/K-prefixed 4-letter affiliate signs (WABC, KCAL, etc.) and lowercases them as the slug. Returns `None` for unrecognized items, which causes the scanner to file the item under `pending_review`.
+
+Adding a new channel = add a `lowercase pattern: canonical-slug` entry to `KNOWN_CHANNELS` and re-deploy.
+
+## `video_grabber.pipeline`
+
+### `flows.py`
+
+[`pipeline/flows.py`](../video_grabber/pipeline/flows.py)
+
+The Prefect entry points. See [pipeline.md](./pipeline.md) for the stage-by-stage walkthrough. Three notes on the implementation:
+
+- `get_db()` opens a new SQLAlchemy connection per call. There is no pooling at this layer; pooling is whatever `sqlalchemy.create_engine` defaults to (which is fine for one flow run per worker pod at a time).
+- The `ArchiveSession` import is guarded with `try/except ImportError` so unit tests can import `flows.py` without `internetarchive` installed.
+- `transition_job(error=...)` writes both the error message and the `failed` stage in one UPDATE.
+
+### `downloader.py`
+
+[`pipeline/downloader.py`](../video_grabber/pipeline/downloader.py)
+
+Talks to the public IA HTTP API (`https://archive.org`), not the Python SDK, to keep the HTTP semantics explicit. `get_ia_files(identifier)` hits `/metadata/<id>/files`.
+
+`select_best_file()` orders candidates by format priority (`.mp4` > `.mpg`/`.mpeg2` > `.avi` > `.ogv`) and skips known low-quality derivatives (anything containing `512kb`, `256kb`, `128kb`, `_small`, `_tiny`, `_thumb`). Raises `ValueError` when nothing qualifies.
+
+`download_item()` is the streaming download with resume support:
+
+- If the destination file already exists, sends `Range: bytes=<size>-` and appends.
+- Streams 1 MiB chunks with `httpx.stream` (no full-buffer load).
+- Calls `update_bytes_downloaded()` per chunk — the actual DB write is currently a no-op stub; the live progress counter is reserved for a future "what % done" view.
+
+## `video_grabber.video`
+
+### `encoder.py`
+
+[`video/encoder.py`](../video_grabber/video/encoder.py)
+
+Three subprocess calls — one per rendition — instead of one ffmpeg invocation with `-map` arrays. The trade-off: slightly longer wall-clock time, much simpler error attribution. If `mid` fails, you know exactly which command failed and can rerun just that step.
+
+| Rendition | Resolution | Video | Audio | Bandwidth (master.m3u8) |
+| --- | --- | --- | --- | --- |
+| `full` | 854×480 | CRF 21, maxrate 2500k | 128k stereo | 2 628 000 |
+| `mid` | 320×240 | CBR ~300k, maxrate 350k | 96k stereo | 396 000 |
+| `thumb` | 160×120 | CBR ~128k, maxrate 160k | 8k mono | 136 000 |
+
+Common encoding flags (shared across all rungs):
+
+- `libx264`, profile main, level 3.1.
+- `-preset slow` — long encode times, smaller files, better quality.
+- 29.97 fps with `-g 60 -keyint_min 60 -sc_threshold 0` — fixed 2-second GOP, no scene-cut keyframe insertion. Required for `independent_segments`.
+- Audio: `aac` at 44 100 Hz.
+
+HLS flags: `fmp4`/CMAF (`init.mp4` + `seg%04d.m4s`), VOD playlist type, 6-second segments, `independent_segments` so any rendition can be started from any segment.
+
+`scale_keep_aspect()` rounds output dimensions to even numbers (H.264 requirement) and refuses to upscale — small source videos stay small in the upper rungs rather than being blown up.
+
+`probe_resolution()` shells out to `ffprobe` to determine source dimensions before computing scale targets.
+
+### `gap_filler.py`
+
+[`video/gap_filler.py`](../video_grabber/video/gap_filler.py)
+
+Generates fMP4 segments of solid blue (`#0000f5`, the EBU colour-bar "no signal" blue used by US broadcast continuity) plus silent audio, sized to match each `RENDITIONS` entry so hls.js's level-switching logic doesn't reject them as codec-incompatible.
+
+Critical: **the thumb rung keeps audio (8kbps mono)** even though no human listens to a 160×120 stream. hls.js requires every rendition in the master playlist to expose the same audio profile, so dropping audio on thumb causes silent-rung fallbacks to behave incorrectly. Don't "optimize" this.
+
+Outputs the same directory layout as `encoder.py` so the EPG assembler can treat real content and gap content interchangeably.
+
+## `video_grabber.storage`
+
+### `wasabi.py`
+
+[`storage/wasabi.py`](../video_grabber/storage/wasabi.py)
+
+Wasabi-specific boto3 client. Three quirks that all exist for one bug each:
+
+1. **`addressing_style="path"`** — Wasabi's virtual-hosted DNS for bucket names containing dots (`files.911realtime.org` does) is unreliable; path-style addressing is the supported workaround.
+2. **`request_checksum_calculation="when_required"`** — boto3 ≥ 1.36 started injecting `x-amz-checksum-*` headers on every PUT. Wasabi rejects unrecognized checksum algorithms with HTTP 400. This setting reverts boto3 to the pre-1.36 behavior.
+3. **`response_checksum_validation="when_required"`** — same root cause, GET path.
+
+Upload key layout: `hls/<channel-slug>/<YYYYMMDD>/<ia-identifier>/<file>`. Returns the `master.m3u8` key so the caller can write it to `video_jobs.wasabi_key`.
+
+`Content-Type` and `Cache-Control` are set per extension:
+
+| Extension | Content-Type | Cache-Control |
+| --- | --- | --- |
+| `.m3u8` | `application/vnd.apple.mpegurl` | `max-age=5` (playlists change; segments don't) |
+| `.mp4` (init.mp4) | `video/mp4` | `max-age=31536000` (immutable) |
+| `.m4s` | `video/iso.segment` | `max-age=31536000` (immutable) |
+
+Multipart upload trips at 100 MiB with 50 MiB chunks and 10-way concurrency.
+
+## `video_grabber.directus`
+
+### `writer.py`
+
+[`directus/writer.py`](../video_grabber/directus/writer.py)
+
+Writes one row to Directus `media_items`. Idempotent on rerun: the first action is a `GET /items/media_items?filter[content][ia_identifier][_eq]=...`. If a row exists, the writer returns early.
+
+Static Bearer token only — see the `.env.example` warning about session-token races. Date strings use Directus's naive-UTC convention (`%Y-%m-%dT%H:%M:%S`, no `Z`, no offset). `end_date` is computed from `air_date + duration_seconds`.
+
+`source` is a foreign key resolved by `_resolve_source_id()` which queries `/items/sources?filter[slug][_eq]=<channel_slug>` and returns the first match's `id`. If no source exists, `source` is `None` and Directus must accept the nullable FK.
+
+`approved` is `0` if `job.passed_through_review` is truthy (i.e. the job was once in `pending_review` and a human cleared it), `1` otherwise — so reviewed items go to a human-validation queue downstream while clean-pipeline items go live.
+
+The `content` field is `json.dumps({"ia_identifier": …})`. Directus stores it as a JSON column; the round-trip through `json.dumps` is required because the field's schema is `string`, not `json`, in this project's Directus config.
+
+## `video_grabber.epg`
+
+See [epg.md](./epg.md) — large enough to warrant its own document.
+
+## `video_grabber.db`
+
+Alembic migrations only. `env.py` overrides `sqlalchemy.url` from `DATABASE_URL` if set, so the same migrations script runs both locally and in the cluster against the in-cluster Postgres. `target_metadata = None` — migrations are hand-written, not autogenerated.
+
+Run migrations: `alembic -c <config> upgrade head`. There is no `alembic.ini` in the repo today; if you need to run migrations outside the deploy hook, supply your own config that points at `video_grabber/db/migrations`.

--- a/packages/tools/video-grabber/docs/pipeline.md
+++ b/packages/tools/video-grabber/docs/pipeline.md
@@ -1,0 +1,91 @@
+# Pipeline stages
+
+The pipeline is implemented as Prefect flows in [`video_grabber/pipeline/flows.py`](../video_grabber/pipeline/flows.py). All stage names are values of the Postgres `pipeline_stage` enum defined in migration `001` ([`video_grabber/db/migrations/versions/001_initial_schema.py:22-28`](../video_grabber/db/migrations/versions/001_initial_schema.py)).
+
+## The state machine
+
+```
+              ┌─► pending_review ─(human triage)─┐
+              │                                  │
+discovered ─► metadata_extracted ─► downloading ─► downloaded ─►
+   encoding ─► encoded ─► uploading ─► complete
+
+      (any) ─► failed
+```
+
+| Stage | Set by | Means |
+| --- | --- | --- |
+| `discovered` | `scan_collections_flow` | Row inserted from an IA item that passed the candidate filter and has a known channel. |
+| `pending_review` | `scan_collections_flow` | Same as `discovered`, but channel could not be normalized. Held until a human classifies it. |
+| `metadata_extracted` | (currently inlined; reserved for future air-date/duration extraction stage) | Air date, channel, and duration written to `programs`. |
+| `downloading` | `process_item_flow` | Worker is fetching source bytes from IA into `/tmp/vg-scratch/<id>/`. |
+| `downloaded` | `process_item_flow` | Source file is on disk. |
+| `encoding` | `process_item_flow` | ffmpeg is running the three rendition jobs. |
+| `encoded` | `process_item_flow` | HLS package is on disk in `encoded/`. |
+| `uploading` | `process_item_flow` | Worker is pushing the package to Wasabi. |
+| `complete` | `process_item_flow` | Wasabi key written to `video_jobs.wasabi_key`; Directus `media_items` row inserted. |
+| `failed` | `process_item_flow` (`except` branch) | Exception captured in `video_jobs.error_message`. |
+
+## The two flows
+
+### `scan-collections`
+
+[`flows.py:87-96`](../video_grabber/pipeline/flows.py)
+
+Crawls each named IA collection recursively. Rate-limited by `IA_RATE_PER_SEC` (default 2/s, matching IA's bulk-access guidance). Items with `mediatype == "collection"` are recursed into; leaf items are passed to `upsert_job()` which uses `ON CONFLICT (ia_identifier) DO NOTHING` so reruns are free.
+
+```python
+@flow(name="scan-collections")
+def scan_collections_flow(collections: list[str] = ["sept_11_tv_archive", "911"]):
+```
+
+Default collections are the two pre-imported IA sets. Pass any IA collection ID to scan it.
+
+### `process-item`
+
+[`flows.py:99-135`](../video_grabber/pipeline/flows.py)
+
+One run per `video_jobs.id`. Walks `downloading → downloaded → encoding → encoded → uploading → complete`, calling `transition_job()` between each step. On exception, transitions to `failed` and re-raises so Prefect marks the run as failed.
+
+```python
+@flow(name="process-item")
+def process_item_flow(job_id: str):
+```
+
+## Atomic transitions
+
+Every stage change goes through [`transition_job()`](../video_grabber/pipeline/flows.py) (`flows.py:46-84`), which performs both writes — the cached state on `video_jobs.stage` and the audit row in `pipeline_transitions` — on the same connection and commits them together. The enum cast is explicit because SQLAlchemy doesn't auto-cast string→enum for Postgres custom types:
+
+```sql
+UPDATE video_jobs SET stage = CAST(:stage AS pipeline_stage), ...
+INSERT INTO pipeline_transitions (job_id, from_stage, to_stage, worker_id)
+  VALUES (:job_id, CAST(:from_stage AS pipeline_stage), CAST(:to_stage AS pipeline_stage), :worker_id);
+```
+
+`worker_id` is sourced from `HOSTNAME`, which Kubernetes sets to the pod name — useful for correlating audit rows back to Prefect run logs.
+
+## Failure handling
+
+The `try/except` in `process_item_flow` (`flows.py:108-135`) catches every exception, records it with `to_stage="failed"` and `error=str(exc)`, then re-raises. Two consequences:
+
+1. `pipeline_transitions` records the transition into `failed` with `from_stage=NULL` (the previous in-flight stage is not recorded because we don't capture it before re-raising). The original stage can be recovered by querying the second-to-last transition row for the job.
+2. Prefect's UI shows the run as failed, so Prefect-level retry policies apply.
+
+A failed job is **not** automatically retried. Operators query for `WHERE stage = 'failed'` and decide whether to clear `error_message`, reset `stage`, and rerun.
+
+## Scratch directory
+
+Worker-local: `SCRATCH_DIR` env var (default `/tmp/vg-scratch`) is mounted as a 50Gi `emptyDir` in the worker pod. Layout:
+
+```
+/tmp/vg-scratch/
+└── <ia_identifier>/
+    ├── <source>.mp4         # downloader output
+    └── encoded/
+        ├── master.m3u8
+        ├── full/  index.m3u8  init.mp4  seg0000.m4s  …
+        ├── mid/   …
+        └── thumb/ …
+```
+
+Nothing cleans this up on success today. If pods churn over many items, expect the volume to fill — see the runbook for `kubectl exec` cleanup notes.

--- a/packages/tools/video-grabber/docs/runbook.md
+++ b/packages/tools/video-grabber/docs/runbook.md
@@ -1,0 +1,200 @@
+# Runbook
+
+Operational playbook for the common things that go wrong. Assumes you have `kubectl` access to the `video-grabber` namespace and `psql` access to the pipeline database.
+
+## Where things live
+
+- **Prefect UI** — `https://prefect-ui.dev.keepinghistory.org` (BasicAuth).
+- **Worker logs** — `kubectl logs -n video-grabber deploy/video-grabber-worker -f`.
+- **Pipeline DB** — `video_grabber` database on the shared Postgres referenced by `video-grabber-secrets/DATABASE_URL`.
+- **Scratch volume** — inside the worker pod at `/tmp/vg-scratch`.
+
+## Flows don't appear in the Prefect UI
+
+Symptom: Prefect UI shows the worker connected but the Deployments tab is empty, or the deployments you expected aren't there.
+
+Almost always one of:
+
+1. **The worker container is running `prefect worker start` instead of `python -m video_grabber.serve`.** Check the running command:
+   ```bash
+   kubectl describe pod -n video-grabber -l app=video-grabber-worker | grep -A2 Command
+   ```
+   If you see `prefect worker start`, the image is stale. Rebuild + push the image (Dockerfile `CMD` should be `["python", "-m", "video_grabber.serve"]`) and `kubectl rollout restart deploy/video-grabber-worker -n video-grabber`.
+
+2. **A stale `video-grabber-pool` of type `process` exists from an earlier setup.** This package no longer uses a work pool — `serve()` registers deployments directly. If you see the pool in `prefect work-pool ls` you can delete it:
+   ```bash
+   kubectl exec -it -n video-grabber deploy/video-grabber-worker -- \
+     prefect work-pool delete video-grabber-pool
+   ```
+   Don't try to "fix" the pool's type — `serve()` doesn't read from it.
+
+3. **`PREFECT_API_URL` is wrong or unreachable.** The ConfigMap value is `http://prefect-server.video-grabber.svc.cluster.local:4200/api`. Test from the worker:
+   ```bash
+   kubectl exec -n video-grabber deploy/video-grabber-worker -- \
+     curl -sf "$PREFECT_API_URL/health"
+   ```
+   Anything but `true` means the worker can't talk to the server.
+
+Historical context: an earlier iteration of this deployment tried to use a Kubernetes-typed work pool with `flow.deploy(image=...)`. That blows up with `ValueError: Work pool 'video-grabber-pool' does not support custom Docker images` because the pool was auto-created as `process` type when the worker first connected. The current design sidesteps the whole work-pool model by using `serve()` instead. See [deployment.md](./deployment.md#execution-model) for the reasoning.
+
+## Rescan a collection
+
+Idempotent. Run from the Prefect UI:
+
+1. Trigger `scan-collections` with no parameters → uses defaults `["sept_11_tv_archive", "911"]`.
+2. Or pass a custom list:
+   ```python
+   scan_collections_flow(collections=["another_ia_collection"])
+   ```
+
+New items are upserted with `ON CONFLICT DO NOTHING`. Existing rows are unchanged. Recognized-channel items land at `discovered`; unknown-channel items land at `pending_review`.
+
+## Promote a `pending_review` item
+
+You've decided the channel for an item is, say, `cnn`. There is no admin UI today — fix it directly in SQL:
+
+```sql
+UPDATE video_jobs
+SET stage = 'discovered',
+    channel_id = (SELECT id FROM channels WHERE slug = 'cnn'),
+    last_transition_at = now()
+WHERE id = '<job-uuid>';
+
+INSERT INTO pipeline_transitions (job_id, from_stage, to_stage, worker_id)
+VALUES ('<job-uuid>', 'pending_review', 'discovered', 'manual-review');
+```
+
+Then trigger `process_item_flow(job_id='<job-uuid>')` from the Prefect UI.
+
+The downstream `directus/writer.py` checks `job.passed_through_review` to decide `approved=0` vs `approved=1`. That flag is **not** on the table today — if you want reviewed items to land in Directus as `approved=0` (i.e. needing human validation), set the flag on whatever in-memory job object the flow builds. The current code reads `job.passed_through_review` directly from the DB row, so plumbing it requires a schema column. Track this as a known gap.
+
+## Retry a failed job
+
+Find failed jobs:
+
+```sql
+SELECT id, ia_identifier, error_message, last_transition_at
+FROM video_jobs
+WHERE stage = 'failed'
+ORDER BY last_transition_at DESC;
+```
+
+Decide whether the failure is transient (IA timeout, Wasabi 503, Directus 5xx) or permanent (`select_best_file` raised "no suitable file found"). For transient failures:
+
+```sql
+UPDATE video_jobs
+SET stage = 'discovered',
+    error_message = NULL,
+    last_transition_at = now()
+WHERE id = '<job-uuid>';
+```
+
+Then trigger `process_item_flow(job_id='<job-uuid>')`. The audit log retains the original failure row, so the history isn't lost.
+
+For permanent failures, leave the job at `stage='failed'` (or move it back to `pending_review` for human notes). Don't keep retrying something that's never going to succeed.
+
+## Job is stuck mid-pipeline
+
+If a worker pod died mid-encode, the job will sit at `stage='encoding'` or wherever it was. The next Prefect run for that job restarts from the beginning of `process_item_flow`; the resumable downloader picks up where the previous attempt left off (per-pod, not cross-pod — see caveat below).
+
+```sql
+SELECT id, ia_identifier, stage, last_transition_at, error_message
+FROM video_jobs
+WHERE stage NOT IN ('complete', 'pending_review')
+  AND last_transition_at < now() - interval '30 minutes'
+ORDER BY last_transition_at;
+```
+
+To force a fresh restart from `discovered`:
+
+```sql
+UPDATE video_jobs
+SET stage = 'discovered', error_message = NULL, last_transition_at = now()
+WHERE id = '<job-uuid>';
+```
+
+The byte-range resume in `downloader.py` only works if the partial file is still on `/tmp/vg-scratch` — once the pod restarts, the `emptyDir` is gone and the next attempt re-downloads from offset 0.
+
+## Scratch volume is full
+
+```bash
+kubectl exec -n video-grabber deploy/video-grabber-worker -- df -h /tmp/vg-scratch
+```
+
+The pipeline doesn't clean up automatically. Either restart the pod (loses any in-flight resume state but reclaims the whole volume) or clean selectively:
+
+```bash
+# remove everything for completed jobs
+kubectl exec -n video-grabber deploy/video-grabber-worker -- \
+  sh -c 'cd /tmp/vg-scratch && ls -d */ | xargs -I {} sh -c "test -d {} && echo {}"'
+# then rm -rf the IA identifiers you've confirmed are at stage='complete' in the DB
+```
+
+If this becomes a frequent problem, the right fix is to add a cleanup step at the end of `process_item_flow` after `transition_job(...complete...)`.
+
+## Wasabi upload returns 400
+
+Most likely cause: boto3 was upgraded past 1.36 and the checksum-header workaround in [`storage/wasabi.py`](../video_grabber/storage/wasabi.py) regressed. Look at the response body for `InvalidArgument` mentioning `x-amz-checksum-*`. The fix is in `_make_s3_client`:
+
+```python
+request_checksum_calculation="when_required",
+response_checksum_validation="when_required",
+```
+
+Both must be present. If either is missing or set to `when_supported`, Wasabi rejects the upload.
+
+## Directus write returns 401
+
+The static API token in `video-grabber-secrets/DIRECTUS_API_TOKEN` was rotated or revoked. Generate a new static token in Directus (Settings → Access Tokens → static), update the Secret, and restart the worker:
+
+```bash
+kubectl rollout restart deploy/video-grabber-worker -n video-grabber
+```
+
+If you see intermittent 401s rather than uniform 401s, somebody set `DIRECTUS_API_TOKEN` to a session token. Get a static one — see [configuration.md](./configuration.md) for why.
+
+## Playlist plays for 5 seconds then stalls
+
+Symptom: `master.m3u8` loads, video starts, freezes after the first segment.
+
+Likely cause: a gap segment referenced in the playlist isn't actually on Wasabi. The assembler emits `seg_gap_<remainder>s.m4s` for fractional-duration gaps; if `gap_filler.py` only pre-generated a 6-second gap, any 1–5 second remainder reference 404s.
+
+Check the playlist for `seg_gap_*` and verify those keys exist:
+
+```bash
+aws s3 ls s3://files.911realtime.org/hls/cnn/20010911/_gap/full/ \
+  --endpoint-url https://s3.us-central-1.wasabisys.com
+```
+
+Regenerate the missing durations with `gap_filler.generate_gap_fmp4()` and re-upload.
+
+## Frontend isn't seeing a new program
+
+The Wasabi upload succeeded but Directus doesn't have the row.
+
+```sql
+SELECT stage, wasabi_key, error_message FROM video_jobs WHERE ia_identifier = '...';
+```
+
+If `stage = 'complete'` and `wasabi_key` is set, look at worker logs from the `complete` transition window — Directus may have returned a non-2xx that wasn't surfaced as an exception. The writer is idempotent, so it's safe to call `write_media_item(job, wasabi_key, cfg)` again from a Python shell inside the worker:
+
+```python
+from video_grabber.directus.writer import write_media_item
+from video_grabber.config import Config
+# … reconstruct job from DB row …
+write_media_item(job, job.wasabi_key, Config())
+```
+
+## Database migration needed
+
+Right now there's only `001_initial_schema`. To add a column or a new stage:
+
+1. `cd packages/tools/video-grabber`
+2. Author a new revision under `video_grabber/db/migrations/versions/` (manual — autogeneration isn't wired up).
+3. From a worker pod with `DATABASE_URL` set:
+   ```bash
+   alembic -c alembic.ini upgrade head
+   ```
+   There is no committed `alembic.ini`; supply one that points at `video_grabber/db/migrations`. (Filing this as a known gap.)
+
+Or migrate from a developer laptop with `DATABASE_URL` port-forwarded to the in-cluster Postgres.

--- a/packages/tools/video-grabber/docs/testing.md
+++ b/packages/tools/video-grabber/docs/testing.md
@@ -1,0 +1,69 @@
+# Testing
+
+Tests live under [`tests/`](../tests). One test module per source module, named `test_<module>.py`. Run everything from the package root:
+
+```bash
+pip install -e ".[dev]"
+pytest
+```
+
+`pytest.ini_options.testpaths = ["tests"]` is set in `pyproject.toml`, so the bare `pytest` command works from anywhere inside the package.
+
+## What the tests cover
+
+| Test file | Exercises |
+| --- | --- |
+| `test_config.py` | `Config()` env-var reads and defaults. |
+| `test_scanner.py` | `is_candidate()`, `upsert_job()`, recursive `crawl_collection()` with mocked `ArchiveSession`. |
+| `test_metadata.py` | Air-date parsing across ISO and named-month formats, AM/PM, TZ resolution, default-EDT fallback. |
+| `test_downloader.py` | `select_best_file()` priority, skip-pattern filtering, byte-range `Range` header on resume. |
+| `test_encoder.py` | `scale_keep_aspect()` math, `probe_resolution()` with mocked ffprobe, the per-rendition ffmpeg command shape. |
+| `test_gap_filler.py` | Gap segment dimensions per rendition, audio retention on the thumb rung. |
+| `test_uploader.py` | Wasabi `upload_hls_package()` with `moto[s3]`: key layout, `Content-Type` and `Cache-Control` per extension. |
+| `test_directus_writer.py` | Idempotency check (early return on existing item), payload shape, source-id resolution, approved-flag logic. |
+| `test_flows.py` | `transition_job()` writes both UPDATE and INSERT; `scan_collections_flow()` and `process_item_flow()` orchestration with all components patched. |
+| `test_epg.py`, `test_epg_json.py` | EPG assembler with mock slots: gap insertion, discontinuity tags, EPG JSON grid shape. |
+| `test_migrations.py` | Alembic revision sanity. |
+
+## Mocking strategy
+
+The pipeline talks to four external systems (IA, Postgres, Wasabi, Directus) plus a heavyweight local binary (ffmpeg/ffprobe). The tests mock each at the boundary closest to the unit under test:
+
+- **IA SDK** — `unittest.mock.patch("video_grabber.pipeline.flows.ArchiveSession")` and stubbed `session.search_items()` returning canned dicts.
+- **IA HTTP API** — `respx` mocks `httpx` calls for the downloader and the Directus writer.
+- **Postgres** — `MagicMock` for the SQLAlchemy connection. Tests assert on `db.execute.call_args_list` rather than spinning up a real Postgres. Migration tests use a SQLite stub or a `pytest-postgresql` fixture, depending on the test.
+- **Wasabi S3** — `moto[s3]` provides a fake S3 endpoint. The uploader's `boto3.client("s3", endpoint_url=…)` is pointed at the moto server.
+- **Directus HTTP API** — `respx` mocks all four calls (the idempotency GET, the source-resolve GET, the create POST, error branches).
+- **ffmpeg / ffprobe** — `subprocess.run` is patched. Tests assert on the constructed argv rather than on encoded output.
+
+The flow tests illustrate the pattern (`tests/test_flows.py`):
+
+```python
+with patch("video_grabber.pipeline.flows.crawl_collection") as mock_crawl, \
+     patch("video_grabber.pipeline.flows.ArchiveSession") as mock_session_cls, \
+     patch("video_grabber.pipeline.flows.get_db") as mock_db, \
+     patch("video_grabber.pipeline.flows.get_run_logger", return_value=MagicMock()):
+    …
+```
+
+The `@flow` decorator is consumed at import time, but Prefect lets a flow run synchronously in-process during tests without a Prefect server.
+
+## Why no live integration suite
+
+A live integration test would need:
+
+- An IA item we can re-download (slow, fragile).
+- A real Wasabi bucket with cleanup (costs money, leaks state on failure).
+- A real Directus instance (deployment-specific schema drift risk).
+- A real ffmpeg run on real footage (minutes per test).
+
+Given the small number of system boundaries and the well-mocked test suite, the trade-off has been to skip live integration tests and rely on staging deployments for end-to-end verification. If you reintroduce them, run them only in CI on `main` and gate them with a `pytest.mark.integration` marker that's deselected by default.
+
+## Adding a test
+
+Style matches surrounding tests:
+
+- Use `from unittest.mock import MagicMock, patch` for everything except HTTP and S3.
+- Use `respx` for `httpx` mocks, `moto` for S3.
+- Assert on the **shape** of arguments rather than re-implementing the function's logic.
+- For new modules under `video_grabber/`, add a matching `tests/test_<module>.py` rather than extending an existing test file.

--- a/packages/tools/video-grabber/pyproject.toml
+++ b/packages/tools/video-grabber/pyproject.toml
@@ -16,8 +16,6 @@ dependencies = [
     "boto3>=1.36",
     "tenacity>=8.2",
     "prefect>=3.0",
-    "prefect-kubernetes>=0.4",
-    "httpx>=0.27",
 ]
 
 [project.optional-dependencies]

--- a/packages/tools/video-grabber/video_grabber/serve.py
+++ b/packages/tools/video-grabber/video_grabber/serve.py
@@ -1,0 +1,21 @@
+"""
+Long-lived process that registers and serves video-grabber flows.
+
+Runs in place of `prefect worker start` for process-type work pools.
+The flows execute in this process, using the worker pod's mounted
+/tmp/vg-scratch volume (see k8s/worker-deployment.yaml).
+"""
+from prefect import serve
+
+from video_grabber.pipeline.flows import process_item_flow, scan_collections_flow
+
+
+def main() -> None:
+    serve(
+        process_item_flow.to_deployment(name="process-item"),
+        scan_collections_flow.to_deployment(name="scan-collections"),
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Replace work-pool execution with serve(). Unblocks UI-triggered flow runs. Adds full docs/ tree.