### PR TITLE
fix(video-grabber): force sync psycopg2 driver in get_db()

### DIFF
--- a/packages/tools/video-grabber/tests/test_flows.py
+++ b/packages/tools/video-grabber/tests/test_flows.py
@@ -6,6 +6,28 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 
+# --- _sync_db_url ---
+
+def test_sync_db_url_rewrites_asyncpg_to_psycopg2():
+    from video_grabber.pipeline.flows import _sync_db_url
+
+    rewritten = _sync_db_url("postgresql+asyncpg://u:p@h:5432/db")
+    assert rewritten == "postgresql+psycopg2://u:p@h:5432/db"
+
+
+def test_sync_db_url_passes_through_plain_postgresql():
+    from video_grabber.pipeline.flows import _sync_db_url
+
+    assert _sync_db_url("postgresql://u:p@h/db") == "postgresql://u:p@h/db"
+
+
+def test_sync_db_url_passes_through_explicit_psycopg2():
+    from video_grabber.pipeline.flows import _sync_db_url
+
+    url = "postgresql+psycopg2://u:p@h/db"
+    assert _sync_db_url(url) == url
+
+
 # --- transition_job ---
 
 def test_transition_job_updates_stage_and_logs():

--- a/packages/tools/video-grabber/video_grabber/pipeline/flows.py
+++ b/packages/tools/video-grabber/video_grabber/pipeline/flows.py
@@ -27,10 +27,23 @@ except ImportError:
 _SCRATCH = Path(os.getenv("SCRATCH_DIR", "/tmp/vg-scratch"))
 
 
+_ASYNCPG_PREFIX = "postgresql+asyncpg://"
+_PSYCOPG2_PREFIX = "postgresql+psycopg2://"
+
+
+def _sync_db_url(url: str) -> str:
+    """Force a sync psycopg2 driver. The shared Secret often uses the asyncpg
+    scheme (Prefect's own server requires it), which raises MissingGreenlet
+    inside sync flow code."""
+    if url.startswith(_ASYNCPG_PREFIX):
+        return _PSYCOPG2_PREFIX + url[len(_ASYNCPG_PREFIX):]
+    return url
+
+
 def get_db():
-    """Return a SQLAlchemy connection from DATABASE_URL env var."""
+    """Return a sync SQLAlchemy connection from DATABASE_URL env var."""
     cfg = Config()
-    engine = sa.create_engine(cfg.database_url)
+    engine = sa.create_engine(_sync_db_url(cfg.database_url))
     return engine.connect()
 
 


### PR DESCRIPTION
## Summary

Runtime fix. `MissingGreenlet` surfaced when triggering a flow from the Prefect UI:

\`\`\`
sqlalchemy.exc.MissingGreenlet: greenlet_spawn has not been called;
can't call await_only() here.
\`\`\`

Root cause: the shared \`DATABASE_URL\` Secret is set to \`postgresql+asyncpg://...\` (correct for Prefect's own server, which is async). The pipeline flows use sync SQLAlchemy, so reaching into asyncpg from a sync context blows up at the first \`engine.connect()\` in \`get_db()\`.

Fix: normalize the URL inside \`get_db()\` — replace \`postgresql+asyncpg://\` with \`postgresql+psycopg2://\` before \`create_engine\`. The operator-side Secret is left as-is; the code is now robust to either scheme.

## Test plan

- [x] Added \`test_sync_db_url_*\` tests covering asyncpg → psycopg2, passthrough for plain \`postgresql://\`, and passthrough for explicit \`postgresql+psycopg2://\`.
- [ ] CI tests + lint pass.
- [ ] After merge + image rebuild + ArgoCD sync: trigger \`scan-collections\` from the Prefect UI and watch it complete without \`MissingGreenlet\`.