### PR TITLE
feat(video-grabber): cap concurrent flow runs at 1 per deployment

### DIFF
--- a/packages/tools/video-grabber/docs/deployment.md
+++ b/packages/tools/video-grabber/docs/deployment.md
@@ -14,12 +14,28 @@ The entrypoint is [`video_grabber/serve.py`](../video_grabber/serve.py):
 
 ```python
 serve(
-    process_item_flow.to_deployment(name="process-item"),
-    scan_collections_flow.to_deployment(name="scan-collections"),
+    process_item_flow.to_deployment(
+        name="process-item",
+        concurrency_limit=1,
+    ),
+    scan_collections_flow.to_deployment(
+        name="scan-collections",
+        concurrency_limit=1,
+    ),
 )
 ```
 
 This is idempotent — every pod restart re-registers the same two deployments, and Prefect deduplicates by name.
+
+### Concurrency limits
+
+Both deployments are pinned to `concurrency_limit=1` with Prefect's default `ENQUEUE` collision strategy. The effect:
+
+- A second trigger of either deployment while one is already running **queues** rather than cancelling — Prefect picks it up when the first finishes.
+- IA-facing HTTP calls stay under the bulk-access guideline (2 concurrent) because at most one downloader (`process-item`) plus one scanner (`scan-collections`) run at once.
+- The 50 GiB worker scratch volume only ever holds one in-flight item; no risk of two parallel 4–8 GiB downloads filling it.
+
+To raise these limits, edit `_PROCESS_ITEM_LIMIT` / `_SCAN_LIMIT` in `serve.py`. If you push `process-item` past 2, also revisit `worker-deployment.yaml`'s scratch sizing and `IA_RATE_PER_SEC`.
 
 ## Container image
 

--- a/packages/tools/video-grabber/docs/pipeline.md
+++ b/packages/tools/video-grabber/docs/pipeline.md
@@ -32,7 +32,12 @@ discovered ─► metadata_extracted ─► downloading ─► downloaded ─►
 
 [`flows.py:87-96`](../video_grabber/pipeline/flows.py)
 
-Crawls each named IA collection recursively. Rate-limited by `IA_RATE_PER_SEC` (default 2/s, matching IA's bulk-access guidance). Items with `mediatype == "collection"` are recursed into; leaf items are passed to `upsert_job()` which uses `ON CONFLICT (ia_identifier) DO NOTHING` so reruns are free.
+Crawls each named IA collection recursively. Rate-limited at two levels:
+
+- **Per-call**: `IA_RATE_PER_SEC` (default 2/s) — the scanner sleeps `1 / IA_RATE_PER_SEC` between items, governing the serial rate inside one run.
+- **Per-deployment**: `concurrency_limit=1` in [`serve.py`](../video_grabber/serve.py) — only one `scan-collections` run executes at a time. A second trigger queues (Prefect `ENQUEUE` strategy) rather than stacking IA load.
+
+Items with `mediatype == "collection"` are recursed into; leaf items are passed to `upsert_job()` which uses `ON CONFLICT (ia_identifier) DO NOTHING` so reruns are free.
 
 ```python
 @flow(name="scan-collections")

--- a/packages/tools/video-grabber/video_grabber/serve.py
+++ b/packages/tools/video-grabber/video_grabber/serve.py
@@ -4,16 +4,32 @@ Long-lived process that registers and serves video-grabber flows.
 Runs in place of `prefect worker start` for process-type work pools.
 The flows execute in this process, using the worker pod's mounted
 /tmp/vg-scratch volume (see k8s/worker-deployment.yaml).
+
+Concurrency limits cap simultaneous flow runs so we stay within IA's
+2-concurrent bulk-access guideline and don't blow out the 50 GiB scratch
+volume by stacking parallel downloads. Default collision strategy in
+Prefect 3 is ENQUEUE, so excess runs queue rather than cancelling.
 """
 from prefect import serve
 
 from video_grabber.pipeline.flows import process_item_flow, scan_collections_flow
 
+# One heavy IA download + ffmpeg encode at a time (50 GiB scratch is sized for one item).
+_PROCESS_ITEM_LIMIT = 1
+# Scanner is serial by design; per-call rate-limit lives in IA_RATE_PER_SEC.
+_SCAN_LIMIT = 1
+
 
 def main() -> None:
     serve(
-        process_item_flow.to_deployment(name="process-item"),
-        scan_collections_flow.to_deployment(name="scan-collections"),
+        process_item_flow.to_deployment(
+            name="process-item",
+            concurrency_limit=_PROCESS_ITEM_LIMIT,
+        ),
+        scan_collections_flow.to_deployment(
+            name="scan-collections",
+            concurrency_limit=_SCAN_LIMIT,
+        ),
     )
 
 


### PR DESCRIPTION
Pin both deployments to concurrency_limit=1 in serve.py. Stays inside IA's 2-concurrent bulk-access guideline and prevents parallel downloads from filling the 50 GiB scratch. Default ENQUEUE strategy queues excess triggers rather than cancelling.