### PR TITLE
fix(video-grabber): accept items with unknown length + add scan progress logs

### DIFF
--- a/packages/tools/video-grabber/tests/test_scanner.py
+++ b/packages/tools/video-grabber/tests/test_scanner.py
@@ -62,13 +62,25 @@ def test_candidate_unknown_network_not_filtered_to_false():
     assert is_candidate(UNKNOWN_NETWORK_ITEM) is True
 
 
-def test_candidate_zero_length():
+def test_candidate_none_length_is_accepted():
+    """Items with no length in the search response are treated as unknown
+    duration — accepted so downstream stages can verify, not dropped."""
     item = dict(SEPT_11_ITEM, length=None)
-    assert is_candidate(item) is False
+    assert is_candidate(item) is True
 
 
-def test_candidate_empty_length_string():
+def test_candidate_empty_length_string_is_accepted():
     item = dict(SEPT_11_ITEM, length="")
+    assert is_candidate(item) is True
+
+
+def test_candidate_unparseable_length_is_accepted():
+    item = dict(SEPT_11_ITEM, length="not-a-number")
+    assert is_candidate(item) is True
+
+
+def test_candidate_known_short_length_is_rejected():
+    item = dict(SEPT_11_ITEM, length="60")
     assert is_candidate(item) is False
 
 

--- a/packages/tools/video-grabber/video_grabber/ia/scanner.py
+++ b/packages/tools/video-grabber/video_grabber/ia/scanner.py
@@ -3,6 +3,7 @@ Recursive IA collection crawler that writes video_jobs rows.
 
 Dedup is DB-level via ON CONFLICT (ia_identifier) DO NOTHING.
 """
+import logging
 import time
 import sqlalchemy as sa
 
@@ -10,15 +11,26 @@ from video_grabber.ia.channel_map import normalize_slug
 
 MIN_DURATION_SECONDS = 720  # 12 minutes
 
+_LOG_EVERY = 50  # progress log cadence inside crawl_collection
+_log = logging.getLogger(__name__)
+
 
 def is_candidate(item: dict) -> bool:
-    """Return True if the item meets minimum duration. Network check is permissive —
-    unknown-network items go to pending_review rather than being dropped."""
-    raw = item.get("length") or ""
+    """Return True if the item is plausibly a long-form broadcast.
+
+    Many IA collections only expose ``length`` via the per-item metadata
+    endpoint, not the advancedsearch results, so an item with no ``length``
+    is treated as "unknown duration — let downstream stages verify" rather
+    than dropped. We only reject items whose ``length`` is set *and*
+    parseably shorter than ``MIN_DURATION_SECONDS``.
+    """
+    raw = item.get("length")
+    if raw is None or str(raw).strip() == "":
+        return True
     try:
         duration = float(str(raw).strip())
     except (ValueError, TypeError):
-        return False
+        return True
     return duration >= MIN_DURATION_SECONDS
 
 
@@ -52,13 +64,18 @@ def crawl_collection(
     visited: set[str] | None = None,
     sleep_sec: float = 0.0,
 ) -> None:
-    """Recursively crawl an IA collection, writing video_jobs for leaf items."""
+    """Recursively crawl an IA collection, writing video_jobs for leaf items.
+
+    Emits progress logs every ``_LOG_EVERY`` items so operators can tell a
+    rate-limited-but-working scan apart from a hang.
+    """
     if visited is None:
         visited = set()
     if identifier in visited:
         return
     visited.add(identifier)
 
+    _log.info("crawl_collection: %s — searching", identifier)
     results = session.search_items(
         f"collection:{identifier}",
         fields=[
@@ -66,13 +83,26 @@ def crawl_collection(
             "subject", "creator", "date", "length",
         ],
     )
+    seen = inserted = nested = 0
     for item in results:
         if sleep_sec:
             time.sleep(sleep_sec)
+        seen += 1
         if item.get("mediatype") == "collection":
+            nested += 1
             crawl_collection(session, item["identifier"], db, visited, sleep_sec)
         elif is_candidate(item):
             upsert_job(db, item, collection=identifier)
+            inserted += 1
+        if seen % _LOG_EVERY == 0:
+            _log.info(
+                "crawl_collection: %s — seen=%d upserted=%d nested=%d",
+                identifier, seen, inserted, nested,
+            )
+    _log.info(
+        "crawl_collection: %s — DONE seen=%d upserted=%d nested=%d",
+        identifier, seen, inserted, nested,
+    )
 
 
 def _json_dumps(obj) -> str:

--- a/packages/tools/video-grabber/video_grabber/serve.py
+++ b/packages/tools/video-grabber/video_grabber/serve.py
@@ -9,10 +9,19 @@ Concurrency limits cap simultaneous flow runs so we stay within IA's
 2-concurrent bulk-access guideline and don't blow out the 50 GiB scratch
 volume by stacking parallel downloads. Default collision strategy in
 Prefect 3 is ENQUEUE, so excess runs queue rather than cancelling.
-"""
-from prefect import serve
 
-from video_grabber.pipeline.flows import process_item_flow, scan_collections_flow
+PREFECT_LOGGING_EXTRA_LOGGERS makes Prefect capture our stdlib loggers
+so scanner progress (and other in-package log calls) surface in the
+Prefect UI alongside the engine's own messages. Must be set before
+`prefect` is imported.
+"""
+import os
+
+os.environ.setdefault("PREFECT_LOGGING_EXTRA_LOGGERS", "video_grabber")
+
+from prefect import serve  # noqa: E402
+
+from video_grabber.pipeline.flows import process_item_flow, scan_collections_flow  # noqa: E402
 
 # One heavy IA download + ffmpeg encode at a time (50 GiB scratch is sized for one item).
 _PROCESS_ITEM_LIMIT = 1


### PR DESCRIPTION
Two real bugs surfaced when triggering scan-collections end-to-end:

1. **`is_candidate()` rejected items with no `length` field.** IA's advancedsearch list-mode response does not include `length` for items in `sept_11_tv_archive` (verified: 0 of 425 items have it set). Our filter therefore dropped 100% of candidates and the scanner wrote zero rows after minutes of work. Fix: treat unknown duration as 'let downstream verify' and only reject items we *know* are shorter than `MIN_DURATION_SECONDS`.

2. **Scanner had no progress logging.** Between 'Beginning flow run' and 'Scan complete' the operator saw nothing — a working scan looked identical to a hang. Added per-collection start/done logs plus a progress line every 50 items inside `crawl_collection`. Set `PREFECT_LOGGING_EXTRA_LOGGERS=video_grabber` in `serve.py` so these stdlib log calls surface in the Prefect UI.

## Test plan
- [x] Updated `test_scanner.py` to assert the new permissive contract on None / empty / unparseable length.
- [x] Pre-existing `test_candidate_passes_min_duration` and `test_candidate_below_min_duration_rejected` still encode the "known short → reject" path.
- [ ] CI green.
- [ ] After rollout: trigger scan-collections, watch Prefect UI for periodic `crawl_collection: ... seen=X upserted=Y` lines.
- [ ] Confirm `video_jobs` row count grows in real time.