### PR TITLE
fix(video-grabber): use CAST(... AS jsonb) in upsert_job

### DIFF
--- a/packages/tools/video-grabber/tests/test_scanner.py
+++ b/packages/tools/video-grabber/tests/test_scanner.py
@@ -84,6 +84,28 @@ def test_candidate_known_short_length_is_rejected():
     assert is_candidate(item) is False
 
 
+# --- upsert_job SQL shape ---
+
+def test_upsert_job_sql_uses_cast_not_double_colon():
+    """Regression: ``:ia_metadata::jsonb`` confused SQLAlchemy text()'s
+    bind-parameter parser into leaving ``:ia_metadata`` un-substituted in
+    the rendered SQL, causing Postgres to raise ``syntax error at or near
+    ":"``. The fix is to use the explicit ``CAST(:ia_metadata AS jsonb)``
+    form (mirroring the pre-existing CAST on :stage)."""
+    from video_grabber.ia.scanner import upsert_job
+
+    db = MagicMock()
+    upsert_job(db, {"identifier": "x", "title": "t"}, collection="c")
+
+    stmt_arg = db.execute.call_args[0][0]
+    sql = str(stmt_arg)
+    assert "CAST(:ia_metadata AS jsonb)" in sql
+    assert "::jsonb" not in sql, (
+        "Postgres ::jsonb cast next to a :bindparam name breaks "
+        "SQLAlchemy text() substitution — use CAST(... AS jsonb) instead."
+    )
+
+
 # --- crawl_collection ---
 
 def make_session(items_per_call: dict[str, list]):

--- a/packages/tools/video-grabber/video_grabber/ia/scanner.py
+++ b/packages/tools/video-grabber/video_grabber/ia/scanner.py
@@ -44,7 +44,12 @@ def upsert_job(db, item: dict, *, collection: str) -> None:
         sa.text(
             """
             INSERT INTO video_jobs (ia_identifier, collection, stage, ia_metadata)
-            VALUES (:ia_identifier, :collection, CAST(:stage AS pipeline_stage), :ia_metadata::jsonb)
+            VALUES (
+                :ia_identifier,
+                :collection,
+                CAST(:stage AS pipeline_stage),
+                CAST(:ia_metadata AS jsonb)
+            )
             ON CONFLICT (ia_identifier) DO NOTHING
             """
         ),


### PR DESCRIPTION
SQLAlchemy text() bind-parameter parser misreads `:ia_metadata::jsonb` — the second `:` (start of Postgres's `::type` cast) is interpreted as a fresh bind marker, leaving `:ia_metadata` un-substituted in the rendered SQL. Postgres then raises `syntax error at or near ":"`.

Use the explicit `CAST(:ia_metadata AS jsonb)` form, mirroring the pre-existing `CAST(:stage AS pipeline_stage)` one line above.

Added a regression test that parses the rendered SQL string and asserts on the `CAST(... AS jsonb)` pattern. The existing upsert_job tests mock the DB connection so SQL syntax issues were invisible.