### PR TITLE
fix(video-grabber): commit batched upserts so scanner rows persist

### DIFF
--- a/packages/tools/video-grabber/tests/test_scanner.py
+++ b/packages/tools/video-grabber/tests/test_scanner.py
@@ -133,6 +133,25 @@ def test_crawl_fan_out_recurses_into_subcollection():
     assert mock_upsert.call_count == 2
 
 
+def test_crawl_commits_so_rows_are_persisted():
+    """Regression: SQLAlchemy 2.0's engine.connect() autobegins an implicit
+    transaction; without an explicit db.commit() every upserted row is
+    rolled back when the connection closes. The scanner now commits at
+    every progress checkpoint and once more on collection completion."""
+    session = make_session({
+        "sept_11_tv_archive": [SEPT_11_ITEM, UNKNOWN_NETWORK_ITEM],
+    })
+    db = MagicMock()
+
+    with patch("video_grabber.ia.scanner.upsert_job"):
+        crawl_collection(session, "sept_11_tv_archive", db)
+
+    assert db.commit.called, (
+        "Scanner must commit so upserted rows survive the connection close — "
+        "otherwise the whole crawl gets rolled back silently."
+    )
+
+
 def test_crawl_visited_set_prevents_cycles():
     """A collection that references itself should not loop."""
     cycle_col = {"identifier": "loop_col", "mediatype": "collection", "title": "loop"}

--- a/packages/tools/video-grabber/video_grabber/ia/scanner.py
+++ b/packages/tools/video-grabber/video_grabber/ia/scanner.py
@@ -100,10 +100,14 @@ def crawl_collection(
             upsert_job(db, item, collection=identifier)
             inserted += 1
         if seen % _LOG_EVERY == 0:
+            # Batch commit so rows become visible to other readers during the
+            # crawl and survive a worker restart mid-scan.
+            db.commit()
             _log.info(
                 "crawl_collection: %s — seen=%d upserted=%d nested=%d",
                 identifier, seen, inserted, nested,
             )
+    db.commit()
     _log.info(
         "crawl_collection: %s — DONE seen=%d upserted=%d nested=%d",
         identifier, seen, inserted, nested,


### PR DESCRIPTION
Root cause for the long-running 'scan looks stuck' symptom: SQLAlchemy 2.0's `engine.connect()` autobegins an implicit transaction; without `db.commit()` everything rolls back when the connection closes. The pipeline `flows.transition_job` already commits; `scanner.crawl_collection` did not.

Verified by direct repro in the worker pod: scanner reports `upserted=150` but a fresh connection from a second process sees 0 rows.

Fix commits every `_LOG_EVERY=50` items plus once at collection completion. Gives:

- Rows visible to other readers during the scan
- Partial progress survives a worker restart mid-crawl
- Reasonable batch size — not committing per item

Added a regression test asserting `db.commit` is called from `crawl_collection`. The existing tests only verified `upsert_job` invocation, so the missing-commit gap was invisible.