### PR TITLE
fix(video-grabber): inject flow logger into scanner so progress shows in Prefect UI

### DIFF
--- a/packages/tools/video-grabber/video_grabber/ia/scanner.py
+++ b/packages/tools/video-grabber/video_grabber/ia/scanner.py
@@ -5,6 +5,7 @@ Dedup is DB-level via ON CONFLICT (ia_identifier) DO NOTHING.
 """
 import logging
 import time
+from typing import Optional
 import sqlalchemy as sa
 
 from video_grabber.ia.channel_map import normalize_slug
@@ -12,7 +13,7 @@ from video_grabber.ia.channel_map import normalize_slug
 MIN_DURATION_SECONDS = 720  # 12 minutes
 
 _LOG_EVERY = 50  # progress log cadence inside crawl_collection
-_log = logging.getLogger(__name__)
+_default_log = logging.getLogger(__name__)
 
 
 def is_candidate(item: dict) -> bool:
@@ -68,19 +69,23 @@ def crawl_collection(
     db,
     visited: set[str] | None = None,
     sleep_sec: float = 0.0,
+    logger: Optional[logging.Logger] = None,
 ) -> None:
     """Recursively crawl an IA collection, writing video_jobs for leaf items.
 
     Emits progress logs every ``_LOG_EVERY`` items so operators can tell a
-    rate-limited-but-working scan apart from a hang.
+    rate-limited-but-working scan apart from a hang. The flow passes its
+    Prefect ``get_run_logger()`` so progress shows in the Prefect UI; tests
+    and direct-invocation get the stdlib module logger.
     """
+    log = logger if logger is not None else _default_log
     if visited is None:
         visited = set()
     if identifier in visited:
         return
     visited.add(identifier)
 
-    _log.info("crawl_collection: %s — searching", identifier)
+    log.info("crawl_collection: %s — searching", identifier)
     results = session.search_items(
         f"collection:{identifier}",
         fields=[
@@ -95,7 +100,7 @@ def crawl_collection(
         seen += 1
         if item.get("mediatype") == "collection":
             nested += 1
-            crawl_collection(session, item["identifier"], db, visited, sleep_sec)
+            crawl_collection(session, item["identifier"], db, visited, sleep_sec, logger=log)
         elif is_candidate(item):
             upsert_job(db, item, collection=identifier)
             inserted += 1
@@ -103,12 +108,12 @@ def crawl_collection(
             # Batch commit so rows become visible to other readers during the
             # crawl and survive a worker restart mid-scan.
             db.commit()
-            _log.info(
+            log.info(
                 "crawl_collection: %s — seen=%d upserted=%d nested=%d",
                 identifier, seen, inserted, nested,
             )
     db.commit()
-    _log.info(
+    log.info(
         "crawl_collection: %s — DONE seen=%d upserted=%d nested=%d",
         identifier, seen, inserted, nested,
     )

--- a/packages/tools/video-grabber/video_grabber/pipeline/flows.py
+++ b/packages/tools/video-grabber/video_grabber/pipeline/flows.py
@@ -105,7 +105,12 @@ def scan_collections_flow(collections: list[str] = ["sept_11_tv_archive", "911"]
     session = ArchiveSession()
     db = get_db()
     for coll in collections:
-        crawl_collection(session, coll, db, visited=set(), sleep_sec=sleep_sec)
+        crawl_collection(
+            session, coll, db,
+            visited=set(),
+            sleep_sec=sleep_sec,
+            logger=logger,
+        )
     logger.info("Scan complete")
 
 

--- a/packages/tools/video-grabber/video_grabber/serve.py
+++ b/packages/tools/video-grabber/video_grabber/serve.py
@@ -10,18 +10,15 @@ Concurrency limits cap simultaneous flow runs so we stay within IA's
 volume by stacking parallel downloads. Default collision strategy in
 Prefect 3 is ENQUEUE, so excess runs queue rather than cancelling.
 
-PREFECT_LOGGING_EXTRA_LOGGERS makes Prefect capture our stdlib loggers
-so scanner progress (and other in-package log calls) surface in the
-Prefect UI alongside the engine's own messages. Must be set before
-`prefect` is imported.
+In-package modules (e.g. the scanner) receive ``get_run_logger()`` as
+an injected ``logger`` argument from the flow rather than relying on
+PREFECT_LOGGING_EXTRA_LOGGERS — that env var didn't surface the
+stdlib loggers in the Prefect UI reliably, and dependency injection
+avoids coupling pure modules to Prefect's runtime.
 """
-import os
+from prefect import serve
 
-os.environ.setdefault("PREFECT_LOGGING_EXTRA_LOGGERS", "video_grabber")
-
-from prefect import serve  # noqa: E402
-
-from video_grabber.pipeline.flows import process_item_flow, scan_collections_flow  # noqa: E402
+from video_grabber.pipeline.flows import process_item_flow, scan_collections_flow
 
 # One heavy IA download + ffmpeg encode at a time (50 GiB scratch is sized for one item).
 _PROCESS_ITEM_LIMIT = 1


### PR DESCRIPTION
PREFECT_LOGGING_EXTRA_LOGGERS=video_grabber didn't reliably surface our stdlib log calls in the Prefect flow-run logs. Rather than debug Prefect's logger config ordering, switch to dependency injection: scanner.crawl_collection accepts an optional `logger` arg, and the flow passes `get_run_logger()` through. Direct invocations (tests, repro scripts) get the stdlib module logger via the default.

Drops the now-unused PREFECT_LOGGING_EXTRA_LOGGERS env-var hack from serve.py.