### PR TITLE
feat(video-grabber): run alembic migrations on deploy via ArgoCD PreSync hook

### DIFF
--- a/packages/tools/video-grabber/Dockerfile
+++ b/packages/tools/video-grabber/Dockerfile
@@ -3,5 +3,6 @@ RUN apt-get update && apt-get install -y ffmpeg ca-certificates && rm -rf /var/l
 WORKDIR /app
 COPY pyproject.toml .
 COPY video_grabber/ ./video_grabber/
+COPY alembic.ini .
 RUN pip install --no-cache-dir .
 CMD ["python", "-m", "video_grabber.serve"]

--- a/packages/tools/video-grabber/alembic.ini
+++ b/packages/tools/video-grabber/alembic.ini
@@ -1,0 +1,43 @@
+[alembic]
+# Used by the db-migrate ArgoCD PreSync hook (k8s/migrate-job.yaml).
+# Inside the container the working dir is /app, so the script_location is relative.
+script_location = video_grabber/db/migrations
+
+# env.py reads DATABASE_URL from the environment and normalizes asyncpg →
+# psycopg2; this URL is the local-development fallback when DATABASE_URL is
+# unset. Real values come from the Secret in production.
+sqlalchemy.url = postgresql+psycopg2://postgres:postgres@localhost:5432/video_grabber
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/packages/tools/video-grabber/docs/runbook.md
+++ b/packages/tools/video-grabber/docs/runbook.md
@@ -187,14 +187,29 @@ write_media_item(job, job.wasabi_key, Config())
 
 ## Database migration needed
 
-Right now there's only `001_initial_schema`. To add a column or a new stage:
+Schema migrations run automatically on every ArgoCD sync via the `db-migrate` Job ([`k8s/migrate-job.yaml`](../k8s/migrate-job.yaml)) — a PreSync hook at sync-wave 1 (after `db-init`). To ship a new revision:
 
 1. `cd packages/tools/video-grabber`
-2. Author a new revision under `video_grabber/db/migrations/versions/` (manual — autogeneration isn't wired up).
-3. From a worker pod with `DATABASE_URL` set:
-   ```bash
-   alembic -c alembic.ini upgrade head
-   ```
-   There is no committed `alembic.ini`; supply one that points at `video_grabber/db/migrations`. (Filing this as a known gap.)
+2. Author a new revision under `video_grabber/db/migrations/versions/`. Hand-write the migration — `target_metadata` is `None`, so autogeneration is not wired up.
+3. Open a PR with the new revision file. On merge:
+   - CI rebuilds the image (migration code ships in `/app/video_grabber/db/migrations/`).
+   - ArgoCD Image Updater bumps the SHA in the infra repo.
+   - The next ArgoCD sync triggers the `db-migrate` PreSync hook, which runs `alembic -c /app/alembic.ini upgrade head` against the live database.
+   - The worker then rolls out with the schema already at the new HEAD.
 
-Or migrate from a developer laptop with `DATABASE_URL` port-forwarded to the in-cluster Postgres.
+To run migrations out of band (debugging, or against an unmanaged environment):
+
+```bash
+kubectl exec -n video-grabber deploy/video-grabber-worker -- \
+  alembic -c /app/alembic.ini upgrade head
+```
+
+Or from a developer laptop with `DATABASE_URL` port-forwarded:
+
+```bash
+cd packages/tools/video-grabber
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/video_grabber \
+  alembic upgrade head
+```
+
+`env.py` rewrites the `postgresql+asyncpg://` scheme to `postgresql+psycopg2://` automatically, so the same Secret can be reused without modification.

--- a/packages/tools/video-grabber/k8s/migrate-job.yaml
+++ b/packages/tools/video-grabber/k8s/migrate-job.yaml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: db-migrate
+  namespace: video-grabber
+  annotations:
+    # Run before the main sync so the schema is at HEAD before the worker pod
+    # references it. Sync-wave 1 places this after db-init (wave 0, defaulted).
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  backoffLimit: 2
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: db-migrate
+          image: ghcr.io/keeping-history/video-grabber:latest
+          # The same env that the worker uses — same Secret, same DATABASE_URL.
+          # env.py rewrites the +asyncpg scheme to +psycopg2 before Alembic runs.
+          envFrom:
+            - secretRef:
+                name: video-grabber-secrets
+          command: ["alembic", "-c", "/app/alembic.ini", "upgrade", "head"]

--- a/packages/tools/video-grabber/video_grabber/db/migrations/env.py
+++ b/packages/tools/video-grabber/video_grabber/db/migrations/env.py
@@ -8,9 +8,14 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-# Override sqlalchemy.url from env if set
+# Override sqlalchemy.url from env if set. The DATABASE_URL Secret is often
+# provisioned with the postgresql+asyncpg:// scheme to satisfy Prefect's
+# server, but Alembic runs synchronously and would raise MissingGreenlet
+# against asyncpg — rewrite to psycopg2 first.
 db_url = os.getenv("DATABASE_URL")
 if db_url:
+    if db_url.startswith("postgresql+asyncpg://"):
+        db_url = "postgresql+psycopg2://" + db_url[len("postgresql+asyncpg://"):]
     config.set_main_option("sqlalchemy.url", db_url)
 
 target_metadata = None


### PR DESCRIPTION
Schema migrations were previously manual — db-init-job only created the empty DB. Adds `db-migrate` as a sibling PreSync Job (sync-wave 1, after db-init) running `alembic upgrade head` with the new worker image.

Includes:
- `alembic.ini` at the package root, copied into `/app` by the Dockerfile.
- `env.py` normalization of the `postgresql+asyncpg://` Secret scheme to psycopg2 (so Alembic's sync engine doesn't MissingGreenlet).
- `k8s/migrate-job.yaml` as the source-of-truth manifest.
- Runbook rewrite describing the new automated flow.

The matching ArgoCD-managed copy goes into the `keeping-history/infra` repo in a parallel PR — that's the manifest set ArgoCD actually applies.