### PR TITLE
test(video-grabber): Postgres integration suite for SQL + transaction coverage

### DIFF
--- a/packages/tools/video-grabber/docs/testing.md
+++ b/packages/tools/video-grabber/docs/testing.md
@@ -48,16 +48,29 @@ with patch("video_grabber.pipeline.flows.crawl_collection") as mock_crawl, \
 
 The `@flow` decorator is consumed at import time, but Prefect lets a flow run synchronously in-process during tests without a Prefect server.
 
-## Why no live integration suite
+## Postgres integration tests
 
-A live integration test would need:
+[`tests/test_postgres_integration.py`](../tests/test_postgres_integration.py) runs real SQL against a live Postgres — the schema is applied via `alembic upgrade head` once per module and every test executes inside a savepoint that's rolled back at teardown, so tests don't see each other's writes.
+
+The whole file is skipped when `TEST_DATABASE_URL` is unset, so a bare `pytest` from a developer laptop without Postgres still passes. CI's `build-video-grabber.yml` spins up a Postgres 16 service container and sets the env var, so these run on every PR.
+
+What this suite catches that the MagicMock'd unit tests can't:
+
+- **SQL syntax errors.** The `:ia_metadata::jsonb` bug from June 2026 — SQLAlchemy's `text()` bind-parser broke on the Postgres `::` cast operator and left the colon-prefixed name in the rendered SQL. MagicMock'd connections happily accepted the malformed string; Postgres did not. `test_upsert_job_writes_row_with_jsonb_metadata` round-trips a real insert + select.
+- **Missing commits.** Scanner upserts were silently rolled back because `SQLAlchemy 2.0`'s `engine.connect()` autobegins a transaction without auto-commit. Round-trip tests fail the moment a write doesn't reach disk.
+- **Driver scheme issues.** `test_sync_db_url_keeps_test_database_url_compatible` proves `_sync_db_url()` produces a connectable URL — guards against the `postgresql+asyncpg://` MissingGreenlet regression.
+- **Enum cast bugs.** Pipeline stage transitions exercise the `CAST(... AS pipeline_stage)` path against the live enum.
+
+## Why no IA / Wasabi / Directus / ffmpeg integration suite
+
+The external integrations still mock at the boundary:
 
 - An IA item we can re-download (slow, fragile).
 - A real Wasabi bucket with cleanup (costs money, leaks state on failure).
 - A real Directus instance (deployment-specific schema drift risk).
 - A real ffmpeg run on real footage (minutes per test).
 
-Given the small number of system boundaries and the well-mocked test suite, the trade-off has been to skip live integration tests and rely on staging deployments for end-to-end verification. If you reintroduce them, run them only in CI on `main` and gate them with a `pytest.mark.integration` marker that's deselected by default.
+The Postgres suite covers the highest-risk boundary (schema + SQL) without those trade-offs. If you add live tests for the others later, gate them with a `pytest.mark.integration` marker that's deselected by default and only run on `main`.
 
 ## Adding a test
 

--- a/packages/tools/video-grabber/tests/test_postgres_integration.py
+++ b/packages/tools/video-grabber/tests/test_postgres_integration.py
@@ -113,15 +113,13 @@ def test_upsert_job_is_idempotent_on_duplicate_identifier(connection):
     item = {"identifier": "int-test-dup", "title": "first", "creator": "CNN"}
     upsert_job(connection, item, collection="test_collection_a")
     # Second upsert with same identifier but different collection — ON CONFLICT keeps the first.
-    upsert_job(connection, dict(item, title="second"), collection="test_collection_b")
+    upsert_job(connection, item, collection="test_collection_b")
     connection.commit()
 
     rows = connection.execute(
-        sa.text("SELECT title, collection FROM video_jobs WHERE ia_identifier = :id"),
+        sa.text("SELECT collection FROM video_jobs WHERE ia_identifier = :id"),
         {"id": "int-test-dup"},
     ).all()
-    # Title isn't a column on video_jobs; the only persisted-from-upsert title
-    # is inside ia_metadata. Just assert one row exists with the first collection.
     assert len(rows) == 1
     assert rows[0].collection == "test_collection_a"
 

--- a/packages/tools/video-grabber/tests/test_postgres_integration.py
+++ b/packages/tools/video-grabber/tests/test_postgres_integration.py
@@ -1,0 +1,203 @@
+"""
+Integration tests that exercise the schema, SQL strings, and transaction
+behavior against a *real* Postgres rather than a MagicMock'd connection.
+
+Skipped when ``TEST_DATABASE_URL`` is unset, so a bare ``pytest`` from a
+developer laptop without Postgres still passes. The CI workflow
+(.github/workflows/build-video-grabber.yml) spins up a Postgres 16 service
+container and sets the env var, so these run on every PR.
+
+These tests fill the coverage gap that let three SQL/transaction bugs
+slip through unit tests in mid-June 2026:
+
+  * :ia_metadata::jsonb confused SQLAlchemy text()'s bind-param parser.
+  * Scanner never called db.commit(), so every row got rolled back.
+  * DATABASE_URL with the postgresql+asyncpg:// scheme raised
+    MissingGreenlet inside the sync flow code.
+"""
+import os
+import pytest
+import sqlalchemy as sa
+
+from alembic import command
+from alembic.config import Config as AlembicConfig
+
+from video_grabber.ia.scanner import upsert_job
+from video_grabber.pipeline.flows import _sync_db_url, transition_job
+
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("TEST_DATABASE_URL"),
+    reason="TEST_DATABASE_URL not set — skipping Postgres integration tests",
+)
+
+
+@pytest.fixture(scope="module")
+def engine():
+    url = _sync_db_url(os.environ["TEST_DATABASE_URL"])
+    eng = sa.create_engine(url)
+    cfg = AlembicConfig()
+    cfg.set_main_option("script_location", "video_grabber/db/migrations")
+    cfg.set_main_option("sqlalchemy.url", url)
+    command.upgrade(cfg, "head")
+    yield eng
+    eng.dispose()
+
+
+@pytest.fixture
+def connection(engine):
+    """Per-test connection wrapped in a savepoint that's rolled back at teardown,
+    so tests don't see each other's writes but real SQL still executes."""
+    conn = engine.connect()
+    trans = conn.begin()
+    try:
+        yield conn
+    finally:
+        trans.rollback()
+        conn.close()
+
+
+# --- schema sanity ---
+
+def test_schema_has_pipeline_tables(connection):
+    tables = connection.execute(
+        sa.text(
+            "SELECT tablename FROM pg_tables WHERE schemaname = current_schema()"
+        )
+    ).scalars().all()
+    expected = {"channels", "programs", "video_jobs", "schedule_slots", "pipeline_transitions"}
+    assert expected.issubset(set(tables)), f"missing tables: {expected - set(tables)}"
+
+
+def test_pipeline_stage_enum_exists(connection):
+    values = connection.execute(
+        sa.text(
+            "SELECT enumlabel FROM pg_enum "
+            "WHERE enumtypid = 'pipeline_stage'::regtype ORDER BY enumsortorder"
+        )
+    ).scalars().all()
+    assert "discovered" in values
+    assert "complete" in values
+    assert "failed" in values
+    assert "pending_review" in values
+
+
+# --- upsert_job round-trip (catches the ::jsonb syntax bug) ---
+
+def test_upsert_job_writes_row_with_jsonb_metadata(connection):
+    item = {
+        "identifier": "int-test-1",
+        "title": "Integration test broadcast",
+        "creator": "CNN",
+        "length": "3600",
+    }
+    upsert_job(connection, item, collection="test_collection")
+    connection.commit()  # commit so the subsequent SELECT sees it within this savepoint
+
+    row = connection.execute(
+        sa.text(
+            "SELECT ia_identifier, collection, stage, ia_metadata "
+            "FROM video_jobs WHERE ia_identifier = :id"
+        ),
+        {"id": "int-test-1"},
+    ).one()
+
+    assert row.ia_identifier == "int-test-1"
+    assert row.collection == "test_collection"
+    assert str(row.stage) == "discovered"  # CNN normalizes to a known slug
+    assert row.ia_metadata["identifier"] == "int-test-1"
+    assert row.ia_metadata["creator"] == "CNN"
+
+
+def test_upsert_job_is_idempotent_on_duplicate_identifier(connection):
+    item = {"identifier": "int-test-dup", "title": "first", "creator": "CNN"}
+    upsert_job(connection, item, collection="test_collection_a")
+    # Second upsert with same identifier but different collection — ON CONFLICT keeps the first.
+    upsert_job(connection, dict(item, title="second"), collection="test_collection_b")
+    connection.commit()
+
+    rows = connection.execute(
+        sa.text("SELECT title, collection FROM video_jobs WHERE ia_identifier = :id"),
+        {"id": "int-test-dup"},
+    ).all()
+    # Title isn't a column on video_jobs; the only persisted-from-upsert title
+    # is inside ia_metadata. Just assert one row exists with the first collection.
+    assert len(rows) == 1
+    assert rows[0].collection == "test_collection_a"
+
+
+def test_upsert_job_unknown_channel_goes_to_pending_review(connection):
+    item = {"identifier": "int-test-unknown", "title": "Local 5pm news"}
+    upsert_job(connection, item, collection="test_collection")
+    connection.commit()
+    stage = connection.execute(
+        sa.text("SELECT stage FROM video_jobs WHERE ia_identifier = :id"),
+        {"id": "int-test-unknown"},
+    ).scalar()
+    assert str(stage) == "pending_review"
+
+
+# --- transition_job round-trip (catches stage-cast and audit-row bugs) ---
+
+def test_transition_job_updates_stage_and_writes_audit_row(connection):
+    upsert_job(
+        connection,
+        {"identifier": "int-test-trans", "title": "t", "creator": "CNN"},
+        collection="test_collection",
+    )
+    connection.commit()
+    job_id = connection.execute(
+        sa.text("SELECT id FROM video_jobs WHERE ia_identifier = :id"),
+        {"id": "int-test-trans"},
+    ).scalar()
+
+    transition_job(connection, str(job_id), "downloading", from_stage="discovered")
+
+    stage = connection.execute(
+        sa.text("SELECT stage FROM video_jobs WHERE id = :id"), {"id": job_id},
+    ).scalar()
+    assert str(stage) == "downloading"
+
+    audit = connection.execute(
+        sa.text(
+            "SELECT from_stage, to_stage FROM pipeline_transitions "
+            "WHERE job_id = :id ORDER BY occurred_at DESC LIMIT 1"
+        ),
+        {"id": job_id},
+    ).one()
+    assert str(audit.from_stage) == "discovered"
+    assert str(audit.to_stage) == "downloading"
+
+
+def test_transition_job_failed_with_error_message_persists(connection):
+    upsert_job(
+        connection,
+        {"identifier": "int-test-fail", "title": "t", "creator": "CNN"},
+        collection="test_collection",
+    )
+    connection.commit()
+    job_id = connection.execute(
+        sa.text("SELECT id FROM video_jobs WHERE ia_identifier = :id"),
+        {"id": "int-test-fail"},
+    ).scalar()
+
+    transition_job(connection, str(job_id), "failed", error="boom")
+
+    err, stage = connection.execute(
+        sa.text("SELECT error_message, stage FROM video_jobs WHERE id = :id"),
+        {"id": job_id},
+    ).one()
+    assert err == "boom"
+    assert str(stage) == "failed"
+
+
+# --- URL normalization (catches the asyncpg/MissingGreenlet bug) ---
+
+def test_sync_db_url_keeps_test_database_url_compatible():
+    """The TEST_DATABASE_URL in CI uses postgresql:// (no driver suffix);
+    _sync_db_url should leave it untouched and the engine should connect."""
+    url = _sync_db_url(os.environ["TEST_DATABASE_URL"])
+    eng = sa.create_engine(url)
+    with eng.connect() as c:
+        assert c.execute(sa.text("SELECT 1")).scalar() == 1
+    eng.dispose()


### PR DESCRIPTION
Closes the test-coverage gap that let three SQL/transaction bugs slip into production in a single session:

1. `:ia_metadata::jsonb` confused SQLAlchemy text()'s bind-param parser (rendered SQL had bare colon-prefixed name; Postgres rejected it).
2. Scanner never called `db.commit()` — every upserted row was rolled back when the connection closed.
3. `DATABASE_URL` with `postgresql+asyncpg://` raised MissingGreenlet inside sync flow code.

All three passed every existing test because the unit tests mocked the DB connection with MagicMock. CI already runs a Postgres 16 service container and sets `TEST_DATABASE_URL` — adds a test module that actually uses it.

Coverage:
- Schema sanity (tables + `pipeline_stage` enum).
- `upsert_job` round-trip with real `::jsonb` cast.
- `upsert_job` idempotency on `ia_identifier` conflict.
- Unknown channel → `pending_review`.
- `transition_job` updates `video_jobs.stage` AND writes `pipeline_transitions`.
- `transition_job(error=...)` persists the failure message.
- `_sync_db_url` produces a connectable URL.

Module is skipped when `TEST_DATABASE_URL` is unset, so laptop pytest still passes. Per-test savepoint isolation makes tests order-independent without schema teardown.