### PR TITLE
fix(video-grabber): point DIRECTUS_URL at rt911-api service

### DIFF
--- a/packages/tools/video-grabber/docs/deployment.md
+++ b/packages/tools/video-grabber/docs/deployment.md
@@ -91,7 +91,7 @@ Defined inline in `worker-deployment.yaml`:
 PREFECT_API_URL: "http://prefect-server.video-grabber.svc.cluster.local:4200/api"
 WASABI_ENDPOINT_URL: "https://s3.us-central-1.wasabisys.com"
 WASABI_BUCKET: "files.911realtime.org"
-DIRECTUS_URL: "http://directus.rt911.svc.cluster.local:8055"
+DIRECTUS_URL: "http://rt911-api.rt911.svc.cluster.local:8055"
 IA_RATE_PER_SEC: "2"
 MIN_DURATION_SECONDS: "720"
 SCRATCH_DIR: "/tmp/vg-scratch"

--- a/packages/tools/video-grabber/k8s/worker-deployment.yaml
+++ b/packages/tools/video-grabber/k8s/worker-deployment.yaml
@@ -46,7 +46,10 @@ data:
   PREFECT_API_URL: "http://prefect-server.video-grabber.svc.cluster.local:4200/api"
   WASABI_ENDPOINT_URL: "https://s3.us-central-1.wasabisys.com"
   WASABI_BUCKET: "files.911realtime.org"
-  DIRECTUS_URL: "http://directus.rt911.svc.cluster.local:8055"
+  # The Directus deployment in the rt911 namespace is named rt911-api, not
+  # directus — port 8055 is Directus's default. Using the wrong name caused
+  # the directus.writer step to fail with DNS NXDOMAIN.
+  DIRECTUS_URL: "http://rt911-api.rt911.svc.cluster.local:8055"
   IA_RATE_PER_SEC: "2"
   MIN_DURATION_SECONDS: "720"
   SCRATCH_DIR: "/tmp/vg-scratch"


### PR DESCRIPTION
ConfigMap referenced `http://directus.rt911.svc.cluster.local:8055` but the Directus deployment in the rt911 namespace is named `rt911-api` (port 8055 is Directus's default). The wrong name would cause every `process-item` run to die at the final `write_media_item` step with DNS NXDOMAIN — invisible until now because no run has completed end-to-end.

Source-of-truth manifest only. ArgoCD-managed copy in keeping-history/infra goes in a parallel PR.