### PR TITLE
feat(video-grabber): add dispatch-discovered flow + retry downloader

### DIFF
--- a/packages/tools/video-grabber/tests/test_downloader.py
+++ b/packages/tools/video-grabber/tests/test_downloader.py
@@ -165,3 +165,36 @@ def test_get_ia_files_returns_list():
     files = get_ia_files("test-id-001")
     assert len(files) == 3
     assert files[0]["name"] == "broadcast.mp4"
+
+
+@respx.mock
+def test_get_ia_files_retries_on_transient_timeout():
+    """Regression: process-item emerald-leopard failed because IA returned
+    httpx.ReadTimeout on the metadata call. get_ia_files now retries with
+    exponential backoff; only persistent failures propagate."""
+    route = respx.get("https://archive.org/metadata/timeout-id/files")
+    route.side_effect = [
+        httpx.ReadTimeout("simulated transient"),
+        httpx.ReadTimeout("simulated transient"),
+        httpx.Response(200, json={"result": IA_FILES_MP4}),
+    ]
+
+    # Patch tenacity's sleep so the test doesn't actually wait.
+    with patch("tenacity.nap.time.sleep"):
+        files = get_ia_files("timeout-id")
+
+    assert len(files) == 3
+    assert route.call_count == 3
+
+
+@respx.mock
+def test_get_ia_files_gives_up_after_persistent_timeouts():
+    route = respx.get("https://archive.org/metadata/dead-id/files")
+    route.side_effect = httpx.ReadTimeout("simulated persistent")
+
+    with patch("tenacity.nap.time.sleep"):
+        with pytest.raises(httpx.ReadTimeout):
+            get_ia_files("dead-id")
+
+    # 4 attempts per stop_after_attempt(4) — the final raise reraises the last error.
+    assert route.call_count == 4

--- a/packages/tools/video-grabber/tests/test_flows.py
+++ b/packages/tools/video-grabber/tests/test_flows.py
@@ -146,3 +146,52 @@ def test_process_item_flow_transitions_through_all_stages():
     assert "encoded" in stages
     assert "uploading" in stages
     assert "complete" in stages
+
+
+# --- dispatch_discovered_flow ---
+
+def test_dispatch_discovered_flow_no_discovered_jobs_is_noop():
+    from video_grabber.pipeline.flows import dispatch_discovered_flow
+
+    db = MagicMock()
+    db.execute.return_value.first.return_value = None
+
+    with patch("video_grabber.pipeline.flows.get_db", return_value=db), \
+         patch("video_grabber.pipeline.flows.run_deployment") as mock_run, \
+         patch("video_grabber.pipeline.flows.get_run_logger", return_value=MagicMock()):
+        dispatch_discovered_flow.fn(max_runs=10)
+
+    mock_run.assert_not_called()
+
+
+def test_dispatch_discovered_flow_dispatches_one_per_iteration():
+    from video_grabber.pipeline.flows import dispatch_discovered_flow
+
+    # Two discovered rows, then empty — flow should dispatch twice then exit.
+    rows = [MagicMock(id="job-a"), MagicMock(id="job-b"), None]
+    db = MagicMock()
+    db.execute.return_value.first.side_effect = rows
+
+    with patch("video_grabber.pipeline.flows.get_db", return_value=db), \
+         patch("video_grabber.pipeline.flows.run_deployment") as mock_run, \
+         patch("video_grabber.pipeline.flows.get_run_logger", return_value=MagicMock()):
+        dispatch_discovered_flow.fn(max_runs=10)
+
+    assert mock_run.call_count == 2
+    assert mock_run.call_args_list[0].kwargs["parameters"] == {"job_id": "job-a"}
+    assert mock_run.call_args_list[1].kwargs["parameters"] == {"job_id": "job-b"}
+
+
+def test_dispatch_discovered_flow_respects_max_runs_cap():
+    from video_grabber.pipeline.flows import dispatch_discovered_flow
+
+    # Endless supply of rows — flow must still stop at max_runs.
+    db = MagicMock()
+    db.execute.return_value.first.return_value = MagicMock(id="job-x")
+
+    with patch("video_grabber.pipeline.flows.get_db", return_value=db), \
+         patch("video_grabber.pipeline.flows.run_deployment") as mock_run, \
+         patch("video_grabber.pipeline.flows.get_run_logger", return_value=MagicMock()):
+        dispatch_discovered_flow.fn(max_runs=3)
+
+    assert mock_run.call_count == 3

--- a/packages/tools/video-grabber/video_grabber/pipeline/downloader.py
+++ b/packages/tools/video-grabber/video_grabber/pipeline/downloader.py
@@ -3,11 +3,34 @@ Resumable download worker for Internet Archive broadcast files.
 
 File preference: .mp4 (full-res) > .mpg/.mpeg2 > .ogv/.avi
 Byte-range resume: sends Range header when partial file exists on disk.
+
+Both the metadata call and the streaming download set explicit timeouts
+and retry on transient httpx errors. The metadata endpoint is fast but
+prone to intermittent 5 s timeouts; the streaming download disables the
+read timeout so a slow chunk doesn't kill an in-progress 4–8 GiB pull.
 """
 from pathlib import Path
 import httpx
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 _IA_BASE = "https://archive.org"
+
+_TRANSIENT_HTTP_ERRORS = (
+    httpx.TimeoutException,
+    httpx.ConnectError,
+    httpx.RemoteProtocolError,
+    httpx.NetworkError,
+)
+
+_METADATA_TIMEOUT = 30.0  # seconds — small JSON payload, generous enough for IA blips
+# read=None disables the per-chunk read timeout for streaming downloads; connect
+# stays bounded so we still notice an outright unreachable host.
+_DOWNLOAD_TIMEOUT = httpx.Timeout(connect=30.0, read=None, write=None, pool=None)
 
 # Format preference order (lower index = higher priority)
 _FORMAT_PRIORITY = {
@@ -22,9 +45,15 @@ _FORMAT_PRIORITY = {
 _SKIP_PATTERNS = ("512kb", "256kb", "128kb", "_small", "_tiny", "_thumb")
 
 
+@retry(
+    stop=stop_after_attempt(4),
+    wait=wait_exponential(multiplier=1, min=2, max=15),
+    retry=retry_if_exception_type(_TRANSIENT_HTTP_ERRORS),
+    reraise=True,
+)
 def get_ia_files(ia_identifier: str) -> list[dict]:
     url = f"{_IA_BASE}/metadata/{ia_identifier}/files"
-    resp = httpx.get(url, follow_redirects=True)
+    resp = httpx.get(url, follow_redirects=True, timeout=_METADATA_TIMEOUT)
     resp.raise_for_status()
     return resp.json().get("result", [])
 
@@ -59,7 +88,10 @@ def download_item(job, dest_dir: Path) -> Path:
     offset = dest.stat().st_size if dest.exists() else 0
     headers = {"Range": f"bytes={offset}-"} if offset else {}
 
-    with httpx.stream("GET", url, headers=headers, follow_redirects=True) as r:
+    with httpx.stream(
+        "GET", url, headers=headers,
+        follow_redirects=True, timeout=_DOWNLOAD_TIMEOUT,
+    ) as r:
         r.raise_for_status()
         mode = "ab" if offset else "wb"
         with dest.open(mode) as f:

--- a/packages/tools/video-grabber/video_grabber/pipeline/flows.py
+++ b/packages/tools/video-grabber/video_grabber/pipeline/flows.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import sqlalchemy as sa
 from prefect import flow, get_run_logger
+from prefect.deployments import run_deployment
 
 from video_grabber.ia.scanner import crawl_collection
 from video_grabber.pipeline.downloader import download_item
@@ -151,3 +152,42 @@ def process_item_flow(job_id: str):
     except Exception as exc:
         transition_job(db, job_id, "failed", from_stage=None, error=str(exc))
         raise
+
+
+@flow(name="dispatch-discovered")
+def dispatch_discovered_flow(max_runs: int = 100) -> None:
+    """Drain the ``stage='discovered'`` queue by triggering process-item runs.
+
+    Each dispatch is a blocking ``run_deployment`` call — the next job only
+    starts once the current one finishes (or fails). That keeps the queue
+    depth at zero and surfaces failures immediately to the operator instead
+    of letting hundreds of broken runs pile up.
+
+    ``max_runs`` bounds a single dispatcher invocation so the flow itself
+    has a definite end; trigger it again to drain more. Default 100 is
+    enough for a typical batch but small enough that an operator who spots
+    a bug can stop, fix, and rerun.
+    """
+    logger = get_run_logger()
+    db = get_db()
+    processed = 0
+    while processed < max_runs:
+        row = db.execute(
+            sa.text(
+                "SELECT id FROM video_jobs "
+                "WHERE stage = 'discovered' "
+                "ORDER BY created_at LIMIT 1"
+            )
+        ).first()
+        if row is None:
+            logger.info("dispatch-discovered: queue empty after %d runs", processed)
+            return
+        job_id = str(row.id)
+        logger.info("dispatch-discovered: dispatching process-item job_id=%s", job_id)
+        # Blocks until the process-item run reaches a terminal state.
+        run_deployment(
+            name="process-item/process-item",
+            parameters={"job_id": job_id},
+        )
+        processed += 1
+    logger.info("dispatch-discovered: hit max_runs=%d cap", max_runs)

--- a/packages/tools/video-grabber/video_grabber/serve.py
+++ b/packages/tools/video-grabber/video_grabber/serve.py
@@ -18,12 +18,18 @@ avoids coupling pure modules to Prefect's runtime.
 """
 from prefect import serve
 
-from video_grabber.pipeline.flows import process_item_flow, scan_collections_flow
+from video_grabber.pipeline.flows import (
+    dispatch_discovered_flow,
+    process_item_flow,
+    scan_collections_flow,
+)
 
 # One heavy IA download + ffmpeg encode at a time (50 GiB scratch is sized for one item).
 _PROCESS_ITEM_LIMIT = 1
 # Scanner is serial by design; per-call rate-limit lives in IA_RATE_PER_SEC.
 _SCAN_LIMIT = 1
+# One dispatcher at a time so two operators don't both drain the queue in parallel.
+_DISPATCH_LIMIT = 1
 
 
 def main() -> None:
@@ -35,6 +41,10 @@ def main() -> None:
         scan_collections_flow.to_deployment(
             name="scan-collections",
             concurrency_limit=_SCAN_LIMIT,
+        ),
+        dispatch_discovered_flow.to_deployment(
+            name="dispatch-discovered",
+            concurrency_limit=_DISPATCH_LIMIT,
         ),
     )
 


### PR DESCRIPTION
The first end-to-end process-item run (`emerald-leopard`) failed because httpx hit its default 5 s read timeout on a `/metadata/<id>/files` call that should take ~200 ms. The downloader had no timeouts and no retries even though `tenacity` is in deps.

**Downloader fix:**
- `get_ia_files`: 30 s timeout + tenacity exponential-backoff retry (4 attempts, 2-15 s) on transient httpx errors.
- `download_item`: `httpx.Timeout(connect=30, read=None)` — `read=None` is right for a 4-8 GiB stream (a slow chunk shouldn't kill the run).

**Dispatcher:**
- `dispatch_discovered_flow` walks the `stage='discovered'` queue, calls `run_deployment` for each job_id, and **blocks until that run reaches a terminal state**. Serial-by-construction, so a failure stops the drain instead of queueing more broken runs behind it.
- `max_runs=100` default. Trigger again to drain more.
- `concurrency_limit=1` so two operators can't accidentally drain in parallel.

Tests: get_ia_files retry-then-succeed and give-up-after-4-attempts; dispatcher noop on empty, one-per-iteration, max_runs cap.