### PR TITLE
fix(video-grabber): load channel/program relationships in get_job

### DIFF
--- a/packages/tools/video-grabber/tests/test_flows.py
+++ b/packages/tools/video-grabber/tests/test_flows.py
@@ -28,6 +28,60 @@ def test_sync_db_url_passes_through_explicit_psycopg2():
     assert _sync_db_url(url) == url
 
 
+# --- get_job ---
+
+def _mock_db_returning(mapping):
+    """Build a MagicMock db whose execute(...).mappings().fetchone() yields `mapping`."""
+    db = MagicMock()
+    db.execute.return_value.mappings.return_value.fetchone.return_value = mapping
+    return db
+
+
+def test_get_job_flattens_channel_and_program_into_namespaces():
+    from video_grabber.pipeline.flows import get_job
+    from datetime import datetime, timezone
+
+    row = {
+        "id": "job-001",
+        "ia_identifier": "cnn-sep11-0800",
+        "stage": "uploading",
+        "channel_id": "chan-1",
+        "program_id": "prog-1",
+        "channel_slug": "cnn",
+        "channel_display_name": "CNN",
+        "channel_timezone": "America/New_York",
+        "program_title": "Live Coverage",
+        "program_description": "Broadcast",
+        "program_air_date": datetime(2001, 9, 11, 12, 0, tzinfo=timezone.utc),
+        "program_duration_seconds": 3600,
+        "passed_through_review": False,
+    }
+
+    with patch("video_grabber.pipeline.flows.get_db", return_value=_mock_db_returning(row)):
+        job = get_job("job-001")
+
+    # Nested relationship objects the downstream stages dereference.
+    assert job.channel.slug == "cnn"
+    assert job.channel.timezone == "America/New_York"
+    assert job.program.title == "Live Coverage"
+    assert job.program.duration_seconds == 3600
+    # Flat video_jobs columns remain at the top level.
+    assert job.ia_identifier == "cnn-sep11-0800"
+    assert job.id == "job-001"
+    assert job.passed_through_review is False
+    # Aliased columns must not leak onto the top-level object.
+    assert not hasattr(job, "channel_slug")
+    assert not hasattr(job, "program_title")
+
+
+def test_get_job_raises_when_row_missing():
+    from video_grabber.pipeline.flows import get_job
+
+    with patch("video_grabber.pipeline.flows.get_db", return_value=_mock_db_returning(None)):
+        with pytest.raises(ValueError, match="not found"):
+            get_job("nope")
+
+
 # --- transition_job ---
 
 def test_transition_job_updates_stage_and_logs():

--- a/packages/tools/video-grabber/video_grabber/pipeline/flows.py
+++ b/packages/tools/video-grabber/video_grabber/pipeline/flows.py
@@ -7,6 +7,7 @@ PREFECT_API_URL: http://prefect-server.video-grabber.svc.cluster.local:4200/api
 """
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import sqlalchemy as sa
 from prefect import flow, get_run_logger
@@ -49,12 +50,63 @@ def get_db():
 
 
 def get_job(job_id: str):
+    """Load a video_jobs row joined with its channel and program.
+
+    Returns a SimpleNamespace whose shape matches what the downstream
+    pipeline stages expect: the flat ``video_jobs`` columns at the top
+    level, plus nested ``.channel`` and ``.program`` objects (the related
+    rows reached via the ``channel_id`` / ``program_id`` foreign keys).
+    A bare ``SELECT *`` row only carries the FK ids, so accessing
+    ``job.channel`` on it raises NoSuchColumnError.
+
+    ``passed_through_review`` is not a stored column; it is derived from
+    the audit trail — true iff the job ever transitioned into the
+    ``pending_review`` stage. It gates Directus ``approved`` (0 = awaiting
+    human sign-off, 1 = auto-approved).
+    """
     db = get_db()
-    result = db.execute(
-        sa.text("SELECT * FROM video_jobs WHERE id = :id"),
+    row = db.execute(
+        sa.text(
+            """
+            SELECT
+                j.*,
+                c.slug             AS channel_slug,
+                c.display_name     AS channel_display_name,
+                c.timezone         AS channel_timezone,
+                p.title            AS program_title,
+                p.description      AS program_description,
+                p.air_date         AS program_air_date,
+                p.duration_seconds AS program_duration_seconds,
+                EXISTS (
+                    SELECT 1 FROM pipeline_transitions t
+                    WHERE t.job_id = j.id
+                      AND t.to_stage = 'pending_review'
+                ) AS passed_through_review
+            FROM video_jobs j
+            LEFT JOIN channels c ON c.id = j.channel_id
+            LEFT JOIN programs p ON p.id = j.program_id
+            WHERE j.id = :id
+            """
+        ),
         {"id": job_id},
+    ).mappings().fetchone()
+
+    if row is None:
+        raise ValueError(f"video_jobs row not found: {job_id}")
+
+    m = dict(row)
+    channel = SimpleNamespace(
+        slug=m.pop("channel_slug"),
+        display_name=m.pop("channel_display_name"),
+        timezone=m.pop("channel_timezone"),
     )
-    return result.fetchone()
+    program = SimpleNamespace(
+        title=m.pop("program_title"),
+        description=m.pop("program_description"),
+        air_date=m.pop("program_air_date"),
+        duration_seconds=m.pop("program_duration_seconds"),
+    )
+    return SimpleNamespace(channel=channel, program=program, **m)
 
 
 def transition_job(db, job_id: str, to_stage: str, *, from_stage: str = None, error: str = None) -> None:


### PR DESCRIPTION
## Problem

The `process-item` Prefect flow ([failed run](https://prefect-ui.dev.keepinghistory.org/v2/runs/flow-run/d335d24b-5b2d-4438-829e-93acf51af089)) crashed at the **upload** stage:

```
AttributeError: Could not locate column in row for column 'channel'
  File ".../video_grabber/storage/wasabi.py", line 52, in upload_hls_package
    f"hls/{job.channel.slug}"
```

`get_job()` ran `SELECT * FROM video_jobs` and returned the raw SQLAlchemy **Core Row**, which only carries the `channel_id` / `program_id` foreign keys. But every downstream stage treats `job` as an ORM object with nested relationships — `job.channel.slug`, `job.program.air_date`, `job.passed_through_review`. The first relationship dereference (`upload_hls_package`) raised `NoSuchColumnError` → `AttributeError`, **after** the ~1.5 h encode had already completed.

The unit tests never caught it because `test_uploader.py` / `test_directus_writer.py` build `job` with nested `MagicMock`s — they encode the intended contract and mock right over the broken seam (`get_job`).

## Fix

- `get_job` now LEFT JOINs `channels` and `programs` and returns a `SimpleNamespace` with nested `.channel` / `.program` objects plus the flat `video_jobs` columns — the exact shape the existing tests mock.
- `passed_through_review` (no stored column) is derived from the `pipeline_transitions` audit trail: true iff the job ever entered `pending_review`. It gates Directus `approved` (`0` = awaiting human sign-off, `1` = auto-publish).
- Adds direct `get_job` tests that mock at `get_db()` rather than over `get_job`, covering the FK-flattening seam the suite previously skipped.

## Testing

`124 passed, 8 skipped` (12 errors in `test_migrations.py` are pre-existing — they require a live Postgres). `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)