### PR TITLE
fix(video-grabber): retry failed jobs on full run; tame IA stampede

### DIFF
--- a/packages/tools/video-grabber/CLAUDE.md
+++ b/packages/tools/video-grabber/CLAUDE.md
@@ -1,0 +1,66 @@
+# video-grabber
+
+Prefect pipeline that pulls 9/11 broadcast footage from the Internet Archive,
+encodes it to ABR fMP4/CMAF HLS, uploads to Wasabi, and registers it in Directus.
+Also stitches per-channel continuous HLS streams + EPG guide JSON.
+
+## Layout
+
+- `video_grabber/pipeline/` — the per-item flow (`flows.py`), `downloader.py`,
+  `resolve.py` (derive channel/program from IA metadata).
+- `video_grabber/video/` — `encoder.py` (libx264 + h264_vaapi paths), `gap_filler.py`.
+- `video_grabber/epg/` — `assembler.py`, `scheduler.py` (channel stitching).
+- `video_grabber/{storage,directus,ia,db}/` — Wasabi S3, Directus writer, IA scan, migrations.
+- `k8s/` — deployment manifests (see Deploy below).
+- `tests/` — pytest. `test_migrations.py` needs a live Postgres; it **errors** (not
+  fails) when none is reachable — that's an environment gap, not a regression.
+
+## Build & deploy workflow
+
+**This is the canonical way to ship a code change to the live worker.** Images are
+tagged by git commit SHA; the running worker pins a specific SHA, so deploying =
+landing code on `main` (CI builds the image) then rolling the Deployment to the new tag.
+
+1. **Land on `main`.** CI (`.github/workflows/build-video-grabber.yml`) triggers on
+   push/PR touching `packages/tools/video-grabber/**`:
+   - `test` job: spins a `postgres:16` service, `pip install -e ".[dev]"`,
+     `pytest tests/ -v`, then `ruff check video_grabber/ tests/`. Run both locally
+     first (`pytest`, `ruff check`) — a ruff failure blocks the build.
+   - `build` job: **only runs on non-PR events** (`if: github.event_name != 'pull_request'`),
+     so a PR validates but does **not** produce an image. The image is built and pushed
+     only once the commit is on `main`. Tags: `ghcr.io/keeping-history/video-grabber:<sha>`
+     and `:latest`.
+2. **Wait for the image.** Watch the run with `gh run watch` / `gh run list`. The image
+   tag is the full commit SHA (`git rev-parse HEAD`).
+3. **Roll the worker** to the new SHA (do NOT use `--job-variable image`; the pipeline
+   runs in the worker pod via an in-pod Prefect runner, no work pool):
+   ```sh
+   SHA=$(git rev-parse HEAD)
+   kubectl -n video-grabber set image deploy/video-grabber-worker \
+     worker=ghcr.io/keeping-history/video-grabber:$SHA
+   kubectl -n video-grabber rollout status deploy/video-grabber-worker
+   ```
+4. **Schema changes only:** also update + run the migrate Job
+   (`k8s/migrate-job.yaml`, runs `alembic upgrade head`) before rolling the worker.
+
+The k3s cluster is **local to the dev host** — `kubectl` works directly (the
+`open /etc/rancher/k3s/config.yaml: permission denied` warnings are harmless and can
+be ignored). Namespace is `video-grabber`. Prefect server + worker run there;
+`prefect-server` is reachable in-cluster at
+`http://prefect-server.video-grabber.svc.cluster.local:4200/api`.
+
+## Operating the pipeline
+
+- **Dispatch work:** the `dispatch-discovered` flow drains the queue one job at a time
+  (blocking `run_deployment`). It dispatches fresh `stage='discovered'` jobs first, then
+  auto-requeues `stage='failed'` jobs with `retry_count < max_retries` (default 3),
+  bumping `retry_count` each time so a permanently-broken source stops after N tries.
+  **A failed job is automatically retried on the next full run** — no manual re-trigger.
+- **Inspect run state:** query the Prefect API from inside the worker pod, which already
+  has `PREFECT_API_URL` set:
+  `kubectl -n video-grabber exec -i deploy/video-grabber-worker -- python - < script.py`.
+  Prefect's flow-run history and the DB diverge — `video_jobs.stage` is the source of
+  truth for what still needs work (failed runs that were retried show as `complete` there).
+- **Encoding:** `h264_vaapi` hardware path activates when `VAAPI_DEVICE` (e.g.
+  `/dev/dri/renderD128`) is set on a host with an AMD/Intel iGPU (encode-1 node, ~26×
+  realtime); otherwise falls back to libx264 `preset slow` (~2.4×).

--- a/packages/tools/video-grabber/tests/test_downloader.py
+++ b/packages/tools/video-grabber/tests/test_downloader.py
@@ -196,8 +196,8 @@ def test_get_ia_files_gives_up_after_persistent_timeouts():
         with pytest.raises(httpx.ReadTimeout):
             get_ia_files("dead-id")
 
-    # 4 attempts per stop_after_attempt(4) — the final raise reraises the last error.
-    assert route.call_count == 4
+    # 5 attempts per stop_after_attempt(5) — the final raise reraises the last error.
+    assert route.call_count == 5
 
 
 # --- Wasabi-first source reuse ---

--- a/packages/tools/video-grabber/tests/test_flows.py
+++ b/packages/tools/video-grabber/tests/test_flows.py
@@ -251,3 +251,44 @@ def test_dispatch_discovered_flow_respects_max_runs_cap():
         dispatch_discovered_flow.fn(max_runs=3)
 
     assert mock_run.call_count == 3
+
+
+def test_dispatch_requeues_failed_job_and_bumps_retry_count():
+    from video_grabber.pipeline.flows import dispatch_discovered_flow
+
+    # A retryable failed job, then an empty queue: the dispatcher must spend a
+    # retry (bump retry_count, flip back to discovered) and re-dispatch it.
+    failed = MagicMock(id="job-f", stage="failed", retry_count=1)
+    db = MagicMock()
+    db.execute.return_value.first.side_effect = [failed, None]
+
+    with patch("video_grabber.pipeline.flows.get_db", return_value=db), \
+         patch("video_grabber.pipeline.flows.run_deployment") as mock_run, \
+         patch("video_grabber.pipeline.flows.get_run_logger", return_value=MagicMock()):
+        dispatch_discovered_flow.fn(max_runs=10, max_retries=3)
+
+    # Re-dispatched the failed job exactly once.
+    assert mock_run.call_count == 1
+    assert mock_run.call_args_list[0].kwargs["parameters"] == {"job_id": "job-f"}
+    # And issued the retry_count bump UPDATE before dispatching.
+    all_sql = " ".join(c.args[0].text for c in db.execute.call_args_list)
+    assert "retry_count = retry_count + 1" in all_sql
+
+
+def test_dispatch_skips_failed_jobs_over_retry_budget():
+    from video_grabber.pipeline.flows import dispatch_discovered_flow
+
+    # The SELECT itself filters out failed jobs at/over the retry cap, so an
+    # exhausted job is simply never returned — modeled here as an empty queue.
+    db = MagicMock()
+    db.execute.return_value.first.return_value = None
+
+    with patch("video_grabber.pipeline.flows.get_db", return_value=db), \
+         patch("video_grabber.pipeline.flows.run_deployment") as mock_run, \
+         patch("video_grabber.pipeline.flows.get_run_logger", return_value=MagicMock()):
+        dispatch_discovered_flow.fn(max_runs=10, max_retries=3)
+
+    mock_run.assert_not_called()
+    # The selecting query must carry the retry-budget guard.
+    select_sql = " ".join(c.args[0].text for c in db.execute.call_args_list)
+    assert "retry_count < :max_retries" in select_sql

--- a/packages/tools/video-grabber/video_grabber/pipeline/downloader.py
+++ b/packages/tools/video-grabber/video_grabber/pipeline/downloader.py
@@ -18,7 +18,7 @@ from tenacity import (
     retry,
     retry_if_exception_type,
     stop_after_attempt,
-    wait_exponential,
+    wait_random_exponential,
 )
 
 from video_grabber.storage.wasabi import _make_s3_client
@@ -54,9 +54,13 @@ _FORMAT_PRIORITY = {
 _SKIP_PATTERNS = ("512kb", "256kb", "128kb", "_small", "_tiny", "_thumb")
 
 
+# Full-jitter backoff (random in [0, exp]) rather than a deterministic ramp:
+# a batch of jobs that all time out against an overloaded archive.org would,
+# with a fixed schedule, retry in lockstep and re-stampede it at the same
+# instants. Jitter spreads the retries out so IA can recover between waves.
 @retry(
-    stop=stop_after_attempt(4),
-    wait=wait_exponential(multiplier=1, min=2, max=15),
+    stop=stop_after_attempt(5),
+    wait=wait_random_exponential(multiplier=1, max=20),
     retry=retry_if_exception_type(_TRANSIENT_HTTP_ERRORS),
     reraise=True,
 )

--- a/packages/tools/video-grabber/video_grabber/pipeline/flows.py
+++ b/packages/tools/video-grabber/video_grabber/pipeline/flows.py
@@ -175,9 +175,18 @@ def scan_collections_flow(collections: list[str] = ["sept_11_tv_archive", "911"]
     logger.info("Scan complete")
 
 
-@flow(name="process-item")
+@flow(name="process-item", retries=2, retry_delay_seconds=[30, 120])
 def process_item_flow(job_id: str):
-    """Download → encode → upload for a single video_jobs row."""
+    """Download → encode → upload for a single video_jobs row.
+
+    Flow-level ``retries`` give transient failures (an Internet Archive
+    handshake timeout, a Wasabi/Directus blip) a couple of in-place reattempts
+    with a backoff before the job is left in ``failed`` for the dispatcher to
+    requeue on the next pass. Every stage is idempotent — download resumes via
+    byte-range, encode/upload/Directus overwrite — so re-running the flow body
+    is safe. The dominant failure mode (IA metadata fetch) fails before the
+    expensive encode, so a retry there is cheap.
+    """
     logger = get_run_logger()
     db = get_db()
     job = get_job(job_id)
@@ -287,8 +296,19 @@ def _rebuild_epg_guide(cfg: Config) -> None:
 
 
 @flow(name="dispatch-discovered")
-def dispatch_discovered_flow(max_runs: int = 100) -> None:
-    """Drain the ``stage='discovered'`` queue by triggering process-item runs.
+def dispatch_discovered_flow(max_runs: int = 100, max_retries: int = 3) -> None:
+    """Drain the work queue by triggering process-item runs.
+
+    Fresh ``discovered`` jobs are dispatched first; once they are exhausted the
+    dispatcher re-queues jobs that previously landed in ``failed`` but still
+    have retry budget (``retry_count < max_retries``). This is what makes a
+    full run self-healing: a transient failure (e.g. an Internet Archive
+    handshake timeout during a large batch) is reattempted automatically
+    instead of being stranded in ``failed`` until someone re-triggers it by
+    hand. Re-queuing bumps ``retry_count`` and flips the row back to
+    ``discovered``, so a job that keeps failing is retried at most
+    ``max_retries`` times and then left in ``failed`` for human inspection —
+    the bump is what bounds the loop.
 
     Each dispatch is a blocking ``run_deployment`` call — the next job only
     starts once the current one finishes (or fails). That keeps the queue
@@ -304,18 +324,44 @@ def dispatch_discovered_flow(max_runs: int = 100) -> None:
     db = get_db()
     processed = 0
     while processed < max_runs:
+        # Prefer fresh work (stage='discovered' sorts as FALSE = 0) over
+        # retryable failures (TRUE = 1); break ties by age.
         row = db.execute(
             sa.text(
-                "SELECT id FROM video_jobs "
-                "WHERE stage = 'discovered' "
-                "ORDER BY created_at LIMIT 1"
-            )
+                """
+                SELECT id, stage, retry_count
+                FROM video_jobs
+                WHERE stage = 'discovered'
+                   OR (stage = 'failed' AND retry_count < :max_retries)
+                ORDER BY (stage = 'failed'), created_at
+                LIMIT 1
+                """
+            ),
+            {"max_retries": max_retries},
         ).first()
         if row is None:
             logger.info("dispatch-discovered: queue empty after %d runs", processed)
             return
         job_id = str(row.id)
-        logger.info("dispatch-discovered: dispatching process-item job_id=%s", job_id)
+        if row.stage == "failed":
+            # Spend one retry and flip back to discovered *before* dispatching,
+            # so a repeat failure is bounded by the bumped retry_count rather
+            # than re-selecting the same row forever.
+            db.execute(
+                sa.text(
+                    "UPDATE video_jobs "
+                    "SET stage = 'discovered', retry_count = retry_count + 1, "
+                    "last_transition_at = now() WHERE id = :id"
+                ),
+                {"id": job_id},
+            )
+            db.commit()
+            logger.info(
+                "dispatch-discovered: retrying failed job_id=%s (attempt %d/%d)",
+                job_id, row.retry_count + 1, max_retries,
+            )
+        else:
+            logger.info("dispatch-discovered: dispatching process-item job_id=%s", job_id)
         # Blocks until the process-item run reaches a terminal state.
         run_deployment(
             name="process-item/process-item",


### PR DESCRIPTION
## What & why

Triaging the last batch's Prefect failures: 46 of 51 were archive.org TLS handshake/read timeouts (a connection **stampede** during the big concurrent dispatch); the other 5 were already-fixed code bugs (PRs #89/#90/#91) that only appeared on pre-fix runs. The DB shows just 3 jobs actually stuck at `stage='failed'`.

The structural gap: a failed job transitions to `stage='failed'`, but `dispatch-discovered` only ever `SELECT`s `stage='discovered'` — so **failed work is invisible to a rerun** and had to be re-triggered by hand.

## Changes

- **`dispatch-discovered`** — selects `discovered` OR (`failed AND retry_count < max_retries`, default 3); drains fresh work first, then auto-requeues failures, bumping `retry_count` each time (self-bounding, no infinite loop). *Failed jobs now retry automatically on the next full run.*
- **`process-item`** — flow-level `retries=2` (30s, 120s backoff) so transient blips self-heal before reaching `failed`. All stages are idempotent.
- **`get_ia_files`** — `wait_exponential` → `wait_random_exponential` (full jitter) + 4→5 attempts, so retrying jobs don't re-collide and re-stampede archive.org.
- **CLAUDE.md** — documents the SHA-tagged CI build + `kubectl set image` worker-roll deploy workflow.

## Tests

`pytest` 166 passed / 8 skipped (12 `test_migrations.py` errors are the live-Postgres requirement, unrelated). `ruff check` clean. Added coverage for requeue + retry-budget guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)