### PR TITLE
feat(video-grabber): make 2 concurrent dispatchers the default

### DIFF
--- a/packages/tools/video-grabber/video_grabber/serve.py
+++ b/packages/tools/video-grabber/video_grabber/serve.py
@@ -32,8 +32,16 @@ from video_grabber.pipeline.flows import (
 _PROCESS_ITEM_LIMIT = 2
 # Scanner is serial by design; per-call rate-limit lives in IA_RATE_PER_SEC.
 _SCAN_LIMIT = 1
-# One dispatcher at a time so two operators don't both drain the queue in parallel.
-_DISPATCH_LIMIT = 1
+# Two concurrent dispatchers, to actually saturate the two-encode pipeline
+# (_PROCESS_ITEM_LIMIT). Each dispatcher is blocking — it drives one process-item
+# at a time — so it takes two dispatchers to keep two encodes running; a single
+# one only ever reaches 1x. The two share the queue via stage transitions
+# (process-item flips a job to 'downloading' at start, so the other dispatcher
+# stops seeing it). A rare double-pick of the same job is possible in the brief
+# window before that flip, but harmless: upload + Directus writes are idempotent,
+# so the worst case is one wasted re-encode. (If that waste ever matters, claim
+# rows atomically with SELECT ... FOR UPDATE SKIP LOCKED in the dispatcher.)
+_DISPATCH_LIMIT = 2
 # Channel assembly is ffmpeg-light (tiny gap segments) but writes shared
 # playlists; one at a time keeps per-channel publishes from racing.
 _BUILD_CHANNEL_LIMIT = 2


### PR DESCRIPTION
## Hold until the current drain finishes — do not merge yet

Merging rebuilds the image → infra automation bumps the SHA → ArgoCD rolls the worker, which **kills the in-flight drain** and resets the runtime concurrency override. This PR is staged to land *after* the current 2,231-job drain completes.

## What

`_DISPATCH_LIMIT` 1 → 2 in `serve.py`, making two concurrent dispatchers the durable default.

## Why

`_PROCESS_ITEM_LIMIT=2` allows two concurrent encodes, but `dispatch-discovered` is **blocking** (one `process-item` per dispatcher at a time), so a single dispatcher only ever reaches 1×. Two dispatchers are required to saturate the two-encode pipeline. We're currently getting 2× via a runtime global-concurrency-limit override on the dispatch deployment, but that **reverts to 1 on every worker pod restart** (serve() re-registers it). This bakes 2× in.

## Tradeoff / caveat

The original `_DISPATCH_LIMIT=1` existed to prevent two dispatchers double-draining. With two dispatchers there's a small race: both could pick the same job in the brief window before `process-item` flips it to `downloading`. It's harmless — upload + Directus writes are idempotent, so the worst case is one wasted re-encode. If that waste ever matters, the follow-up is atomic row claiming (`SELECT … FOR UPDATE SKIP LOCKED`) in the dispatcher; noted in the code comment.

## Test

`ruff` clean; `serve.py` parses. No behavior change exercised by unit tests (config only). Validated equivalently in production via the runtime limit bump — the live drain is running at 2× with this exact setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)