### PR TITLE
feat(video-grabber): rescue pending_review jobs via identifier-prefix channel map

### DIFF
--- a/packages/tools/video-grabber/tests/test_channel_map.py
+++ b/packages/tools/video-grabber/tests/test_channel_map.py
@@ -1,0 +1,43 @@
+"""Tests for channel slug normalization, including the identifier-prefix fallback."""
+from video_grabber.ia.channel_map import normalize_slug
+
+
+def test_known_network_from_title():
+    assert normalize_slug({"title": "CNN : September 11, 2001"}) == "cnn"
+
+
+def test_known_network_from_creator():
+    assert normalize_slug({"creator": "Cable News Network"}) == "cnn"
+
+
+def test_local_call_sign_from_title():
+    # W/K + 3 letters is treated as a local affiliate slug.
+    assert normalize_slug({"title": "WETA broadcast"}) == "weta"
+
+
+def test_identifier_prefix_fallback_for_international_feed():
+    # No recognizable network in the human fields -> fall back to the
+    # identifier's channel-code prefix (the previously-stranded case).
+    assert normalize_slug(
+        {"identifier": "ANT1_20010914_010000_Antenna_1_Greece",
+         "title": "Antenna 1 Greece : ANT1 : September 13, 2001"}
+    ) == "ant1"
+    assert normalize_slug({"identifier": "NHK_20010914_010000_News"}) == "nhk"
+    assert normalize_slug({"identifier": "CCTV3_20010914_010000_x"}) == "cctv3"
+
+
+def test_identifier_prefix_requires_leading_letter():
+    # A date- or number-led identifier must NOT become a channel.
+    assert normalize_slug({"identifier": "20010911_0900_unknown"}) is None
+
+
+def test_unresolvable_returns_none():
+    assert normalize_slug({}) is None
+    assert normalize_slug({"identifier": "", "title": ""}) is None
+
+
+def test_human_field_wins_over_identifier_prefix():
+    # When the title names a known network, that wins over the raw prefix.
+    assert normalize_slug(
+        {"identifier": "FOX5NEWS_20010911_x", "title": "Fox 5 News"}
+    ) == "fox-news"

--- a/packages/tools/video-grabber/tests/test_flows.py
+++ b/packages/tools/video-grabber/tests/test_flows.py
@@ -216,6 +216,49 @@ def test_process_item_flow_transitions_through_all_stages():
 
 # --- dispatch_discovered_flow ---
 
+def test_requeue_pending_review_promotes_only_resolvable_jobs():
+    from video_grabber.pipeline.flows import requeue_pending_review_flow
+
+    rows = [
+        # Resolves via identifier-prefix fallback.
+        {"id": "j1", "ia_identifier": "ANT1_20010914_010000_x",
+         "ia_metadata": {"identifier": "ANT1_20010914_010000_x", "title": "Antenna 1 Greece"}},
+        # No leading-letter prefix and no network in fields -> stays parked.
+        {"id": "j2", "ia_identifier": "20010911_0900_x",
+         "ia_metadata": {"identifier": "20010911_0900_x", "title": ""}},
+    ]
+    db = MagicMock()
+    db.execute.return_value.mappings.return_value.all.return_value = rows
+
+    with patch("video_grabber.pipeline.flows.get_db", return_value=db), \
+         patch("video_grabber.pipeline.flows.get_run_logger", return_value=MagicMock()):
+        result = requeue_pending_review_flow.fn(dry_run=False)
+
+    assert result == {"promoted": 1, "evaluated": 2}
+    sql = " ".join(c.args[0].text for c in db.execute.call_args_list if c.args)
+    assert "UPDATE video_jobs SET stage = 'discovered'" in sql
+    assert "INSERT INTO pipeline_transitions" in sql
+
+
+def test_requeue_pending_review_dry_run_makes_no_changes():
+    from video_grabber.pipeline.flows import requeue_pending_review_flow
+
+    rows = [{"id": "j1", "ia_identifier": "NHK_20010914_010000_x",
+             "ia_metadata": {"identifier": "NHK_20010914_010000_x"}}]
+    db = MagicMock()
+    db.execute.return_value.mappings.return_value.all.return_value = rows
+
+    with patch("video_grabber.pipeline.flows.get_db", return_value=db), \
+         patch("video_grabber.pipeline.flows.get_run_logger", return_value=MagicMock()):
+        result = requeue_pending_review_flow.fn(dry_run=True)
+
+    assert result == {"promoted": 1, "evaluated": 1}
+    # dry run: only the SELECT ran, no UPDATE/INSERT, no commit.
+    sql = " ".join(c.args[0].text for c in db.execute.call_args_list if c.args)
+    assert "UPDATE" not in sql and "INSERT" not in sql
+    db.commit.assert_not_called()
+
+
 def test_dispatch_discovered_flow_no_discovered_jobs_is_noop():
     from video_grabber.pipeline.flows import dispatch_discovered_flow
 

--- a/packages/tools/video-grabber/video_grabber/ia/channel_map.py
+++ b/packages/tools/video-grabber/video_grabber/ia/channel_map.py
@@ -30,6 +30,15 @@ KNOWN_CHANNELS: dict[str, str] = {
 # Local affiliate call-sign pattern: W/K followed by 3 uppercase letters
 _LOCAL_CALL_SIGN = re.compile(r"\b([WK][A-Z]{3})\b")
 
+# Channel-code prefix of an IA identifier, e.g. "ANT1" in
+# "ANT1_20010914_010000_Antenna_1_Greece". The Sept-11 archive names every
+# capture <CHANNEL>_<YYYYMMDD>_<HHMMSS>_<desc>, so the leading token is a clean,
+# stable per-channel code. Used as a last-resort slug source for broadcasters
+# not in KNOWN_CHANNELS (mostly international feeds: NHK, CCTV3, ANT1, WORLDNET,
+# …). Requires a leading letter so a date- or number-led identifier never
+# becomes a "channel".
+_IDENT_PREFIX = re.compile(r"^([A-Za-z][A-Za-z0-9]{1,15})_")
+
 
 def normalize_slug(item: dict) -> str | None:
     """Return a channel slug from IA item metadata, or None if unrecognized."""
@@ -42,7 +51,14 @@ def normalize_slug(item: dict) -> str | None:
         slug = _slug_from_text(value)
         if slug:
             return slug
-    return None
+    # Last resort: the identifier's channel-code prefix. Only reached when the
+    # human-readable fields named no known network and carried no call sign.
+    return _slug_from_identifier(item.get("identifier", ""))
+
+
+def _slug_from_identifier(identifier: str) -> str | None:
+    m = _IDENT_PREFIX.match(identifier or "")
+    return m.group(1).lower() if m else None
 
 
 def _slug_from_text(text: str) -> str | None:

--- a/packages/tools/video-grabber/video_grabber/pipeline/flows.py
+++ b/packages/tools/video-grabber/video_grabber/pipeline/flows.py
@@ -15,6 +15,7 @@ import sqlalchemy as sa
 from prefect import flow, get_run_logger
 from prefect.deployments import run_deployment
 
+from video_grabber.ia.channel_map import normalize_slug
 from video_grabber.ia.scanner import crawl_collection
 from video_grabber.pipeline.downloader import download_item
 from video_grabber.pipeline.resolve import resolve_job
@@ -374,3 +375,68 @@ def dispatch_discovered_flow(max_runs: int = 100, max_retries: int = 3) -> None:
         )
         processed += 1
     logger.info("dispatch-discovered: hit max_runs=%d cap", max_runs)
+
+
+@flow(name="requeue-pending-review")
+def requeue_pending_review_flow(max_jobs: int = 20000, dry_run: bool = False) -> dict:
+    """Re-evaluate ``pending_review`` jobs and promote the now-recognized ones.
+
+    A job lands in ``pending_review`` when ``normalize_slug`` can't derive a
+    channel from its metadata at scan time. Once the channel map gains coverage
+    (e.g. the identifier-prefix fallback for international feeds), this flow
+    re-checks each parked job against the *current* mapping and flips the ones
+    that now resolve back to ``discovered`` so the dispatcher processes them.
+
+    Idempotent: a job that still doesn't resolve is left untouched. Pass
+    ``dry_run=True`` first to preview how many would be promoted without
+    changing anything. Returns ``{"promoted": n, "evaluated": m}``.
+    """
+    logger = get_run_logger()
+    db = get_db()
+    rows = db.execute(
+        sa.text(
+            "SELECT id, ia_identifier, ia_metadata FROM video_jobs "
+            "WHERE stage = 'pending_review' ORDER BY created_at LIMIT :n"
+        ),
+        {"n": max_jobs},
+    ).mappings().all()
+
+    to_promote: list[str] = []
+    for r in rows:
+        meta = r["ia_metadata"] or {}
+        if isinstance(meta, str):
+            try:
+                meta = json.loads(meta)
+            except json.JSONDecodeError:
+                meta = {}
+        # The stored blob carries "identifier", but fall back to the column so
+        # the identifier-prefix rule still fires on older/sparse metadata.
+        meta.setdefault("identifier", r["ia_identifier"])
+        if normalize_slug(meta):
+            to_promote.append(str(r["id"]))
+
+    logger.info(
+        "requeue-pending-review: %d of %d evaluated jobs now resolve to a channel%s",
+        len(to_promote), len(rows), " (dry run — no changes made)" if dry_run else "",
+    )
+    if to_promote and not dry_run:
+        worker = os.getenv("HOSTNAME", "unknown")
+        db.execute(
+            sa.text(
+                "UPDATE video_jobs SET stage = 'discovered', last_transition_at = now() "
+                "WHERE id = ANY(CAST(:ids AS uuid[]))"
+            ),
+            {"ids": to_promote},
+        )
+        # Audit trail, mirroring transition_job but in one bulk insert.
+        db.execute(
+            sa.text(
+                "INSERT INTO pipeline_transitions (job_id, from_stage, to_stage, worker_id) "
+                "SELECT unnest(CAST(:ids AS uuid[])), "
+                "CAST('pending_review' AS pipeline_stage), "
+                "CAST('discovered' AS pipeline_stage), :worker"
+            ),
+            {"ids": to_promote, "worker": worker},
+        )
+        db.commit()
+    return {"promoted": len(to_promote), "evaluated": len(rows)}

--- a/packages/tools/video-grabber/video_grabber/serve.py
+++ b/packages/tools/video-grabber/video_grabber/serve.py
@@ -22,6 +22,7 @@ from video_grabber.pipeline.flows import (
     build_channel_flow,
     dispatch_discovered_flow,
     process_item_flow,
+    requeue_pending_review_flow,
     scan_collections_flow,
 )
 
@@ -37,6 +38,8 @@ _DISPATCH_LIMIT = 1
 # Channel assembly is ffmpeg-light (tiny gap segments) but writes shared
 # playlists; one at a time keeps per-channel publishes from racing.
 _BUILD_CHANNEL_LIMIT = 2
+# DB-only re-classification of the pending_review backlog; serial is plenty.
+_REQUEUE_LIMIT = 1
 
 
 def main() -> None:
@@ -56,6 +59,10 @@ def main() -> None:
         build_channel_flow.to_deployment(
             name="build-channel",
             concurrency_limit=_BUILD_CHANNEL_LIMIT,
+        ),
+        requeue_pending_review_flow.to_deployment(
+            name="requeue-pending-review",
+            concurrency_limit=_REQUEUE_LIMIT,
         ),
     )
 


### PR DESCRIPTION
## Hold until after the drain — do not merge yet

Like #93, merging this rebuilds the image → ArgoCD rolls the worker, which kills the in-flight drain. Staged to land *after* the current drain completes. **Merge #93 and this together** (both touch `serve.py`, in different regions — should be conflict-free).

## Problem

The ~3,373 `pending_review` jobs are **~16 international / minor broadcasters** — `NHK`, `CCTV3`, `ANT1` (Greece), `WORLDNET`, `IRAQ`, `MCM`, `NTV`, `BET`, `WRC`, … — whose names aren't in the 10-network `KNOWN_CHANNELS` map and whose codes don't match the US `W/K###` call-sign regex. `normalize_slug` returned `None`, so the scanner parked them. There is no UI and **no code ever promoted them** out of `pending_review`.

## Change

1. **`normalize_slug` identifier-prefix fallback.** The archive names every capture `<CHANNEL>_<YYYYMMDD>_<HHMMSS>_<desc>`, so the leading token is a clean per-channel code. As a *last resort* (only when `creator`/`subject`/`title` name no known network and carry no call sign), derive the slug from that prefix — gated on a leading letter so a date/number-led identifier can't become a "channel". Existing classifications are unchanged.
2. **New `requeue-pending-review` flow.** Re-evaluates parked jobs against the current map and flips the now-resolvable ones to `discovered` (bulk `UPDATE` + audit insert into `pipeline_transitions`). Idempotent; `dry_run=True` previews counts without writing.
3. Registers the flow in `serve.py`.

## How to run it (after merge + worker roll)

```
# preview
prefect deployment run requeue-pending-review/requeue-pending-review --param dry_run=true
# promote
prefect deployment run requeue-pending-review/requeue-pending-review
```
Promoted jobs then flow through the normal dispatcher. (Items that passed through `pending_review` are written to Directus with `approved=0`, so they still await sign-off in the Directus UI before publishing.)

## Tests

`pytest` 44 passed (new `test_channel_map.py` for the fallback + leading-letter guard + human-field precedence; two `requeue-pending-review` flow tests covering promote-only-resolvable and dry-run-makes-no-changes). `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)