### PR TITLE
fix(video-grabber): download public derivatives for stream-only items

### DIFF
--- a/packages/tools/video-grabber/tests/test_downloader.py
+++ b/packages/tools/video-grabber/tests/test_downloader.py
@@ -49,8 +49,41 @@ def test_ogv_fallback():
 
 
 def test_no_files_raises():
-    with pytest.raises(ValueError, match="no suitable file"):
+    with pytest.raises(ValueError, match="no downloadable file"):
         select_best_file([])
+
+
+# Stream-only items: full-res original is private; only derivatives are public.
+IA_FILES_STREAM_ONLY = [
+    {"name": "V08553-05.mpg", "format": "MPEG2", "size": "1073741824", "private": "true"},
+    {"name": "V08553-05.ogv", "format": "Ogg Video", "size": "211524456"},
+    {"name": "V08553-05_512kb.mp4", "format": "512Kb MPEG4", "size": "180118431"},
+]
+
+IA_FILES_PRIVATE_PLUS_LOWQ_ONLY = [
+    {"name": "V1.mpg", "format": "MPEG2", "size": "1073741824", "private": "true"},
+    {"name": "V1_512kb.mp4", "format": "512Kb MPEG4", "size": "180000000"},
+    {"name": "V1_256kb.mp4", "format": "256Kb MPEG4", "size": "90000000"},
+]
+
+
+def test_skips_private_original_prefers_public_ogv():
+    # The private original must be skipped; the .ogv beats the 512kb mp4.
+    best = select_best_file(IA_FILES_STREAM_ONLY)
+    assert best["name"] == "V08553-05.ogv"
+
+
+def test_falls_back_to_low_bitrate_mp4_when_only_public_option():
+    # No full-quality public file -> take the largest low-bitrate derivative.
+    best = select_best_file(IA_FILES_PRIVATE_PLUS_LOWQ_ONLY)
+    assert best["name"] == "V1_512kb.mp4"
+
+
+def test_all_private_raises():
+    with pytest.raises(ValueError, match="no downloadable file"):
+        select_best_file([
+            {"name": "a.mpg", "format": "MPEG2", "size": "1", "private": "true"},
+        ])
 
 
 # --- download_item ---

--- a/packages/tools/video-grabber/video_grabber/pipeline/downloader.py
+++ b/packages/tools/video-grabber/video_grabber/pipeline/downloader.py
@@ -72,22 +72,38 @@ def get_ia_files(ia_identifier: str) -> list[dict]:
 
 
 def select_best_file(files: list[dict]) -> dict:
-    """Return the best source file by format priority. Raises ValueError if none qualify."""
+    """Return the best *downloadable* source file. Raises ValueError if none qualify.
+
+    Skips ``private`` files. Stream-only items (most of the Sept-11 news archive)
+    mark the full-res original ``private=true`` — it 401s for everyone, with or
+    without credentials — while still exposing public ``.ogv`` / low-bitrate
+    ``.mp4`` derivatives. Among downloadable files we prefer a full-quality source
+    over a low-bitrate derivative (``_SKIP_PATTERNS``), then by container format,
+    then by larger size. So a public original wins when present; for a stream-only
+    item the largest non-low-bitrate derivative (typically the ``.ogv``) is taken,
+    with the ``512kb``/etc. mp4 only as a last resort.
+    """
     candidates = []
     for f in files:
+        if str(f.get("private", "")).lower() == "true":
+            continue
         name = f.get("name", "").lower()
         suffix = "." + name.rsplit(".", 1)[-1] if "." in name else ""
         if suffix not in _FORMAT_PRIORITY:
             continue
-        if any(pat in name for pat in _SKIP_PATTERNS):
-            continue
-        candidates.append((f, _FORMAT_PRIORITY[suffix]))
+        is_low_bitrate = any(pat in name for pat in _SKIP_PATTERNS)
+        try:
+            size = int(f.get("size") or 0)
+        except (TypeError, ValueError):
+            size = 0
+        candidates.append((is_low_bitrate, _FORMAT_PRIORITY[suffix], -size, f))
 
     if not candidates:
-        raise ValueError("no suitable file found in IA item")
+        raise ValueError("no downloadable file found in IA item")
 
-    candidates.sort(key=lambda x: x[1])
-    return candidates[0][0]
+    # Full-quality before low-bitrate, then format priority, then larger size.
+    candidates.sort(key=lambda c: (c[0], c[1], c[2]))
+    return candidates[0][3]
 
 
 def find_wasabi_source(ia_identifier: str, best: dict, cfg, *, s3=None) -> Optional[str]:


### PR DESCRIPTION
## The fix that actually unblocks the drain

During the full drain, ~87% of jobs failed with `401 Unauthorized` at download. Investigation (12/12 sampled items): the `sept_11_tv_archive` is largely **`stream_only`** — the full-res original is `private=true` and 401s **for everyone, credentials or not** — but the public `.ogv` (~211 MB) and low-bitrate `.mp4` (~182 MB) derivatives download anonymously (verified HTTP 206).

`select_best_file` was choosing the **private original** (by format priority) and **skipping the public `_512kb.mp4`** (via `_SKIP_PATTERNS`) — i.e. picking the one file it couldn't fetch.

## Change

`select_best_file` now skips `private` files and ranks downloadable ones as `(full-quality before low-bitrate, then format priority, then larger size)`:
- a public **original wins** when present (cached 716 items unaffected);
- for stream-only items the largest non-low-bitrate derivative (the **`.ogv`**) is taken;
- `512kb`/`256kb` mp4 only as a last resort.

## Tradeoff

Stream-only items are sourced from the ~211 MB `.ogv` instead of the 1 GB original. We re-encode to 480p/240p/120p HLS, so the `.ogv` is adequate for the 480p rung — and it's the best obtainable for content whose original is undownloadable.

## Tests

`pytest tests/test_downloader.py` 20 passed — added private-skip, `.ogv`-preference, low-bitrate fallback, and all-private-raises cases; existing format-priority tests still hold. `ruff` clean.

## Merge plan

The drain is currently **stopped** (it was failing on this), so there's no in-flight work to protect. Recommend merging this together with #93 (durable 2× dispatch) and #94 (pending_review rescue) in one worker roll, then re-running the drain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)