### PR TITLE
fix(video-grabber): handle already-complete download (416 on retry)

### DIFF
--- a/packages/tools/video-grabber/tests/test_downloader.py
+++ b/packages/tools/video-grabber/tests/test_downloader.py
@@ -147,6 +147,31 @@ def test_download_resume_sends_range_header(tmp_path):
 
 
 @respx.mock
+def test_download_skips_when_file_already_complete(tmp_path):
+    """Regression: a complete file on disk (from a prior attempt or a
+    double-picked job) must NOT trigger a Range request — IA returns 416 for a
+    range at EOF. We short-circuit and return the existing file."""
+    job = make_job()
+    full = b"z" * 4096
+    dest_dir = tmp_path / job.ia_identifier
+    dest_dir.mkdir(parents=True)
+    (dest_dir / "broadcast.mp4").write_bytes(full)
+
+    respx.get(
+        "https://archive.org/metadata/cnn-sep11-0800/files"
+    ).mock(return_value=httpx.Response(200, json={"result": [
+        {"name": "broadcast.mp4", "format": "MPEG4", "size": str(len(full))},
+    ]}))
+    dl_route = respx.get("https://archive.org/download/cnn-sep11-0800/broadcast.mp4")
+
+    with patch("video_grabber.pipeline.downloader.update_bytes_downloaded"):
+        result = download_item(job, tmp_path)
+
+    assert result.read_bytes() == full
+    assert not dl_route.called  # never hit the download endpoint
+
+
+@respx.mock
 def test_download_updates_bytes_downloaded(tmp_path):
     job = make_job()
     content = b"a" * 2 * 1024 * 1024  # 2 MB

--- a/packages/tools/video-grabber/video_grabber/pipeline/downloader.py
+++ b/packages/tools/video-grabber/video_grabber/pipeline/downloader.py
@@ -154,7 +154,27 @@ def download_item(job, dest_dir: Path, cfg=None, *, logger=None) -> Path:
             logger.info("download: %s not in Wasabi, pulling from IA", job.ia_identifier)
 
     url = f"{_IA_BASE}/download/{job.ia_identifier}/{best['name']}"
+    try:
+        expected = int(best.get("size") or 0)
+    except (TypeError, ValueError):
+        expected = 0
     offset = dest.stat().st_size if dest.exists() else 0
+
+    # A prior attempt may have already fetched the whole file — a flow retry
+    # after a later-stage failure, or a second dispatcher that double-picked the
+    # same job and lost the race. Requesting ``Range: bytes=<size>-`` on a
+    # complete file makes IA return 416 Range Not Satisfiable, which would fail
+    # the job spuriously. Short-circuit when the local copy already matches IA's
+    # size; if it is somehow larger (corrupt), discard and re-fetch from scratch.
+    if expected and offset == expected:
+        if logger:
+            logger.info("download: %s already complete on disk (%d bytes)",
+                        job.ia_identifier, offset)
+        return dest
+    if expected and offset > expected:
+        dest.unlink()
+        offset = 0
+
     headers = {"Range": f"bytes={offset}-"} if offset else {}
 
     with httpx.stream(


### PR DESCRIPTION
## Hold until the next worker roll — do not merge mid-drain

Merging rolls the worker (kills the in-flight drain and resets the runtime concurrency bump back to the code defaults). Land this at the next planned roll.

## Bug (observed live: job `belligerent-wildcat`, `bbc200109120730-0811`)

`download_item` resumes via `Range: bytes=<offset>-`. When a prior attempt already fetched the whole file, `offset == filesize`, so IA returns **416 Range Not Satisfiable** and the job fails spuriously.

Triggers:
- a flow retry after a *later*-stage failure (download was fine, re-runs from the top), and
- **double-picked jobs at higher dispatch concurrency** — two blocking dispatchers grab the same `discovered` job; the winner completes the download, the loser finds the complete file in shared scratch and 416s.

Not data-losing (the winning attempt still produces the content), but it creates failed records.

## Fix

Before downloading, compare the on-disk size to IA's reported `size`:
- equal → already complete, return the file (no request);
- larger → corrupt, discard and re-fetch from scratch;
- smaller → resume with Range as before.

## Tests

`tests/test_downloader.py` 21 passed — added `test_download_skips_when_file_already_complete` (asserts the download endpoint is never hit when the file is already complete). `ruff` clean.

## Note
This also softens the double-pick race from running 4 blocking dispatchers. The cleaner long-term fix is atomic job claiming (`SELECT … FOR UPDATE SKIP LOCKED`) in the dispatcher; this PR makes the symptom harmless in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)