### PR TITLE
perf(video-grabber): make 4 concurrent pipelines the default

### DIFF
--- a/packages/tools/video-grabber/video_grabber/serve.py
+++ b/packages/tools/video-grabber/video_grabber/serve.py
@@ -26,23 +26,26 @@ from video_grabber.pipeline.flows import (
     scan_collections_flow,
 )
 
-# Two concurrent download+encode pipelines. The worker pod is sized to give each
-# ~4 CPU cores (limit 8) so the two encodes run at full speed rather than
-# time-slicing; 50 GiB scratch comfortably holds two in-flight items (~a few GiB
-# each). Raise in lockstep with the pod CPU limit in infra worker.yaml.
-_PROCESS_ITEM_LIMIT = 2
+# Four concurrent download+encode pipelines. These jobs are largely
+# download-bound (pulling the ~200 MB .ogv derivative from IA) with VAAPI doing
+# the video encode on the iGPU, so concurrency overlaps the network waits and
+# 4x measurably beats 2x in practice. Keep the pod CPU limit and 50 GiB scratch
+# in lockstep in infra worker.yaml (each in-flight item is ~a few GiB; raise pod
+# CPU so the per-job decode/scale/audio work isn't CFS-throttled at this width).
+_PROCESS_ITEM_LIMIT = 4
 # Scanner is serial by design; per-call rate-limit lives in IA_RATE_PER_SEC.
 _SCAN_LIMIT = 1
-# Two concurrent dispatchers, to actually saturate the two-encode pipeline
+# Four concurrent dispatchers, to actually saturate the four-encode pipeline
 # (_PROCESS_ITEM_LIMIT). Each dispatcher is blocking — it drives one process-item
-# at a time — so it takes two dispatchers to keep two encodes running; a single
-# one only ever reaches 1x. The two share the queue via stage transitions
-# (process-item flips a job to 'downloading' at start, so the other dispatcher
-# stops seeing it). A rare double-pick of the same job is possible in the brief
-# window before that flip, but harmless: upload + Directus writes are idempotent,
-# so the worst case is one wasted re-encode. (If that waste ever matters, claim
-# rows atomically with SELECT ... FOR UPDATE SKIP LOCKED in the dispatcher.)
-_DISPATCH_LIMIT = 2
+# at a time — so it takes N dispatchers to keep N encodes running; a single one
+# only ever reaches 1x. They share the queue via stage transitions (process-item
+# flips a job to 'downloading' at start, so the others stop seeing it). A rare
+# double-pick of the same job is possible in the brief window before that flip;
+# it is harmless (upload + Directus are idempotent) and a completed-on-disk copy
+# is now reused rather than re-fetched, so the worst case is one wasted re-encode.
+# Raising the ceiling does not by itself start N dispatchers — that is still an
+# operational step (launch N dispatch-discovered runs, or add a schedule).
+_DISPATCH_LIMIT = 4
 # Channel assembly is ffmpeg-light (tiny gap segments) but writes shared
 # playlists; one at a time keeps per-channel publishes from racing.
 _BUILD_CHANNEL_LIMIT = 2


### PR DESCRIPTION
## Hold — do not merge yet

Merging rolls the worker (kills the in-flight drain). Land at the next planned roll, ideally **together with #96** (the 416 already-complete-download fix) so one roll picks up both. This PR's dispatcher comment assumes #96's "reuse completed-on-disk copy" behavior.

## What

Bakes in the runtime 2→4 concurrency bump permanently: `_PROCESS_ITEM_LIMIT` and `_DISPATCH_LIMIT` 2 → 4 in `serve.py`. Today's 4× is a runtime global-concurrency-limit override that **reverts to 2 on every worker restart**; this makes 4× the durable default.

## Why

Jobs are download-bound (~200 MB `.ogv` from IA) with VAAPI doing the video encode on the iGPU, so going 4-wide overlaps the network waits. Measured live: `complete` rose **11 → 35 in ~10 min** right after the bump.

## Two caveats (also in the code comments)

1. **This sets the ceiling; it doesn't start 4 dispatchers.** The dispatcher is blocking (one encode each), so 4× still requires launching 4 `dispatch-discovered` runs. After a worker restart you'd have 0 dispatchers until they're launched. Fully hands-off would need either a schedule that keeps N dispatchers running, or a non-blocking dispatcher that fires up to `_PROCESS_ITEM_LIMIT` itself (bigger change; happy to design it).
2. **Pod CPU must keep pace.** The worker pod is currently `cpu limit=4` (infra `worker.yaml`). 4 concurrent works now because the load is download-bound, but to avoid CFS throttling on the per-job decode/scale/audio at this width, bump pod CPU (the `encode-1` node has ~10 idle cores). That's a **separate infra-repo PR** — want me to open it (held) alongside this?

## Tests
Config-only; `ruff` clean, module parses. Behavior validated live (the running 4× drain is this exact configuration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)