### PR TITLE
fix(video-grabber): reclaim per-job scratch (pod eviction / orphans)

### DIFF
--- a/packages/tools/video-grabber/tests/test_flows.py
+++ b/packages/tools/video-grabber/tests/test_flows.py
@@ -186,6 +186,42 @@ def test_process_item_flow_transitions_to_failed_on_download_error():
     assert "failed" in stages
 
 
+def test_process_item_flow_cleans_scratch_on_success():
+    from video_grabber.pipeline import flows
+
+    job = MagicMock(id="job-001", ia_identifier="cnn-sep11-0800")
+    with patch("video_grabber.pipeline.flows.get_job", return_value=job), \
+         patch("video_grabber.pipeline.flows.get_db"), \
+         patch("video_grabber.pipeline.flows.download_item", return_value=MagicMock()), \
+         patch("video_grabber.pipeline.flows.resolve_job", return_value=job), \
+         patch("video_grabber.pipeline.flows.encode_to_hls", return_value=MagicMock()), \
+         patch("video_grabber.pipeline.flows.upload_hls_package", return_value="k"), \
+         patch("video_grabber.pipeline.flows.write_media_item"), \
+         patch("video_grabber.pipeline.flows.transition_job"), \
+         patch("video_grabber.pipeline.flows.shutil.rmtree") as mock_rm, \
+         patch("video_grabber.pipeline.flows.get_run_logger", return_value=MagicMock()):
+        flows.process_item_flow.fn("job-001")
+
+    assert mock_rm.called
+    assert str(mock_rm.call_args[0][0]).endswith("cnn-sep11-0800")
+
+
+def test_process_item_flow_cleans_scratch_on_failure():
+    from video_grabber.pipeline import flows
+
+    job = MagicMock(id="job-001", ia_identifier="cnn-sep11-0800")
+    with patch("video_grabber.pipeline.flows.get_job", return_value=job), \
+         patch("video_grabber.pipeline.flows.get_db"), \
+         patch("video_grabber.pipeline.flows.download_item", side_effect=Exception("boom")), \
+         patch("video_grabber.pipeline.flows.transition_job"), \
+         patch("video_grabber.pipeline.flows.shutil.rmtree") as mock_rm, \
+         patch("video_grabber.pipeline.flows.get_run_logger", return_value=MagicMock()):
+        with pytest.raises(Exception, match="boom"):
+            flows.process_item_flow.fn("job-001")
+
+    assert mock_rm.called  # scratch reclaimed even when the job fails
+
+
 def test_process_item_flow_transitions_through_all_stages():
     from video_grabber.pipeline.flows import process_item_flow
 

--- a/packages/tools/video-grabber/video_grabber/pipeline/flows.py
+++ b/packages/tools/video-grabber/video_grabber/pipeline/flows.py
@@ -7,6 +7,7 @@ PREFECT_API_URL: http://prefect-server.video-grabber.svc.cluster.local:4200/api
 """
 import json
 import os
+import shutil
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -233,6 +234,13 @@ def process_item_flow(job_id: str):
     except Exception as exc:
         transition_job(db, job_id, "failed", from_stage=None, error=str(exc))
         raise
+    finally:
+        # Reclaim the per-job scratch (downloaded source + encoded HLS). Without
+        # this every processed job leaks its files into the 50 GiB scratch
+        # emptyDir until the kubelet evicts the pod for exceeding sizeLimit,
+        # which orphans every in-flight run. Runs on success AND failure; the
+        # source is re-downloadable and the HLS is already uploaded.
+        shutil.rmtree(scratch, ignore_errors=True)
 
 
 def _load_channel(db, channel_id: str):


### PR DESCRIPTION
## Critical — this is what's stalling the drain

The worker pod was **evicted**: `Usage of EmptyDir volume "scratch" exceeds the limit "50Gi"`. `process_item_flow` writes the downloaded source + encoded HLS into `_SCRATCH/<ia_identifier>` and **never deletes it**, so scratch grows every job until the 50 GiB `emptyDir` limit triggers a kubelet eviction. Each eviction **orphans all in-flight runs** (zombie-`Running` in Prefect, stuck mid-stage in the DB). It bites ~every 100 jobs, faster at 4×.

## Fix

`finally: shutil.rmtree(scratch, ignore_errors=True)` in `process_item_flow` — reclaims each job's working dir on success and failure. Safe: the source is re-downloadable and the HLS is already uploaded before cleanup.

## Tests
`tests/test_flows.py` 21 passed — added cleanup-on-success and cleanup-on-failure cases. `ruff` clean.

## Merge context
This is the highest-priority of the held PRs — without it any sustained drain re-evicts. Land it with **#96** (416 fix), **#97** (durable 4×), and infra **#7** (pod CPU) in one worker roll, then recover the orphaned mid-stage jobs and re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)