### PR TITLE
fix(streamer): chunk cache warm/resync pipelines (Redis write timeout)

### DIFF
--- a/packages/backend/internal/cache/listen.go
+++ b/packages/backend/internal/cache/listen.go
@@ -131,12 +131,18 @@ func resync(ctx context.Context, rdb *goredis.Client, pool *pgxpool.Pool, logger
 	}
 
 	pipe := rdb.Pipeline()
+	n := 0
 	removed := 0
 	for _, id := range cacheIDs {
 		if _, ok := liveIDs[id]; !ok {
 			pipe.HDel(ctx, keyItems, id)
 			pipe.ZRem(ctx, keyByStart, id)
 			removed++
+			n++
+			var err error
+			if pipe, err = flushIfFull(ctx, rdb, pipe, n); err != nil {
+				return fmt.Errorf("pipeline exec: %w", err)
+			}
 		}
 	}
 	for _, it := range liveItems {
@@ -147,6 +153,10 @@ func resync(ctx context.Context, rdb *goredis.Client, pool *pgxpool.Pool, logger
 		id := strconv.Itoa(it.ID)
 		pipe.HSet(ctx, keyItems, id, data)
 		pipe.ZAdd(ctx, keyByStart, goredis.Z{Score: float64(it.StartDate.Unix()), Member: id})
+		n++
+		if pipe, err = flushIfFull(ctx, rdb, pipe, n); err != nil {
+			return fmt.Errorf("pipeline exec: %w", err)
+		}
 	}
 	if _, err := pipe.Exec(ctx); err != nil {
 		return fmt.Errorf("pipeline exec: %w", err)

--- a/packages/backend/internal/cache/pager.go
+++ b/packages/backend/internal/cache/pager.go
@@ -38,6 +38,7 @@ func WarmPagerCache(ctx context.Context, rdb *goredis.Client, pool *pgxpool.Pool
 	}
 
 	pipe := rdb.Pipeline()
+	count := 0
 	for _, it := range items {
 		data, err := json.Marshal(it)
 		if err != nil {
@@ -49,6 +50,10 @@ func WarmPagerCache(ctx context.Context, rdb *goredis.Client, pool *pgxpool.Pool
 			Score:  float64(it.StartDate.Unix()),
 			Member: id,
 		})
+		count++
+		if pipe, err = flushIfFull(ctx, rdb, pipe, count); err != nil {
+			return fmt.Errorf("pipeline exec: %w", err)
+		}
 	}
 	if _, err := pipe.Exec(ctx); err != nil {
 		return fmt.Errorf("pipeline exec: %w", err)

--- a/packages/backend/internal/cache/pager_listen.go
+++ b/packages/backend/internal/cache/pager_listen.go
@@ -155,12 +155,18 @@ func resyncPager(ctx context.Context, rdb *goredis.Client, pool *pgxpool.Pool, l
 	}
 
 	pipe := rdb.Pipeline()
+	n := 0
 	removed := 0
 	for _, id := range cacheIDs {
 		if _, ok := liveIDs[id]; !ok {
 			pipe.HDel(ctx, keyPagerItems, id)
 			pipe.ZRem(ctx, keyPagerByStart, id)
 			removed++
+			n++
+			var err error
+			if pipe, err = flushIfFull(ctx, rdb, pipe, n); err != nil {
+				return fmt.Errorf("pipeline exec: %w", err)
+			}
 		}
 	}
 	for _, it := range liveItems {
@@ -171,6 +177,10 @@ func resyncPager(ctx context.Context, rdb *goredis.Client, pool *pgxpool.Pool, l
 		id := strconv.Itoa(it.ID)
 		pipe.HSet(ctx, keyPagerItems, id, data)
 		pipe.ZAdd(ctx, keyPagerByStart, goredis.Z{Score: float64(it.StartDate.Unix()), Member: id})
+		n++
+		if pipe, err = flushIfFull(ctx, rdb, pipe, n); err != nil {
+			return fmt.Errorf("pipeline exec: %w", err)
+		}
 	}
 	if _, err := pipe.Exec(ctx); err != nil {
 		return fmt.Errorf("pipeline exec: %w", err)

--- a/packages/backend/internal/cache/pager_test.go
+++ b/packages/backend/internal/cache/pager_test.go
@@ -2,10 +2,13 @@ package cache
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
 	"classicy/streamer/internal/model"
+
+	goredis "github.com/redis/go-redis/v9"
 )
 
 func TestUpsertPagerThenPagerItemsAt(t *testing.T) {
@@ -62,6 +65,37 @@ func TestForgetPagerRemovesItem(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Fatalf("expected no items after ForgetPager, got %+v", got)
+	}
+}
+
+// flushIfFull must flush at every chunk boundary and the caller's trailing
+// Exec must persist the remainder — across a count that is not a chunk multiple,
+// every item is written exactly once.
+func TestFlushIfFullWritesAllAcrossChunks(t *testing.T) {
+	rdb, done := newTestRedis(t)
+	defer done()
+	ctx := context.Background()
+
+	total := pipelineChunk*2 + 37 // spans two full chunks plus a partial remainder
+	pipe := rdb.Pipeline()
+	for i := 0; i < total; i++ {
+		pipe.HSet(ctx, keyPagerItems, strconv.Itoa(i), "x")
+		pipe.ZAdd(ctx, keyPagerByStart, goredis.Z{Score: float64(i), Member: strconv.Itoa(i)})
+		var err error
+		if pipe, err = flushIfFull(ctx, rdb, pipe, i+1); err != nil {
+			t.Fatalf("flushIfFull at %d: %v", i, err)
+		}
+	}
+	if _, err := pipe.Exec(ctx); err != nil {
+		t.Fatalf("final Exec: %v", err)
+	}
+
+	n, err := rdb.ZCard(ctx, keyPagerByStart).Result()
+	if err != nil {
+		t.Fatalf("ZCard: %v", err)
+	}
+	if n != int64(total) {
+		t.Fatalf("expected %d members, got %d", total, n)
 	}
 }
 

--- a/packages/backend/internal/cache/redis.go
+++ b/packages/backend/internal/cache/redis.go
@@ -20,6 +20,24 @@ const (
 	keyByStart = "media:by_start" // ZSET  score=unix_start, member=id
 )
 
+// pipelineChunk bounds how many items we buffer into a single Redis pipeline
+// before flushing. Warm/resync touch the full dataset (hundreds of thousands of
+// rows × 2 commands each); one giant Exec exceeds the client write timeout, so
+// we flush in chunks. See flushIfFull.
+const pipelineChunk = 2000
+
+// flushIfFull executes and replaces pipe once count is a non-zero multiple of
+// pipelineChunk. Returns the pipe to keep using (a fresh one after a flush).
+func flushIfFull(ctx context.Context, rdb *goredis.Client, pipe goredis.Pipeliner, count int) (goredis.Pipeliner, error) {
+	if count > 0 && count%pipelineChunk == 0 {
+		if _, err := pipe.Exec(ctx); err != nil {
+			return nil, err
+		}
+		return rdb.Pipeline(), nil
+	}
+	return pipe, nil
+}
+
 // Connect parses a Redis URL and returns a client.
 func Connect(url string) *goredis.Client {
 	opt, err := goredis.ParseURL(url)
@@ -44,6 +62,7 @@ func WarmCache(ctx context.Context, rdb *goredis.Client, pool *pgxpool.Pool, log
 	}
 
 	pipe := rdb.Pipeline()
+	count := 0
 	for _, it := range items {
 		data, err := json.Marshal(it)
 		if err != nil {
@@ -55,6 +74,10 @@ func WarmCache(ctx context.Context, rdb *goredis.Client, pool *pgxpool.Pool, log
 			Score:  float64(it.StartDate.Unix()),
 			Member: id,
 		})
+		count++
+		if pipe, err = flushIfFull(ctx, rdb, pipe, count); err != nil {
+			return fmt.Errorf("pipeline exec: %w", err)
+		}
 	}
 	if _, err := pipe.Exec(ctx); err != nil {
 		return fmt.Errorf("pipeline exec: %w", err)


### PR DESCRIPTION
## Why
After #100 deployed, the new streamer logged:
- `pager cache warm failed; pager channel disabled … i/o timeout`
- media `notify listener disconnected … resync: pipeline exec: … i/o timeout`

Root cause (pre-existing, exposed by the 447k-row pager warm): `WarmCache` / `WarmPagerCache` / `resync` / `resyncPager` buffer the **entire** dataset into one `pipeline.Exec()`. At 447k rows that's ~900k commands in a single Redis write, exceeding the client write timeout. The media cache was even left partially warm (219k of ~457k) from the same issue.

## Fix
Flush the pipeline every `pipelineChunk` (2000) items via a small `flushIfFull` helper — bounds each `Exec` to ~4k commands. Trailing `Exec` persists the remainder.

`TestFlushIfFullWritesAllAcrossChunks` covers the boundary + remainder (2×chunk+37 items → all present).

Follow-up to #100; unblocks the pager channel and a clean media resync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)