### PR TITLE
fix(streamer): pager snapshot is forward-only (requested second, no lookback)

### DIFF
--- a/packages/backend/SPEC.md
+++ b/packages/backend/SPEC.md
@@ -90,11 +90,13 @@ The frontend at [911realtime.org](https://911realtime.org) lets users pick any m
   **opt-in**: a session receives no pager items until it subscribes.
 - `{"type":"subscribe","channel":"pager"}` opts the session in and replies
   `{"type":"subscribe_ack","channel":"pager"}`. If the session already has a virtual time, the
-  server immediately delivers a snapshot — the 5-minute pager lookback at the current virtual
-  time — as a `pager` frame.
+  server delivers a snapshot of just the requested second `[t, t+1s)` as a `pager` frame.
+- Pager is **forward-only**: the snapshot never looks backward (subscribing does not dump prior
+  traffic) and is never a bulk future window (so the client renders pages paced by the clock, not
+  all at once). Everything after `t` arrives second-by-second via the tick path.
 - While subscribed, each tick that produces ≥ 1 pager item (via `cache.PagerItemsAt`, Redis-only
   on the tick path) sends `{"type":"pager","time":"…","pager":[…]}`. Empty seconds send nothing.
-- `init` and `seek` additionally deliver a pager snapshot when the session is subscribed.
+- `init` and `seek` additionally deliver the requested-second pager snapshot when subscribed.
 - `{"type":"unsubscribe","channel":"pager"}` stops delivery and replies
   `{"type":"unsubscribe_ack","channel":"pager"}`.
 - `"pager"` is currently the only valid channel; any other value yields an `error`. Subscriptions

--- a/packages/backend/docs/data-model.md
+++ b/packages/backend/docs/data-model.md
@@ -111,7 +111,7 @@ media tick path, and delivers it only to sessions that `subscribe` to the `pager
 | Column         | Type        | Required | Streamer use                                                       |
 | -------------- | ----------- | -------- | ------------------------------------------------------------------ |
 | `id`           | int         | yes      | Stable identity, Redis HASH key in `pager:items`.                  |
-| `start_date`   | timestamptz | yes      | Redis ZSET score; 5-minute lookback window on subscribe/init/seek. |
+| `start_date`   | timestamptz | yes      | Redis ZSET score; forward-only delivery (snapshot is the requested second only). |
 | `provider`     | text        | no       | Pager network name.                                                |
 | `recipient_id` | text        | no       | Destination capcode/ID.                                            |
 | `id_type`      | text        | no       | Recipient ID classification.                                       |

--- a/packages/backend/docs/websocket-protocol.md
+++ b/packages/backend/docs/websocket-protocol.md
@@ -162,9 +162,10 @@ Response:
 ```
 
 Pager items live in their own table and are **not** delivered by default. After subscribing, the
-server delivers them on the `pager` channel: an immediate snapshot (the 5-minute lookback window
-at the current virtual time, if the session has been `init`ed) followed by one `pager` frame per
-virtual second that produces pager traffic.
+server delivers them on the `pager` channel: an immediate snapshot of just the requested second
+`[t, t+1s)` (if the session has been `init`ed) followed by one `pager` frame per virtual second
+that produces pager traffic. Delivery is **forward-only** — no backward lookback, and never a bulk
+future window — so the client renders pages paced by the virtual clock rather than all at once.
 
 `"pager"` is currently the only valid channel; any other value yields
 `{"type":"error","message":"unknown channel \"…\""}`. (News, MP3, and HTML channels are planned.)

--- a/packages/backend/internal/db/postgres.go
+++ b/packages/backend/internal/db/postgres.go
@@ -105,16 +105,19 @@ func PagerItemByID(ctx context.Context, pool *pgxpool.Pool, id int) (*model.Page
 	return &items[0], nil
 }
 
-// CurrentPagerItems returns approved pager items whose start_date falls within
-// the 5-minute lookback window [t-5m, t]. Pager items are instant, so this is
-// the pager equivalent of CurrentItems and is used by the init/seek/subscribe
-// snapshot paths.
+// CurrentPagerItems returns approved pager items in the single requested second
+// [t, t+1s), used by the init/seek/subscribe snapshot paths. Pager is delivered
+// forward-only: no backward lookback (so subscribing doesn't dump prior traffic)
+// and no bulk future window (so the client renders messages paced by the tick,
+// not all at once). Everything after t arrives second-by-second via the 1 Hz
+// tick path (cache.PagerItemsAt); this snapshot just covers the boundary second
+// the first tick would otherwise skip.
 func CurrentPagerItems(ctx context.Context, pool *pgxpool.Pool, t time.Time) ([]model.PagerItem, error) {
 	return queryPagerItems(ctx, pool,
 		pagerSelectFrom+`
 		 WHERE pi.approved = 1
-		   AND pi.start_date <= $1
-		   AND pi.start_date >= $1 - INTERVAL '5 minutes'
+		   AND pi.start_date >= $1
+		   AND pi.start_date < $1 + INTERVAL '1 second'
 		 ORDER BY pi.start_date`, t)
 }
 


### PR DESCRIPTION
## Why
Per feedback: pager should stream **forward** from the requested time, not backward, and must not dump a batch the PagerDecoder then renders all at once.

The subscribe/init/seek snapshot (`db.CurrentPagerItems`) used a 5-minute **backward** lookback — at peak 9/11 traffic that's ~1,967 pages in a single ~1.2MB frame, which the decoder tried to animate simultaneously.

## Fix
Narrow `CurrentPagerItems` to the single requested second `[t, t+1s)`:
- no backward lookback (subscribing no longer dumps prior traffic)
- no bulk future window (no "display everything at once")

The 1 Hz tick path (`cache.PagerItemsAt`) already streams everything after `t` second-by-second; the snapshot now only covers the boundary second the first tick would skip. Docs (SPEC / websocket-protocol / data-model) updated.

Follow-up to #100/#101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)