### PR TITLE
fix(browser): show the de-proxied URL in the address bar

### DIFF
--- a/packages/frontend/src/Applications/Browser/browserUtils.test.ts
+++ b/packages/frontend/src/Applications/Browser/browserUtils.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { normalizeUrl, stripProxyUrl } from "./browserUtils";
+
+const HOST = "timemachine.911realtime.org";
+
+describe("stripProxyUrl", () => {
+	it("strips the TimeMachine /web/<url> path wrapper", () => {
+		expect(
+			stripProxyUrl(
+				"https://timemachine.911realtime.org/web/http://www.cnn.com/WEATHER/",
+				HOST,
+			),
+		).toBe("http://www.cnn.com/WEATHER/");
+	});
+
+	it("strips an archive.org-style /web/<timestamp>/<url> wrapper", () => {
+		expect(
+			stripProxyUrl(
+				"https://timemachine.911realtime.org/web/20010912000000/http://www.cnn.com/",
+				HOST,
+			),
+		).toBe("http://www.cnn.com/");
+	});
+
+	it("extracts the original from the ?url= query form", () => {
+		expect(
+			stripProxyUrl(
+				`https://timemachine.911realtime.org/?url=${encodeURIComponent("http://www.cnn.com/WEATHER/")}&time=20010912000000`,
+				HOST,
+			),
+		).toBe("http://www.cnn.com/WEATHER/");
+	});
+
+	it("leaves a non-proxy URL unchanged", () => {
+		expect(stripProxyUrl("http://www.cnn.com/WEATHER/", HOST)).toBe(
+			"http://www.cnn.com/WEATHER/",
+		);
+	});
+
+	it("leaves a proxy-host URL with no embedded target unchanged", () => {
+		expect(stripProxyUrl("https://timemachine.911realtime.org/about", HOST)).toBe(
+			"https://timemachine.911realtime.org/about",
+		);
+	});
+
+	it("returns non-URL input unchanged", () => {
+		expect(stripProxyUrl("not a url", HOST)).toBe("not a url");
+	});
+
+	it("preserves query strings and fragments on the original URL", () => {
+		expect(
+			stripProxyUrl(
+				"https://timemachine.911realtime.org/web/http://www.cnn.com/search?q=news#top",
+				HOST,
+			),
+		).toBe("http://www.cnn.com/search?q=news#top");
+	});
+});
+
+describe("normalizeUrl", () => {
+	it("drops www and trailing slash", () => {
+		expect(normalizeUrl("http://www.cnn.com/")).toBe("http://cnn.com");
+	});
+});

--- a/packages/frontend/src/Applications/Browser/browserUtils.ts
+++ b/packages/frontend/src/Applications/Browser/browserUtils.ts
@@ -1,3 +1,35 @@
+/**
+ * Strip a TimeMachine/archive proxy wrapper from a URL, returning the original
+ * target so the address bar and history hold clean URLs (not proxy URLs).
+ *
+ * Handles the proxy URL shapes the proxy emits when it rewrites page links:
+ *   - <proxyHost>/…?url=<encoded original>&time=…   (query-param form)
+ *   - <proxyHost>/web/<timestamp>/<original>         (archive.org style)
+ *   - <proxyHost>/web/<original>                     (TimeMachine style)
+ *
+ * Returns the input unchanged if it is not a proxy URL for proxyHost.
+ */
+export const stripProxyUrl = (url: string, proxyHost: string): string => {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return url;
+	}
+	if (parsed.hostname !== proxyHost) return url;
+
+	// Query-param form: …?url=<encoded original>
+	const queryUrl = parsed.searchParams.get("url");
+	if (queryUrl) return queryUrl;
+
+	// Path form: /web/<original> or /web/<timestamp>/<original>. Match the full
+	// string so the embedded scheme's "://" survives URL pathname parsing.
+	const match = url.match(/\/web\/(?:\d+\*?\/)?(https?:\/\/.+)$/i);
+	if (match) return match[1];
+
+	return url;
+};
+
 export const normalizeUrl = (u: string): string => {
 	try {
 		const parsed = new URL(u);

--- a/packages/frontend/src/Applications/Browser/useBrowserNavigation.ts
+++ b/packages/frontend/src/Applications/Browser/useBrowserNavigation.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { normalizeUrl } from "./browserUtils";
+import { normalizeUrl, stripProxyUrl } from "./browserUtils";
 
 export const DEFAULT_PROXY_ON = true;
 export const DEFAULT_PROXY_PROTOCOL = import.meta.env.VITE_PROXY_PROTOCOL ?? "http:";
@@ -53,8 +53,8 @@ const extractOriginalUrl = (href: string, proxyHost: string): string | null => {
 		/* not a valid URL, fall through */
 	}
 
-	// Archive.org link — extract the original URL after the timestamp
-	const match = href.match(/\/web\/\d+\*?\/(.+)/);
+	// Path-form proxy link: /web/<original> or /web/<timestamp>/<original>.
+	const match = href.match(/\/web\/(?:\d+\*?\/)?(https?:\/\/.+)$/i);
 	return match ? match[1] : null;
 };
 
@@ -296,7 +296,10 @@ export const useBrowserNavigation = ({
 	}, []);
 
 	const navigateTo = useCallback(
-		(url: string) => {
+		(rawUrl: string) => {
+			// De-proxy first so history, the address bar, and the fetch all use the
+			// original URL — proxy-rewritten links resolve to <proxyHost>/web/<url>.
+			const url = stripProxyUrl(rawUrl, proxyHost);
 			// Skip if already on this page (normalize trailing slash and www.)
 			setHistory((h) => {
 				const idx = historyIndexRef.current;
@@ -312,7 +315,7 @@ export const useBrowserNavigation = ({
 			onRecordVisit(url);
 			fetchPage(url);
 		},
-		[fetchPage, onRecordVisit],
+		[fetchPage, onRecordVisit, proxyHost],
 	);
 
 	// Stable refs so handleContentClick doesn't churn


### PR DESCRIPTION
## Why
The address bar showed proxy URLs like `https://timemachine.911realtime.org/web/http://www.cnn.com/WEATHER/` instead of `http://www.cnn.com/WEATHER/`.

The proxy rewrites in-page links to `<proxyHost>/web/<original>`. `extractOriginalUrl` only recognized the `?url=` query form and the archive.org `/web/<timestamp>/<url>` form, so a `/web/<url>` link fell through `handleContentClick` and the **full proxy URL** was navigated to — landing in the address bar and getting double-proxied on the next fetch.

## Fix
- New exported `stripProxyUrl(url, proxyHost)` in `browserUtils.ts` handling all three proxy shapes (`?url=`, `/web/<timestamp>/<url>`, `/web/<url>`).
- De-proxy at the single `navigateTo` chokepoint, so **history, the address bar, and the fetch** all use the original URL.
- Teach `extractOriginalUrl` the no-timestamp `/web/<url>` form so clicked proxy links extract at the right place.

## Tests
8 new `browserUtils.test.ts` cases (all proxy shapes, non-proxy passthrough, query/fragment preservation, invalid input). Frontend `tsc -b` + `eslint` + 45 vitest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)