### PR TITLE
feat(streamer): MessagePack binary wire (server→client /stream)

### DIFF
--- a/packages/backend/CLAUDE.md
+++ b/packages/backend/CLAUDE.md
@@ -50,6 +50,7 @@ Each `Session` also runs two more goroutines under the WebSocket handler: a `wri
 6. **All times are UTC `time.Time`.** Wire format is RFC3339 (or one of the fallbacks in `parseTime`). Never compare formatted strings; always parse first.
 7. **Nullable text columns are `*string` at scan time.** Directus emits `NULL` for empty strings; pgx cannot scan `NULL` into a non-pointer string. Use `derefStr` like `queryItems` already does — don't shortcut to `&it.Field` directly.
 8. **No backwards-compat shims.** This service has one consumer (the frontend in `packages/frontend/`). If you change the wire protocol, update the frontend in the same commit; do not add `if msg.Version == "v1"` branches.
+   - **The wire is split by direction.** Server→client frames are **binary MessagePack** (`websocket.BinaryMessage`); `send_` encodes via `encodeMsg` (msgpack with `SetCustomStructTag("json")`, so the json tags stay the wire field names and `time.Time` rides the timestamp ext). Client→server frames stay **JSON text** (`json.Unmarshal` in `ws.go`). Don't reintroduce text output (`websocket.TextMessage` / `json.Marshal` on the outbound path), and don't flip inbound to binary — the asymmetry is intentional (the win is the 1 Hz item fan-out; control frames are tiny). See [`docs/websocket-protocol.md`](./docs/websocket-protocol.md).
 
 ---
 

--- a/packages/backend/docs/websocket-protocol.md
+++ b/packages/backend/docs/websocket-protocol.md
@@ -1,12 +1,27 @@
 # WebSocket protocol
 
-Wire-level reference for `/stream`. All frames are JSON-encoded text frames. Binary frames are not used.
+Wire-level reference for `/stream`. The protocol is **split by direction**:
+
+- **Server → client** frames are **binary MessagePack** (`websocket.BinaryMessage`). `time.Time`
+  fields are encoded with the msgpack timestamp extension; everything else uses the existing `json:`
+  struct tags as field names (via `Encoder.SetCustomStructTag("json")`), so the wire keys are
+  identical to the previous JSON encoding. There is no version handshake — the single consumer
+  (`packages/frontend/`) decodes binary unconditionally (CLAUDE.md hard rule #8).
+- **Client → server** frames stay **JSON-encoded text frames** — they are tiny and infrequent, so
+  binary buys nothing. The read loop ignores frame type and unmarshals JSON.
+
+The JSON shapes shown below describe the **logical** payload of each frame. Server→client examples
+are the decoded form; on the wire they are MessagePack, with timestamps as the binary ext rather
+than RFC3339 strings (the client's extension codec decodes them back to ISO strings).
 
 ---
 
 ## Connection
 
 Endpoint: `ws://host:8080/stream` (plain WS) or `wss://…` behind TLS termination.
+
+A browser client must set `ws.binaryType = "arraybuffer"` synchronously at construction so inbound
+binary frames arrive as `ArrayBuffer` (not `Blob`) before the first frame can be delivered.
 
 The handshake currently accepts every origin (`CheckOrigin: func(r) bool { return true }` in `internal/handler/ws.go`). Lock this down at the reverse proxy in production — there is no per-connection auth.
 
@@ -50,7 +65,10 @@ All unknown `type` values produce an `error` reply but do not terminate the sess
 | `mp3`             | `time`, `items[]`             | mp3/Radio snapshot (items active at `t`) and each tick that produces ≥ 1 mp3 item while subscribed. Reuses the `items` field. |
 | `error`           | `message`                     | Reply to a malformed or unrecognised request.          |
 
-All `time` values are RFC3339 UTC (e.g. `"2001-09-11T08:46:00Z"`). `items[]` and `pager[]` are documented in [`data-model.md`](./data-model.md).
+The frame-level `time` field is a string (RFC3339 UTC, e.g. `"2001-09-11T08:46:00Z"`) in both the
+logical and wire forms. The `time.Time` date fields **inside** `items[]`/`pager[]` (`start_date`,
+`end_date`) ride the binary msgpack timestamp ext on the wire and decode to ISO strings on the
+client. `items[]` and `pager[]` are documented in [`data-model.md`](./data-model.md).
 
 ---
 

--- a/packages/backend/go.mod
+++ b/packages/backend/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/redis/go-redis/v9 v9.20.1
+	github.com/vmihailenco/msgpack/v5 v5.4.1
 )
 
 require (
@@ -14,6 +15,7 @@ require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/sync v0.18.0 // indirect

--- a/packages/backend/go.sum
+++ b/packages/backend/go.sum
@@ -30,6 +30,10 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
+github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=

--- a/packages/backend/internal/handler/ws.go
+++ b/packages/backend/internal/handler/ws.go
@@ -67,7 +67,7 @@ func NewWSHandler(hub *session.Hub, rdb *goredis.Client, pool *pgxpool.Pool, log
 					return
 				case msg := <-sess.Send():
 					conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
-					if err := conn.WriteMessage(websocket.TextMessage, msg); err != nil {
+					if err := conn.WriteMessage(websocket.BinaryMessage, msg); err != nil {
 						sess.Close()
 						return
 					}

--- a/packages/backend/internal/session/session.go
+++ b/packages/backend/internal/session/session.go
@@ -1,10 +1,10 @@
 package session
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"log/slog"
 	"sync"
 	"time"
@@ -13,6 +13,7 @@ import (
 	"classicy/streamer/internal/model"
 
 	goredis "github.com/redis/go-redis/v9"
+	"github.com/vmihailenco/msgpack/v5"
 )
 
 const (
@@ -282,6 +283,21 @@ func (s *Session) RunTimePump() {
 	}
 }
 
+// encodeMsg serialises an outbound envelope as a MessagePack binary frame.
+// SetCustomStructTag("json") reuses the existing json: struct tags as msgpack
+// field names, so the wire keys (and the frontend TS interfaces) stay identical.
+// time.Time fields encode as the msgpack timestamp extension; the client decodes
+// them back to ISO strings.
+func encodeMsg(m outMsg) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := msgpack.NewEncoder(&buf)
+	enc.SetCustomStructTag("json")
+	if err := enc.Encode(m); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
 func (s *Session) send_(m outMsg) {
 	// Don't write to a closed session.
 	select {
@@ -290,7 +306,7 @@ func (s *Session) send_(m outMsg) {
 	default:
 	}
 
-	data, err := json.Marshal(m)
+	data, err := encodeMsg(m)
 	if err != nil {
 		return
 	}

--- a/packages/backend/internal/session/session_test.go
+++ b/packages/backend/internal/session/session_test.go
@@ -1,13 +1,15 @@
 package session
 
 import (
-	"encoding/json"
+	"bytes"
 	"io"
 	"log/slog"
 	"testing"
 	"time"
 
 	"classicy/streamer/internal/model"
+
+	"github.com/vmihailenco/msgpack/v5"
 )
 
 func newTestSession(t *testing.T) *Session {
@@ -23,8 +25,10 @@ func recvType(t *testing.T, s *Session) outMsg {
 	select {
 	case data := <-s.send:
 		var m outMsg
-		if err := json.Unmarshal(data, &m); err != nil {
-			t.Fatalf("unmarshal outbound: %v", err)
+		dec := msgpack.NewDecoder(bytes.NewReader(data))
+		dec.SetCustomStructTag("json")
+		if err := dec.Decode(&m); err != nil {
+			t.Fatalf("decode outbound: %v", err)
 		}
 		return m
 	default:

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -17,6 +17,7 @@
 		"proxy:down": "cd timemachine && docker compose down"
 	},
 	"dependencies": {
+		"@msgpack/msgpack": "^3.1.3",
 		"audiomotion-analyzer": "^4.5.4",
 		"classicy": "latest",
 		"classnames": "^2.5.1",

--- a/packages/frontend/src/Providers/MediaStream/MediaStreamProvider.tsx
+++ b/packages/frontend/src/Providers/MediaStream/MediaStreamProvider.tsx
@@ -12,6 +12,7 @@ import {
 	type MediaItem,
 	type PagerItem,
 } from "./MediaStreamContext";
+import { decodeWireMessage } from "./wireCodec";
 
 // Instant items (start_date = end_date or calc_duration = 0) are kept for
 // this many milliseconds after their start time before being pruned.
@@ -205,6 +206,9 @@ export const MediaStreamProvider: FC<MediaStreamProviderProps> = ({
 		let active = true;
 		let heartbeatId: ReturnType<typeof setInterval>;
 		const ws = new WebSocket(WS_URL);
+		// Must be set synchronously at construction (not in onopen) so the first
+		// binary frame arrives as an ArrayBuffer, not a Blob.
+		ws.binaryType = "arraybuffer";
 		wsRef.current = ws;
 
 		ws.onopen = () => {
@@ -240,11 +244,11 @@ export const MediaStreamProvider: FC<MediaStreamProviderProps> = ({
 			}, HEARTBEAT_INTERVAL_MS);
 		};
 
-		ws.onmessage = (event: MessageEvent<string>) => {
+		ws.onmessage = (event: MessageEvent<ArrayBuffer>) => {
 			if (!active) return;
 			let msg: WsIncomingMessage;
 			try {
-				msg = JSON.parse(event.data) as WsIncomingMessage;
+				msg = decodeWireMessage<WsIncomingMessage>(event.data);
 			} catch {
 				return;
 			}

--- a/packages/frontend/src/Providers/MediaStream/wireCodec.test.ts
+++ b/packages/frontend/src/Providers/MediaStream/wireCodec.test.ts
@@ -1,0 +1,75 @@
+import { encode } from "@msgpack/msgpack";
+import { describe, expect, it } from "vitest";
+import { decodeWireMessage } from "./wireCodec";
+
+// Mirror the server path: Go encodes time.Time as the msgpack timestamp
+// extension. msgpack's default encoder does the same for a JS Date, so encoding
+// a Date here produces the exact ext bytes the backend emits.
+function frame(obj: unknown): ArrayBuffer {
+	const bytes = encode(obj);
+	return bytes.buffer.slice(
+		bytes.byteOffset,
+		bytes.byteOffset + bytes.byteLength,
+	) as ArrayBuffer;
+}
+
+describe("decodeWireMessage", () => {
+	it("decodes a timestamp extension to an ISO string", () => {
+		const at = new Date("2001-09-11T15:26:00Z");
+		const decoded = decodeWireMessage<{ time: string }>(frame({ time: at }));
+		expect(decoded.time).toBe("2001-09-11T15:26:00.000Z");
+		// Same instant must compare equal — instant-item detection relies on this.
+		expect(new Date(decoded.time).getTime()).toBe(at.getTime());
+	});
+
+	it("decodes a full items frame to the expected object", () => {
+		const start = new Date("2001-09-11T15:26:00Z");
+		const decoded = decodeWireMessage<{
+			type: string;
+			time: string;
+			items: Array<{
+				id: number;
+				title: string;
+				start_date: string;
+				end_date: string;
+				format: string;
+			}>;
+		}>(
+			frame({
+				type: "items",
+				time: start,
+				items: [
+					{
+						id: 5821,
+						title: "ID Rountree",
+						start_date: start,
+						end_date: start,
+						format: "mp3",
+					},
+				],
+			}),
+		);
+
+		expect(decoded.type).toBe("items");
+		expect(decoded.items).toHaveLength(1);
+		const item = decoded.items[0];
+		expect(item.id).toBe(5821);
+		expect(item.title).toBe("ID Rountree");
+		expect(typeof item.start_date).toBe("string");
+		// start_date === end_date is the instant-item signal the provider checks.
+		expect(item.start_date).toBe(item.end_date);
+	});
+
+	it("preserves numeric and string field types across the wire", () => {
+		const decoded = decodeWireMessage<{
+			id: number;
+			volume: number;
+			url: string;
+			approved: number;
+		}>(frame({ id: 42, volume: 0.5, url: "x.mp3", approved: 1 }));
+		expect(decoded.id).toBe(42);
+		expect(decoded.volume).toBeCloseTo(0.5);
+		expect(decoded.url).toBe("x.mp3");
+		expect(decoded.approved).toBe(1);
+	});
+});

--- a/packages/frontend/src/Providers/MediaStream/wireCodec.ts
+++ b/packages/frontend/src/Providers/MediaStream/wireCodec.ts
@@ -1,0 +1,29 @@
+import {
+	decode,
+	decodeTimestampToTimeSpec,
+	EXT_TIMESTAMP,
+	ExtensionCodec,
+} from "@msgpack/msgpack";
+
+// Server→client frames are MessagePack binary (client→server stays JSON text).
+// Go encodes time.Time as the msgpack timestamp extension; we override that ext
+// to return an ISO string so the decoded shape matches the TS interfaces exactly
+// (MediaItem.start_date/end_date stay string-typed, and the provider's
+// `start_date === end_date` instant check + `new Date(...)` calls keep working).
+// A fresh ExtensionCodec carries no built-in registrations, so registering
+// EXT_TIMESTAMP here is what gives us timestamp decoding at all.
+export const extensionCodec = new ExtensionCodec();
+extensionCodec.register({
+	type: EXT_TIMESTAMP,
+	encode: () => null, // client never encodes binary
+	decode: (data: Uint8Array): string => {
+		const { sec, nsec } = decodeTimestampToTimeSpec(data);
+		return new Date(sec * 1000 + Math.floor(nsec / 1e6)).toISOString();
+	},
+});
+
+// decodeWireMessage turns a raw binary frame into its decoded object. Timestamps
+// arrive as ISO strings (see the extension codec above).
+export function decodeWireMessage<T = unknown>(data: ArrayBuffer): T {
+	return decode(new Uint8Array(data), { extensionCodec }) as T;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
 
   packages/frontend:
     dependencies:
+      '@msgpack/msgpack':
+        specifier: ^3.1.3
+        version: 3.1.3
       audiomotion-analyzer:
         specifier: ^4.5.4
         version: 4.5.4
@@ -768,6 +771,10 @@ packages:
       react: '>= 18 || >= 19'
       react-dom: '>= 18 || >= 19'
 
+  '@msgpack/msgpack@3.1.3':
+    resolution: {integrity: sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==}
+    engines: {node: '>= 18'}
+
   '@mux/mux-data-google-ima@0.3.16':
     resolution: {integrity: sha512-ZJm/qV7pTfEKe9WDZYF1gixofyZeX5M8Bnzpzqpvk7lAKOxa2fC+nnKEQpYATdNd9s9aOe6kmSZWMRcXqlS6KQ==}
 
@@ -838,36 +845,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -1316,36 +1329,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
@@ -2266,24 +2285,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2748,48 +2771,56 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: glibc
 
   sass-embedded-linux-arm@1.100.0:
     resolution: {integrity: sha512-9Ul7O1eKrc5YlhwWjkp8tZPSe3UEwSZ1uwUZOQom1HL0pRlBA6F/IlGZYFTLwnHMIP1fc77MMNaBRfc05mKMpw==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: glibc
 
   sass-embedded-linux-musl-arm64@1.100.0:
     resolution: {integrity: sha512-XpACJB2KjSLjf2e9uuvGVdOURsoNrFqgRiihhXyUHK9W0t3LIHb7z5MA/7XGPIT9bWSOO2zyw+rH/FHtDV/Yrg==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-musl-arm@1.100.0:
     resolution: {integrity: sha512-sl0JgbGloPyJg66XXx5UDSDScZ0oU85DpMQU4JU/sCUCFj1Z8zZ69SJWKTCNE4/jwnce7WI2zPCV5AG+RHOZJw==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-musl-riscv64@1.100.0:
     resolution: {integrity: sha512-ShvI0Kx04mwoCARwZ0UjiT97isQvzO80tAt91zmFyHLN9kelc/IrQi940farSm2xQVPCKdeVyeG0ekBsokSpYQ==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-musl-x64@1.100.0:
     resolution: {integrity: sha512-TDBCRWNuS4RDLQXvRc1gjZlWiWTWaWGp0Bwu/IKwJxov81lsvrCs3TihTyNXtW7V5aoN4Ky3r0QOkNb3mwmBnA==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-riscv64@1.100.0:
     resolution: {integrity: sha512-j4ENJGOheO+fm3j/yorLxCjBP6/XskrZx7dTLlT+lXYwN/qqCqoA/gsNLI0McS3DFM6GBwPiffzWsdWS8t6sEQ==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
+    libc: glibc
 
   sass-embedded-linux-x64@1.100.0:
     resolution: {integrity: sha512-0vUSN8j0WGtCJIOPh//EmUvYGHW0QOe5iul8qyhPk50MAcw49MA0r34AhftjDdx94ILPF6vApFs0gwHPQRlpVA==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: glibc
 
   sass-embedded-unknown-all@1.100.0:
     resolution: {integrity: sha512-c+naBgWId4MIpToXcI0DgqetjdAkwTTAxFAuOaBz7HUXLdyG1oZRrEvSsbe41nEdQOKH0vgofVFCeSQgoXOG9A==}
@@ -4226,6 +4257,8 @@ snapshots:
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
+
+  '@msgpack/msgpack@3.1.3': {}
 
   '@mux/mux-data-google-ima@0.3.16':
     dependencies:


### PR DESCRIPTION
## Summary

Replaces JSON text frames with **MessagePack binary frames** on the **server→client** half of the `/stream` WebSocket protocol (`packages/backend` → `packages/frontend`). Client→server control messages (`init`/`seek`/`heartbeat`/`filter`/`subscribe`/`unsubscribe`/`pause`/`resume`) stay JSON text — they are tiny and infrequent, so binary buys nothing there.

Decisions locked with Boss: **MessagePack** (not protobuf/CBOR), **server→client only**.

## Why

`Session.send_` runs once per session per virtual second, and the browser parses every inbound frame. Binary gives smaller frames (no JSON quoting/whitespace, binary ints/floats, `time.Time` as the msgpack timestamp ext instead of 20-byte RFC3339 strings), faster client decode, and less server CPU.

## How

- Backend encodes via `msgpack` with `SetCustomStructTag("json")` — reuses the existing `json:` struct tags as field names, so wire keys (and the frontend TS interfaces) are **unchanged**, no struct edits.
- `time.Time` rides the msgpack timestamp extension. The frontend registers an `ExtensionCodec` (`wireCodec.ts`) that overrides `EXT_TIMESTAMP` to return an **ISO string**, so `MediaItem.start_date`/`end_date` stay `string`-typed and the instant-item (`start_date === end_date`) check keeps working unchanged.
- Single consumer + no version handshake (hard rule #8): backend and frontend flip text→binary **atomically** in this PR. `ws.binaryType = "arraybuffer"` is set synchronously at socket construction.

## Result

A representative 2-item `items` frame drops **802 → 637 bytes (20.6% smaller)**. Savings are structural + numeric + timestamps (MessagePack is schemaless, so field-name strings remain — inherent to the MessagePack choice).

## Verification

- Backend: `go vet ./...` clean, `go test ./...` green (`session_test.go` now decodes msgpack, mirroring the encoder's tag config).
- Frontend: `tsc -b` clean, `eslint` clean, `vitest` green incl. new `wireCodec.test.ts` (timestamp ext → ISO round-trip, full items frame, numeric/string type preservation).

Docs updated: `docs/websocket-protocol.md` and backend `CLAUDE.md` hard rule #8 now describe the binary-out / JSON-in split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)