### PR TITLE
fix(seed): news timestamps to UTC; stop importing html news-duplicates

### DIFF
--- a/packages/backend/docs/data-model.md
+++ b/packages/backend/docs/data-model.md
@@ -155,7 +155,9 @@ CREATE INDEX news_items_start_date_idx ON news_items (start_date);
 ```
 
 News is mostly **instant** (`start_date = end_date` — a headline at a moment), with a few
-durational entries. Kept in its own Redis keyspace (`news:items` / `news:by_start`); the
+durational entries. Timestamps are **UTC**: clock times parsed from titles are Eastern (EDT for
+the 9/11-era data) and converted to UTC on import (`transformNewsEntry` → `etToUtc`), matching
+every other stream; date-only historical entries stay at naive midnight. Kept in its own Redis keyspace (`news:items` / `news:by_start`); the
 subscribe/init/seek snapshot uses the same **overlap + 5-minute instant lookback** window as
 `CurrentItems`, so a seek to `t` shows stories from the preceding minutes. The tick path then
 delivers news starting at each forward second.
@@ -170,13 +172,14 @@ delivers news starting at each forward second.
 | ------- | ------------------------------------------------------------------------- |
 | `m3u8`  | HLS live-stream playlists (e.g. archived TV broadcasts).                  |
 | `mp4`   | On-demand video files.                                                    |
-| `html`  | Inline HTML to render.                                                    |
 | `modal` | Modal/overlay events — fire on `start_date` and show until dismissed.     |
 | `usenet`| Usenet posts imported via `import-usenet.mjs`.                            |
 
 Pager, mp3 and news are no longer `media_items.format`s — they live in `pager_items` /
 `mp3_items` / `news_items` and ride the `pager` / `mp3` / `news` subscription channels (see
-[`websocket-protocol.md`](./websocket-protocol.md)).
+[`websocket-protocol.md`](./websocket-protocol.md)). The former `html` format was dropped: those
+529 rows were duplicate History Commons articles already present in `news_items` (matched by
+`url`), so the seed no longer imports them.
 
 The streamer does **not** enforce this vocabulary — it passes whatever `format` it reads straight to the client. The frontend chooses how to render unknown formats. The format filter (Section 3.7 of `SPEC.md`) matches exact strings.
 

--- a/packages/backend/seed.mjs
+++ b/packages/backend/seed.mjs
@@ -138,7 +138,7 @@ async function createCollections(token) {
     { field: "end_date",      type: "dateTime", schema: { is_nullable: true }, meta: { interface: "datetime", width: "half" } },
     { field: "timezone",      type: "string",   schema: { is_nullable: true }, meta: { interface: "input", width: "half" } },
     { field: "url",           type: "string",   schema: { is_nullable: true }, meta: { interface: "input", width: "full" } },
-    { field: "format",        type: "string",   schema: { is_nullable: true }, meta: { interface: "select-dropdown", width: "half", options: { choices: ["m3u8", "mp4", "html", "modal"].map((v) => ({ text: v.toUpperCase(), value: v })) } } },
+    { field: "format",        type: "string",   schema: { is_nullable: true }, meta: { interface: "select-dropdown", width: "half", options: { choices: ["m3u8", "mp4", "modal"].map((v) => ({ text: v.toUpperCase(), value: v })) } } },
     { field: "image",         type: "string",   schema: { is_nullable: true }, meta: { interface: "input", width: "half" } },
     { field: "image_caption", type: "string",   schema: { is_nullable: true }, meta: { interface: "input", width: "half" } },
     { field: "content",       type: "text",     schema: { is_nullable: true }, meta: { interface: "input-multiline" } },
@@ -345,11 +345,13 @@ async function importMediaItems(token, records, sourceMap) {
     console.log("media_items already has records, skipping TV import.");
     return;
   }
-  // mp3 lives in its own table/channel — keep it out of media_items.
-  const nonMp3 = records.filter((r) => r.format !== "mp3");
+  // mp3 lives in its own table/channel; html entries are duplicates of news
+  // items (same History Commons articles) — keep both out of media_items.
+  const EXCLUDED = new Set(["mp3", "html"]);
+  const tvOnly = records.filter((r) => !EXCLUDED.has(r.format));
   widenMediaLikeColumns("media_items");
-  console.log(`Importing ${nonMp3.length} TV media items (excluding mp3) in batches of 500…`);
-  insertMediaLikeRecords("media_items", nonMp3, sourceMap);
+  console.log(`Importing ${tvOnly.length} TV media items (excluding mp3 + html) in batches of 500…`);
+  insertMediaLikeRecords("media_items", tvOnly, sourceMap);
 }
 
 async function importMp3Items(token, records, sourceMap) {
@@ -480,7 +482,13 @@ function parseTitleDate(title) {
 }
 
 function transformNewsEntry(entry, sort, sourceId) {
-  const { startDate, parsedEndDate, durationSeconds } = parseTitleDate(entry.title ?? "");
+  let { startDate, parsedEndDate, durationSeconds } = parseTitleDate(entry.title ?? "");
+
+  // Clock times parsed from titles are Eastern (EDT for the 9/11-era data); store
+  // UTC like every other stream. Date-only entries (midnight) carry no real
+  // time-of-day, so they stay naive — only convert when a time was parsed.
+  if (startDate && !startDate.endsWith(" 00:00:00")) startDate = etToUtc(startDate);
+  if (parsedEndDate && !parsedEndDate.endsWith(" 00:00:00")) parsedEndDate = etToUtc(parsedEndDate);
 
   const calcDuration =
     durationSeconds !== null && durationSeconds > 0 && durationSeconds < ONE_HOUR_SECONDS


### PR DESCRIPTION
Two data-quality fixes — **already applied to the live DB**; this makes fresh installs match. Seed/docs only, no streamer code change.

## (b) News timestamps → UTC
Clock times parsed from news titles were stored naive **Eastern (EDT)** — 4 hours off from the UTC convention every other stream uses, so news surfaced ~4h early in the replay. `transformNewsEntry` now converts *timed* entries EDT→UTC via the existing `etToUtc` helper; date-only historical entries keep naive midnight (no real time-of-day).

## (c) Drop html news-duplicates
The 529 `format='html'` rows are duplicate History Commons articles already in `news_items` (100% `url` overlap; news is the **fuller** copy — full text + `<cite>` citations vs the html ~500-char excerpt). Exclude `html` from the media import and drop it from the format dropdown.

## Live DB already migrated (verified)
- `UPDATE 1072` news rows `+4h` (e.g. SF-Mayor entry 01:00→**05:00 UTC**, now appears at the right moment, confirmed via live WS).
- `DELETE 529` html rows; streamer bounced → media cache **−464**, news cache re-scored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)