### PR TITLE
feat(tv): cross-app remote control + EPG tune-to-channel

### DIFF
--- a/packages/frontend/src/Applications/EPG/EPG.tsx
+++ b/packages/frontend/src/Applications/EPG/EPG.tsx
@@ -6,6 +6,7 @@ import {
 	ClassicyWindow,
 	quitMenuItemHelper,
 	useAppManager,
+	useAppManagerDispatch,
 } from "classicy";
 import classNames from "classnames";
 import type React from "react";
@@ -17,6 +18,15 @@ import {
 	useMemo,
 	useState,
 } from "react";
+import {
+	tvExitGrid,
+	tvPause,
+	tvResume,
+	tvSetGridChannels,
+	tvSetMuted,
+	tvSetVolumeLimit,
+	tvTuneChannel,
+} from "../TV/TVContext";
 import epgStyles from "./EPG.module.scss";
 import data from "./testdata.json" with { type: "json" };
 
@@ -78,6 +88,16 @@ export const EPG: React.FC<ClassicyEPGProps> = ({
 	const dateTime      = useAppManager((s) => s.System.Manager.DateAndTime.dateTime);
 	const timeZoneOffset = useAppManager((s) => s.System.Manager.DateAndTime.timeZoneOffset);
 	const tzOffset = parseInt(timeZoneOffset, 10);
+
+	const desktopEventDispatch = useAppManagerDispatch();
+
+	// Ask the TV app to tune to a channel. EPG channels are keyed by call sign
+	// (name); the TV resolves that against the stream's `source` slug. This is a
+	// fire-and-forget cross-app event — EPG never imports the TV component.
+	const tuneToChannel = useCallback(
+		(channelName: string) => desktopEventDispatch(tvTuneChannel(channelName)),
+		[desktopEventDispatch],
+	);
 
 	const [showSettings, setShowSettings] = useState<boolean>(false);
 
@@ -179,6 +199,14 @@ export const EPG: React.FC<ClassicyEPGProps> = ({
 						style={{
 							gridRowStart: channelIndex + 2,
 							gridColumn: `${gridProgramStart + 2}/ span ${gridProgramEnd}`,
+							cursor: "pointer",
+						}}
+						role="button"
+						tabIndex={0}
+						title={`Watch ${channel.name} on TV`}
+						onClick={() => tuneToChannel(channel.name)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter" || e.key === " ") tuneToChannel(channel.name);
 						}}
 					>
 						<div className={epgStyles.epgEntryTitle}>
@@ -208,7 +236,7 @@ export const EPG: React.FC<ClassicyEPGProps> = ({
 				);
 			});
 		},
-		[gridWidth, minutesPerGrid, gridStartTime, gridEndTime, currentTime, toLocal],
+		[gridWidth, minutesPerGrid, gridStartTime, gridEndTime, currentTime, toLocal, tuneToChannel],
 	);
 
 	const epgHeader = useMemo(() => {
@@ -270,6 +298,14 @@ export const EPG: React.FC<ClassicyEPGProps> = ({
 							gridRowStart: channelIndex + 2,
 							gridColumnStart: 1,
 							gridColumnEnd: 2,
+							cursor: "pointer",
+						}}
+						role="button"
+						tabIndex={0}
+						title={`Watch ${channel.name} on TV`}
+						onClick={() => tuneToChannel(channel.name)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter" || e.key === " ") tuneToChannel(channel.name);
 						}}
 					>
 						<img
@@ -285,7 +321,7 @@ export const EPG: React.FC<ClassicyEPGProps> = ({
 				</Fragment>
 			);
 		});
-	}, [getProgramData, gridData]);
+	}, [getProgramData, gridData, tuneToChannel]);
 
 	return (
 		<ClassicyApp
@@ -353,6 +389,52 @@ export const EPG: React.FC<ClassicyEPGProps> = ({
 						<ClassicyButton onClickFunc={jumpBack}>&lt;&lt;</ClassicyButton>
 						<ClassicyButton onClickFunc={jumpToNow}>Now</ClassicyButton>
 						<ClassicyButton onClickFunc={jumpForward}>&gt;&gt;</ClassicyButton>
+					</div>
+					{/* TV remote-control test bar: every button is a fire-and-forget
+					    cross-app event handled by the TV app (see TVContext). */}
+					<div style={{ display: "flex", flexWrap: "wrap", alignItems: "center" }}>
+						<ClassicyControlLabel label="TV Remote:" />
+						<ClassicyButton
+							onClickFunc={() =>
+								desktopEventDispatch(
+									tvSetGridChannels(["CNN", "MSNBC", "BBC", "WETA"]),
+								)
+							}
+						>
+							Grid
+						</ClassicyButton>
+						<ClassicyButton onClickFunc={() => desktopEventDispatch(tvExitGrid())}>
+							Single
+						</ClassicyButton>
+						<ClassicyButton onClickFunc={() => desktopEventDispatch(tvPause())}>
+							Pause
+						</ClassicyButton>
+						<ClassicyButton onClickFunc={() => desktopEventDispatch(tvResume())}>
+							Play
+						</ClassicyButton>
+						<ClassicyButton onClickFunc={() => desktopEventDispatch(tvSetMuted(true))}>
+							Mute
+						</ClassicyButton>
+						<ClassicyButton
+							onClickFunc={() => desktopEventDispatch(tvSetMuted(false))}
+						>
+							Unmute
+						</ClassicyButton>
+						<ClassicyButton
+							onClickFunc={() => desktopEventDispatch(tvSetVolumeLimit(1))}
+						>
+							Vol 100%
+						</ClassicyButton>
+						<ClassicyButton
+							onClickFunc={() => desktopEventDispatch(tvSetVolumeLimit(0.5))}
+						>
+							Vol 50%
+						</ClassicyButton>
+						<ClassicyButton
+							onClickFunc={() => desktopEventDispatch(tvSetVolumeLimit(0.25))}
+						>
+							Vol 25%
+						</ClassicyButton>
 					</div>
 					<div
 						className={epgStyles.epgHolder}

--- a/packages/frontend/src/Applications/TV/TV.tsx
+++ b/packages/frontend/src/Applications/TV/TV.tsx
@@ -20,7 +20,25 @@ import type {
 } from "../../Providers/MediaStream/MediaStreamContext";
 import { useMediaStream } from "../../Providers/MediaStream/useMediaStream";
 import styles from "./TV.module.scss";
-import "./TVContext";
+import {
+	type TVChannelRef,
+	type TVRemoteCommand,
+	tvPause,
+	tvResume,
+	tvSetMuted,
+} from "./TVContext";
+
+/** Resolve a remote channel reference (numeric id or `source` name) to an item id. */
+function resolveChannelId(
+	channel: TVChannelRef,
+	pool: MediaItem[],
+): number | undefined {
+	if (typeof channel === "number") {
+		return pool.find((i) => i.id === channel)?.id;
+	}
+	const lc = channel.toLowerCase();
+	return pool.find((i) => i.source?.toLowerCase() === lc)?.id;
+}
 
 // Every approved HLS channel in the stream, before any per-channel selection.
 // Hoisted to a module constant so its reference is stable across renders —
@@ -91,6 +109,16 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 	);
 	const { items } = useMediaStream(tvFilter);
 
+	// --- Remote-control state, driven by ClassicyAppTV* events (see TVContext) ---
+	// Persistent settings, read straight from app data each render.
+	const volumeLimit = (appState?.data?.volumeLimit as number | undefined) ?? 1;
+	const overallMuted = (appState?.data?.overallMuted as boolean | undefined) ?? false;
+	// TV-local pause — independent of the global clock, which keeps running so
+	// resume can jump forward to live time.
+	const tvPaused = (appState?.data?.tvPaused as boolean | undefined) ?? false;
+	// One-shot view command (tune / grid / exitGrid), applied once per seq.
+	const command = appState?.data?.command as TVRemoteCommand | undefined;
+
 	const [showSettings, setShowSettings] = useState<boolean>(false);
 	// Settings form: local working copy of the disabled set, committed on Save.
 	const [channelForm, setChannelForm] = useState<string[]>(disabledChannels);
@@ -118,6 +146,9 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 	// Stable ref to clockPaused so the health-check interval sees the latest value.
 	const clockPausedRef = useRef(clockPaused);
 	clockPausedRef.current = clockPaused;
+	// Same for the TV-local pause set by the remote (separate from the clock).
+	const tvPausedRef = useRef(tvPaused);
+	tvPausedRef.current = tvPaused;
 	// Stable ref to items so the seek effect never captures a stale closure.
 	const itemsRef = useRef(items);
 	itemsRef.current = items;
@@ -162,8 +193,8 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 				const el = videoRefs.current.get(item.id);
 				if (!el) continue;
 
-				// Resume if stalled or paused (skip when the system clock is paused)
-				if (!clockPausedRef.current && (el.paused || el.ended)) {
+				// Resume if stalled or paused (skip when the clock or the TV is paused)
+				if (!clockPausedRef.current && !tvPausedRef.current && (el.paused || el.ended)) {
 					el.play().catch(() => {});
 				}
 
@@ -212,6 +243,64 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 			el.currentTime = calcSeekSeconds(item, nowMs);
 		}
 	}, [clockPaused]);
+
+	// When the TV-local pause is released, jump every player forward to the live
+	// clock instant — resume "catches up" to now rather than continuing from the
+	// frozen frame. Pausing itself needs no seek (the frame is already correct).
+	// biome-ignore lint/correctness/useExhaustiveDependencies: itemsRef/dateTimeRef/videoRefs are stable refs
+	useEffect(() => {
+		if (tvPaused) return;
+		const elapsedRealMs = Date.now() - dateTimeUpdatedAtRef.current;
+		const nowMs = new Date(dateTimeRef.current).getTime() + elapsedRealMs;
+		for (const item of itemsRef.current) {
+			const el = videoRefs.current.get(item.id);
+			if (el) el.currentTime = calcSeekSeconds(item, nowMs);
+		}
+	}, [tvPaused]);
+
+	// Apply each remote view command (tune / grid / exitGrid) exactly once,
+	// tracked by its monotonic seq. If the referenced channel isn't in the stream
+	// yet, the seq is left unconsumed so the effect retries when `items` updates —
+	// this lets a command issued before the stream loaded still land.
+	const lastCommandSeqRef = useRef(0);
+	useEffect(() => {
+		if (!command || command.seq <= lastCommandSeqRef.current) return;
+
+		if (command.kind === "exitGrid") {
+			lastCommandSeqRef.current = command.seq;
+			setMultiSelectMode(false);
+			return;
+		}
+
+		if (command.kind === "tune" && command.channel !== undefined) {
+			const id = resolveChannelId(command.channel, items);
+			if (id === undefined) return; // not in stream yet — retry on next update
+			lastCommandSeqRef.current = command.seq;
+			setMultiSelectMode(false);
+			setActivePlayer(id);
+			setHasInteracted(true);
+		} else if (command.kind === "grid" && command.channels) {
+			const ids = command.channels
+				.map((c) => resolveChannelId(c, items))
+				.filter((x): x is number => x !== undefined);
+			if (ids.length === 0) return; // none resolved yet — retry
+			lastCommandSeqRef.current = command.seq;
+			setMultiSelectMode(true);
+			setSelectedPlayers(ids);
+			setMutedGridPlayers([]);
+			setHasInteracted(true);
+		} else {
+			lastCommandSeqRef.current = command.seq;
+			return;
+		}
+
+		// Bring the TV's main window forward so the tuned channel is visible.
+		desktopEventDispatch({
+			type: "ClassicyWindowFocus",
+			app: { id: appId },
+			window: { id: `${appId}_main` },
+		});
+	}, [command, items, desktopEventDispatch]);
 
 	// Persist grid layout and mute state to app settings on every change.
 	useEffect(() => {
@@ -376,7 +465,8 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 								{selectedPlayers.map((id) => {
 									const item = items.find((i) => i.id === id);
 									if (!item) return null;
-									const isGridMuted = !hasInteracted || mutedGridPlayers.includes(id);
+									const isGridMuted =
+										overallMuted || !hasInteracted || mutedGridPlayers.includes(id);
 									return (
 										<div key={id} className={styles.tvGridPlayer}>
 											<div className={styles.tvChannelTitleHolder}>
@@ -410,12 +500,12 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 												}}
 												onReady={() => seekToCurrentTime(item)}
 												src={item.url}
-												playing={!clockPaused}
+												playing={!clockPaused && !tvPaused}
 												loop={false}
 												controls={false}
 												playsInline={true}
 												muted={isGridMuted}
-												volume={isGridMuted ? 0 : 1}
+												volume={isGridMuted ? 0 : volumeLimit}
 												width="100%"
 												height="100%"
 												config={hlsActiveConfigsRef.current.get(id)}
@@ -430,6 +520,23 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 						<div className={styles.tvControlPanel}>
 							<ClassicyButton onClickFunc={toggleMultiSelect} depressed={multiSelectMode}>
 								Grid
+							</ClassicyButton>
+							<ClassicyButton
+								onClickFunc={() =>
+									desktopEventDispatch(tvPaused ? tvResume() : tvPause())
+								}
+								depressed={tvPaused}
+							>
+								{tvPaused ? "Play" : "Pause"}
+							</ClassicyButton>
+							<ClassicyButton
+								onClickFunc={() => {
+									setHasInteracted(true);
+									desktopEventDispatch(tvSetMuted(!overallMuted));
+								}}
+								depressed={overallMuted}
+							>
+								Mute
 							</ClassicyButton>
 						</div>
 						<div className={styles.tvThumbnailStrip}>
@@ -501,12 +608,14 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 												}}
 												onReady={() => seekToCurrentTime(item)}
 												src={item.url}
-												playing={!clockPaused}
+												playing={!clockPaused && !tvPaused}
 												loop={false}
 												controls={false}
 												playsInline={true}
-												muted={!(isActive && hasInteracted)}
-												volume={isActive && hasInteracted ? 1 : 0}
+												muted={overallMuted || !(isActive && hasInteracted)}
+												volume={
+													overallMuted || !(isActive && hasInteracted) ? 0 : volumeLimit
+												}
 												width="100%"
 												height="100%"
 												config={itemConfig}

--- a/packages/frontend/src/Applications/TV/TVContext.ts
+++ b/packages/frontend/src/Applications/TV/TVContext.ts
@@ -1,7 +1,74 @@
 import type { ActionMessage, ClassicyStore } from "classicy";
 import { registerAppEventHandler } from "classicy";
 
-const appId = "TV.app";
+export const TV_APP_ID = "TV.app";
+const appId = TV_APP_ID;
+
+/**
+ * A channel is referenced either by its numeric MediaItem id or by its channel
+ * name (the `source` slug, e.g. "WETA"). Remote callers usually only know the
+ * name, so both are accepted and resolved inside the TV app.
+ */
+export type TVChannelRef = number | string;
+
+/**
+ * One-shot view command delivered through the store. `seq` is monotonic so the
+ * TV component can apply each command exactly once (and apply the latest one on
+ * mount, even if it was issued while the app was closed).
+ */
+export interface TVRemoteCommand {
+	seq: number;
+	kind: "tune" | "grid" | "exitGrid";
+	channel?: TVChannelRef;
+	channels?: TVChannelRef[];
+}
+
+// --- Cross-app remote-control API ---------------------------------------
+// Other apps dispatch these action creators to drive the TV without importing
+// any of its internals. Action types share the "ClassicyAppTV" prefix so they
+// route to the handler registered below.
+
+/** Tune to a single channel and show it as the only video. */
+export const tvTuneChannel = (channel: TVChannelRef): ActionMessage => ({
+	type: "ClassicyAppTVTuneChannel",
+	channel,
+});
+
+/** Show a grid of the given channels (by id or name). */
+export const tvSetGridChannels = (channels: TVChannelRef[]): ActionMessage => ({
+	type: "ClassicyAppTVSetGrid",
+	channels,
+});
+
+/** Leave grid view and return to a single active channel. */
+export const tvExitGrid = (): ActionMessage => ({ type: "ClassicyAppTVExitGrid" });
+
+/** Set the maximum volume (0..1) applied to any playing video. */
+export const tvSetVolumeLimit = (volumeLimit: number): ActionMessage => ({
+	type: "ClassicyAppTVSetVolumeLimit",
+	volumeLimit,
+});
+
+/** Mute or unmute every video at once. */
+export const tvSetMuted = (muted: boolean): ActionMessage => ({
+	type: "ClassicyAppTVSetMuted",
+	muted,
+});
+
+/** Freeze every video (the Classicy clock keeps running). */
+export const tvPause = (): ActionMessage => ({ type: "ClassicyAppTVPause" });
+
+/** Resume playback at the live Classicy clock time (not where it was paused). */
+export const tvResume = (): ActionMessage => ({ type: "ClassicyAppTVPlay" });
+
+/** Alias for {@link tvResume} — there is no separate "from a stop" state. */
+export const tvPlay = tvResume;
+
+const clamp01 = (n: number): number => Math.min(1, Math.max(0, n));
+
+// Next command sequence number = previous + 1 (starts at 1).
+const nextSeq = (appData: Record<string, unknown>): number =>
+	((appData.command as TVRemoteCommand | undefined)?.seq ?? 0) + 1;
 
 export const classicyTVEventHandler = (
 	ds: ClassicyStore,
@@ -9,10 +76,11 @@ export const classicyTVEventHandler = (
 ) => {
 	if (!ds.System.Manager.Applications.apps[appId]) return ds;
 	const appData = ds.System.Manager.Applications.apps[appId].data ?? {};
+	const apps = ds.System.Manager.Applications.apps;
 
 	switch (action.type) {
 		case "ClassicyAppTVSetGridState":
-			ds.System.Manager.Applications.apps[appId].data = {
+			apps[appId].data = {
 				...appData,
 				multiSelectMode: action.multiSelectMode,
 				selectedPlayers: action.selectedPlayers,
@@ -22,10 +90,52 @@ export const classicyTVEventHandler = (
 		// Channels the user has turned off in Settings. Stored as a blacklist of
 		// `source` slugs so any channel that appears later defaults to enabled.
 		case "ClassicyAppTVSetDisabledChannels":
-			ds.System.Manager.Applications.apps[appId].data = {
+			apps[appId].data = { ...appData, disabledChannels: action.disabledChannels };
+			return ds;
+		// --- Remote-control commands ---
+		case "ClassicyAppTVTuneChannel":
+			apps[appId].data = {
 				...appData,
-				disabledChannels: action.disabledChannels,
+				command: {
+					seq: nextSeq(appData),
+					kind: "tune",
+					channel: action.channel as TVChannelRef,
+				} satisfies TVRemoteCommand,
 			};
+			return ds;
+		case "ClassicyAppTVSetGrid":
+			apps[appId].data = {
+				...appData,
+				command: {
+					seq: nextSeq(appData),
+					kind: "grid",
+					channels: action.channels as TVChannelRef[],
+				} satisfies TVRemoteCommand,
+			};
+			return ds;
+		case "ClassicyAppTVExitGrid":
+			apps[appId].data = {
+				...appData,
+				command: { seq: nextSeq(appData), kind: "exitGrid" } satisfies TVRemoteCommand,
+			};
+			return ds;
+		case "ClassicyAppTVSetVolumeLimit":
+			apps[appId].data = {
+				...appData,
+				volumeLimit: clamp01(action.volumeLimit as number),
+			};
+			return ds;
+		case "ClassicyAppTVSetMuted":
+			apps[appId].data = { ...appData, overallMuted: action.muted as boolean };
+			return ds;
+		case "ClassicyAppTVPause":
+			apps[appId].data = { ...appData, tvPaused: true };
+			return ds;
+		// Play and Resume are the same: unpause and let the component seek to the
+		// live clock. Fast-forward / rewind are intentionally unsupported — video
+		// position is always derived from the Classicy clock.
+		case "ClassicyAppTVPlay":
+			apps[appId].data = { ...appData, tvPaused: false };
 			return ds;
 		default:
 			return ds;


### PR DESCRIPTION
Rebased cleanly onto current `main` (which already has the #109 settings work). Supersedes the malformed #111 and the stale stacked branch.

## Summary

Lets other apps drive the TV through **fire-and-forget store events** — no direct imports between apps. `TVContext` exposes an action-creator API; the TV app listens and reacts; **EPG is wired as the test driver**.

## Remote functions (events the TV handles)

- **Tune to a channel** by id or name → shows it as the only video and focuses the TV window
- **Grid view** defined from a list of channels (by id or name)
- **Overall volume limit** (max volume applied to any video) and **overall mute**
- **Play / pause / resume** — resume seeks every player to **live Classicy clock time**, not where it paused. TV pause is independent of the global clock (the clock keeps running).
- **No fast-forward / rewind** — position is always derived from the clock, by design.

## How it works

- **Cross-app seam:** `registerAppEventHandler("ClassicyAppTV", …)` routes any dispatched `ClassicyAppTV*` action into the TV reducer, which writes app `data`. The TV component reads that data and reacts. EPG dispatches via the exported action creators (`tvTuneChannel`, `tvSetGridChannels`, `tvSetVolumeLimit`, `tvSetMuted`, `tvPause`, `tvResume`, `tvExitGrid`).
- **View commands vs. settings:** tune/grid/exitGrid use a monotonic-`seq` command object so each applies exactly once. If the referenced channel isn't in the stream yet, the `seq` is left unconsumed and the effect retries when `items` updates. Volume/mute/pause are persistent fields read each render.
- **Channel resolution:** by id *or* name; names resolve against the stream's `source` slug (EPG call signs like WETA/CNN map directly).
- TV control panel gains **Play/Pause + Mute** buttons that dispatch the same events.

## EPG test driver

- Clicking a **channel header** or any **program cell** tunes the TV to that channel.
- A **"TV Remote" toolbar**: Grid (CNN/MSNBC/BBC/WETA), Single, Pause, Play, Mute, Unmute, Vol 100/50/25%.

## Testing

- `tsc -b` clean
- `eslint` clean
- 51/51 vitest tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)