### PR TITLE
feat(streamer): send time-independent available-source lists for filters

### DIFF
--- a/packages/backend/docs/websocket-protocol.md
+++ b/packages/backend/docs/websocket-protocol.md
@@ -64,6 +64,7 @@ All unknown `type` values produce an `error` reply but do not terminate the sess
 | `pager`           | `time`, `pager[]`             | Pager snapshot (on subscribe/init/seek) + a forward **window** (default 600 s) per refill while subscribed. Client reveal-gate preserves forward-only pacing. |
 | `mp3`             | `time`, `items[]`             | mp3/Radio snapshot (items active at `t`) + a forward **window** (default 300 s) per refill while subscribed. Reuses the `items` field. |
 | `news`            | `time`, `items[]`             | News snapshot (active at `t` + 5-min instant lookback) + a forward **window** (default 600 s) per refill while subscribed. Reuses the `items` field. |
+| `sources`         | `sources`                     | Sent once after `init_ack`: the time-independent set of selectable sources per filter (`sources.video`, `sources.pager`). Not resent on `seek`. |
 | `error`           | `message`                     | Reply to a malformed or unrecognised request.          |
 
 The frame-level `time` field is a string (RFC3339 UTC, e.g. `"2001-09-11T08:46:00Z"`) in both the
@@ -231,6 +232,30 @@ resume the recording mid-file via the `jump` offset.
 The `news` channel (News app) likewise carries `MediaItem`s on `news`-typed frames. Most news is
 instant, so its snapshot uses the media overlap-plus-5-minute-instant-lookback window — a seek to
 `t` shows headlines from the preceding minutes.
+
+### `sources`
+
+Sent once, unprompted, right after `init_ack` (and again after any reconnect's
+`init_ack`). Carries the **time-independent** set of selectable sources for each
+client-side filter, so a filter UI can list every option up front instead of only
+those that have scrolled past in the current virtual-time window.
+
+```json
+{
+  "type": "sources",
+  "sources": {
+    "video": ["BBC", "CNN", "MSNBC", "WETA"],
+    "pager": ["Arch", "Skytel"]
+  }
+}
+```
+
+- `video` — source slugs with at least one approved `m3u8` media item (the TV app's channel filter).
+- `pager` — providers across all approved pager items (the Pager app's provider filter).
+
+Each list is derived from **actual usage** in its table: the `sources` table does not record which
+media type a source belongs to, so membership is inferred from the rows that reference it. The lists
+do not depend on the virtual clock, so `seek` does not resend them.
 
 ### `unsubscribe`
 

--- a/packages/backend/internal/db/postgres.go
+++ b/packages/backend/internal/db/postgres.go
@@ -77,6 +77,26 @@ func CurrentItems(ctx context.Context, pool *pgxpool.Pool, t time.Time) ([]model
 		 ORDER BY mi.start_date`, t)
 }
 
+// videoFormat is the media_items.format value the TV app plays. The TV's source
+// filter is derived from items of this format only — media_items also holds
+// non-video formats (html/modal/usenet) the TV never shows, and the sources table
+// does not record which media type a source belongs to, so usage is the only signal.
+const videoFormat = "m3u8"
+
+// AvailableVideoSources returns the distinct, sorted source slugs that have at
+// least one approved video (m3u8) media item, independent of time. It populates
+// the TV app's channel filter with every selectable channel up front, rather than
+// only those that have scrolled past in the current virtual-time window.
+func AvailableVideoSources(ctx context.Context, pool *pgxpool.Pool) ([]string, error) {
+	return queryStrings(ctx, pool, `
+		SELECT DISTINCT s.slug
+		FROM media_items mi
+		JOIN sources s ON s.id = mi.source
+		WHERE mi.approved = 1 AND mi.format = $1
+		  AND s.slug IS NOT NULL AND s.slug <> ''
+		ORDER BY s.slug`, videoFormat)
+}
+
 // pagerSelectFrom is the shared SELECT … FROM clause for all pager queries.
 // provider is a plain text column on pager_items (not a sources FK), so no JOIN
 // is needed here.
@@ -119,6 +139,17 @@ func CurrentPagerItems(ctx context.Context, pool *pgxpool.Pool, t time.Time) ([]
 		   AND pi.start_date >= $1
 		   AND pi.start_date < $1 + INTERVAL '1 second'
 		 ORDER BY pi.start_date`, t)
+}
+
+// AvailablePagerProviders returns the distinct, sorted set of providers across all
+// approved pager items, independent of time. Populates the Pager app's provider
+// filter. provider is a plain text column (not a sources FK), so no join is needed.
+func AvailablePagerProviders(ctx context.Context, pool *pgxpool.Pool) ([]string, error) {
+	return queryStrings(ctx, pool, `
+		SELECT DISTINCT provider
+		FROM pager_items
+		WHERE approved = 1 AND provider IS NOT NULL AND provider <> ''
+		ORDER BY provider`)
 }
 
 func queryPagerItems(ctx context.Context, pool *pgxpool.Pool, q string, args ...any) ([]model.PagerItem, error) {
@@ -251,6 +282,26 @@ func derefStr(dst *string, src *string) {
 	if src != nil {
 		*dst = *src
 	}
+}
+
+// queryStrings runs a query selecting a single non-null text column and returns
+// the values in row order. Used by the distinct-source helpers.
+func queryStrings(ctx context.Context, pool *pgxpool.Pool, q string, args ...any) ([]string, error) {
+	rows, err := pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query: %w", err)
+	}
+	defer rows.Close()
+
+	var out []string
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil {
+			return nil, fmt.Errorf("scan: %w", err)
+		}
+		out = append(out, v)
+	}
+	return out, rows.Err()
 }
 
 func queryItems(ctx context.Context, pool *pgxpool.Pool, q string, args ...any) ([]model.MediaItem, error) {

--- a/packages/backend/internal/handler/ws.go
+++ b/packages/backend/internal/handler/ws.go
@@ -122,6 +122,7 @@ func NewWSHandler(hub *session.Hub, rdb *goredis.Client, pool *pgxpool.Pool, log
 				}
 				sess.Init(t, items)
 				sendSubscribedSnapshots(r, sess, pool, t, logger)
+				sendSources(r, sess, pool, logger)
 
 			case "seek":
 				t, err := parseTime(msg.Time)
@@ -258,6 +259,22 @@ func sendNewsSnapshot(r *http.Request, sess *session.Session, pool *pgxpool.Pool
 		return
 	}
 	sess.SendNews(t, items)
+}
+
+// sendSources delivers the time-independent available-source lists for client
+// filters (TV channels, pager providers). Called once per init — sources don't
+// change with virtual time, so seek does not resend them. Failures are non-fatal:
+// a missing list only degrades a filter UI, it must not break streaming.
+func sendSources(r *http.Request, sess *session.Session, pool *pgxpool.Pool, logger *slog.Logger) {
+	video, err := db.AvailableVideoSources(r.Context(), pool)
+	if err != nil {
+		logger.Warn("available video sources query failed", "error", err)
+	}
+	providers, err := db.AvailablePagerProviders(r.Context(), pool)
+	if err != nil {
+		logger.Warn("available pager providers query failed", "error", err)
+	}
+	sess.SendSources(video, providers)
 }
 
 // knownChannel reports whether ch is a valid subscription channel.

--- a/packages/backend/internal/session/session.go
+++ b/packages/backend/internal/session/session.go
@@ -48,6 +48,14 @@ const (
 	windowNews  = 600 * time.Second
 )
 
+// SourceList carries the time-independent set of selectable sources for each
+// client-side filter. The sources table does not record which media type a source
+// belongs to, so each list is derived from actual usage in its table.
+type SourceList struct {
+	Video []string `json:"video"` // TV: sources of approved m3u8 media items
+	Pager []string `json:"pager"` // Pager: providers of approved pager items
+}
+
 // outMsg is the envelope for every server→client message.
 type outMsg struct {
 	Type    string            `json:"type"`
@@ -55,6 +63,7 @@ type outMsg struct {
 	Channel string            `json:"channel,omitempty"`
 	Items   []model.MediaItem `json:"items,omitempty"`
 	Pager   []model.PagerItem `json:"pager,omitempty"`
+	Sources *SourceList       `json:"sources,omitempty"`
 	Msg     string            `json:"message,omitempty"`
 }
 
@@ -238,6 +247,14 @@ func (s *Session) SendNews(t time.Time, items []model.MediaItem) {
 		return
 	}
 	s.send_(outMsg{Type: "news", Time: t.Format(time.RFC3339), Items: items})
+}
+
+// SendSources delivers the available-source lists for the client's filters. The
+// lists are derived from all history (not the current window), so the client's
+// filter UIs are complete regardless of virtual time. Sent once per init; sources
+// don't change with the virtual clock, so seek does not resend them.
+func (s *Session) SendSources(video, pager []string) {
+	s.send_(outMsg{Type: "sources", Sources: &SourceList{Video: video, Pager: pager}})
 }
 
 // Init sets the client's starting virtual time and sends the initial snapshot.

--- a/packages/backend/internal/session/session_test.go
+++ b/packages/backend/internal/session/session_test.go
@@ -79,6 +79,29 @@ func TestSendMp3EmitsFrameWithMediaItems(t *testing.T) {
 	}
 }
 
+func TestSendSourcesEmitsSourceLists(t *testing.T) {
+	s := newTestSession(t)
+
+	s.SendSources([]string{"BBC", "CNN", "WETA"}, []string{"Arch", "Skytel"})
+
+	m := recvType(t, s)
+	if m.Type != "sources" {
+		t.Fatalf("expected sources frame, got %q", m.Type)
+	}
+	if m.Sources == nil {
+		t.Fatal("expected sources payload, got nil")
+	}
+	if len(m.Sources.Video) != 3 || m.Sources.Video[0] != "BBC" {
+		t.Fatalf("unexpected video sources: %+v", m.Sources.Video)
+	}
+	if len(m.Sources.Pager) != 2 || m.Sources.Pager[1] != "Skytel" {
+		t.Fatalf("unexpected pager providers: %+v", m.Sources.Pager)
+	}
+	if len(m.Items) != 0 || len(m.Pager) != 0 {
+		t.Fatalf("sources frame must not carry item payloads, got items=%+v pager=%+v", m.Items, m.Pager)
+	}
+}
+
 func TestMp3ChannelIndependentOfPager(t *testing.T) {
 	s := newTestSession(t)
 	s.Subscribe(ChannelMp3)

--- a/packages/frontend/src/Applications/PagerDecoder/usePagerPlayback.test.ts
+++ b/packages/frontend/src/Applications/PagerDecoder/usePagerPlayback.test.ts
@@ -59,6 +59,7 @@ function makeWrapper(pagerItems: PagerItem[]) {
 					newsItems: [],
 					subscribeNews: vi.fn(),
 					unsubscribeNews: vi.fn(),
+					sources: { video: [], pager: [] },
 				},
 				children,
 			}),

--- a/packages/frontend/src/Applications/PagerDecoder/usePagerPlayback.ts
+++ b/packages/frontend/src/Applications/PagerDecoder/usePagerPlayback.ts
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useRef, useState } from "react";
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import {
 	MediaStreamContext,
 	type PagerItem,
@@ -59,7 +59,8 @@ export function usePagerPlayback(
 	settings: PagerDecoderSettings = DEFAULT_PAGER_SETTINGS,
 	paused = false,
 ): PlaybackState {
-	const { pagerItems, subscribePager, unsubscribePager } = useContext(MediaStreamContext);
+	const { pagerItems, subscribePager, unsubscribePager, sources } =
+		useContext(MediaStreamContext);
 
 	// Opt into the pager channel so the server delivers pager items to this session.
 	useEffect(() => {
@@ -179,5 +180,17 @@ export function usePagerPlayback(
 		return () => clearInterval(streamId);
 	}, []);
 
-	return { lines, streamingText, streamingMeta, uniqueValues };
+	// The provider filter list is the server's complete, time-independent provider
+	// set (sources.pager) unioned with any providers already seen in-stream — so
+	// the dropdown is fully populated immediately, not only after items scroll past.
+	const mergedUniqueValues = useMemo<PlaybackState["uniqueValues"]>(
+		() => ({
+			provider: [...new Set([...sources.pager, ...uniqueValues.provider])].sort(),
+			id_type: uniqueValues.id_type,
+			channel: uniqueValues.channel,
+		}),
+		[sources.pager, uniqueValues],
+	);
+
+	return { lines, streamingText, streamingMeta, uniqueValues: mergedUniqueValues };
 }

--- a/packages/frontend/src/Applications/TV/TV.tsx
+++ b/packages/frontend/src/Applications/TV/TV.tsx
@@ -74,7 +74,8 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 
 	// Unfiltered-by-source list, used only to enumerate which channels exist so
 	// Settings can list them all (even ones the user has currently disabled).
-	const { items: allChannelItems } = useMediaStream(ALL_CHANNELS_FILTER);
+	// `sources.video` is the authoritative, time-independent list from the server.
+	const { items: allChannelItems, sources } = useMediaStream(ALL_CHANNELS_FILTER);
 	const { dateTime, paused: clockPaused } = useClassicyDateTime();
 
 	// Persisted blacklist of channels the user has switched off.
@@ -83,15 +84,17 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 		[appState?.data?.disabledChannels],
 	);
 
-	// Distinct channel slugs currently present in the stream, sorted for a stable
-	// Settings list. `source` is optional on MediaItem, so empties are dropped.
+	// Distinct channel slugs available for selection, sorted for a stable Settings
+	// list. Seeded from the server's complete `sources.video` list (every channel,
+	// regardless of virtual time) and unioned with anything already seen in-stream
+	// so the list is populated even before the `sources` frame arrives.
 	const availableChannels = useMemo(() => {
-		const seen = new Set<string>();
+		const seen = new Set<string>(sources.video);
 		for (const item of allChannelItems) {
 			if (item.source) seen.add(item.source);
 		}
 		return [...seen].sort();
-	}, [allChannelItems]);
+	}, [allChannelItems, sources.video]);
 
 	// The channels left enabled = everything present minus the blacklist. This is
 	// the whitelist handed to the streaming filter below.

--- a/packages/frontend/src/Providers/MediaStream/MediaStreamContext.ts
+++ b/packages/frontend/src/Providers/MediaStream/MediaStreamContext.ts
@@ -63,6 +63,19 @@ export interface PagerItem {
 	approved?: number;
 }
 
+/**
+ * Time-independent sets of selectable sources for each filter, delivered once by
+ * the server on the `sources` frame (see the streamer's websocket-protocol.md).
+ * Unlike the source values derived from streamed items, these list every option
+ * across all history — so filter UIs are complete regardless of the virtual clock.
+ */
+export interface AvailableSources {
+	/** Source slugs with approved video (m3u8) media — the TV channel filter. */
+	video: string[];
+	/** Providers across approved pager items — the Pager provider filter. */
+	pager: string[];
+}
+
 export interface MediaStreamContextValue {
 	items: MediaItem[];
 	/** Pager items received while subscribed to the pager channel. */
@@ -71,6 +84,8 @@ export interface MediaStreamContextValue {
 	mp3Items: MediaItem[];
 	/** news items received while subscribed to the news channel. Same shape as items. */
 	newsItems: MediaItem[];
+	/** All selectable sources per filter, sent once by the server at init. */
+	sources: AvailableSources;
 	connected: boolean;
 	addItems: (items: MediaItem[]) => void;
 	/** Register a set of desired formats for an app. null = want all formats. */
@@ -96,6 +111,7 @@ export const MediaStreamContext = createContext<MediaStreamContextValue>({
 	pagerItems: [],
 	mp3Items: [],
 	newsItems: [],
+	sources: { video: [], pager: [] },
 	connected: false,
 	addItems: () => {},
 	subscribeFormats: () => {},

--- a/packages/frontend/src/Providers/MediaStream/MediaStreamProvider.tsx
+++ b/packages/frontend/src/Providers/MediaStream/MediaStreamProvider.tsx
@@ -8,6 +8,7 @@ import {
 	useState,
 } from "react";
 import {
+	type AvailableSources,
 	MediaStreamContext,
 	type MediaItem,
 	type PagerItem,
@@ -73,11 +74,17 @@ interface WsNewsMessage {
 	items: MediaItem[];
 }
 
+interface WsSourcesMessage {
+	type: "sources";
+	sources: AvailableSources;
+}
+
 type WsIncomingMessage =
 	| WsItemsMessage
 	| WsPagerMessage
 	| WsMp3Message
 	| WsNewsMessage
+	| WsSourcesMessage
 	| { type: string };
 
 interface MediaStreamProviderProps {
@@ -93,6 +100,7 @@ export const MediaStreamProvider: FC<MediaStreamProviderProps> = ({
 	const [pagerItems, setPagerItems] = useState<PagerItem[]>([]);
 	const [mp3Items, setMp3Items] = useState<MediaItem[]>([]);
 	const [newsItems, setNewsItems] = useState<MediaItem[]>([]);
+	const [sources, setSources] = useState<AvailableSources>({ video: [], pager: [] });
 	const [connected, setConnected] = useState(false);
 
 	// Per-app format subscriptions. null = wants all formats.
@@ -332,6 +340,19 @@ export const MediaStreamProvider: FC<MediaStreamProviderProps> = ({
 			// seek_ack snapshots are all active-now, so they land entirely in `due`.
 			const now = localDateRef.current.getTime();
 
+			// Time-independent source lists for filters — sent once at init. Replace
+			// wholesale (the server always sends the complete set).
+			if (msg.type === "sources") {
+				const incoming = (msg as WsSourcesMessage).sources;
+				if (incoming) {
+					setSources({
+						video: incoming.video ?? [],
+						pager: incoming.pager ?? [],
+					});
+				}
+				return;
+			}
+
 			if (msg.type === "pager") {
 				const incomingPager = (msg as WsPagerMessage).pager;
 				if (!incomingPager || incomingPager.length === 0) return;
@@ -406,6 +427,7 @@ export const MediaStreamProvider: FC<MediaStreamProviderProps> = ({
 				pagerItems,
 				mp3Items,
 				newsItems,
+				sources,
 				connected,
 				addItems,
 				subscribeFormats,


### PR DESCRIPTION
## Summary

The TV channel filter and Pager provider filter previously only learned a source **after** it had scrolled past in the current virtual-time window — so the lists were incomplete until enough history had played. The streamer now pushes a **`sources`** frame once at init carrying every selectable source up front, independent of the virtual clock.

## Why derive from usage

The shared `sources` table in Directus does **not** record which media type a source belongs to, so membership can only be inferred from the rows that reference it:

- **`video`** — `DISTINCT s.slug` among approved **m3u8** `media_items` → the TV's channel filter
- **`pager`** — `DISTINCT provider` among approved `pager_items` (provider is free text, not even a `sources` FK) → the Pager's provider filter

No Directus schema change is required.

## Backend

- `db.AvailableVideoSources` / `AvailablePagerProviders` + a `queryStrings` helper. The video format lives in a documented `videoFormat = "m3u8"` constant.
- `SourceList{Video, Pager}` type, `outMsg.Sources`, `Session.SendSources`.
- Sent from the `init` handler (non-fatal on query error — a missing list only degrades a filter, never breaks streaming). **Not** resent on `seek` (time-independent).
- `docs/websocket-protocol.md` documents the new frame; `TestSendSourcesEmitsSourceLists` added.

## Frontend

- `MediaStreamContext.AvailableSources` + `sources` on the context value.
- `MediaStreamProvider` decodes the `sources` frame into state.
- TV seeds `availableChannels` from `sources.video` (unioned with anything seen in-stream as a pre-frame fallback).
- `usePagerPlayback` merges `sources.pager` into the provider dropdown.

## Testing

- Backend: `go build` / `go vet` / `go test ./...` green (new session test included)
- Frontend: `tsc -b` clean, `eslint` clean, 51/51 vitest tests pass

## Follow-ups (not in this PR)

- Extend the frame with `mp3`/`news` source lists for the Radio/News apps.
- If you ever want to show a channel before it has approved video, or disambiguate multi-type sources, add an explicit media-type column to `sources` and switch the queries to use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)