### PR TITLE
fix(usenet): drain IA search cursor before DB writes (large-collection scan truncation)

### DIFF
--- a/packages/tools/video-grabber/tests/test_usenet_scanner.py
+++ b/packages/tools/video-grabber/tests/test_usenet_scanner.py
@@ -56,6 +56,33 @@ def test_scan_collection_upserts_one_row_per_item():
     assert db.commits >= 1  # final commit at minimum
 
 
+def test_scan_collection_drains_search_before_db_writes():
+    """Regression: the scanner must fully drain the IA search cursor before any
+    per-item DB write. Holding the scraping cursor open across slow per-item
+    upserts expires it (~400 items on a loaded worker), truncating large
+    collections — giganews scanned only ~400 of 25,328."""
+    state = {"drained": False}
+
+    def gen():
+        for i in range(5):
+            yield {"identifier": f"usenet-{i}", "mediatype": "texts"}
+        state["drained"] = True  # set only once the generator is fully consumed
+
+    class GenSession:
+        def search_items(self, query, fields=None):
+            return gen()
+
+    class AssertDrainedDB(FakeDB):
+        def execute(self, stmt, params):
+            assert state["drained"], "search cursor not fully drained before DB write"
+            super().execute(stmt, params)
+
+    db = AssertDrainedDB()
+    n = scanner.scan_collection(GenSession(), "giganews", db)
+    assert n == 5
+    assert len(db.rows) == 5
+
+
 def test_scan_collection_recurses_nested_collections():
     session = FakeSession({
         "root": [

--- a/packages/tools/video-grabber/video_grabber/usenet/scanner.py
+++ b/packages/tools/video-grabber/video_grabber/usenet/scanner.py
@@ -93,15 +93,23 @@ def scan_collection(
         return 0
     visited.add(identifier)
 
+    if sleep_sec:
+        time.sleep(sleep_sec)
     log.info("usenet scan: %s — searching", identifier)
-    results = session.search_items(
+    # Fully drain the IA search cursor *before* any per-item DB write. The scraping
+    # cursor expires if it is held open across slow per-item upserts (each commit,
+    # on a loaded shared worker) — which silently truncated large collections:
+    # giganews (25,328 items) stopped at ~400. Materializing the result list first
+    # keeps the cursor short-lived, then the slow upserts run against memory. The
+    # old per-item sleep made it worse (slower loop, longer-held cursor) and is
+    # dropped; sleep_sec now throttles between *searches* instead.
+    items = list(session.search_items(
         f"collection:{identifier}",
         fields=["identifier", "mediatype", "title", "format", "collection"],
-    )
+    ))
+    log.info("usenet scan: %s — %d items found, upserting", identifier, len(items))
     seen = inserted = nested = 0
-    for item in results:
-        if sleep_sec:
-            time.sleep(sleep_sec)
+    for item in items:
         seen += 1
         if item.get("mediatype") == "collection":
             nested += 1


### PR DESCRIPTION
## Problem (found live)

`scan-usenet` for **giganews** only ingested **~400 of 25,328** newsgroup archives. Root cause: `scan_collection` iterates the IA scraping-search cursor **while** doing the per-item DB upsert (commit every 100) **and** a per-item `sleep_sec`. On a large collection — on a worker also running the 8× video drain — each page takes long enough that the scraping cursor **expires after ~400 items**, and the iteration silently stops. (The video scanner never hit this on smaller/faster scans.)

usenethistorical (1,019 items) scanned fine; giganews (25k) exposed it.

## Fix

Materialize the search results into a list **first** (cursor stays short-lived), then run the slow upserts against memory:

```python
items = list(session.search_items(f"collection:{identifier}", fields=[...]))
for item in items:
    ... upsert ...
```

- Drops the per-item `sleep_sec` (it made the cursor-hold *worse*); `sleep_sec` now throttles between *searches*.
- Nested collections still recurse, each draining its own search before its upserts.
- Memory: ~25k small dicts ≈ a few MB.

## Test

Adds `test_scan_collection_drains_search_before_db_writes` — a generator-backed search whose "fully drained" flag must be set before the first DB write (fails on the old interleaved code, passes now). `pytest tests/test_usenet_scanner.py` 5 passed; `ruff` clean.

## Note

I already backfilled the missing giganews records out-of-band (direct enumerate + bulk insert) so nothing's blocked on this merge. This PR fixes the scanner so future large-collection scans (re-scans, new collections) don't truncate.

⚠️ Merging rebuilds the shared worker image → ArgoCD rolls the worker (the video-grabber self-healer will auto-recover the drain). Land it whenever convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)