### PR TITLE
fix(video-grabber): trust IA identifier prefix over call-sign title guess

### DIFF
--- a/packages/tools/video-grabber/tests/test_channel_map.py
+++ b/packages/tools/video-grabber/tests/test_channel_map.py
@@ -41,3 +41,27 @@ def test_human_field_wins_over_identifier_prefix():
     assert normalize_slug(
         {"identifier": "FOX5NEWS_20010911_x", "title": "Fox 5 News"}
     ) == "fox-news"
+
+
+def test_identifier_prefix_beats_call_sign_in_title():
+    # Regression: four-letter title words (WOLF, KING, WILL, WITH, WALL, ...)
+    # match the [WK][A-Z]{3} call-sign pattern and previously minted bogus
+    # channels. The identifier prefix is authoritative and must win.
+    cases = {
+        "CNN_20010911_000000_Wolf_Blitzer_Reports": "cnn",
+        "CNN_20010911_010000_Larry_King_Live": "cnn",
+        "WRC_20010914_010000_Will__Grace": "wrc",
+        "WETA_20010910_230000_The_NewsHour_With_Jim_Lehrer": "weta",
+        "NEWSW_20010911_140000_Need_to_Know": "newsw",
+        "NTV_20010913_160500_Kino": "ntv",
+        "WSBK_20010912_080000_Sex_Wars": "wsbk",
+    }
+    for identifier, expected in cases.items():
+        title = identifier.split("_", 3)[-1].replace("_", " ")
+        assert normalize_slug({"identifier": identifier, "title": title}) == expected
+
+
+def test_call_sign_in_title_still_works_without_identifier():
+    # The call-sign path is preserved as a last resort when no identifier
+    # prefix is present.
+    assert normalize_slug({"title": "WUSA broadcast"}) == "wusa"

--- a/packages/tools/video-grabber/video_grabber/ia/channel_map.py
+++ b/packages/tools/video-grabber/video_grabber/ia/channel_map.py
@@ -41,32 +41,61 @@ _IDENT_PREFIX = re.compile(r"^([A-Za-z][A-Za-z0-9]{1,15})_")
 
 
 def normalize_slug(item: dict) -> str | None:
-    """Return a channel slug from IA item metadata, or None if unrecognized."""
+    """Return a channel slug from IA item metadata, or None if unrecognized.
+
+    Priority:
+      1. A *known network* named in creator/subject/title (e.g. "ABC News").
+      2. The IA identifier's channel-code prefix (``CNN_``, ``WETA_``, ``ANT1_``,
+         …) — the authoritative per-capture broadcaster code in the Sept-11
+         archive.
+      3. A bare W/K call sign found in the text — last resort only.
+
+    Step 2 must precede step 3: the ``[WK][A-Z]{3}`` call-sign pattern also
+    matches ordinary four-letter title words ("WOLF" in *Wolf Blitzer*, "KING"
+    in *Larry King Live*, "WITH"/"WALL"/"WILD"/"WIND"/…), which previously minted
+    bogus channels out of program titles. The identifier prefix is unambiguous,
+    so trust it before guessing from free text.
+    """
     for field in ("creator", "subject", "title"):
-        value = item.get(field, "")
-        if isinstance(value, list):
-            value = " ".join(value)
-        if not value:
-            continue
-        slug = _slug_from_text(value)
+        slug = _known_network(_as_text(item.get(field)))
         if slug:
             return slug
-    # Last resort: the identifier's channel-code prefix. Only reached when the
-    # human-readable fields named no known network and carried no call sign.
-    return _slug_from_identifier(item.get("identifier", ""))
+
+    ident = _slug_from_identifier(item.get("identifier", ""))
+    if ident:
+        return ident
+
+    for field in ("creator", "subject", "title"):
+        slug = _call_sign(_as_text(item.get(field)))
+        if slug:
+            return slug
+    return None
+
+
+def _as_text(value) -> str:
+    if isinstance(value, list):
+        return " ".join(value)
+    return value or ""
 
 
 def _slug_from_identifier(identifier: str) -> str | None:
     m = _IDENT_PREFIX.match(identifier or "")
-    return m.group(1).lower() if m else None
+    if not m:
+        return None
+    raw = m.group(1).lower()
+    # Normalize aliases (e.g. an "ABC_" prefix -> abc-news); unknown codes
+    # (nhk, weta, ant1, …) pass through unchanged.
+    return KNOWN_CHANNELS.get(raw, raw)
 
 
-def _slug_from_text(text: str) -> str | None:
+def _known_network(text: str) -> str | None:
     lower = text.lower()
     for pattern, slug in KNOWN_CHANNELS.items():
         if pattern in lower:
             return slug
-    m = _LOCAL_CALL_SIGN.search(text.upper())
-    if m:
-        return m.group(1).lower()
     return None
+
+
+def _call_sign(text: str) -> str | None:
+    m = _LOCAL_CALL_SIGN.search(text.upper())
+    return m.group(1).lower() if m else None


### PR DESCRIPTION
## Problem

`normalize_slug` ran the `[WK][A-Z]{3}` call-sign regex against the program **title** *before* consulting the authoritative IA identifier prefix. Ordinary four-letter title words match that pattern, so programs were filed under bogus "channels" minted from their titles:

| Bad slug | Real example | True channel |
|---|---|---|
| `wolf` | `CNN_..._Wolf_Blitzer_Reports` | cnn |
| `king` | `CNN_..._Larry_King_Live` | cnn |
| `with` | `WETA_..._The_NewsHour_With_Jim_Lehrer` | weta |
| `know` | `NEWSW_..._Need_to_Know` | newsw |
| `kino` | `NTV_..._Kino` | ntv |
| `wars` | `WSBK_..._Sex_Wars` | wsbk |

…plus `will`, `wall`, `wild`, `wind`, `week`, `kids`, `walt` — 13 fake channels holding ~120 misclassified programs, pulling marquee shows off their real station.

## Fix

Reorder resolution to **known-network(text) → identifier prefix → call-sign(text)**. The identifier prefix (`CNN_`, `WETA_`, `NEWSW_`, …) is the unambiguous per-capture broadcaster code in the Sept-11 archive, so it's trusted before guessing a call sign from free text.

- Known-network title matches still win first, so `"ABC News"`-style classification (and the existing network channels) are unchanged.
- The call-sign-from-text path is retained as a last resort for items with no identifier.
- The identifier prefix is normalized through `KNOWN_CHANNELS` so an aliased prefix maps to its canonical slug.

The already-ingested data was corrected operationally (123 programs reassigned by identifier prefix, fake channels dropped); this prevents recurrence on any future scan.

## Tests

- `test_identifier_prefix_beats_call_sign_in_title` — the 7 regression cases above.
- `test_call_sign_in_title_still_works_without_identifier` — last-resort path preserved.
- All pre-existing `test_channel_map` cases still green (9 passed locally; `ruff` clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)