### PR TITLE
fix(video-grabber): channel-aware TZ disambiguation + prefer scheduled programs over generic coverage

### DIFF
--- a/packages/tools/video-grabber/tests/test_metadata.py
+++ b/packages/tools/video-grabber/tests/test_metadata.py
@@ -145,6 +145,27 @@ def test_resolve_unknown_abbr_falls_back_to_edt():
     assert tz.utcoffset(datetime(2001, 9, 11)) == timedelta(hours=-4)
 
 
+def test_resolve_ambiguous_cst_uses_china_for_cctv3():
+    # "CST" means China Standard Time (+8) for CCTV3, not US Central (-6).
+    tz = resolve_timezone("CST", "cctv3")
+    assert tz.utcoffset(datetime(2001, 9, 11)) == timedelta(hours=8)
+
+
+def test_resolve_ambiguous_cst_stays_us_central_for_us_channel():
+    # A US channel with no canonical override keeps the literal US reading.
+    tz = resolve_timezone("CST", "cbs-news")
+    assert tz.utcoffset(datetime(2001, 9, 11)) == timedelta(hours=-6)
+
+
+def test_air_date_uses_channel_to_disambiguate_cst():
+    # Same title, two channels: China (+8) vs US Central (-6).
+    title = "China Central TV : CCTV3 : September 11, 2001 4:00am CST"
+    cn = extract_air_date_utc(title, "", channel_slug="cctv3")
+    assert cn == datetime(2001, 9, 10, 20, 0, tzinfo=timezone.utc)  # 4am +8
+    us = extract_air_date_utc(title, "", channel_slug="tcn")
+    assert us == datetime(2001, 9, 11, 10, 0, tzinfo=timezone.utc)  # 4am -6
+
+
 # ---------------------------------------------------------------------------
 # Channel slug extraction
 # ---------------------------------------------------------------------------

--- a/packages/tools/video-grabber/tests/test_scheduler.py
+++ b/packages/tools/video-grabber/tests/test_scheduler.py
@@ -4,7 +4,7 @@ assembler depends on, independent of which overlap policy is chosen.
 
 If these pass, assemble_range can safely consume the output.
 """
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 
 from video_grabber.epg.scheduler import (
@@ -16,10 +16,23 @@ WS = datetime(2001, 9, 9, 0, 0, tzinfo=timezone.utc)
 WE = datetime(2001, 9, 18, 0, 0, tzinfo=timezone.utc)
 
 
-def prog(pid, start, dur):
+def prog(pid, start, dur, ia_identifier=None):
     return ScheduledProgram(
-        program_id=pid, ia_identifier=pid, air_date=start, duration_seconds=dur
+        program_id=pid,
+        ia_identifier=ia_identifier if ia_identifier is not None else pid,
+        air_date=start,
+        duration_seconds=dur,
     )
+
+
+def scheduled(pid, start, dur):
+    """A program whose identifier carries an explicit air time (EPG-grid)."""
+    return prog(pid, start, dur, ia_identifier=f"CNN_20010911_120000_{pid}")
+
+
+def generic(pid, start, dur):
+    """A continuous-coverage capture with no identifier timestamp."""
+    return prog(pid, start, dur, ia_identifier=f"cnn200109111545-{pid}")
 
 
 def assert_assembler_contract(slots, window_start=WS, window_end=WE):
@@ -60,3 +73,32 @@ def test_program_outside_window_is_dropped_or_clipped():
     progs = [prog("early", datetime(2001, 9, 8, 23, 0, tzinfo=timezone.utc), 3600)]
     slots = resolve_slots(progs, WS, WE)
     assert_assembler_contract(slots)
+
+
+def test_scheduled_program_wins_over_overlapping_generic():
+    # A generic "Television News" block overlaps a named scheduled program;
+    # the scheduled program must keep its full airtime.
+    t = datetime(2001, 9, 11, 13, 0, tzinfo=timezone.utc)
+    progs = [
+        generic("news", t, 3600),                                   # 13:00-14:00
+        scheduled("sched", t + timedelta(minutes=15), 1800),        # 13:15-13:45
+    ]
+    slots = resolve_slots(progs, WS, WE)
+    assert_assembler_contract(slots)
+    by_id = {s.program_id: s for s in slots}
+    # Scheduled keeps its exact slot...
+    assert by_id["sched"].starts_at == t + timedelta(minutes=15)
+    assert by_id["sched"].ends_at == t + timedelta(minutes=45)
+    # ...and the generic fills only the gaps around it.
+    gen = sorted((s for s in slots if s.program_id == "news"), key=lambda s: s.starts_at)
+    assert gen[0].starts_at == t and gen[0].ends_at == t + timedelta(minutes=15)
+    assert gen[-1].ends_at == t + timedelta(hours=1)
+
+
+def test_generic_fills_gap_when_no_scheduled_overlap():
+    # With no competing scheduled program, the generic capture is placed as-is.
+    t = datetime(2001, 9, 11, 13, 0, tzinfo=timezone.utc)
+    slots = resolve_slots([generic("news", t, 1800)], WS, WE)
+    assert_assembler_contract(slots)
+    assert [s.program_id for s in slots] == ["news"]
+    assert slots[0].starts_at == t and slots[0].ends_at == t + timedelta(minutes=30)

--- a/packages/tools/video-grabber/video_grabber/epg/scheduler.py
+++ b/packages/tools/video-grabber/video_grabber/epg/scheduler.py
@@ -16,10 +16,18 @@ overlaps is the one real policy decision in this module — it lives in
 """
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 import sqlalchemy as sa
+
+# An EPG-grid recording embeds an explicit air time in its identifier, e.g.
+# "CNN_20010911_210000_Inside_Politics". The other archive source uses a
+# generic continuous-coverage form ("cnn200109111545-1626") with no such
+# timestamp — those are the "Television News" captures that should yield to a
+# named scheduled program when the two overlap (see resolve_slots).
+_SCHEDULED_TS = re.compile(r"_\d{8}_\d{6}(?:_|$)")
 
 
 @dataclass(frozen=True)
@@ -33,6 +41,13 @@ class ScheduledProgram:
     @property
     def natural_end(self) -> datetime:
         return self.air_date + timedelta(seconds=self.duration_seconds)
+
+    @property
+    def is_scheduled(self) -> bool:
+        """True for EPG-grid recordings (identifier carries an explicit
+        ``_YYYYMMDD_HHMMSS``). These outrank generic live-coverage captures on
+        overlap, so a named program always claims its airtime."""
+        return bool(_SCHEDULED_TS.search(self.ia_identifier or ""))
 
 
 @dataclass(frozen=True)
@@ -94,12 +109,22 @@ def resolve_slots(
 ) -> list[ResolvedSlot]:
     """Turn raw, possibly-overlapping programs into a clean slot timeline.
 
-    Policy: **first-wins (clip)**. Programs are processed in ``air_date`` order;
-    whoever claims the air first keeps it, and a later program that overlaps has
-    its start clipped to the running cursor. This is the most forgiving choice
-    for archive content, where ``air_date`` is heuristically derived (see
-    resolve.py) and small overlaps are usually timing error rather than a real
-    contest — clipping preserves as much footage as fits instead of dropping it.
+    Policy: **priority tiers, then first-wins (clip)**. Programs are placed in
+    two passes:
+
+    1. *Scheduled* programs (``is_scheduled`` — EPG-grid recordings with an
+       explicit identifier timestamp) are laid down first, in ``air_date``
+       order, each clipped to the running cursor. A named program therefore
+       always claims its airtime.
+    2. *Generic* live-coverage captures (the "Television News" form) then fill
+       only the gaps the scheduled pass left open, clipped to each free span.
+
+    Within a tier the rule is the forgiving first-wins clip — ``air_date`` is
+    heuristically derived (see resolve.py) and small overlaps are usually timing
+    error, so clipping preserves as much footage as fits. The cross-tier
+    priority is the real decision: where the two archive sources double-cover
+    the same minutes (the Sep 11-13 breaking-news window), the scheduled program
+    wins and the generic feed is relegated to the leftover gaps.
 
     Guarantees the assembler's forward-only cursor depends on — the returned
     list is sorted by ``starts_at``, non-overlapping, and clamped to
@@ -108,15 +133,58 @@ def resolve_slots(
     at least one segment long.
     """
     slots: list[ResolvedSlot] = []
-    cursor = window_start
-    for p in sorted(programs, key=lambda p: p.air_date):
-        start = max(p.air_date, cursor)
-        end = min(p.natural_end, window_end)
-        if (end - start).total_seconds() < _MIN_SLOT_SECONDS:
-            continue  # entirely before the cursor, past the window, or too short
-        slots.append(ResolvedSlot(p.program_id, start, end))
-        cursor = end
+    occupied: list[tuple[datetime, datetime]] = []  # sorted, merged
+
+    def place(candidates: list[ScheduledProgram]) -> None:
+        for p in sorted(candidates, key=lambda p: p.air_date):
+            lo = max(p.air_date, window_start)
+            hi = min(p.natural_end, window_end)
+            for span_start, span_end in _free_spans(occupied, lo, hi):
+                if (span_end - span_start).total_seconds() < _MIN_SLOT_SECONDS:
+                    continue
+                slots.append(ResolvedSlot(p.program_id, span_start, span_end))
+                _occupy(occupied, span_start, span_end)
+
+    place([p for p in programs if p.is_scheduled])
+    place([p for p in programs if not p.is_scheduled])
+    slots.sort(key=lambda s: s.starts_at)
     return slots
+
+
+def _free_spans(
+    occupied: list[tuple[datetime, datetime]], lo: datetime, hi: datetime
+) -> list[tuple[datetime, datetime]]:
+    """Maximal sub-spans of ``[lo, hi)`` not covered by ``occupied`` (which must
+    be sorted and merged)."""
+    spans: list[tuple[datetime, datetime]] = []
+    cursor = lo
+    for start, end in occupied:
+        if end <= cursor or start >= hi:
+            continue
+        if start > cursor:
+            spans.append((cursor, min(start, hi)))
+        cursor = max(cursor, end)
+        if cursor >= hi:
+            break
+    if cursor < hi:
+        spans.append((cursor, hi))
+    return spans
+
+
+def _occupy(
+    occupied: list[tuple[datetime, datetime]], start: datetime, end: datetime
+) -> None:
+    """Insert ``[start, end)`` and re-merge so ``occupied`` stays sorted and
+    overlap-free (the invariant ``_free_spans`` relies on)."""
+    occupied.append((start, end))
+    occupied.sort()
+    merged: list[tuple[datetime, datetime]] = []
+    for a, b in occupied:
+        if merged and a <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], b))
+        else:
+            merged.append((a, b))
+    occupied[:] = merged
 
 
 def _fetch_programs(

--- a/packages/tools/video-grabber/video_grabber/ia/metadata.py
+++ b/packages/tools/video-grabber/video_grabber/ia/metadata.py
@@ -31,6 +31,44 @@ _TZABBR: dict[str, timedelta] = {
 # Default offset when no tz abbreviation is found — EDT matches US East Coast 9/11 coverage
 _DEFAULT_OFFSET = timedelta(hours=-4)
 
+# Some abbreviations are genuinely ambiguous across regions. "CST" is US Central
+# (-6) in a US title but China Standard Time (+8) for CCTV3; "CT" likewise. When
+# one of these appears for a channel with a known canonical timezone, trust the
+# channel's region over the literal abbreviation.
+_AMBIGUOUS_ABBR: frozenset[str] = frozenset({"CST", "CT"})
+
+# Canonical Sept-2001 UTC offset per channel, used to disambiguate the entries
+# in _AMBIGUOUS_ABBR. Only non-US broadcasters need an entry; US channels fall
+# through to the literal (US) reading. Sept 2001 is inside summer DST for the
+# Northern Hemisphere with no transition in our window, so fixed offsets are
+# exact. (Most channels resolve air time from the UTC identifier timestamp and
+# never reach this path; this is the authoritative fallback when they do.)
+_CHANNEL_OFFSET: dict[str, timedelta] = {
+    "cctv3": timedelta(hours=8),   # China Standard Time
+    "nhk": timedelta(hours=9),     # Japan Standard Time
+    "bbc": timedelta(hours=1),     # British Summer Time
+    "mcm": timedelta(hours=2),     # Central European Summer Time
+    "ant1": timedelta(hours=3),    # Greece, Eastern European Summer Time
+    "ntv": timedelta(hours=4),     # Moscow Summer Time
+}
+
+
+def _resolve_offset(
+    tz_abbr: str | None, channel_slug: str | None, default: timedelta
+) -> timedelta:
+    """UTC offset for a parsed title time. An explicit abbreviation wins, except
+    that an *ambiguous* one (see _AMBIGUOUS_ABBR) defers to the channel's known
+    region. Falls back to ``default`` when nothing matches."""
+    if tz_abbr:
+        abbr = tz_abbr.upper()
+        canonical = _CHANNEL_OFFSET.get((channel_slug or "").lower())
+        if abbr in _AMBIGUOUS_ABBR and canonical is not None:
+            return canonical
+        off = _TZABBR.get(abbr)
+        if off is not None:
+            return off
+    return default
+
 # Ordered patterns — most specific first. Use named groups to avoid index shifting.
 _MONTH_NAMES = (
     "january|february|march|april|may|june|july|august|september|"
@@ -67,30 +105,37 @@ _MONTH_MAP = {
 }
 
 
-def extract_air_date_utc(title: str, description: str = "") -> datetime | None:
-    """Parse air date from title then description; return UTC datetime or None."""
+def extract_air_date_utc(
+    title: str, description: str = "", channel_slug: str | None = None
+) -> datetime | None:
+    """Parse air date from title then description; return UTC datetime or None.
+
+    ``channel_slug`` disambiguates region-ambiguous timezone abbreviations in
+    the title (e.g. CCTV3's "CST" is China, not US Central)."""
     for text in (title, description):
         if not text:
             continue
-        result = _parse_text(text)
+        result = _parse_text(text, channel_slug)
         if result is not None:
             return result
     return None
 
 
-def _parse_text(text: str) -> datetime | None:
+def _parse_text(text: str, channel_slug: str | None = None) -> datetime | None:
     for kind, pattern in _PATTERNS:
         m = pattern.search(text)
         if m is None:
             continue
         try:
-            return _build_datetime(kind, m)
+            return _build_datetime(kind, m, channel_slug)
         except (ValueError, KeyError):
             continue
     return None
 
 
-def _build_datetime(kind: str, m: re.Match) -> datetime | None:
+def _build_datetime(
+    kind: str, m: re.Match, channel_slug: str | None = None
+) -> datetime | None:
     gd = m.groupdict()
 
     if kind == "iso":
@@ -99,7 +144,7 @@ def _build_datetime(kind: str, m: re.Match) -> datetime | None:
         tz_abbr = gd.get("isotz")
         year, month, day = map(int, date_str.split("-"))
         # ISO without tz → treat as UTC (not local time)
-        offset = _TZABBR.get((tz_abbr or "UTC").upper(), timedelta(0))
+        offset = _resolve_offset(tz_abbr, channel_slug, default=timedelta(0))
     else:
         month = _MONTH_MAP[gd["month"].lower()]
         day = int(gd["day"])
@@ -108,7 +153,7 @@ def _build_datetime(kind: str, m: re.Match) -> datetime | None:
         ampm = gd.get("ampm")
         tz_abbr = gd.get("tz")
         time_str = _apply_ampm(time_str, ampm)
-        offset = _TZABBR.get((tz_abbr or "").upper(), _DEFAULT_OFFSET)
+        offset = _resolve_offset(tz_abbr, channel_slug, default=_DEFAULT_OFFSET)
 
     h, mn, sec = _parse_time(time_str)
     tz = timezone(offset)
@@ -138,12 +183,9 @@ def _parse_time(time_str: str) -> tuple[int, int, int]:
 
 
 def resolve_timezone(tz_str: str | None, channel_slug: str) -> timezone:
-    """Return a fixed-offset timezone. Falls back to EDT (UTC-4) when unknown."""
-    if tz_str:
-        offset = _TZABBR.get(tz_str.upper())
-        if offset is not None:
-            return timezone(offset)
-    return timezone(_DEFAULT_OFFSET)
+    """Return a fixed-offset timezone, disambiguating region-ambiguous
+    abbreviations by ``channel_slug``. Falls back to EDT (UTC-4) when unknown."""
+    return timezone(_resolve_offset(tz_str, channel_slug, _DEFAULT_OFFSET))
 
 
 def extract_channel_slug(item: dict) -> str | None:

--- a/packages/tools/video-grabber/video_grabber/pipeline/resolve.py
+++ b/packages/tools/video-grabber/video_grabber/pipeline/resolve.py
@@ -88,7 +88,7 @@ def _air_date_from_identifier(identifier: str) -> Optional[datetime]:
         return None
 
 
-def _air_date(meta: dict) -> datetime:
+def _air_date(meta: dict, channel_slug: str | None = None) -> datetime:
     """Resolve the program's UTC air time.
 
     Priority: the UTC timestamp embedded in the identifier → the human title →
@@ -107,7 +107,8 @@ def _air_date(meta: dict) -> datetime:
         return from_ident
 
     parsed = extract_air_date_utc(
-        meta.get("title", ""), meta.get("description", "") or ""
+        meta.get("title", ""), meta.get("description", "") or "",
+        channel_slug=channel_slug,
     )
     if parsed is not None:
         return parsed
@@ -157,7 +158,7 @@ def resolve_job(job, db, media_path: Optional[Path] = None):
 
     display_name = _DISPLAY_NAMES.get(slug, slug.upper())
     tz = _timezone_abbr(meta)
-    air_date = _air_date(meta)
+    air_date = _air_date(meta, slug)
     title = _program_title(meta)
     description = meta.get("description")
     duration = probe_duration_seconds(media_path) if media_path is not None else 0


### PR DESCRIPTION
Two correctness fixes surfaced while auditing the 9-day channel timeline for timezone alignment.

## 1. Timezone disambiguation

`_TZABBR` mapped `"CST"` unconditionally to **US Central (−6)**, but CCTV3's titles use `"CST"` for **China Standard Time (+8)** (and `"CT"` is likewise ambiguous). Today every channel resolves its air time from the **authoritative UTC identifier timestamp** and never reaches the title parser, so no stored `air_date` is wrong — but the fallback was latent-buggy.

The fix adds a per-channel canonical Sept-2001 offset table and routes title-time parsing through a channel-aware resolver:
- An explicit **ambiguous** abbreviation (`CST`/`CT`) now defers to the channel's known region (`cctv3` → +8, US channel → −6).
- Unambiguous abbreviations and the **EDT default** — the US-recorder convention for the lowercase-identifier captures — are unchanged.
- `extract_air_date_utc` / `resolve_timezone` gain a `channel_slug` arg; `resolve.py` threads the resolved slug through.

Audit confirmed the underscore-identifier captures are genuinely UTC across 9 real offsets (−5 Mexico → +9 Japan), and the lowercase captures are US-Eastern — so this is hardening, not a live data change.

## 2. Scheduled programs win over generic "Television News"

The archive has two sources that **double-cover Sep 11–13**: EPG-grid recordings (identifier carries `_YYYYMMDD_HHMMSS_`) and a separate continuous live-coverage capture (titled "Television News") of the same minutes. Previously `resolve_slots` was pure first-wins-clip by `air_date`, so whichever started first won — often the generic block.

`resolve_slots` is now two-tier:
1. **Scheduled** programs are laid down first (each first-wins-clipped) — a named program always claims its airtime.
2. **Generic** captures then fill only the leftover gaps.

The assembler contract (sorted, non-overlapping, clamped to window) is preserved; the three existing contract tests still pass.

## Tests
- `test_resolve_ambiguous_cst_*` + `test_air_date_uses_channel_to_disambiguate_cst` — China vs US `CST`.
- `test_scheduled_program_wins_over_overlapping_generic` + `test_generic_fills_gap_when_no_scheduled_overlap`.
- All pre-existing metadata/scheduler tests green (43 passed for the touched modules; 177 across the locally-collectible suite; `ruff` clean).

## Deploy note
#2 changes `build-channel` output, so after this lands + deploys, the channels that actually have both sources (**`bbc`, `cnn`**) should be rebuilt. The other lowercase feeds (`abc`/`nbc`/`cbs`/`fox`) have no scheduled competitor, so they're unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)