### PR TITLE
fix(video-grabber): path HLS segments from stored upload key, not current channel slug

### DIFF
--- a/packages/tools/video-grabber/tests/test_epg_range.py
+++ b/packages/tools/video-grabber/tests/test_epg_range.py
@@ -116,6 +116,7 @@ def test_fetch_slots_path_reshapes_joined_rows():
         "ia_identifier": "WETA_20010911_123000_Demo",
         "title": "Demo",
         "description": "Desc",
+        "wasabi_key": "hls/weta/20010911/WETA_20010911_123000_Demo/master.m3u8",
     }
     db = MagicMock()
     db.execute.return_value.mappings.return_value.all.return_value = [row]
@@ -126,3 +127,31 @@ def test_fetch_slots_path_reshapes_joined_rows():
     assert "/weta/20010911/WETA_20010911_123000_Demo/full/" in playlists["full"]
     assert any(g["title"] == "Demo" for g in epg["grid"])
     assert _count_playlist_duration(playlists["full"]) == WINDOW_SECS
+
+
+def test_segment_path_uses_stored_upload_key_after_reassignment():
+    """A program reassigned to a new channel keeps its segments at the original
+    upload location (keyed by the slug at encode time). assemble_range must path
+    them from the stored ``segment_base``, not the program's current slug — else
+    every reassigned program points at a dead URL."""
+    ch = make_channel("cnn")  # program now lives on cnn...
+    slot = make_slot(
+        "CNN_20010911_010000_Larry_King_Live",
+        datetime(2001, 9, 11, 1, 0, tzinfo=timezone.utc),
+        1800,
+    )
+    # ...but its segments were uploaded while it was mis-slugged "king".
+    slot.program.segment_base = "hls/king/20010911/CNN_20010911_010000_Larry_King_Live"
+    playlists, _ = assemble_range(ch, WINDOW_START, WINDOW_END, None, slots=[slot])
+    full = playlists["full"]
+    assert "/hls/king/20010911/CNN_20010911_010000_Larry_King_Live/full/" in full
+    assert "/hls/cnn/20010911/" not in full  # never under the new slug
+
+
+def test_segment_path_falls_back_to_slug_without_key():
+    """With no stored key (segment_base=None), fall back to the slug-based path."""
+    ch = make_channel("cnn")
+    slot = make_slot("prog-x", datetime(2001, 9, 11, 1, 0, tzinfo=timezone.utc), 1800)
+    slot.program.segment_base = None
+    playlists, _ = assemble_range(ch, WINDOW_START, WINDOW_END, None, slots=[slot])
+    assert "/hls/cnn/20010911/prog-x/full/" in playlists["full"]

--- a/packages/tools/video-grabber/video_grabber/epg/assembler.py
+++ b/packages/tools/video-grabber/video_grabber/epg/assembler.py
@@ -19,6 +19,7 @@ Gap logic ported from packages/backend/gen-epg.mjs:65-101.
 Every slot boundary gets #EXT-X-DISCONTINUITY + absolute #EXT-X-MAP URL +
 #EXT-X-PROGRAM-DATE-TIME.
 """
+import posixpath
 from datetime import datetime, date, timedelta, timezone
 from types import SimpleNamespace
 from typing import Optional
@@ -79,12 +80,21 @@ def assemble_range(
                 "end": slot.starts_at.isoformat(),
             })
 
-        # Segments live under the program's own air date (== slot.starts_at),
-        # matching the upload path in storage/wasabi.py.
-        slot_yyyymmdd = slot.starts_at.strftime("%Y%m%d")
-        slot_prefix = (
-            f"{WASABI_BASE}/hls/{channel.slug}/{slot_yyyymmdd}/{slot.program.ia_identifier}"
-        )
+        # Segments live at their original upload location (storage/wasabi.py),
+        # which is keyed by the channel slug *at encode time*. That slug can
+        # later change when a program is reassigned to its correct channel, so
+        # path the segments from the authoritative stored upload key — otherwise
+        # every reassigned program points at a dead URL under the new slug. Fall
+        # back to reconstructing from the current slug when no key is recorded
+        # (e.g. unit tests that hand-build slots).
+        seg_base = getattr(slot.program, "segment_base", None)
+        if isinstance(seg_base, str) and seg_base:
+            slot_prefix = f"{WASABI_BASE}/{seg_base}"
+        else:
+            slot_yyyymmdd = slot.starts_at.strftime("%Y%m%d")
+            slot_prefix = (
+                f"{WASABI_BASE}/hls/{channel.slug}/{slot_yyyymmdd}/{slot.program.ia_identifier}"
+            )
         _append_slot(rend_lines, slot, slot_prefix)
         epg_grid.append({
             "title": slot.program.title,
@@ -180,10 +190,16 @@ def _fetch_slots(db, channel_id: str, window_start: datetime, window_end: dateti
     pattern ``flows.get_job`` uses for its channel/program relationships).
     """
     from sqlalchemy import text
+    # Pull the program's actual upload key via a scalar subquery (rather than a
+    # JOIN) so a program with more than one video_jobs row can't multiply the
+    # slot into duplicate segments. Newest uploaded key wins.
     rows = db.execute(
         text(
             "SELECT s.starts_at, s.ends_at, "
-            "       p.ia_identifier, p.title, p.description "
+            "       p.ia_identifier, p.title, p.description, "
+            "       (SELECT v.wasabi_key FROM video_jobs v "
+            "        WHERE v.program_id = p.id AND v.wasabi_key IS NOT NULL "
+            "        ORDER BY v.last_transition_at DESC LIMIT 1) AS wasabi_key "
             "FROM schedule_slots s "
             "JOIN programs p ON p.id = s.program_id "
             "WHERE s.channel_id = :cid AND s.starts_at >= :ws AND s.ends_at <= :we "
@@ -199,7 +215,23 @@ def _fetch_slots(db, channel_id: str, window_start: datetime, window_end: dateti
                 ia_identifier=r["ia_identifier"],
                 title=r["title"],
                 description=r["description"],
+                segment_base=_segment_base(r["wasabi_key"]),
             ),
         )
         for r in rows
     ]
+
+
+def _segment_base(wasabi_key: Optional[str]) -> Optional[str]:
+    """The directory holding a program's rendition folders, taken from its
+    stored upload key (e.g.
+    ``hls/king/20010911/CNN_..._Larry_King_Live/master.m3u8`` ->
+    ``hls/king/20010911/CNN_..._Larry_King_Live``).
+
+    This is the *actual* upload location — keyed by the channel slug at encode
+    time — and stays correct after a program is reassigned to a different
+    channel, where ``channel.slug`` no longer matches the stored path.
+    """
+    if not wasabi_key:
+        return None
+    return posixpath.dirname(wasabi_key)


### PR DESCRIPTION
## Problem

`assemble_range` built each program's segment URL by reconstructing the path from `channel.slug`:

```
hls/<channel.slug>/<air_date>/<ia_identifier>/<rend>/segNNNN.m4s
```

But segments are uploaded (`storage/wasabi.py`) under the slug resolved at **encode time**. When a program is later reassigned to its correct channel, `channel.slug` no longer matches the upload path, so the playlist entry points at a **dead URL**.

This is not hypothetical — the channel-taxonomy cleanup reassigned **476 programs** off the title-matcher's bogus slugs (`king→cnn`, `abc-news→wjla`, `fox-news→wttg`, `nbc-news→wrc`, `cbs-news→wusa`, the `with`/`wolf`/… fakes, etc.). Every one of those had segments stranded at `hls/<old-slug>/…`, so the prior build silently referenced missing segments for them (e.g. Larry King Live segments live at `hls/king/…`, not `hls/cnn/…`).

## Fix

Derive the segment prefix from the authoritative upload location stored in `video_jobs.wasabi_key` (whose dirname is `hls/<slug-at-encode>/<date>/<ident>`), which stays correct across reassignment.

- `_fetch_slots` pulls the key via a **scalar subquery** (so a program with more than one job row can't multiply a slot into duplicate segments) and exposes `slot.program.segment_base`.
- `assemble_range` uses `segment_base`, falling back to the slug-based path only when no key is recorded (hand-built test slots; guarded with `isinstance(... str)` so `MagicMock` test programs take the fallback).

## Tests
- `test_segment_path_uses_stored_upload_key_after_reassignment` — reassigned program (`cnn` now, uploaded as `king`) references `hls/king/…`, never `hls/cnn/<date>/`.
- `test_segment_path_falls_back_to_slug_without_key`.
- `test_fetch_slots_path_reshapes_joined_rows` updated for the new `wasabi_key` column.
- 28 passed across the EPG/assembler tests; 181 across the locally-collectible suite; `ruff` clean.

## Deploy note
This must land + deploy **before** the channel rebuild — otherwise the rebuilt playlists for all 476 reassigned programs would reference dead segment URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)