### PR TITLE
fix(video-grabber): accurate #EXTINF so the VOD timeline matches the media (QuickTime drift)

### DIFF
--- a/packages/tools/video-grabber/tests/test_build_channel.py
+++ b/packages/tools/video-grabber/tests/test_build_channel.py
@@ -28,6 +28,7 @@ def test_build_channel_flow_wires_schedule_assemble_publish():
          patch.object(flows, "build_schedule", return_value=7) as m_sched, \
          patch.object(flows, "assemble_range", return_value=(playlists, epg_channel)) as m_asm, \
          patch.object(flows, "generate_gap_fmp4") as m_gap, \
+         patch.object(flows, "gap_segment_durations", return_value={6: 6.029}), \
          patch.object(flows, "upload_tree") as m_tree, \
          patch.object(flows, "upload_text") as m_text, \
          patch.object(flows, "list_keys", return_value=["epg/cnn.json"]) as m_list, \

--- a/packages/tools/video-grabber/tests/test_epg_range.py
+++ b/packages/tools/video-grabber/tests/test_epg_range.py
@@ -155,3 +155,118 @@ def test_segment_path_falls_back_to_slug_without_key():
     slot.program.segment_base = None
     playlists, _ = assemble_range(ch, WINDOW_START, WINDOW_END, None, slots=[slot])
     assert "/hls/cnn/20010911/prog-x/full/" in playlists["full"]
+
+
+# --- accurate #EXTINF (the QuickTime-drift fix) ---------------------------------
+
+def _extinfs(playlist: str) -> list[float]:
+    return [float(ln.split(":")[1].rstrip(","))
+            for ln in playlist.splitlines() if ln.startswith("#EXTINF:")]
+
+
+def _fake_wasabi(monkeypatch, index_text):
+    """Inject a boto3-free stand-in for storage.wasabi so the assembler's lazy
+    import resolves to it (the real module imports boto3, absent in unit env)."""
+    import sys
+    import types
+
+    mod = types.ModuleType("video_grabber.storage.wasabi")
+    mod._make_s3_client = lambda cfg: object()
+    mod.read_text = lambda key, cfg, s3=None: index_text
+    monkeypatch.setitem(sys.modules, "video_grabber.storage.wasabi", mod)
+
+
+def test_program_extinf_comes_from_real_index_when_cfg_present(monkeypatch):
+    """With cfg set, the assembler reads the program's uploaded index.m3u8 and
+    emits its *real* fractional EXTINF + segment names — not a synthesized
+    integer-6s layout. This is what keeps a sample-timestamp player locked to
+    the playlist timeline."""
+    real_index = (
+        "#EXTM3U\n#EXT-X-VERSION:7\n#EXT-X-TARGETDURATION:6\n"
+        '#EXT-X-MAP:URI="init.mp4"\n'
+        "#EXTINF:6.006006,\nseg0000.m4s\n"
+        "#EXTINF:6.006006,\nseg0001.m4s\n"
+        "#EXTINF:4.004000,\nseg0002.m4s\n"
+        "#EXT-X-ENDLIST\n"
+    )
+    _fake_wasabi(monkeypatch, real_index)
+
+    ch = make_channel("cnn")
+    # Slot span (20s) exceeds the program (16.016s) so no segment is clipped —
+    # the real fractional EXTINF pass through verbatim (clipping has its own test).
+    slot = make_slot("CNN_x", datetime(2001, 9, 11, 1, 0, tzinfo=timezone.utc), 20)
+    slot.program.segment_base = "hls/king/20010911/CNN_x"
+    playlists, _ = assemble_range(
+        ch, WINDOW_START, WINDOW_END, None, slots=[slot], cfg=object(),
+    )
+    full = playlists["full"]
+    # Real segment names + fractional EXTINF appear verbatim.
+    assert "/hls/king/20010911/CNN_x/full/seg0000.m4s" in full
+    assert "#EXTINF:6.006," in full   # %g trims 6.006006 -> 6.006
+    assert "#EXTINF:4.004," in full
+    # The synthesized integer fallback ("seg0000.m4s" via range + EXTINF:6) is
+    # not what produced these — verify a fractional value is present.
+    assert any(abs(d - 6.006006) < 1e-3 for d in _extinfs(full))
+
+
+def test_clipped_slot_drops_segments_past_its_window(monkeypatch):
+    """A slot shorter than its program (scheduler clipped an overlap) emits only
+    whole segments up to the slot span; the rest are dropped, not overrun."""
+    # Program is 18s of real media (3x6s) but the slot is only ~12s.
+    real_index = (
+        "#EXTM3U\n"
+        "#EXTINF:6.006,\nseg0000.m4s\n"
+        "#EXTINF:6.006,\nseg0001.m4s\n"
+        "#EXTINF:6.006,\nseg0002.m4s\n#EXT-X-ENDLIST\n"
+    )
+    _fake_wasabi(monkeypatch, real_index)
+
+    ch = make_channel("cnn")
+    slot = make_slot("CNN_x", datetime(2001, 9, 11, 1, 0, tzinfo=timezone.utc), 12)
+    slot.program.segment_base = "hls/cnn/20010911/CNN_x"
+    playlists, _ = assemble_range(
+        ch, WINDOW_START, WINDOW_END, None, slots=[slot], cfg=object(),
+    )
+    full = playlists["full"]
+    assert "/CNN_x/full/seg0001.m4s" in full       # fills the 12s slot
+    assert "/CNN_x/full/seg0002.m4s" not in full    # 3rd would overrun the slot
+    # The program's EXTINF total lands on the slot span exactly (final segment
+    # clipped), so cumulative time stays equal to wall-clock at the boundary.
+    prog_extinfs = [
+        float(ln.split(":")[1].rstrip(","))
+        for ln, nxt in zip(full.splitlines(), full.splitlines()[1:])
+        if ln.startswith("#EXTINF:") and "/CNN_x/full/" in nxt
+    ]
+    assert abs(sum(prog_extinfs) - 12.0) < 1e-6
+
+
+def test_gap_extinf_uses_measured_tile_durations():
+    """gap_durations makes the blue tiles carry their true ~6.029s length and
+    sizes the fill by real media, so EXTINF sums track wall-clock without the
+    +0.029s/tile bias that drifted QuickTime."""
+    ch = make_channel("cnn")
+    gap_durations = {6: 6.029, 5: 5.027, 4: 4.027, 3: 3.026, 2: 2.025, 1: 1.024}
+    playlists, _ = assemble_range(
+        ch, WINDOW_START, WINDOW_END, None, slots=[], cfg=None,
+        gap_durations=gap_durations,
+    )
+    full = playlists["full"]
+    durs = _extinfs(full)
+    # Tiles carry the real measured duration, not an integer.
+    assert any(abs(d - 6.029) < 1e-4 for d in durs)
+    # Real media total stays within half a tile of the wall-clock window — the
+    # systematic drift is gone (a 9-day all-gap window is ~777600s).
+    assert abs(sum(durs) - WINDOW_SECS) < 6.029
+
+
+def test_plan_gap_tiles_sizes_by_real_duration():
+    from video_grabber.epg.assembler import _plan_gap_tiles
+
+    durs = {6: 6.029, 5: 5.027, 4: 4.027, 3: 3.026, 2: 2.025, 1: 1.024}
+    # Legacy (None): exact integer fill.
+    legacy = _plan_gap_tiles(20.0, None)
+    assert [lbl for lbl, _ in legacy] == [6, 6, 6, 2]
+    assert sum(d for _, d in legacy) == 20.0
+    # Accurate: real-duration tiling lands within half a tile of the target.
+    accurate = _plan_gap_tiles(20.0, durs)
+    assert abs(sum(d for _, d in accurate) - 20.0) < 6.029 / 2 + 0.01

--- a/packages/tools/video-grabber/video_grabber/epg/assembler.py
+++ b/packages/tools/video-grabber/video_grabber/epg/assembler.py
@@ -39,6 +39,8 @@ def assemble_range(
     db,
     *,
     slots: Optional[list] = None,
+    cfg=None,
+    gap_durations: Optional[dict[int, float]] = None,
 ) -> tuple[dict[str, str], dict]:
     """
     Build continuous HLS playlists and EPG JSON for ``channel`` across
@@ -51,10 +53,23 @@ def assemble_range(
     product serves one continuous stream per channel, regenerated in place as
     more content is acquired. The blue gap package is likewise channel-level
     (``hls/<slug>/_gap``) — its content is date-independent.
+
+    ``cfg`` / ``gap_durations`` enable *accurate* ``#EXTINF``: with ``cfg`` the
+    assembler reads each program's real per-segment durations from its uploaded
+    ``index.m3u8``; ``gap_durations`` (from :func:`gap_filler.gap_segment_durations`)
+    gives the blue tiles' true sub-second lengths. When both are absent the
+    assembler falls back to a synthesized integer-second timeline (the legacy
+    behaviour the unit tests exercise). Honest ``#EXTINF`` keeps a player that
+    advances by sample timestamps (AVFoundation/QuickTime) locked to the
+    playlist timeline instead of creeping ahead by ~0.5 % of all dead air.
     """
     if slots is None:
         slots = _fetch_slots(db, channel.id, window_start, window_end)
 
+    s3 = None
+    if cfg is not None:
+        from video_grabber.storage.wasabi import _make_s3_client
+        s3 = _make_s3_client(cfg)
     gap_prefix = f"{WASABI_BASE}/hls/{channel.slug}/_gap"
 
     rend_lines: dict[str, list[str]] = {
@@ -72,8 +87,8 @@ def assemble_range(
 
     for slot in slots:
         if slot.starts_at > cursor:
-            gap_secs = int((slot.starts_at - cursor).total_seconds())
-            _append_gap(rend_lines, cursor, gap_secs, gap_prefix)
+            gap_secs = (slot.starts_at - cursor).total_seconds()
+            _append_gap(rend_lines, cursor, gap_secs, gap_prefix, gap_durations)
             epg_grid.append({
                 "title": "[No Signal]",
                 "start": cursor.isoformat(),
@@ -88,14 +103,17 @@ def assemble_range(
         # back to reconstructing from the current slug when no key is recorded
         # (e.g. unit tests that hand-build slots).
         seg_base = getattr(slot.program, "segment_base", None)
+        program_segs = None
         if isinstance(seg_base, str) and seg_base:
             slot_prefix = f"{WASABI_BASE}/{seg_base}"
+            if cfg is not None:
+                program_segs = _program_segments(seg_base, cfg, s3)
         else:
             slot_yyyymmdd = slot.starts_at.strftime("%Y%m%d")
             slot_prefix = (
                 f"{WASABI_BASE}/hls/{channel.slug}/{slot_yyyymmdd}/{slot.program.ia_identifier}"
             )
-        _append_slot(rend_lines, slot, slot_prefix)
+        _append_slot(rend_lines, slot, slot_prefix, program_segs)
         epg_grid.append({
             "title": slot.program.title,
             "description": slot.program.description,
@@ -106,8 +124,8 @@ def assemble_range(
         cursor = slot.ends_at
 
     if cursor < window_end:
-        gap_secs = int((window_end - cursor).total_seconds())
-        _append_gap(rend_lines, cursor, gap_secs, gap_prefix)
+        gap_secs = (window_end - cursor).total_seconds()
+        _append_gap(rend_lines, cursor, gap_secs, gap_prefix, gap_durations)
         epg_grid.append({
             "title": "[No Signal]",
             "start": cursor.isoformat(),
@@ -145,30 +163,95 @@ def assemble_day(
     db,
     *,
     slots: Optional[list] = None,
+    cfg=None,
+    gap_durations: Optional[dict[int, float]] = None,
 ) -> tuple[dict[str, str], dict]:
     """24-hour special case of :func:`assemble_range` (one UTC midnight-to-midnight day)."""
     window_start = datetime(day.year, day.month, day.day, tzinfo=timezone.utc)
     window_end = window_start + timedelta(days=1)
-    return assemble_range(channel, window_start, window_end, db, slots=slots)
+    return assemble_range(
+        channel, window_start, window_end, db,
+        slots=slots, cfg=cfg, gap_durations=gap_durations,
+    )
 
 
-def _append_gap(rend_lines: dict, gap_start: datetime, gap_secs: int, gap_prefix: str) -> None:
-    n_segs, remainder = divmod(gap_secs, _SEGMENT_DURATION)
+def _fmt(secs: float) -> str:
+    """Format an ``#EXTINF`` duration to millisecond precision, trimming
+    trailing zeros so whole values render bare (6.0 -> "6", legacy-identical)
+    and real fractional durations stay readable (6.006006 -> "6.006")."""
+    return f"{secs:.3f}".rstrip("0").rstrip(".")
+
+
+def _append_gap(
+    rend_lines: dict, gap_start: datetime, gap_secs: float, gap_prefix: str,
+    gap_durations: Optional[dict[int, float]] = None,
+) -> None:
+    tiles = _plan_gap_tiles(gap_secs, gap_durations)
     for r in REND_NAMES:
         rend_lines[r].append("#EXT-X-DISCONTINUITY")
         rend_lines[r].append(f'#EXT-X-MAP:URI="{gap_prefix}/{r}/init.mp4"')
         rend_lines[r].append(f"#EXT-X-PROGRAM-DATE-TIME:{gap_start.isoformat()}")
-        for _ in range(n_segs):
-            rend_lines[r].append(f"#EXTINF:{_SEGMENT_DURATION},")
-            rend_lines[r].append(f"{gap_prefix}/{r}/seg_gap_{_SEGMENT_DURATION}s.m4s")
+        for label, dur in tiles:
+            rend_lines[r].append(f"#EXTINF:{_fmt(dur)},")
+            rend_lines[r].append(f"{gap_prefix}/{r}/seg_gap_{label}s.m4s")
+
+
+def _plan_gap_tiles(
+    gap_secs: float, gap_durations: Optional[dict[int, float]]
+) -> list[tuple[int, float]]:
+    """Choose blue tiles to fill a gap, returning ``(label_secs, extinf)`` pairs.
+
+    Legacy (``gap_durations is None``): exact integer fill — ⌊G/6⌋ six-second
+    tiles plus one remainder — labelled at their nominal seconds, so the
+    timeline stays integer-isochronous for the unit tests.
+
+    Accurate: tiles are really ~6.029 s, so size the fill by *real* duration
+    (⌊G / real_6s⌋ tiles) and pick the single remainder tile whose real length
+    best closes the leftover. ``#EXTINF`` carries the true durations, so the sum
+    tracks wall-clock to within half a tile with no systematic per-tile bias.
+    """
+    if not gap_durations:
+        n_segs, remainder = divmod(int(gap_secs), _SEGMENT_DURATION)
+        tiles = [(_SEGMENT_DURATION, float(_SEGMENT_DURATION))] * n_segs
         if remainder:
-            rend_lines[r].append(f"#EXTINF:{remainder},")
-            rend_lines[r].append(f"{gap_prefix}/{r}/seg_gap_{remainder}s.m4s")
+            tiles.append((remainder, float(remainder)))
+        return tiles
+
+    d6 = gap_durations.get(_SEGMENT_DURATION, float(_SEGMENT_DURATION))
+    n_segs = int(gap_secs // d6)
+    tiles = [(_SEGMENT_DURATION, d6)] * n_segs
+    remaining = gap_secs - n_segs * d6
+    best_label, best_err = None, abs(remaining)
+    for label, real in sorted(gap_durations.items()):
+        if label == _SEGMENT_DURATION:
+            continue
+        if abs(real - remaining) < best_err:
+            best_err, best_label = abs(real - remaining), label
+    if best_label is not None:
+        tiles.append((best_label, gap_durations[best_label]))
+    return tiles
 
 
-def _append_slot(rend_lines: dict, slot, slot_prefix: str) -> None:
-    slot_secs = int((slot.ends_at - slot.starts_at).total_seconds())
-    n_segs, remainder = divmod(slot_secs, _SEGMENT_DURATION)
+def _append_slot(
+    rend_lines: dict, slot, slot_prefix: str,
+    program_segs: Optional[list[tuple[str, float]]] = None,
+) -> None:
+    slot_secs = (slot.ends_at - slot.starts_at).total_seconds()
+    emitted = _clip_program_segments(program_segs, slot_secs) if program_segs else None
+
+    if emitted:
+        for r in REND_NAMES:
+            rend_lines[r].append("#EXT-X-DISCONTINUITY")
+            rend_lines[r].append(f'#EXT-X-MAP:URI="{slot_prefix}/{r}/init.mp4"')
+            rend_lines[r].append(f"#EXT-X-PROGRAM-DATE-TIME:{slot.starts_at.isoformat()}")
+            for name, dur in emitted:
+                rend_lines[r].append(f"#EXTINF:{_fmt(dur)},")
+                rend_lines[r].append(f"{slot_prefix}/{r}/{name}")
+        return
+
+    # Fallback: synthesize an integer-second layout from the slot duration. Used
+    # in tests (no cfg) and when a program's index.m3u8 can't be read.
+    n_segs, remainder = divmod(int(slot_secs), _SEGMENT_DURATION)
     for r in REND_NAMES:
         rend_lines[r].append("#EXT-X-DISCONTINUITY")
         rend_lines[r].append(f'#EXT-X-MAP:URI="{slot_prefix}/{r}/init.mp4"')
@@ -179,6 +262,64 @@ def _append_slot(rend_lines: dict, slot, slot_prefix: str) -> None:
         if remainder:
             rend_lines[r].append(f"#EXTINF:{remainder},")
             rend_lines[r].append(f"{slot_prefix}/{r}/seg{n_segs:04d}.m4s")
+
+
+def _clip_program_segments(
+    program_segs: list[tuple[str, float]], slot_secs: float
+) -> list[tuple[str, float]]:
+    """Emit real segments filling the slot's wall-clock span *exactly*.
+
+    Whole segments are emitted at their true ``#EXTINF`` until the next one
+    would overrun the slot; that final segment's ``#EXTINF`` is then clipped to
+    land the program's total on ``slot_secs`` to the millisecond (the file still
+    holds its full ~6 s of frames — only the timeline duration is trimmed). This
+    keeps cumulative ``#EXTINF`` equal to wall-clock at every program boundary,
+    so a pure-``#EXTINF`` player's elapsed time matches the burned-in clock with
+    no per-program accumulation. A slot the scheduler clipped for overlap (span
+    ≪ program) simply stops early; the residual under-fill (program shorter than
+    its slot) is under one segment and re-anchored by the next ``PROGRAM-DATE-TIME``."""
+    emitted: list[tuple[str, float]] = []
+    cum = 0.0
+    for name, dur in program_segs:
+        remaining = slot_secs - cum
+        if remaining <= 1e-6:
+            break
+        if dur <= remaining + 1e-6:
+            emitted.append((name, dur))
+            cum += dur
+        else:
+            emitted.append((name, remaining))  # clip final segment to fill slot
+            break
+    return emitted
+
+
+def _program_segments(seg_base: str, cfg, s3) -> Optional[list[tuple[str, float]]]:
+    """Real ``(segment_name, duration)`` pairs from a program's uploaded
+    ``index.m3u8`` (the ``full`` rendition is authoritative — every rendition
+    shares segment timing). Returns None if the playlist can't be read or
+    parsed, so the caller falls back to the synthesized layout. Renditions all
+    use the same segment filenames, so these durations apply to each."""
+    from video_grabber.storage.wasabi import read_text
+
+    try:
+        text = read_text(f"{seg_base}/full/index.m3u8", cfg, s3=s3)
+    except Exception:
+        return None
+
+    segs: list[tuple[str, float]] = []
+    dur: Optional[float] = None
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("#EXTINF:"):
+            try:
+                dur = float(line.split(":", 1)[1].rstrip(","))
+            except ValueError:
+                dur = None
+        elif line and not line.startswith("#"):
+            if dur is not None:
+                segs.append((line.rsplit("/", 1)[-1], dur))
+            dur = None
+    return segs or None
 
 
 def _fetch_slots(db, channel_id: str, window_start: datetime, window_end: datetime) -> list:

--- a/packages/tools/video-grabber/video_grabber/pipeline/flows.py
+++ b/packages/tools/video-grabber/video_grabber/pipeline/flows.py
@@ -21,7 +21,7 @@ from video_grabber.ia.scanner import crawl_collection
 from video_grabber.pipeline.downloader import download_item
 from video_grabber.pipeline.resolve import resolve_job
 from video_grabber.video.encoder import encode_to_hls
-from video_grabber.video.gap_filler import generate_gap_fmp4
+from video_grabber.video.gap_filler import generate_gap_fmp4, gap_segment_durations
 from video_grabber.storage.wasabi import (
     upload_hls_package, upload_tree, upload_text, read_text, list_keys,
 )
@@ -273,12 +273,18 @@ def build_channel_flow(channel_id: str, window_start: str, window_end: str):
     n_slots = build_schedule(channel_id, ws, we, db)
     logger.info("build-channel %s: %d slots scheduled", channel.slug, n_slots)
 
-    playlists, epg_channel = assemble_range(channel, ws, we, db)
-
     # Channel-level blue gap package (date-independent); cheap to regenerate.
+    # Build it first and measure each tile's true sub-second length so the
+    # assembler can write honest #EXTINF for both gaps and programs — keeping
+    # sample-timestamp players (QuickTime) locked to the playlist timeline.
     gap_dir = _SCRATCH / f"_gap_{channel.slug}"
     generate_gap_fmp4(gap_dir)
+    gap_durations = gap_segment_durations(gap_dir)
     upload_tree(gap_dir, f"hls/{channel.slug}/_gap", cfg)
+
+    playlists, epg_channel = assemble_range(
+        channel, ws, we, db, cfg=cfg, gap_durations=gap_durations
+    )
 
     # HLS playlists under playlists/<slug>/ (the EPG JSON guide lives in epg/).
     base = f"playlists/{channel.slug}"

--- a/packages/tools/video-grabber/video_grabber/video/gap_filler.py
+++ b/packages/tools/video-grabber/video_grabber/video/gap_filler.py
@@ -16,7 +16,9 @@ Each segment is encoded standalone with a forced IDR at frame 0 so it decodes
 independently — a hard HLS requirement that the encoder's ``-g 60`` default
 would otherwise violate for sub-2-second segments.
 """
+import json
 import subprocess
+import tempfile
 from pathlib import Path
 from typing import Iterable
 
@@ -81,3 +83,46 @@ def _encode_gap_segment(rend: dict, rend_dir: Path, secs: int, *, write_init: bo
     (rend_dir / "index.m3u8").unlink(missing_ok=True)
     if not write_init:
         (rend_dir / "init_tmp.mp4").unlink(missing_ok=True)
+
+
+def gap_segment_durations(output_dir: Path) -> dict[int, float]:
+    """Measure each gap tile's *real* fMP4 duration, keyed by its labelled
+    seconds (e.g. ``{6: 6.029, 4: 4.027, ...}``).
+
+    The tiles are labelled by integer seconds but a 29.97 fps + AAC fragment
+    can't land on an exact integer duration, so ``seg_gap_6s.m4s`` is really
+    ~6.029 s. The assembler needs these true values to write honest ``#EXTINF``
+    (and to size gaps by real media, not the integer label) — otherwise a
+    player that advances by sample timestamps drifts ahead of the playlist
+    timeline by ~0.5 % of all dead air, which over a multi-day mostly-gap
+    stream is minutes. Durations are identical across renditions (same frame
+    timing), so the ``full`` rendition is authoritative.
+    """
+    full_dir = output_dir / "full"
+    init = full_dir / "init.mp4"
+    durations: dict[int, float] = {}
+    for secs in (_SEGMENT_DURATION, *REMAINDER_SECONDS):
+        seg = full_dir / f"seg_gap_{secs}s.m4s"
+        if init.exists() and seg.exists():
+            durations[secs] = _probe_fragment_seconds(init, seg, fallback=float(secs))
+    return durations
+
+
+def _probe_fragment_seconds(init: Path, seg: Path, *, fallback: float) -> float:
+    """Real duration of a standalone fMP4 fragment. The ``.m4s`` only decodes
+    with its ``init.mp4`` moov, so concatenate the two before probing."""
+    with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
+        tmp.write(init.read_bytes())
+        tmp.write(seg.read_bytes())
+        tmp_path = Path(tmp.name)
+    try:
+        result = subprocess.run(
+            ["ffprobe", "-v", "quiet", "-print_format", "json", "-show_format", str(tmp_path)],
+            capture_output=True,
+        )
+        data = json.loads(result.stdout or "{}")
+        return float(data.get("format", {}).get("duration"))
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return fallback
+    finally:
+        tmp_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Problem

Scrubbing `playlists/cnn/full.m3u8` in QuickTime, the burned-in CNN clock ran ~6 min **ahead** of the scrubber position by hour 60 of the 9-day stream.

Diagnosis (frame-by-frame against the real footage):
- The **data is correct** — decoding the exact segments our playlist places at the reported positions and reading the burned-in clock (CNN's ticker cycles PT/MT/CT/ET) shows every zone converging on our UTC timeline to the second.
- The drift is a **playback artifact**: the assembler *synthesized* the timeline (`EXTINF:6`, segment count from the scheduled slot) instead of reflecting the real fragments.
  - Blue gap tiles are really **6.029 s** (29.97 fps + AAC can't be exactly 6.000 s) but were labelled `EXTINF:6`. Over a mostly-gap multi-day stream that **+0.48 %/tile is a systematic bias**, so a player that advances by sample timestamps (AVFoundation/QuickTime) creeps ahead by minutes.
  - Program segments are really ~6.006 s; the integer label drifts ~7 s across a 2 h slot.
- The **app is unaffected** — `TV.tsx calcSeekSeconds()` seeks by absolute `PROGRAM-DATE-TIME` / wall clock, not by counting segment durations.

## Fix — write honest `#EXTINF`

- `gap_filler.gap_segment_durations()` probes each tile's true sub-second length; the assembler sizes gaps by **real media** and labels tiles accurately, removing the systematic per-tile bias.
- For programs, the assembler reads the encoder's uploaded per-rendition `index.m3u8` (the `full` rendition is authoritative — all three share segment timing, verified) and emits its real segment names + fractional `EXTINF`, **clipping the final segment's `EXTINF`** so each program fills its slot span exactly. Cumulative `EXTINF` stays equal to wall-clock at every boundary with no per-program accumulation.

End-to-end with the real CNN daybreak index (1200 fractional segments): drift over a 4 h window dropped from **+2.07 s → +0.67 s** (only non-systematic gap-remainder rounding remains); the prior systematic bias over 9 days was minutes.

## Safety

Both accurate paths are gated on `cfg` / `gap_durations`, supplied **only** by `build_channel_flow`. Without them the assembler keeps its exact integer-second fallback, so every existing unit test is unaffected. New tests cover the program-index path, exact slot-fill clipping, real-duration gap sizing, and `_plan_gap_tiles`.

**Requires a channel rebuild to take effect** (assembled playlists are regenerated, segments untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)