### PR TITLE
fix(video-grabber): gap-tile extent drift in QuickTime (B-frame reorder)

### DIFF
--- a/packages/tools/video-grabber/video_grabber/video/gap_filler.py
+++ b/packages/tools/video-grabber/video_grabber/video/gap_filler.py
@@ -8,9 +8,20 @@ For each of the 3 renditions this produces, in ``output_dir/<rend>/``:
 
 assembler.py composes any gap of G seconds as ⌊G/6⌋ copies of ``seg_gap_6s``
 plus one ``seg_gap_<G%6>s`` remainder, so this small, bounded package fills a
-gap of any length. Color #0000f5, codec-matched to real content (main@3.1,
-29.97 fps) so hls.js level-switches seamlessly across the splice. Silent audio
-is retained in every rendition because hls.js requires audio in all of them.
+gap of any length. Color #0000f5, main@3.1. Silent audio is retained in every
+rendition because hls.js requires audio in all of them.
+
+**30 fps, no B-frames (``-bf 0``).** Because a gap is the *same* fragment
+repeated, a timestamp-based player (AVFoundation/QuickTime) can only position
+each copy by its presentation extent, so that extent MUST equal the fragment's
+``#EXTINF``. A 29.97 fps B-frame encode left the video's presented extent
+running ~0.066 s past the container (B-frame reorder delay + 29.97 rounding),
+and the assembler labelled the tile by the container duration — a ~0.043 s/tile
+mismatch that accumulated across tens of thousands of gap tiles into *minutes*
+of seek drift over a multi-day stream. ``-bf 0`` removes the reorder and
+``rate=30`` lands 180 frames on exactly 6.000 s, so video-end == audio-end ==
+container (== ``#EXTINF``): zero per-tile drift. Real program fragments are a
+continuous encode with chained decode times, so they don't have this problem.
 
 Each segment is encoded standalone with a forced IDR at frame 0 so it decodes
 independently — a hard HLS requirement that the encoder's ``-g 60`` default
@@ -59,11 +70,14 @@ def _encode_gap_segment(rend: dict, rend_dir: Path, secs: int, *, write_init: bo
     cmd = [
         "ffmpeg", "-y", "-loglevel", "error",
         "-f", "lavfi", "-i",
-        f"color=c=0x0000f5:size={rend['width']}x{rend['height']}:rate=29.97",
+        f"color=c=0x0000f5:size={rend['width']}x{rend['height']}:rate=30",
         "-f", "lavfi", "-i", "anullsrc=r=44100:cl=stereo",
         "-t", str(secs),
         "-c:v", "libx264", "-profile:v", "main", "-level:v", "3.1",
         "-pix_fmt", "yuv420p",
+        # No B-frames: the presented extent must equal #EXTINF for a repeated
+        # fragment, and B-frame reorder delay would push it past the container.
+        "-bf", "0",
         # Standalone segment: force a keyframe at frame 0, no scene-cut splits.
         "-g", "9999", "-keyint_min", "9999", "-sc_threshold", "0",
         "-force_key_frames", "expr:eq(n,0)",


### PR DESCRIPTION
Follow-up to #126/#127.

## Symptom
On the live CNN `full.m3u8`, QuickTime's onscreen clock ran a **constant ~19 min ahead** of the scrubber (e.g. elapsed `58:12` → `:31`, elapsed `60:15` → `:34` — both +19 in the minute field). Constant, not growing through the dense 9/11 morning → drift that accumulated through the **dead-air gaps** before 9/11 and then plateaued.

## Root cause
The blue gap fragment is the **same file repeated**, so a timestamp-based player (AVFoundation/QuickTime) can only position each copy by its presentation extent — which must equal its `#EXTINF`. The 29.97 fps + B-frame encode left the video's presented extent **0.066 s past the container** (B-frame reorder delay), while the assembler labelled the tile by container duration. That **0.043 s/tile** mismatch × ~26k gap tiles before 58 h = **~19 min**. (Real program fragments are a continuous encode with chained decode times, so they don't drift — which is why the offset was constant across the morning programming.)

## Fix
Encode the gap at `rate=30` (180 frames = exactly 6.000 s) with `-bf 0` (no reorder). Now video-end == audio-end == container (6.023 s), so the tile's presentation extent equals its `#EXTINF` regardless of which measure the player uses → zero per-tile drift. Verified `extent == container` for all tile sizes.

Requires a channel rebuild (regenerates the `_gap` package + re-assembles playlists with the new tile durations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)