### PR TITLE
fix(video-grabber): version gap package path so corrected tiles bypass client caches

### DIFF
--- a/packages/tools/video-grabber/tests/test_build_channel.py
+++ b/packages/tools/video-grabber/tests/test_build_channel.py
@@ -49,7 +49,7 @@ def test_build_channel_flow_wires_schedule_assemble_publish():
     # Gap package generated once and uploaded to the channel-level _gap prefix.
     m_gap.assert_called_once()
     m_tree.assert_called_once()
-    assert m_tree.call_args.args[1] == "hls/cnn/_gap"
+    assert m_tree.call_args.args[1] == "hls/cnn/_gap.v2"
 
     published = {c.args[1] for c in m_text.call_args_list}
     # Four HLS playlists under playlists/<slug>/.

--- a/packages/tools/video-grabber/tests/test_epg.py
+++ b/packages/tools/video-grabber/tests/test_epg.py
@@ -143,10 +143,10 @@ def test_gap_map_uses_rendition_specific_url():
 
     playlists, _ = assemble_day(ch, date(2001, 9, 11), db, slots=slots)
 
-    # Gap segments should reference _gap/{rend}/init.mp4
-    assert "_gap/full/init.mp4" in playlists["full"]
-    assert "_gap/mid/init.mp4" in playlists["mid"]
-    assert "_gap/thumb/init.mp4" in playlists["thumb"]
+    # Gap segments should reference _gap.v2/{rend}/init.mp4
+    assert "_gap.v2/full/init.mp4" in playlists["full"]
+    assert "_gap.v2/mid/init.mp4" in playlists["mid"]
+    assert "_gap.v2/thumb/init.mp4" in playlists["thumb"]
 
 
 def test_master_playlist_has_three_streams():

--- a/packages/tools/video-grabber/tests/test_epg_range.py
+++ b/packages/tools/video-grabber/tests/test_epg_range.py
@@ -94,7 +94,7 @@ def test_gap_package_is_channel_level():
     ch = make_channel("cnn")
     playlists, _ = assemble_range(ch, WINDOW_START, WINDOW_END, None, slots=[])
     # Empty window => one big gap, referencing the date-independent _gap package.
-    assert "/hls/cnn/_gap/full/" in playlists["full"]
+    assert "/hls/cnn/_gap.v2/full/" in playlists["full"]
     assert _count_playlist_duration(playlists["full"]) == WINDOW_SECS
 
 
@@ -263,7 +263,7 @@ def test_short_program_is_blue_padded_to_slot_span(monkeypatch):
     )
     full = playlists["full"]
     assert "/CNN_x/full/seg0001.m4s" in full           # real program segments
-    assert "/cnn/_gap/full/seg_gap_6s.m4s" in full       # blue pad fills the rest
+    assert "/cnn/_gap.v2/full/seg_gap_6s.m4s" in full    # blue pad fills the rest
     # No phantom program segments past the real two (the legacy 404 tail).
     assert "/CNN_x/full/seg0002.m4s" not in full
     # The whole window's real media still equals wall-clock (slot fully filled).

--- a/packages/tools/video-grabber/video_grabber/epg/assembler.py
+++ b/packages/tools/video-grabber/video_grabber/epg/assembler.py
@@ -25,6 +25,15 @@ from types import SimpleNamespace
 from typing import Optional
 
 WASABI_BASE = "https://files.911realtime.org"
+
+# Versioned gap-package directory. **Bump the version whenever the gap fragment
+# encoding changes.** The tiles are served with a 1-year max-age at a fixed URL,
+# so re-uploading a corrected tile to the same key never reaches a client: the
+# CDN, the nginx proxy, and crucially the viewer's OS URL cache (AVFoundation's
+# NSURLCache survives an app quit) all keep serving the stale tile for a year. A
+# new path is the only thing that misses every cache layer at once.
+GAP_PACKAGE = "_gap.v2"
+
 REND_NAMES = ["full", "mid", "thumb"]
 REND_BANDWIDTHS = {"full": 2628000, "mid": 396000, "thumb": 136000}
 REND_RESOLUTIONS = {"full": "854x480", "mid": "320x240", "thumb": "160x120"}
@@ -70,7 +79,7 @@ def assemble_range(
     if cfg is not None:
         from video_grabber.storage.wasabi import _make_s3_client
         s3 = _make_s3_client(cfg)
-    gap_prefix = f"{WASABI_BASE}/hls/{channel.slug}/_gap"
+    gap_prefix = f"{WASABI_BASE}/hls/{channel.slug}/{GAP_PACKAGE}"
 
     rend_lines: dict[str, list[str]] = {
         r: [

--- a/packages/tools/video-grabber/video_grabber/pipeline/flows.py
+++ b/packages/tools/video-grabber/video_grabber/pipeline/flows.py
@@ -26,7 +26,7 @@ from video_grabber.storage.wasabi import (
     upload_hls_package, upload_tree, upload_text, read_text, list_keys,
 )
 from video_grabber.directus.writer import write_media_item, upsert_channel_media_item
-from video_grabber.epg.assembler import assemble_range
+from video_grabber.epg.assembler import assemble_range, GAP_PACKAGE
 from video_grabber.epg.scheduler import build_schedule
 from video_grabber.config import Config
 
@@ -280,7 +280,7 @@ def build_channel_flow(channel_id: str, window_start: str, window_end: str):
     gap_dir = _SCRATCH / f"_gap_{channel.slug}"
     generate_gap_fmp4(gap_dir)
     gap_durations = gap_segment_durations(gap_dir)
-    upload_tree(gap_dir, f"hls/{channel.slug}/_gap", cfg)
+    upload_tree(gap_dir, f"hls/{channel.slug}/{GAP_PACKAGE}", cfg)
 
     playlists, epg_channel = assemble_range(
         channel, ws, we, db, cfg=cfg, gap_durations=gap_durations


### PR DESCRIPTION
Follow-up to #133.

## Why #133 didn't reach the user
The gap B-frame fix (#133) was correct — S3 and (after a purge) the CDN serve the new `6.023` tile. But the viewer's QuickTime still drifts, because gap fragments carry a **1-year `max-age` at a fixed URL**. macOS `NSURLCache` is shared and disk-backed and **survives an app quit**, so the Mac keeps serving its year-old `6.072`-extent tile from the same URL forever. Mixing that stale tile against the new playlist's label produced the partial, growing offset (`+4 → +14 min`).

## Fix
Move the gap package to a **versioned path** (`hls/<slug>/_gap.v2/`). A new URL is the only thing that misses every cache layer at once (OS, nginx proxy, Cloudflare), so clients fetch the corrected fragment fresh. `GAP_PACKAGE` is a single constant in `assembler.py` (imported by `flows.py`); bump it on any future gap-encoding change.

Requires a channel rebuild (regenerates the `_gap.v2` package + re-assembles playlists to reference it). The old `_gap/` objects become orphaned and age out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)