### PR TITLE
fix(video-grabber): sequenced gap pool — conformant dead-air for VLC/QuickTime

### DIFF
--- a/packages/tools/video-grabber/tests/test_build_channel.py
+++ b/packages/tools/video-grabber/tests/test_build_channel.py
@@ -27,9 +27,7 @@ def test_build_channel_flow_wires_schedule_assemble_publish():
          patch.object(flows, "_load_channel", return_value=channel), \
          patch.object(flows, "build_schedule", return_value=7) as m_sched, \
          patch.object(flows, "assemble_range", return_value=(playlists, epg_channel)) as m_asm, \
-         patch.object(flows, "generate_gap_fmp4") as m_gap, \
-         patch.object(flows, "gap_segment_durations", return_value={6: 6.029}), \
-         patch.object(flows, "upload_tree") as m_tree, \
+         patch.object(flows, "_ensure_gap_pool") as m_gap, \
          patch.object(flows, "upload_text") as m_text, \
          patch.object(flows, "list_keys", return_value=["epg/cnn.json"]) as m_list, \
          patch.object(flows, "read_text", return_value='{"name": "CNN", "grid": []}'), \
@@ -46,10 +44,8 @@ def test_build_channel_flow_wires_schedule_assemble_publish():
     # Assembler ran for the channel.
     m_asm.assert_called_once()
 
-    # Gap package generated once and uploaded to the channel-level _gap prefix.
+    # Shared gap pool ensured once (idempotent upload lives inside it).
     m_gap.assert_called_once()
-    m_tree.assert_called_once()
-    assert m_tree.call_args.args[1] == "hls/cnn/_gap.v2"
 
     published = {c.args[1] for c in m_text.call_args_list}
     # Four HLS playlists under playlists/<slug>/.

--- a/packages/tools/video-grabber/tests/test_epg.py
+++ b/packages/tools/video-grabber/tests/test_epg.py
@@ -143,10 +143,10 @@ def test_gap_map_uses_rendition_specific_url():
 
     playlists, _ = assemble_day(ch, date(2001, 9, 11), db, slots=slots)
 
-    # Gap segments should reference _gap.v2/{rend}/init.mp4
-    assert "_gap.v2/full/init.mp4" in playlists["full"]
-    assert "_gap.v2/mid/init.mp4" in playlists["mid"]
-    assert "_gap.v2/thumb/init.mp4" in playlists["thumb"]
+    # Gap segments should reference the shared pool's _gap.v3/{rend}/init.mp4
+    assert "_gap.v3/full/init.mp4" in playlists["full"]
+    assert "_gap.v3/mid/init.mp4" in playlists["mid"]
+    assert "_gap.v3/thumb/init.mp4" in playlists["thumb"]
 
 
 def test_master_playlist_has_three_streams():

--- a/packages/tools/video-grabber/tests/test_epg_range.py
+++ b/packages/tools/video-grabber/tests/test_epg_range.py
@@ -2,6 +2,7 @@
 Tests for assemble_range — the continuous multi-day per-channel stitcher and
 its #EXT-X-PROGRAM-DATE-TIME wall-clock anchoring.
 """
+import re
 from datetime import datetime, timezone, timedelta
 from unittest.mock import MagicMock
 
@@ -90,12 +91,15 @@ def test_slot_segment_url_uses_program_air_date_not_window():
     assert "/cnn/20010911/prog-a/full/" in playlists["full"]
 
 
-def test_gap_package_is_channel_level():
+def test_gap_uses_shared_sequenced_pool():
     ch = make_channel("cnn")
     playlists, _ = assemble_range(ch, WINDOW_START, WINDOW_END, None, slots=[])
-    # Empty window => one big gap, referencing the date-independent _gap package.
-    assert "/hls/cnn/_gap.v2/full/" in playlists["full"]
-    assert _count_playlist_duration(playlists["full"]) == WINDOW_SECS
+    full = playlists["full"]
+    # Empty window => one big gap, referencing the shared (channel-independent)
+    # sequenced pool by tile index, starting at seg0000 after each discontinuity.
+    assert "/hls/_gap.v3/full/seg0000.m4s" in full
+    assert "/hls/cnn/_gap" not in full  # not the old per-channel package
+    assert _count_playlist_duration(full) == WINDOW_SECS
 
 
 def test_master_url_is_channel_level():
@@ -256,49 +260,45 @@ def test_short_program_is_blue_padded_to_slot_span(monkeypatch):
     ch = make_channel("cnn")
     slot = make_slot("CNN_x", datetime(2001, 9, 11, 1, 0, tzinfo=timezone.utc), 60)
     slot.program.segment_base = "hls/cnn/20010911/CNN_x"
-    gap_durations = {6: 6.029, 5: 5.028, 4: 4.027, 3: 3.026, 2: 2.025, 1: 1.024}
     playlists, _ = assemble_range(
-        ch, WINDOW_START, WINDOW_END, None, slots=[slot],
-        cfg=object(), gap_durations=gap_durations,
+        ch, WINDOW_START, WINDOW_END, None, slots=[slot], cfg=object(),
     )
     full = playlists["full"]
     assert "/CNN_x/full/seg0001.m4s" in full           # real program segments
-    assert "/cnn/_gap.v2/full/seg_gap_6s.m4s" in full    # blue pad fills the rest
+    assert "/hls/_gap.v3/full/seg0000.m4s" in full      # blue pad fills the rest
     # No phantom program segments past the real two (the legacy 404 tail).
     assert "/CNN_x/full/seg0002.m4s" not in full
     # The whole window's real media still equals wall-clock (slot fully filled).
-    # Sum raw fractional EXTINF — the round-to-int _count helper would shed the
-    # 0.029s/tile across ~130k gap tiles.
     assert abs(sum(_extinfs(full)) - WINDOW_SECS) < 6.5
 
 
-def test_gap_extinf_uses_measured_tile_durations():
-    """gap_durations makes the blue tiles carry their true ~6.029s length and
-    sizes the fill by real media, so EXTINF sums track wall-clock without the
-    +0.029s/tile bias that drifted QuickTime."""
+def test_gap_tiles_are_referenced_in_sequence():
+    """The gap references the pool by ascending index (seg0000, seg0001, …) so
+    each tile carries an increasing fMP4 sequence_number/tfdt — the thing that
+    stops conformant players (VLC) flagging the dead air and drifting."""
     ch = make_channel("cnn")
-    gap_durations = {6: 6.029, 5: 5.027, 4: 4.027, 3: 3.026, 2: 2.025, 1: 1.024}
-    playlists, _ = assemble_range(
-        ch, WINDOW_START, WINDOW_END, None, slots=[], cfg=None,
-        gap_durations=gap_durations,
-    )
+    # A 5-minute gap = 50 tiles, well under POOL_TILES (one run, no reset).
+    slots = [make_slot("p", datetime(2001, 9, 11, 0, 5, tzinfo=timezone.utc), 60)]
+    playlists, _ = assemble_range(ch, WINDOW_START, WINDOW_END, None, slots=slots)
     full = playlists["full"]
-    durs = _extinfs(full)
-    # Tiles carry the real measured duration, not an integer.
-    assert any(abs(d - 6.029) < 1e-4 for d in durs)
-    # Real media total stays within half a tile of the wall-clock window — the
-    # systematic drift is gone (a 9-day all-gap window is ~777600s).
-    assert abs(sum(durs) - WINDOW_SECS) < 6.029
+    seen = [int(m) for m in re.findall(r"/_gap\.v3/full/seg(\d{4})\.m4s", full)]
+    leading = seen[: seen.index(max(seen[:60])) + 1]  # first run's tile indices
+    # Within a run the indices ascend 0,1,2,… (not a single repeated tile).
+    assert leading[:5] == [0, 1, 2, 3, 4]
+    assert max(seen) > 1  # not the old single-tile repeat
 
 
-def test_plan_gap_tiles_sizes_by_real_duration():
-    from video_grabber.epg.assembler import _plan_gap_tiles
-
-    durs = {6: 6.029, 5: 5.027, 4: 4.027, 3: 3.026, 2: 2.025, 1: 1.024}
-    # Legacy (None): exact integer fill.
-    legacy = _plan_gap_tiles(20.0, None)
-    assert [lbl for lbl, _ in legacy] == [6, 6, 6, 2]
-    assert sum(d for _, d in legacy) == 20.0
-    # Accurate: real-duration tiling lands within half a tile of the target.
-    accurate = _plan_gap_tiles(20.0, durs)
-    assert abs(sum(d for _, d in accurate) - 20.0) < 6.029 / 2 + 0.01
+def test_long_gap_resets_pool_with_discontinuity():
+    """A gap longer than POOL_TILES restarts at seg0000 behind a fresh
+    discontinuity so the bounded pool is reused — verified safe in VLC."""
+    from video_grabber.epg.assembler import POOL_TILES, TILE_SECONDS
+    ch = make_channel("cnn")
+    # Empty window => one enormous gap spanning many pool lengths.
+    playlists, _ = assemble_range(ch, WINDOW_START, WINDOW_END, None, slots=[])
+    full = playlists["full"]
+    # seg0000 recurs once per run; the run length is POOL_TILES.
+    runs = full.count("/_gap.v3/full/seg0000.m4s")
+    expected_runs = -(-WINDOW_SECS // (POOL_TILES * TILE_SECONDS))  # ceil
+    assert runs == expected_runs
+    # Each run is preceded by a discontinuity (full-rendition count).
+    assert full.count("#EXT-X-DISCONTINUITY") == runs

--- a/packages/tools/video-grabber/tests/test_gap_filler.py
+++ b/packages/tools/video-grabber/tests/test_gap_filler.py
@@ -1,99 +1,88 @@
 """
-Tests for the blue gap-filler package.
+Tests for the sequenced blue gap pool.
 
 subprocess.run is mocked — tests validate the output layout and ffmpeg flags
-that the EPG assembler's gap references depend on. The package is a set of
-standalone fMP4 segments (no master/index playlist): one canonical 6s segment
-plus 1–5s remainders per rendition, sharing a single init.mp4.
+the EPG assembler's gap references depend on. The pool is one continuous blue
+encode per rendition (seg0000.m4s, seg0001.m4s, … sharing a single init.mp4) so
+each tile carries an increasing fMP4 sequence_number/tfdt.
 """
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
-from video_grabber.video.gap_filler import generate_gap_fmp4, REMAINDER_SECONDS
+from video_grabber.video.gap_filler import generate_gap_pool, POOL_TILES, TILE_SECONDS
 
 
-def fake_ffmpeg_gap(*args, **kwargs):
-    """Emulate ffmpeg: write seg0000.m4s + the requested init file into cwd."""
+def fake_ffmpeg_pool(*args, **kwargs):
+    """Emulate ffmpeg's HLS muxer: write init.mp4 + seg0000..segN-1 into cwd."""
     cmd = args[0]
     cwd = Path(kwargs["cwd"])
     init_name = cmd[cmd.index("-hls_fmp4_init_filename") + 1]
     (cwd / init_name).write_bytes(b"gapinit")
-    (cwd / "seg0000.m4s").write_bytes(b"gapseg")
+    # Pool size is encoded as the -t duration / TILE_SECONDS.
+    seconds = int(cmd[cmd.index("-t") + 1])
+    for i in range(seconds // TILE_SECONDS):
+        (cwd / f"seg{i:04d}.m4s").write_bytes(b"gapseg")
+    (cwd / "index.m3u8").write_text("#EXTM3U\n")
     return MagicMock(returncode=0)
 
 
 def _capturing(captured):
     def capture(*args, **kwargs):
         captured.append(args[0][:])
-        return fake_ffmpeg_gap(*args, **kwargs)
+        return fake_ffmpeg_pool(*args, **kwargs)
     return capture
 
 
-def test_gap_creates_three_rendition_dirs(tmp_path):
-    with patch("subprocess.run", side_effect=fake_ffmpeg_gap):
-        out = generate_gap_fmp4(tmp_path)
-    assert out == tmp_path
+def test_pool_creates_three_rendition_dirs(tmp_path):
+    with patch("subprocess.run", side_effect=fake_ffmpeg_pool):
+        n = generate_gap_pool(tmp_path, pool_tiles=10)
+    assert n == 10
     for rend in ("full", "mid", "thumb"):
-        assert (tmp_path / rend).is_dir()
         assert (tmp_path / rend / "init.mp4").exists()
 
 
-def test_gap_creates_canonical_and_remainder_segments(tmp_path):
-    with patch("subprocess.run", side_effect=fake_ffmpeg_gap):
-        generate_gap_fmp4(tmp_path)
+def test_pool_creates_sequenced_segments(tmp_path):
+    with patch("subprocess.run", side_effect=fake_ffmpeg_pool):
+        generate_gap_pool(tmp_path, pool_tiles=10)
     for rend in ("full", "mid", "thumb"):
-        assert (tmp_path / rend / "seg_gap_6s.m4s").exists()
-        for n in REMAINDER_SECONDS:
-            assert (tmp_path / rend / f"seg_gap_{n}s.m4s").exists()
+        # Tiles are referenced by index (seg0000 … seg0009), in order.
+        assert (tmp_path / rend / "seg0000.m4s").exists()
+        assert (tmp_path / rend / "seg0009.m4s").exists()
 
 
-def test_gap_leaves_no_playlist_or_temp_init(tmp_path):
-    """The gap package is segments only — no index/master playlist, and the
-    throwaway per-segment init copies are cleaned up (one shared init.mp4)."""
-    with patch("subprocess.run", side_effect=fake_ffmpeg_gap):
-        generate_gap_fmp4(tmp_path)
+def test_pool_leaves_no_index_playlist(tmp_path):
+    """The pool is segments only — the throwaway index.m3u8 is removed."""
+    with patch("subprocess.run", side_effect=fake_ffmpeg_pool):
+        generate_gap_pool(tmp_path, pool_tiles=10)
     for rend in ("full", "mid", "thumb"):
-        d = tmp_path / rend
-        assert not (d / "index.m3u8").exists()
-        assert not (d / "init_tmp.mp4").exists()
-        assert not (d / "seg0000.m4s").exists()
-    assert not (tmp_path / "master.m3u8").exists()
+        assert not (tmp_path / rend / "index.m3u8").exists()
 
 
-def test_gap_uses_blue_color(tmp_path):
+def test_pool_encodes_blue_clean_30fps(tmp_path):
     captured = []
     with patch("subprocess.run", side_effect=_capturing(captured)):
-        generate_gap_fmp4(tmp_path)
+        generate_gap_pool(tmp_path, pool_tiles=10)
     for cmd in captured:
-        assert "0x0000f5" in " ".join(str(a) for a in cmd)
+        s = " ".join(str(a) for a in cmd)
+        assert "0x0000f5" in s          # blue
+        assert "rate=30" in s           # exact frame timing
+        assert "-bf 0" in s             # no B-frame reorder
+        assert "fmp4" in s
 
 
-def test_gap_uses_fmp4(tmp_path):
+def test_pool_default_size(tmp_path):
+    with patch("subprocess.run", side_effect=fake_ffmpeg_pool):
+        n = generate_gap_pool(tmp_path)
+    assert n == POOL_TILES
+
+
+def test_pool_thumb_has_audio(tmp_path):
     captured = []
     with patch("subprocess.run", side_effect=_capturing(captured)):
-        generate_gap_fmp4(tmp_path)
-    for cmd in captured:
-        assert "fmp4" in " ".join(str(a) for a in cmd)
-
-
-def test_gap_forces_keyframe_at_frame_zero(tmp_path):
-    """Sub-2s segments must start on an IDR to decode independently."""
-    captured = []
-    with patch("subprocess.run", side_effect=_capturing(captured)):
-        generate_gap_fmp4(tmp_path)
-    for cmd in captured:
-        cmd_str = " ".join(str(a) for a in cmd)
-        assert "-force_key_frames" in cmd_str
-        assert "eq(n,0)" in cmd_str
-
-
-def test_gap_thumb_has_audio(tmp_path):
-    captured = []
-    with patch("subprocess.run", side_effect=_capturing(captured)):
-        generate_gap_fmp4(tmp_path)
+        generate_gap_pool(tmp_path, pool_tiles=10)
     thumb_cmds = [c for c in captured if str(c[-1]).endswith("thumb/index.m3u8")]
     assert thumb_cmds
     for cmd in thumb_cmds:
-        cmd_str = " ".join(str(a) for a in cmd)
-        assert "-c:a" in cmd_str
-        assert "-an" not in cmd_str
+        s = " ".join(str(a) for a in cmd)
+        assert "-c:a" in s
+        assert "-an" not in s

--- a/packages/tools/video-grabber/video_grabber/epg/assembler.py
+++ b/packages/tools/video-grabber/video_grabber/epg/assembler.py
@@ -24,15 +24,15 @@ from datetime import datetime, date, timedelta, timezone
 from types import SimpleNamespace
 from typing import Optional
 
+from video_grabber.video.gap_filler import POOL_TILES, POOL_VERSION, TILE_SECONDS
+
 WASABI_BASE = "https://files.911realtime.org"
 
-# Versioned gap-package directory. **Bump the version whenever the gap fragment
-# encoding changes.** The tiles are served with a 1-year max-age at a fixed URL,
-# so re-uploading a corrected tile to the same key never reaches a client: the
-# CDN, the nginx proxy, and crucially the viewer's OS URL cache (AVFoundation's
-# NSURLCache survives an app quit) all keep serving the stale tile for a year. A
-# new path is the only thing that misses every cache layer at once.
-GAP_PACKAGE = "_gap.v2"
+# Shared, channel-independent sequenced gap pool (see gap_filler). A gap is filled
+# by referencing this pool's tiles IN ORDER so each carries an increasing fMP4
+# sequence_number/tfdt; ``POOL_VERSION`` is in the path so an encoding change
+# lands at a fresh URL that misses every cache layer (CDN, proxy, viewer OS cache).
+GAP_POOL_PREFIX = f"{WASABI_BASE}/hls/{POOL_VERSION}"
 
 REND_NAMES = ["full", "mid", "thumb"]
 REND_BANDWIDTHS = {"full": 2628000, "mid": 396000, "thumb": 136000}
@@ -49,7 +49,6 @@ def assemble_range(
     *,
     slots: Optional[list] = None,
     cfg=None,
-    gap_durations: Optional[dict[int, float]] = None,
 ) -> tuple[dict[str, str], dict]:
     """
     Build continuous HLS playlists and EPG JSON for ``channel`` across
@@ -60,17 +59,14 @@ def assemble_range(
 
     The published playlist URL is channel-level (``playlists/<slug>/``) because the
     product serves one continuous stream per channel, regenerated in place as
-    more content is acquired. The blue gap package is likewise channel-level
-    (``hls/<slug>/_gap``) — its content is date-independent.
+    more content is acquired. Dead air is filled from the shared sequenced gap
+    pool (see :mod:`gap_filler`) so each gap tile carries an increasing fMP4
+    sequence_number/tfdt and conformant players track the timeline.
 
-    ``cfg`` / ``gap_durations`` enable *accurate* ``#EXTINF``: with ``cfg`` the
-    assembler reads each program's real per-segment durations from its uploaded
-    ``index.m3u8``; ``gap_durations`` (from :func:`gap_filler.gap_segment_durations`)
-    gives the blue tiles' true sub-second lengths. When both are absent the
-    assembler falls back to a synthesized integer-second timeline (the legacy
-    behaviour the unit tests exercise). Honest ``#EXTINF`` keeps a player that
-    advances by sample timestamps (AVFoundation/QuickTime) locked to the
-    playlist timeline instead of creeping ahead by ~0.5 % of all dead air.
+    ``cfg`` enables *accurate* program ``#EXTINF``: the assembler reads each
+    program's real per-segment durations from its uploaded ``index.m3u8`` and
+    paths segments from the stored upload key. Without ``cfg`` it falls back to a
+    synthesized integer-second layout (the path the unit tests exercise).
     """
     if slots is None:
         slots = _fetch_slots(db, channel.id, window_start, window_end)
@@ -79,7 +75,7 @@ def assemble_range(
     if cfg is not None:
         from video_grabber.storage.wasabi import _make_s3_client
         s3 = _make_s3_client(cfg)
-    gap_prefix = f"{WASABI_BASE}/hls/{channel.slug}/{GAP_PACKAGE}"
+    gap_prefix = GAP_POOL_PREFIX
 
     rend_lines: dict[str, list[str]] = {
         r: [
@@ -97,7 +93,7 @@ def assemble_range(
     for slot in slots:
         if slot.starts_at > cursor:
             gap_secs = (slot.starts_at - cursor).total_seconds()
-            _append_gap(rend_lines, cursor, gap_secs, gap_prefix, gap_durations)
+            _append_gap(rend_lines, cursor, gap_secs, gap_prefix)
             epg_grid.append({
                 "title": "[No Signal]",
                 "start": cursor.isoformat(),
@@ -134,7 +130,7 @@ def assemble_range(
         if pad > 1.0:
             _append_gap(
                 rend_lines, slot.starts_at + timedelta(seconds=filled),
-                pad, gap_prefix, gap_durations,
+                pad, gap_prefix,
             )
         epg_grid.append({
             "title": slot.program.title,
@@ -147,7 +143,7 @@ def assemble_range(
 
     if cursor < window_end:
         gap_secs = (window_end - cursor).total_seconds()
-        _append_gap(rend_lines, cursor, gap_secs, gap_prefix, gap_durations)
+        _append_gap(rend_lines, cursor, gap_secs, gap_prefix)
         epg_grid.append({
             "title": "[No Signal]",
             "start": cursor.isoformat(),
@@ -186,15 +182,11 @@ def assemble_day(
     *,
     slots: Optional[list] = None,
     cfg=None,
-    gap_durations: Optional[dict[int, float]] = None,
 ) -> tuple[dict[str, str], dict]:
     """24-hour special case of :func:`assemble_range` (one UTC midnight-to-midnight day)."""
     window_start = datetime(day.year, day.month, day.day, tzinfo=timezone.utc)
     window_end = window_start + timedelta(days=1)
-    return assemble_range(
-        channel, window_start, window_end, db,
-        slots=slots, cfg=cfg, gap_durations=gap_durations,
-    )
+    return assemble_range(channel, window_start, window_end, db, slots=slots, cfg=cfg)
 
 
 def _fmt(secs: float) -> str:
@@ -206,52 +198,32 @@ def _fmt(secs: float) -> str:
 
 def _append_gap(
     rend_lines: dict, gap_start: datetime, gap_secs: float, gap_prefix: str,
-    gap_durations: Optional[dict[int, float]] = None,
 ) -> None:
-    tiles = _plan_gap_tiles(gap_secs, gap_durations)
-    for r in REND_NAMES:
-        rend_lines[r].append("#EXT-X-DISCONTINUITY")
-        rend_lines[r].append(f'#EXT-X-MAP:URI="{gap_prefix}/{r}/init.mp4"')
-        rend_lines[r].append(f"#EXT-X-PROGRAM-DATE-TIME:{gap_start.isoformat()}")
-        for label, dur in tiles:
-            rend_lines[r].append(f"#EXTINF:{_fmt(dur)},")
-            rend_lines[r].append(f"{gap_prefix}/{r}/seg_gap_{label}s.m4s")
-
-
-def _plan_gap_tiles(
-    gap_secs: float, gap_durations: Optional[dict[int, float]]
-) -> list[tuple[int, float]]:
-    """Choose blue tiles to fill a gap, returning ``(label_secs, extinf)`` pairs.
-
-    Legacy (``gap_durations is None``): exact integer fill — ⌊G/6⌋ six-second
-    tiles plus one remainder — labelled at their nominal seconds, so the
-    timeline stays integer-isochronous for the unit tests.
-
-    Accurate: tiles are really ~6.029 s, so size the fill by *real* duration
-    (⌊G / real_6s⌋ tiles) and pick the single remainder tile whose real length
-    best closes the leftover. ``#EXTINF`` carries the true durations, so the sum
-    tracks wall-clock to within half a tile with no systematic per-tile bias.
-    """
-    if not gap_durations:
-        n_segs, remainder = divmod(int(gap_secs), _SEGMENT_DURATION)
-        tiles = [(_SEGMENT_DURATION, float(_SEGMENT_DURATION))] * n_segs
-        if remainder:
-            tiles.append((remainder, float(remainder)))
-        return tiles
-
-    d6 = gap_durations.get(_SEGMENT_DURATION, float(_SEGMENT_DURATION))
-    n_segs = int(gap_secs // d6)
-    tiles = [(_SEGMENT_DURATION, d6)] * n_segs
-    remaining = gap_secs - n_segs * d6
-    best_label, best_err = None, abs(remaining)
-    for label, real in sorted(gap_durations.items()):
-        if label == _SEGMENT_DURATION:
-            continue
-        if abs(real - remaining) < best_err:
-            best_err, best_label = abs(real - remaining), label
-    if best_label is not None:
-        tiles.append((best_label, gap_durations[best_label]))
-    return tiles
+    """Fill ``gap_secs`` of dead air by referencing the shared sequenced pool's
+    tiles in order (seg0000, seg0001, …) so each carries an increasing fMP4
+    sequence_number/tfdt. Every ``POOL_TILES`` tiles the run resets with a fresh
+    ``#EXT-X-DISCONTINUITY`` + ``#EXT-X-PROGRAM-DATE-TIME``, letting the bounded
+    pool be reused (and re-anchored to wall-clock) for arbitrarily long gaps. The
+    final tile's ``#EXTINF`` is clipped so the gap fills its span exactly; the
+    cumulative timeline therefore stays equal to wall-clock."""
+    remaining = gap_secs
+    run_start = gap_start
+    while remaining > 1e-6:
+        for r in REND_NAMES:
+            rend_lines[r].append("#EXT-X-DISCONTINUITY")
+            rend_lines[r].append(f'#EXT-X-MAP:URI="{gap_prefix}/{r}/init.mp4"')
+            rend_lines[r].append(f"#EXT-X-PROGRAM-DATE-TIME:{run_start.isoformat()}")
+        run_filled = 0.0
+        k = 0
+        while k < POOL_TILES and remaining > 1e-6:
+            dur = TILE_SECONDS if TILE_SECONDS <= remaining else remaining
+            for r in REND_NAMES:
+                rend_lines[r].append(f"#EXTINF:{_fmt(dur)},")
+                rend_lines[r].append(f"{gap_prefix}/{r}/seg{k:04d}.m4s")
+            remaining -= dur
+            run_filled += dur
+            k += 1
+        run_start = run_start + timedelta(seconds=run_filled)
 
 
 def _append_slot(

--- a/packages/tools/video-grabber/video_grabber/pipeline/flows.py
+++ b/packages/tools/video-grabber/video_grabber/pipeline/flows.py
@@ -21,12 +21,13 @@ from video_grabber.ia.scanner import crawl_collection
 from video_grabber.pipeline.downloader import download_item
 from video_grabber.pipeline.resolve import resolve_job
 from video_grabber.video.encoder import encode_to_hls
-from video_grabber.video.gap_filler import generate_gap_fmp4, gap_segment_durations
+from video_grabber.video.gap_filler import generate_gap_pool, POOL_TILES, POOL_VERSION
 from video_grabber.storage.wasabi import (
     upload_hls_package, upload_tree, upload_text, read_text, list_keys,
+    _make_s3_client,
 )
 from video_grabber.directus.writer import write_media_item, upsert_channel_media_item
-from video_grabber.epg.assembler import assemble_range, GAP_PACKAGE
+from video_grabber.epg.assembler import assemble_range
 from video_grabber.epg.scheduler import build_schedule
 from video_grabber.config import Config
 
@@ -273,18 +274,10 @@ def build_channel_flow(channel_id: str, window_start: str, window_end: str):
     n_slots = build_schedule(channel_id, ws, we, db)
     logger.info("build-channel %s: %d slots scheduled", channel.slug, n_slots)
 
-    # Channel-level blue gap package (date-independent); cheap to regenerate.
-    # Build it first and measure each tile's true sub-second length so the
-    # assembler can write honest #EXTINF for both gaps and programs — keeping
-    # sample-timestamp players (QuickTime) locked to the playlist timeline.
-    gap_dir = _SCRATCH / f"_gap_{channel.slug}"
-    generate_gap_fmp4(gap_dir)
-    gap_durations = gap_segment_durations(gap_dir)
-    upload_tree(gap_dir, f"hls/{channel.slug}/{GAP_PACKAGE}", cfg)
+    # Shared sequenced blue gap pool (channel-independent); uploaded once.
+    _ensure_gap_pool(cfg)
 
-    playlists, epg_channel = assemble_range(
-        channel, ws, we, db, cfg=cfg, gap_durations=gap_durations
-    )
+    playlists, epg_channel = assemble_range(channel, ws, we, db, cfg=cfg)
 
     # HLS playlists under playlists/<slug>/ (the EPG JSON guide lives in epg/).
     base = f"playlists/{channel.slug}"
@@ -298,6 +291,23 @@ def build_channel_flow(channel_id: str, window_start: str, window_end: str):
     master_url = f"{base}/master.m3u8"
     upsert_channel_media_item(channel, master_url, ws, cfg)
     logger.info("build-channel %s: published %s + EPG guide", channel.slug, master_url)
+
+
+def _ensure_gap_pool(cfg: Config) -> None:
+    """Upload the shared sequenced gap pool once. Idempotent: the pool is
+    channel-independent blue tiles, so once present (checked via the last tile)
+    every channel build reuses it. Concurrent first-builds may both upload it —
+    the bytes are identical, so a redundant overwrite is harmless."""
+    s3 = _make_s3_client(cfg)
+    marker = f"hls/{POOL_VERSION}/full/seg{POOL_TILES - 1:04d}.m4s"
+    try:
+        s3.head_object(Bucket=cfg.wasabi_bucket, Key=marker)
+        return
+    except Exception:
+        pass
+    pool_dir = _SCRATCH / POOL_VERSION
+    generate_gap_pool(pool_dir)
+    upload_tree(pool_dir, f"hls/{POOL_VERSION}", cfg, s3=s3)
 
 
 def _rebuild_epg_guide(cfg: Config) -> None:

--- a/packages/tools/video-grabber/video_grabber/video/gap_filler.py
+++ b/packages/tools/video-grabber/video_grabber/video/gap_filler.py
@@ -1,142 +1,80 @@
 """
-Blue gap-filler package — the segments the EPG assembler splices into dead air.
+Blue gap pool — sequenced fMP4 segments the EPG assembler splices into dead air.
 
-For each of the 3 renditions this produces, in ``output_dir/<rend>/``:
-  - ``init.mp4``            — shared fMP4 init (moov) for the rendition
-  - ``seg_gap_6s.m4s``      — the canonical full-length filler segment
-  - ``seg_gap_<n>s.m4s``    — one remainder segment per n in REMAINDER_SECONDS
+A gap (dead air between recordings) is filled by referencing a POOL of pre-encoded
+blue segments **in order** (seg0000, seg0001, …). Because the pool is one
+*continuous* encode, every tile carries a real, increasing fMP4 ``mfhd``
+sequence_number and ``tfdt`` baseMediaDecodeTime — which conformant players
+(VLC, AVFoundation/QuickTime) require. The earlier design repeated ONE fragment,
+so every copy shared ``sequence_number=1`` / ``tfdt=0``; players logged
+"Fragment sequence discontinuity 1 != 2" and mis-timed the dead air into minutes
+of seek drift. Verified in VLC: the repeated fragment throws the error on every
+tile, the sequenced pool throws none.
 
-assembler.py composes any gap of G seconds as ⌊G/6⌋ copies of ``seg_gap_6s``
-plus one ``seg_gap_<G%6>s`` remainder, so this small, bounded package fills a
-gap of any length. Color #0000f5, main@3.1. Silent audio is retained in every
-rendition because hls.js requires audio in all of them.
+For a gap longer than the pool, the assembler resets with ``#EXT-X-DISCONTINUITY``
+and reuses the pool from seg0000 (a discontinuity lets the media timeline
+restart), so this bounded pool fills arbitrarily long gaps. Verified in VLC:
+clean and exact-duration across 50 reuse runs.
 
-**30 fps, no B-frames (``-bf 0``).** Because a gap is the *same* fragment
-repeated, a timestamp-based player (AVFoundation/QuickTime) can only position
-each copy by its presentation extent, so that extent MUST equal the fragment's
-``#EXTINF``. A 29.97 fps B-frame encode left the video's presented extent
-running ~0.066 s past the container (B-frame reorder delay + 29.97 rounding),
-and the assembler labelled the tile by the container duration — a ~0.043 s/tile
-mismatch that accumulated across tens of thousands of gap tiles into *minutes*
-of seek drift over a multi-day stream. ``-bf 0`` removes the reorder and
-``rate=30`` lands 180 frames on exactly 6.000 s, so video-end == audio-end ==
-container (== ``#EXTINF``): zero per-tile drift. Real program fragments are a
-continuous encode with chained decode times, so they don't have this problem.
+The pool is channel-independent (it's just blue), so it lives at a single shared
+prefix and is uploaded once. ``POOL_VERSION`` is part of that path: bump it
+whenever the encoding changes, because segments carry a 1-year ``max-age`` at a
+fixed URL and a new path is the only way past the CDN, the proxy, and a viewer's
+OS URL cache at once.
 
-Each segment is encoded standalone with a forced IDR at frame 0 so it decodes
-independently — a hard HLS requirement that the encoder's ``-g 60`` default
-would otherwise violate for sub-2-second segments.
+30 fps + no B-frames so each tile's presentation extent is clean; one forced IDR
+every 6 s so each segment decodes independently (a hard HLS requirement). Silent
+audio is retained in every rendition because hls.js requires audio in all of them.
 """
-import json
 import subprocess
-import tempfile
 from pathlib import Path
-from typing import Iterable
 
 from video_grabber.video.encoder import RENDITIONS
 
-_SEGMENT_DURATION = 6
-# A gap of G seconds leaves a remainder of G % 6 ∈ {1..5}; those plus the
-# canonical 6s segment cover every gap length the assembler can emit.
-REMAINDER_SECONDS = (1, 2, 3, 4, 5)
+# Bump on any gap-encoding change (see module docstring on caching).
+POOL_VERSION = "_gap.v3"
+# 1 hour of 6 s tiles. The assembler reuses the pool across discontinuities for
+# longer gaps, so this only bounds how often a long gap re-anchors — it does not
+# limit gap length. Kept modest to keep the one-time shared upload small.
+POOL_TILES = 600
+TILE_SECONDS = 6
 
 
-def generate_gap_fmp4(
-    output_dir: Path,
-    *,
-    remainder_seconds: Iterable[int] = REMAINDER_SECONDS,
-) -> Path:
-    """Generate the per-rendition gap package under ``output_dir``.
+def generate_gap_pool(output_dir: Path, *, pool_tiles: int = POOL_TILES) -> int:
+    """Encode the per-rendition sequenced blue pool under ``output_dir``.
 
-    Returns ``output_dir`` (the package root the uploader pushes to
-    ``hls/<slug>/_gap/``). Idempotent per call — overwrites existing segments.
+    Produces ``<rend>/init.mp4`` + ``<rend>/seg0000.m4s … seg{N-1}.m4s`` for each
+    rendition, with native increasing sequence_number/tfdt. Returns the tile count.
     """
-    durations = [_SEGMENT_DURATION, *sorted(set(remainder_seconds))]
     for rend in RENDITIONS:
         rend_dir = output_dir / rend["name"]
         rend_dir.mkdir(parents=True, exist_ok=True)
-        for i, secs in enumerate(durations):
-            # Share one init.mp4 across the rendition's segments (identical codec
-            # config), so generate it only on the first (6s) pass.
-            _encode_gap_segment(
-                rend, rend_dir, secs, write_init=(i == 0),
-            )
-    return output_dir
+        _encode_pool(rend, rend_dir, pool_tiles)
+    return pool_tiles
 
 
-def _encode_gap_segment(rend: dict, rend_dir: Path, secs: int, *, write_init: bool) -> None:
-    """Encode a single standalone ``seg_gap_<secs>s.m4s`` (and init.mp4 if asked)."""
-    init_name = "init.mp4" if write_init else "init_tmp.mp4"
+def _encode_pool(rend: dict, rend_dir: Path, pool_tiles: int) -> None:
+    """One continuous blue encode segmented at ``TILE_SECONDS`` — ffmpeg stamps
+    each fragment with the correct increasing sequence_number and tfdt."""
+    seconds = pool_tiles * TILE_SECONDS
+    keyint = TILE_SECONDS * 30  # one IDR per segment at 30 fps
     cmd = [
         "ffmpeg", "-y", "-loglevel", "error",
         "-f", "lavfi", "-i",
         f"color=c=0x0000f5:size={rend['width']}x{rend['height']}:rate=30",
         "-f", "lavfi", "-i", "anullsrc=r=44100:cl=stereo",
-        "-t", str(secs),
+        "-t", str(seconds),
         "-c:v", "libx264", "-profile:v", "main", "-level:v", "3.1",
-        "-pix_fmt", "yuv420p",
-        # No B-frames: the presented extent must equal #EXTINF for a repeated
-        # fragment, and B-frame reorder delay would push it past the container.
-        "-bf", "0",
-        # Standalone segment: force a keyframe at frame 0, no scene-cut splits.
-        "-g", "9999", "-keyint_min", "9999", "-sc_threshold", "0",
-        "-force_key_frames", "expr:eq(n,0)",
+        "-pix_fmt", "yuv420p", "-bf", "0",
+        "-g", str(keyint), "-keyint_min", str(keyint), "-sc_threshold", "0",
         "-c:a", "aac", "-ar", "44100", *rend["a_flags"],
-        # hls_time > secs guarantees a single output segment.
-        "-hls_time", str(secs + 1),
-        "-hls_list_size", "0", "-hls_playlist_type", "vod",
-        "-hls_segment_type", "fmp4", "-hls_fmp4_init_filename", init_name,
+        "-hls_time", str(TILE_SECONDS), "-hls_list_size", "0", "-hls_playlist_type", "vod",
+        "-hls_segment_type", "fmp4", "-hls_fmp4_init_filename", "init.mp4",
         "-hls_flags", "independent_segments", "-f", "hls",
         "-hls_segment_filename", "seg%04d.m4s",
         str(rend_dir / "index.m3u8"),
     ]
     subprocess.run(cmd, check=True, cwd=rend_dir)
-
-    (rend_dir / "seg0000.m4s").rename(rend_dir / f"seg_gap_{secs}s.m4s")
-    # Drop the throwaway playlist and any non-shared init copy.
+    # The throwaway playlist isn't needed: tiles are uniform TILE_SECONDS and the
+    # assembler references them by index.
     (rend_dir / "index.m3u8").unlink(missing_ok=True)
-    if not write_init:
-        (rend_dir / "init_tmp.mp4").unlink(missing_ok=True)
-
-
-def gap_segment_durations(output_dir: Path) -> dict[int, float]:
-    """Measure each gap tile's *real* fMP4 duration, keyed by its labelled
-    seconds (e.g. ``{6: 6.029, 4: 4.027, ...}``).
-
-    The tiles are labelled by integer seconds but a 29.97 fps + AAC fragment
-    can't land on an exact integer duration, so ``seg_gap_6s.m4s`` is really
-    ~6.029 s. The assembler needs these true values to write honest ``#EXTINF``
-    (and to size gaps by real media, not the integer label) — otherwise a
-    player that advances by sample timestamps drifts ahead of the playlist
-    timeline by ~0.5 % of all dead air, which over a multi-day mostly-gap
-    stream is minutes. Durations are identical across renditions (same frame
-    timing), so the ``full`` rendition is authoritative.
-    """
-    full_dir = output_dir / "full"
-    init = full_dir / "init.mp4"
-    durations: dict[int, float] = {}
-    for secs in (_SEGMENT_DURATION, *REMAINDER_SECONDS):
-        seg = full_dir / f"seg_gap_{secs}s.m4s"
-        if init.exists() and seg.exists():
-            durations[secs] = _probe_fragment_seconds(init, seg, fallback=float(secs))
-    return durations
-
-
-def _probe_fragment_seconds(init: Path, seg: Path, *, fallback: float) -> float:
-    """Real duration of a standalone fMP4 fragment. The ``.m4s`` only decodes
-    with its ``init.mp4`` moov, so concatenate the two before probing."""
-    with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
-        tmp.write(init.read_bytes())
-        tmp.write(seg.read_bytes())
-        tmp_path = Path(tmp.name)
-    try:
-        result = subprocess.run(
-            ["ffprobe", "-v", "quiet", "-print_format", "json", "-show_format", str(tmp_path)],
-            capture_output=True,
-        )
-        data = json.loads(result.stdout or "{}")
-        return float(data.get("format", {}).get("duration"))
-    except (json.JSONDecodeError, TypeError, ValueError):
-        return fallback
-    finally:
-        tmp_path.unlink(missing_ok=True)


### PR DESCRIPTION
Follow-up to #126/#127/#133/#134 — the actual root cause.

## Root cause (VLC's exact error)
Dead air was filled by referencing **one** blue fragment thousands of times. Every copy carries the same fMP4 `mfhd sequence_number = 1` and `tfdt = 0`, so conformant players can't sequence the tiles:
- VLC: `Fragment sequence discontinuity detected 1 != 2` (the user's pasted error), then timeline drift
- ffmpeg: `Invalid NAL unit size` on seek
- QuickTime: minutes of seek drift

The earlier fixes (EXTINF, B-frame extent, caches, versioned path) each removed a real contributing layer, but the repeated-fragment **design** was the core bug.

## Fix — sequenced pool
`gap_filler` now generates one **continuous** blue encode per rendition, so ffmpeg natively stamps each tile (`seg0000`, `seg0001`, …) with an increasing `sequence_number` + `tfdt`. The assembler fills a gap by referencing the pool **in order**; for gaps longer than the pool it resets with `#EXT-X-DISCONTINUITY` + `#EXT-X-PROGRAM-DATE-TIME` and reuses it from `seg0000` (a discontinuity lets the media timeline restart), so a bounded 1-hour pool fills arbitrarily long gaps. The final tile's `#EXTINF` is clipped to fill the span exactly (cumulative timeline stays == wall-clock). The pool is channel-independent → single shared prefix `hls/_gap.v3/`, uploaded once.

## Verified against the actual player (VLC), locally, before deploy
- repeated fragment → sequence error on **every** tile; sequenced pool → **zero**
- 50 discontinuity-reuse runs → clean, exact 3000 s
- **real `assemble_range` output** → 50 tiles = exactly 300 s across 3 reuse runs, ffprobe 300.000 s, **0 VLC sequence errors**

Requires a channel rebuild (publishes the shared pool + re-assembles playlists to reference it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)