### PR TITLE
feat: dedicated tv_channels collection for the stitched HLS channels

### DIFF
--- a/packages/backend/cmd/server/main.go
+++ b/packages/backend/cmd/server/main.go
@@ -74,7 +74,7 @@ func main() {
 	// Postgres directly (per-group, gated by what the client is viewing) — see
 	// session.RunTimePump and db.UsenetItemsInRange.
 
-	// Keep Redis in sync with media_items changes for the process lifetime.
+	// Keep Redis in sync with tv_channels changes for the process lifetime.
 	go cache.Listen(ctx, dbURL, rdb, pool, logger)
 
 	hub := session.NewHub(logger)

--- a/packages/backend/internal/cache/listen.go
+++ b/packages/backend/internal/cache/listen.go
@@ -16,7 +16,9 @@ import (
 )
 
 const (
-	notifyChannel  = "media_items_changed"
+	// The main video channel reads from tv_channels (the stitched per-channel HLS
+	// streams), not media_items. mp3/news/pager/usenet keep their own tables.
+	notifyChannel  = "tv_channels_changed"
 	initialBackoff = 1 * time.Second
 	maxBackoff     = 30 * time.Second
 )
@@ -26,7 +28,7 @@ type changeNotification struct {
 	ID int    `json:"id"`
 }
 
-// Listen subscribes to Postgres NOTIFY on media_items changes and keeps the
+// Listen subscribes to Postgres NOTIFY on tv_channels changes and keeps the
 // Redis cache in sync with the database. Intended to run for the process
 // lifetime in a dedicated goroutine.
 //

--- a/packages/backend/internal/cache/triggers.go
+++ b/packages/backend/internal/cache/triggers.go
@@ -12,7 +12,7 @@ import (
 // with anything Directus or another tenant might install on the same table.
 var (
 	createNotifyFunctionSQL = fmt.Sprintf(`
-CREATE OR REPLACE FUNCTION rt911_notify_media_items_change()
+CREATE OR REPLACE FUNCTION rt911_notify_tv_channels_change()
 RETURNS trigger AS $$
 DECLARE payload json;
 BEGIN
@@ -26,16 +26,16 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;`, notifyChannel)
 
-	dropNotifyTriggerSQL = `DROP TRIGGER IF EXISTS rt911_media_items_changed ON media_items;`
+	dropNotifyTriggerSQL = `DROP TRIGGER IF EXISTS rt911_tv_channels_changed ON tv_channels;`
 
 	createNotifyTriggerSQL = `
-CREATE TRIGGER rt911_media_items_changed
-AFTER INSERT OR UPDATE OR DELETE ON media_items
-FOR EACH ROW EXECUTE FUNCTION rt911_notify_media_items_change();`
+CREATE TRIGGER rt911_tv_channels_changed
+AFTER INSERT OR UPDATE OR DELETE ON tv_channels
+FOR EACH ROW EXECUTE FUNCTION rt911_notify_tv_channels_change();`
 )
 
 // InstallTriggers ensures the Postgres trigger and function that fire
-// NOTIFY on media_items changes are present. Idempotent — safe to call on
+// NOTIFY on tv_channels changes are present. Idempotent — safe to call on
 // every boot.
 func InstallTriggers(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger) error {
 	for _, q := range []string{createNotifyFunctionSQL, dropNotifyTriggerSQL, createNotifyTriggerSQL} {

--- a/packages/backend/internal/db/postgres.go
+++ b/packages/backend/internal/db/postgres.go
@@ -10,16 +10,18 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// selectFrom is the shared SELECT … FROM clause for all item queries.
-// source is resolved to sources.slug via a LEFT JOIN so the client receives
-// the human-readable slug instead of the raw integer foreign-key.
+// selectFrom is the shared SELECT … FROM clause for the main video channel.
+// It reads tv_channels (the stitched per-channel HLS streams), not media_items;
+// the row shape is identical (MediaItem). source is resolved to sources.slug via
+// a LEFT JOIN so the client receives the human-readable slug instead of the raw
+// integer foreign-key. The mi alias is kept for query-suffix compatibility.
 const selectFrom = `
 	SELECT mi.id, mi.title, mi.full_title, s.slug,
 	       mi.start_date, mi.end_date, mi.calc_duration, mi.timezone,
 	       mi.url, mi.format, mi.approved, mi.mute,
 	       mi.volume, mi.jump, mi.trim, mi.image, mi.image_caption,
 	       mi.content, mi.sort
-	FROM media_items mi
+	FROM tv_channels mi
 	LEFT JOIN sources s ON s.id = mi.source`
 
 // Connect opens a pgx connection pool and verifies connectivity.
@@ -77,20 +79,18 @@ func CurrentItems(ctx context.Context, pool *pgxpool.Pool, t time.Time) ([]model
 		 ORDER BY mi.start_date`, t)
 }
 
-// videoFormat is the media_items.format value the TV app plays. The TV's source
-// filter is derived from items of this format only — media_items also holds
-// non-video formats (html/modal/usenet) the TV never shows, and the sources table
-// does not record which media type a source belongs to, so usage is the only signal.
+// videoFormat is the tv_channels.format value the TV app plays. The TV's source
+// filter is derived from approved channels of this format.
 const videoFormat = "m3u8"
 
 // AvailableVideoSources returns the distinct, sorted source slugs that have at
-// least one approved video (m3u8) media item, independent of time. It populates
+// least one approved video (m3u8) channel, independent of time. It populates
 // the TV app's channel filter with every selectable channel up front, rather than
 // only those that have scrolled past in the current virtual-time window.
 func AvailableVideoSources(ctx context.Context, pool *pgxpool.Pool) ([]string, error) {
 	return queryStrings(ctx, pool, `
 		SELECT DISTINCT s.slug
-		FROM media_items mi
+		FROM tv_channels mi
 		JOIN sources s ON s.id = mi.source
 		WHERE mi.approved = 1 AND mi.format = $1
 		  AND s.slug IS NOT NULL AND s.slug <> ''

--- a/packages/backend/seed.mjs
+++ b/packages/backend/seed.mjs
@@ -231,6 +231,24 @@ async function createCollections(token) {
   }
   await ensureNumericFields("news_items");
 
+  // tv_channels — the stitched continuous HLS channels (one row per channel,
+  // each pointing at its playlists/<slug>/master.m3u8), same shape as media_items.
+  // The TV app's main video channel reads from this table (the streamer's
+  // selectFrom / media_items_changed listener point here), separating the 23
+  // channel streams from media_items' per-program clips.
+  if (!names.includes("tv_channels")) {
+    console.log("Creating collection: tv_channels");
+    await api(token, "POST", "/collections", {
+      collection: "tv_channels",
+      meta: { icon: "live_tv", sort_field: "sort", note: "Stitched continuous HLS channels" },
+      schema: {},
+      fields: mediaLikeBaseFields,
+    });
+  } else {
+    console.log("Collection tv_channels already exists, skipping.");
+  }
+  await ensureNumericFields("tv_channels");
+
   // pager_items — pager traffic lives in its own table (not media_items). Every
   // pager item is "instant": a start_date with no duration/end_date. provider is
   // a plain text column, not a sources FK.
@@ -327,7 +345,7 @@ async function createCollections(token) {
 
 async function createRelations(token) {
   const existing = await api(token, "GET", "/relations");
-  for (const collection of ["media_items", "mp3_items", "news_items", "usenet_items", "pager_items"]) {
+  for (const collection of ["media_items", "mp3_items", "news_items", "tv_channels", "usenet_items", "pager_items"]) {
     const alreadyLinked = existing.data.some(
       (r) => r.collection === collection && r.field === "source",
     );

--- a/packages/frontend/src/app.tsx
+++ b/packages/frontend/src/app.tsx
@@ -14,7 +14,7 @@ import { News } from "./Applications/News/News";
 import { Newsgroups } from "./Applications/Newsgroups/Newsgroups";
 import { PagerDecoder } from "./Applications/PagerDecoder/PagerDecoder";
 import { RadioScanner } from "./Applications/RadioScanner/RadioScanner";
-// import { TV } from "./Applications/TV/TV";
+import { TV } from "./Applications/TV/TV";
 import { MediaStreamProvider } from "./Providers/MediaStream/MediaStreamProvider";
 
 const rootElement = document.getElementById("root");
@@ -32,7 +32,7 @@ createRoot(rootElement).render(
 					<Newsgroups />
 					<PagerDecoder />
 					<RadioScanner />
-					{/* <TV /> */}
+					<TV />
 					<Controls />
 				</ClassicyDesktop>
 			</MediaStreamProvider>

--- a/packages/tools/video-grabber/tests/test_directus_writer.py
+++ b/packages/tools/video-grabber/tests/test_directus_writer.py
@@ -243,11 +243,11 @@ def test_upsert_channel_keys_on_url_not_content_subfield():
         captured["params"] = dict(request.url.params)
         return httpx.Response(200, json={"data": []})
 
-    respx.get("http://directus:8055/items/media_items").mock(side_effect=capture_get)
+    respx.get("http://directus:8055/items/tv_channels").mock(side_effect=capture_get)
     respx.get("http://directus:8055/items/sources").mock(
         return_value=httpx.Response(200, json={"data": [{"id": 18}]})
     )
-    post = respx.post("http://directus:8055/items/media_items").mock(
+    post = respx.post("http://directus:8055/items/tv_channels").mock(
         return_value=httpx.Response(200, json={"data": {"id": 1}})
     )
 
@@ -268,16 +268,16 @@ def test_upsert_channel_patches_when_row_exists():
     cfg = make_cfg()
     channel = MagicMock(slug="weta", display_name="WETA", timezone="EDT")
 
-    respx.get("http://directus:8055/items/media_items").mock(
+    respx.get("http://directus:8055/items/tv_channels").mock(
         return_value=httpx.Response(200, json={"data": [{"id": 460681}]})
     )
     respx.get("http://directus:8055/items/sources").mock(
         return_value=httpx.Response(200, json={"data": [{"id": 18}]})
     )
-    post = respx.post("http://directus:8055/items/media_items").mock(
+    post = respx.post("http://directus:8055/items/tv_channels").mock(
         return_value=httpx.Response(200, json={"data": {}})
     )
-    patch = respx.patch("http://directus:8055/items/media_items/460681").mock(
+    patch = respx.patch("http://directus:8055/items/tv_channels/460681").mock(
         return_value=httpx.Response(200, json={"data": {"id": 460681}})
     )
 

--- a/packages/tools/video-grabber/video_grabber/directus/writer.py
+++ b/packages/tools/video-grabber/video_grabber/directus/writer.py
@@ -79,17 +79,17 @@ def write_media_item(job, wasabi_url: str, cfg: Config) -> None:
 
 
 def upsert_channel_media_item(channel, master_url: str, window_start, cfg: Config) -> None:
-    """Upsert the single continuous-stream media_item for a channel.
+    """Upsert the single continuous-stream row for a channel into ``tv_channels``.
 
-    Idempotent on the playlist ``url`` (``epg/<slug>/master.m3u8``), which is
-    fixed and unique per channel — so there is exactly one row per channel and
-    re-runs PATCH it in place as more content is acquired. ``url`` is a normal
-    indexed field; we key on it rather than ``content`` because ``content`` is
-    stored as an opaque JSON *string*. It can only be matched as a whole blob
-    (``filter[content][_eq]``, as ``write_media_item`` does); traversing into a
-    subfield (``filter[content][channel_stream]``) 403s. The
-    ``content.channel_stream`` marker is still written for downstream consumers,
-    just not queried.
+    The stitched per-channel HLS streams live in their own ``tv_channels`` table
+    (same shape as ``media_items``) — that is the table the streamer's main video
+    channel reads. Idempotent on the playlist ``url``
+    (``playlists/<slug>/master.m3u8``), which is fixed and unique per channel — so
+    there is exactly one row per channel and re-runs PATCH it in place as more
+    content is acquired. ``url`` is a normal indexed field; we key on it rather
+    than ``content`` because ``content`` is stored as an opaque JSON *string* that
+    can only be matched as a whole blob. The ``content.channel_stream`` marker is
+    still written for downstream consumers, just not queried.
     """
     token = get_directus_token(cfg)
     headers = {
@@ -111,7 +111,7 @@ def upsert_channel_media_item(channel, master_url: str, window_start, cfg: Confi
     }
 
     resp = httpx.get(
-        f"{cfg.directus_url}/items/media_items",
+        f"{cfg.directus_url}/items/tv_channels",
         params={"filter[url][_eq]": url, "fields": "id"},
         headers=headers,
     )
@@ -121,13 +121,13 @@ def upsert_channel_media_item(channel, master_url: str, window_start, cfg: Confi
     if existing:
         item_id = existing[0]["id"]
         resp = httpx.patch(
-            f"{cfg.directus_url}/items/media_items/{item_id}",
+            f"{cfg.directus_url}/items/tv_channels/{item_id}",
             content=json.dumps(payload),
             headers=headers,
         )
     else:
         resp = httpx.post(
-            f"{cfg.directus_url}/items/media_items",
+            f"{cfg.directus_url}/items/tv_channels",
             content=json.dumps(payload),
             headers=headers,
         )


### PR DESCRIPTION
The 23 continuous per-channel HLS streams now live in their own Directus collection (**`tv_channels`**), same shape as `media_items`, instead of being mixed into `media_items` alongside per-program clips — mirroring how `mp3_items` / `news_items` were split out.

## Changes
- **backend (streamer):** the main video `items` channel reads `tv_channels`. `selectFrom` + `AvailableVideoSources` point at it; the NOTIFY trigger/listener move to `tv_channels_changed`. mp3/news/pager/usenet unchanged. `go build` + `go test ./...` pass.
- **backend `seed.mjs`:** `tv_channels` collection (`mediaLikeBaseFields` + numeric + `source→sources` FK), added to the relations loop.
- **video-grabber:** `upsert_channel_media_item` writes the per-channel stream row to `tv_channels` (idempotent on the `master.m3u8` url) so future builds populate it. Tests + ruff pass.
- **frontend:** re-enable the `<TV />` app (import + render). `tsc` clean.

## Already applied live (Directus)
- Created the `tv_channels` collection (fields + `source` relation; `start_date`/`end_date` as Directus `dateTime` to match `media_items`).
- Created the missing `WNYW` source (type=video).
- Seeded the 23 rebuilt channels (one approved m3u8 row each → `playlists/<slug>/master.m3u8`).
- Removed the orphaned channel rows the old writer had left in `media_items`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)