### PR TITLE
fix(video-grabber): set end_date + calc_duration on tv_channels rows

### DIFF
--- a/packages/tools/video-grabber/tests/test_directus_writer.py
+++ b/packages/tools/video-grabber/tests/test_directus_writer.py
@@ -2,6 +2,7 @@
 Tests for Directus media_items writer.
 Mocks HTTP calls — no real Directus instance required.
 """
+import json
 import respx
 import httpx
 from datetime import datetime, timezone
@@ -243,21 +244,28 @@ def test_upsert_channel_keys_on_url_not_content_subfield():
         captured["params"] = dict(request.url.params)
         return httpx.Response(200, json={"data": []})
 
+    def capture_post(request):
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"data": {"id": 1}})
+
     respx.get("http://directus:8055/items/tv_channels").mock(side_effect=capture_get)
     respx.get("http://directus:8055/items/sources").mock(
         return_value=httpx.Response(200, json={"data": [{"id": 18}]})
     )
-    post = respx.post("http://directus:8055/items/tv_channels").mock(
-        return_value=httpx.Response(200, json={"data": {"id": 1}})
-    )
+    post = respx.post("http://directus:8055/items/tv_channels").mock(side_effect=capture_post)
 
     upsert_channel_media_item(channel, "playlists/weta/master.m3u8",
-                              datetime(2001, 9, 9, tzinfo=timezone.utc), cfg)
+                              datetime(2001, 9, 9, tzinfo=timezone.utc),
+                              datetime(2001, 9, 18, tzinfo=timezone.utc), cfg)
 
     assert captured["params"].get("filter[url][_eq]") == \
         "https://files.911realtime.org/playlists/weta/master.m3u8"
     assert "filter[content][channel_stream][_eq]" not in captured["params"]
     assert post.called
+    # The channel row spans the whole window with a calculated duration.
+    assert captured["body"]["start_date"] == "2001-09-09T00:00:00"
+    assert captured["body"]["end_date"] == "2001-09-18T00:00:00"
+    assert captured["body"]["calc_duration"] == 9 * 86400
 
 
 @respx.mock
@@ -282,6 +290,7 @@ def test_upsert_channel_patches_when_row_exists():
     )
 
     upsert_channel_media_item(channel, "playlists/weta/master.m3u8",
-                              datetime(2001, 9, 9, tzinfo=timezone.utc), cfg)
+                              datetime(2001, 9, 9, tzinfo=timezone.utc),
+                              datetime(2001, 9, 18, tzinfo=timezone.utc), cfg)
 
     assert patch.called and not post.called

--- a/packages/tools/video-grabber/video_grabber/directus/writer.py
+++ b/packages/tools/video-grabber/video_grabber/directus/writer.py
@@ -78,7 +78,9 @@ def write_media_item(job, wasabi_url: str, cfg: Config) -> None:
     resp.raise_for_status()
 
 
-def upsert_channel_media_item(channel, master_url: str, window_start, cfg: Config) -> None:
+def upsert_channel_media_item(
+    channel, master_url: str, window_start, window_end, cfg: Config
+) -> None:
     """Upsert the single continuous-stream row for a channel into ``tv_channels``.
 
     The stitched per-channel HLS streams live in their own ``tv_channels`` table
@@ -90,6 +92,11 @@ def upsert_channel_media_item(channel, master_url: str, window_start, cfg: Confi
     than ``content`` because ``content`` is stored as an opaque JSON *string* that
     can only be matched as a whole blob. The ``content.channel_stream`` marker is
     still written for downstream consumers, just not queried.
+
+    ``start_date``/``end_date`` span the whole assembled window and
+    ``calc_duration`` is its length in seconds — the channel stream is continuous
+    across that span (gaps are blue-filled), so it is "active" for the entire
+    window, not just an instant.
     """
     token = get_directus_token(cfg)
     headers = {
@@ -103,6 +110,8 @@ def upsert_channel_media_item(channel, master_url: str, window_start, cfg: Confi
         "full_title": channel.display_name,
         "source": _resolve_source_id(channel.slug, headers, cfg),
         "start_date": window_start.strftime("%Y-%m-%dT%H:%M:%S"),
+        "end_date": window_end.strftime("%Y-%m-%dT%H:%M:%S"),
+        "calc_duration": int((window_end - window_start).total_seconds()),
         "timezone": channel.timezone,
         "url": url,
         "format": "m3u8",

--- a/packages/tools/video-grabber/video_grabber/pipeline/flows.py
+++ b/packages/tools/video-grabber/video_grabber/pipeline/flows.py
@@ -289,7 +289,7 @@ def build_channel_flow(channel_id: str, window_start: str, window_end: str):
     _rebuild_epg_guide(cfg)
 
     master_url = f"{base}/master.m3u8"
-    upsert_channel_media_item(channel, master_url, ws, cfg)
+    upsert_channel_media_item(channel, master_url, ws, we, cfg)
     logger.info("build-channel %s: published %s + EPG guide", channel.slug, master_url)
 
 


### PR DESCRIPTION
Follow-up to #136. The per-channel stream row only carried `start_date`, so `tv_channels` rows had no `end_date`/`calc_duration`. The channel is continuous across the whole assembled window, so `upsert_channel_media_item` now sets `end_date` = window end and `calc_duration` = its length in seconds (takes a new `window_end` arg; the build-channel flow passes it). The 23 existing rows were already backfilled live; this keeps future rebuilds correct. Tests + ruff pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)