### PR TITLE
fix(frontend): show all TV channels in the thumbnail strip (was capped at 12)

### DIFF
--- a/packages/frontend/src/Applications/TV/TV.tsx
+++ b/packages/frontend/src/Applications/TV/TV.tsx
@@ -543,7 +543,7 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 							</ClassicyButton>
 						</div>
 						<div className={styles.tvThumbnailStrip}>
-							{items.slice(0, 12).map((item) => {
+							{items.map((item) => {
 								// In multi-select mode no thumbnail is "active" (no absolute overlay)
 								const isActive = !multiSelectMode && item.id === activePlayer;
 								const isSelected = selectedPlayers.includes(item.id);


### PR DESCRIPTION
The TV channel thumbnail strip rendered `items.slice(0, 12)`, so with 23 channels everything after the 12th (ANT1–NHK alphabetically) was dropped from the list. The strip is already horizontally scrollable (`overflow-x: auto`), so the cap was purely artificial — now renders all enabled channels. tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)