### PR TITLE
fix(frontend): stream on the UTC virtual clock, not the tz-shifted di…

### DIFF
--- a/packages/frontend/src/Providers/MediaStream/MediaStreamProvider.tsx
+++ b/packages/frontend/src/Providers/MediaStream/MediaStreamProvider.tsx
@@ -16,6 +16,7 @@ import {
 } from "./MediaStreamContext";
 import { decodeWireMessage } from "./wireCodec";
 import { drainDue, partitionByDue } from "./revealBuffer";
+import { virtualUtcMs } from "./virtualClock";
 import {
 	applyUsenetBodyFrame,
 	emptyUsenetBodyState,
@@ -115,7 +116,7 @@ interface MediaStreamProviderProps {
 export const MediaStreamProvider: FC<MediaStreamProviderProps> = ({
 	children,
 }) => {
-	const { localDate, dateTime } = useClassicyDateTime({ tick: true });
+	const { localDate, dateTime, tzOffset } = useClassicyDateTime({ tick: true });
 
 	const [items, setItems] = useState<MediaItem[]>([]);
 	const [pagerItems, setPagerItems] = useState<PagerItem[]>([]);
@@ -159,13 +160,17 @@ export const MediaStreamProvider: FC<MediaStreamProviderProps> = ({
 	}, []);
 
 	const wsRef = useRef<WebSocket | null>(null);
-	// Always-current localDate for use inside WS callbacks and intervals
-	const localDateRef = useRef(localDate);
+	// Always-current virtual *UTC* instant (ms) for use inside WS callbacks and
+	// intervals. localDate is the tz-shifted display clock; the stream lives in
+	// UTC (item start_dates, the backend, seek, calcSeekSeconds), so we strip the
+	// offset back off. Mismatching these is what kept short-lived radio/news items
+	// trapped in the reveal buffer — see virtualClock.ts.
+	const utcMsRef = useRef(virtualUtcMs(localDate, tzOffset));
 	const prevDateTimeRef = useRef(dateTime);
 
 	useEffect(() => {
-		localDateRef.current = localDate;
-	}, [localDate]);
+		utcMsRef.current = virtualUtcMs(localDate, tzOffset);
+	}, [localDate, tzOffset]);
 
 	const send = useCallback((msg: object) => {
 		const ws = wsRef.current;
@@ -335,7 +340,7 @@ export const MediaStreamProvider: FC<MediaStreamProviderProps> = ({
 	// the merged-then-filtered state both surfaces newly-due items and drops
 	// expired ones in a single pass, keyed by the same `now`.
 	useEffect(() => {
-		const now = localDate.getTime();
+		const now = virtualUtcMs(localDate, tzOffset);
 
 		const dueMedia = drainDue(mediaBuffer.current, now);
 		const dueMp3 = drainDue(mp3Buffer.current, now);
@@ -353,7 +358,7 @@ export const MediaStreamProvider: FC<MediaStreamProviderProps> = ({
 		// Usenet messages are not time-pruned: a reader keeps browsing the group's
 		// backlog. They are cleared only on group change, unsubscribe, or seek.
 		if (dueUsenet.length > 0) setUsenetItems((prev) => mergeById(prev, dueUsenet));
-	}, [localDate]);
+	}, [localDate, tzOffset]);
 
 	// Detect manual time changes and send seek; ignore tick-driven minute boundaries
 	useEffect(() => {
@@ -397,7 +402,7 @@ export const MediaStreamProvider: FC<MediaStreamProviderProps> = ({
 			ws.send(
 				JSON.stringify({
 					type: "init",
-					time: localDateRef.current.toISOString(),
+					time: new Date(utcMsRef.current).toISOString(),
 				}),
 			);
 			// Re-establish channel subscriptions after a reconnect — the server
@@ -426,7 +431,7 @@ export const MediaStreamProvider: FC<MediaStreamProviderProps> = ({
 					ws.send(
 						JSON.stringify({
 							type: "heartbeat",
-							time: localDateRef.current.toISOString(),
+							time: new Date(utcMsRef.current).toISOString(),
 						}),
 					);
 				}
@@ -446,7 +451,7 @@ export const MediaStreamProvider: FC<MediaStreamProviderProps> = ({
 			// immediately; future items wait in the reveal buffer until the clock
 			// reaches their start_date (preserving forward-only pacing). init_ack /
 			// seek_ack snapshots are all active-now, so they land entirely in `due`.
-			const now = localDateRef.current.getTime();
+			const now = utcMsRef.current;
 
 			// Time-independent source lists for filters — sent once at init. Replace
 			// wholesale (the server always sends the complete set).
@@ -545,7 +550,7 @@ export const MediaStreamProvider: FC<MediaStreamProviderProps> = ({
 			}
 			wsRef.current = null;
 		};
-		// Intentionally runs once on mount; localDateRef carries the live value
+		// Intentionally runs once on mount; utcMsRef carries the live value
 	}, []);
 
 	return (

--- a/packages/frontend/src/Providers/MediaStream/virtualClock.test.ts
+++ b/packages/frontend/src/Providers/MediaStream/virtualClock.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { virtualUtcMs } from "./virtualClock";
+
+// toLocalDate mirrors the Classicy hook: localDate is the UTC instant shifted by
+// the timezone offset (the display clock). These tests assert that virtualUtcMs
+// inverts that shift, so the stream gate/seek instant stays in UTC.
+const toLocalDate = (utcMs: number, tz: number) =>
+	new Date(utcMs + tz * 60 * 60 * 1000);
+
+describe("virtualUtcMs", () => {
+	it("recovers the UTC instant from the tz-shifted display clock", () => {
+		const utcMs = new Date("2001-09-11T12:46:00.000Z").getTime();
+		for (const tz of [-5, -4, 0, 1, 9]) {
+			expect(virtualUtcMs(toLocalDate(utcMs, tz), tz)).toBe(utcMs);
+		}
+	});
+
+	it("equals the UTC dateTime the seek path sends, not the shifted localDate", () => {
+		// Regression: the reveal gate must equal the seek instant. The old bug used
+		// localDate.getTime() directly, which sits tzOffset hours away from the UTC
+		// instant the server windows around — so fresh items never surface.
+		const utcMs = new Date("2001-09-11T13:00:00.000Z").getTime();
+		const tz = -4;
+		const localDate = toLocalDate(utcMs, tz);
+		expect(virtualUtcMs(localDate, tz)).toBe(utcMs);
+		expect(virtualUtcMs(localDate, tz)).not.toBe(localDate.getTime());
+	});
+
+	it("advances per second as the display clock ticks (UTC frame preserved)", () => {
+		const utcMs = new Date("2001-09-11T13:00:00.000Z").getTime();
+		const tz = 5;
+		// localDate ticks forward one second; the UTC instant must track it 1:1.
+		const t0 = virtualUtcMs(toLocalDate(utcMs, tz), tz);
+		const t1 = virtualUtcMs(toLocalDate(utcMs + 1000, tz), tz);
+		expect(t1 - t0).toBe(1000);
+		expect(t0).toBe(utcMs);
+	});
+});

--- a/packages/frontend/src/Providers/MediaStream/virtualClock.ts
+++ b/packages/frontend/src/Providers/MediaStream/virtualClock.ts
@@ -1,0 +1,15 @@
+// The streamer's virtual clock lives in UTC. Item start_dates, the backend's
+// stored times, the seek instant, and every consuming app's calcSeekSeconds all
+// compare in UTC. The Classicy hook's `localDate` is a *display* value — the UTC
+// instant shifted by the user's timezone offset for the menu-bar clock — and it
+// is the one value that ticks every second. Stripping the offset back off
+// recovers the per-second-ticking UTC instant the stream must send, gate, and
+// seek on. At a minute boundary this equals `new Date(dateTime).getTime()`.
+//
+// Using `localDate` directly here is a bug: for any user whose offset is non-zero
+// (the default is their real local offset) the reveal gate sits `tzOffset` hours
+// away from the instant the server windows around, so short-lived items (radio
+// recordings, instant news headlines) never leave the future buffer.
+export function virtualUtcMs(localDate: Date, tzOffsetHours: number): number {
+	return localDate.getTime() - tzOffsetHours * 60 * 60 * 1000;
+}


### PR DESCRIPTION
…splay clock

MediaStreamProvider used the Classicy hook's `localDate` (= dateTime + tzOffset hours, the per-second display clock for the menu bar) as the stream clock for the init/heartbeat time it sent AND for the reveal-buffer gate, while `seek` correctly sent UTC `dateTime`. The default tzOffset is the user's real local offset, so these diverge by hours.

Result: TV worked (stitched-channel items start days in the past, so they clear any gate) but Radio Scanner (#103) and News (#106) broke — short-lived items near the virtual instant had start_date > shifted-gate, so they sat in the future reveal buffer and never surfaced. On init the shifted clock was self-consistent so items showed but for the wrong instant; on seek the UTC snapshot never passed the shifted gate, so "new items don't appear".

Add virtualUtcMs(localDate, tzOffset) to recover the per-second-ticking UTC instant and use it for the init/heartbeat sends and both reveal gates. seek was already UTC-correct and is unchanged, so the whole provider is now on one UTC clock. This also fixes heartbeats reporting the shifted time, which made the backend "correct" drift by hours every 30s.