### PR TITLE
feat(tv): stagger + virtualize thumbnail loading

### DIFF
--- a/packages/frontend/src/Applications/TV/TV.module.scss
+++ b/packages/frontend/src/Applications/TV/TV.module.scss
@@ -126,7 +126,7 @@ $strip-height: calc(5em + 8px);
   padding: calc(var(--window-padding-size) * 2);
 }
 
-// All players live here in the DOM permanently — active one floats up via absolute position
+// Visible players live here — off-screen thumbnails are unmounted by useStaggeredLoad;
 .tvPlayer {
   position: relative;
   flex-shrink: 0;

--- a/packages/frontend/src/Applications/TV/TV.tsx
+++ b/packages/frontend/src/Applications/TV/TV.tsx
@@ -182,11 +182,13 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 	const videoRefs = useRef<Map<number, HTMLVideoElement>>(new Map());
 	// Scroll container = IntersectionObserver root for staggered thumbnail loading.
 	const stripRef = useRef<HTMLDivElement>(null);
-	// In single-channel mode the active (enlarged) channel loads first; in grid
-	// mode the selected players render in the grid and are not queued here.
+	// In single-channel mode the focused (enlarged) channel loads first; in grid
+	// mode the selected players render as title-only (no <ReactPlayer>) so they
+	// must NOT enter the queue — they would never call markLoaded and would jam
+	// concurrency slots indefinitely.
 	const priorityIds = useMemo(
-		() => (multiSelectMode ? selectedPlayers : [activePlayer]),
-		[multiSelectMode, selectedPlayers, activePlayer],
+		() => (multiSelectMode ? [] : [activePlayer]),
+		[multiSelectMode, activePlayer],
 	);
 	const channelIds = useMemo(() => items.map((i) => i.id), [items]);
 	const { shouldMount, markLoaded, observe } = useStaggeredLoad({
@@ -443,9 +445,23 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 	// at segment boundaries. Idempotent guard avoids redundant ABR re-evaluations.
 	const capHlsLevel = useCallback((id: number, level: number) => {
 		const el = videoRefs.current.get(id) as
-			| (HTMLVideoElement & { api?: { autoLevelCapping: number } })
+			| (HTMLVideoElement & {
+					api?: {
+						autoLevelCapping: number;
+						config: { maxBufferLength: number; backBufferLength: number; maxBufferSize: number };
+					};
+			  })
 			| undefined;
-		if (el?.api && el.api.autoLevelCapping !== level) el.api.autoLevelCapping = level;
+		if (!el?.api || el.api.autoLevelCapping === level) return;
+		el.api.autoLevelCapping = level;
+		// Buffer caps must be updated at runtime (not just at construction) because
+		// hlsConfigFor caches the config object — baking in level-0 caps for all
+		// players on the first render. hls.js re-reads config.maxBufferLength etc. on
+		// each buffering tick, so mutating here takes effect without a remount.
+		const caps = bufferCapsForLevel(level);
+		el.api.config.maxBufferLength = caps.maxBufferLength;
+		el.api.config.backBufferLength = caps.backBufferLength;
+		el.api.config.maxBufferSize = caps.maxBufferSize;
 	}, []);
 
 	// The quality ceiling for a player: the single focused video (the active channel,

--- a/packages/frontend/src/Applications/TV/TV.tsx
+++ b/packages/frontend/src/Applications/TV/TV.tsx
@@ -23,6 +23,7 @@ import { vttUrl } from "../../Providers/MediaStream/MediaStreamContext";
 import { useMediaStream } from "../../Providers/MediaStream/useMediaStream";
 import styles from "./TV.module.scss";
 import { bufferCapsForLevel } from "./staggerLoad";
+import { useStaggeredLoad } from "./useStaggeredLoad";
 import {
 	type TVChannelRef,
 	type TVRemoteCommand,
@@ -179,6 +180,20 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 	// Underlying video elements per item — react-player 3.x forwards refs to
 	// the native <video> element, so we set currentTime directly for seeking.
 	const videoRefs = useRef<Map<number, HTMLVideoElement>>(new Map());
+	// Scroll container = IntersectionObserver root for staggered thumbnail loading.
+	const stripRef = useRef<HTMLDivElement>(null);
+	// In single-channel mode the active (enlarged) channel loads first; in grid
+	// mode the selected players render in the grid and are not queued here.
+	const priorityIds = useMemo(
+		() => (multiSelectMode ? selectedPlayers : [activePlayer]),
+		[multiSelectMode, selectedPlayers, activePlayer],
+	);
+	const channelIds = useMemo(() => items.map((i) => i.id), [items]);
+	const { shouldMount, markLoaded, observe } = useStaggeredLoad({
+		ids: channelIds,
+		priorityIds,
+		rootRef: stripRef,
+	});
 	const prevDateTimeRef = useRef(dateTime);
 	// Stable ref to the latest UTC dateTime string for use in config callbacks.
 	const dateTimeRef = useRef(dateTime);
@@ -721,7 +736,7 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 								}
 							/>
 						</div>
-						<div className={styles.tvThumbnailStrip}>
+						<div className={styles.tvThumbnailStrip} ref={stripRef}>
 							{items.map((item) => {
 								// In multi-select mode no thumbnail is "active" (no absolute overlay)
 								const isActive = !multiSelectMode && item.id === activePlayer;
@@ -737,6 +752,7 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 								return (
 									<button
 										key={item.id}
+										ref={(el) => observe(item.id, el)}
 										className={[
 											styles.tvPlayer,
 											isActive ? styles.tvPlayerActive : "",
@@ -767,7 +783,7 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 										<div className={styles.tvChannelTitleHolder}>
 											<p className={styles.tvChannelTitle}>{item.source}</p>
 										</div>
-										{renderThumbnailPlayer && (
+										{renderThumbnailPlayer && shouldMount(item.id) && (
 											<ReactPlayer
 												ref={(el: HTMLVideoElement | null) => {
 													if (el) videoRefs.current.set(item.id, el);
@@ -776,6 +792,7 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 												onReady={() => {
 													seekToCurrentTime(item);
 													capHlsLevel(item.id, levelForItem(item));
+													markLoaded(item.id);
 												}}
 												src={item.url}
 												playing={!clockPaused && !tvPaused}

--- a/packages/frontend/src/Applications/TV/TV.tsx
+++ b/packages/frontend/src/Applications/TV/TV.tsx
@@ -22,6 +22,7 @@ import type {
 import { vttUrl } from "../../Providers/MediaStream/MediaStreamContext";
 import { useMediaStream } from "../../Providers/MediaStream/useMediaStream";
 import styles from "./TV.module.scss";
+import { bufferCapsForLevel } from "./staggerLoad";
 import {
 	type TVChannelRef,
 	type TVRemoteCommand,
@@ -211,7 +212,13 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 		let config = hlsConfigsRef.current.get(item.id);
 		if (!config) {
 			const nowMs = new Date(dateTimeRef.current).getTime();
-			config = { hls: { startLevel: level, startPosition: calcSeekSeconds(item, nowMs) } };
+			config = {
+				hls: {
+					startLevel: level,
+					startPosition: calcSeekSeconds(item, nowMs),
+					...bufferCapsForLevel(level),
+				},
+			};
 			hlsConfigsRef.current.set(item.id, config);
 		}
 		return config;

--- a/packages/frontend/src/Applications/TV/staggerLoad.test.ts
+++ b/packages/frontend/src/Applications/TV/staggerLoad.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { STAGGER_THRESHOLD, computeConcurrency } from "./staggerLoad";
+import { STAGGER_THRESHOLD, computeConcurrency, bufferCapsForLevel } from "./staggerLoad";
 import { type LoadPhase, markLoaded, reconcile, shouldMount } from "./staggerLoad";
 
 describe("computeConcurrency", () => {
@@ -97,6 +97,21 @@ describe("shouldMount", () => {
 		expect(shouldMount(p, 2)).toBe(true);
 		expect(shouldMount(p, 3)).toBe(false);
 		expect(shouldMount(p, 4)).toBe(false);
+	});
+});
+
+describe("bufferCapsForLevel", () => {
+	it("keeps thumbnails (lowest tier) on a tiny buffer", () => {
+		const caps = bufferCapsForLevel(0);
+		expect(caps.maxBufferLength).toBeLessThanOrEqual(6);
+		expect(caps.backBufferLength).toBe(0);
+		expect(caps.maxBufferSize).toBeLessThanOrEqual(10 * 1000 * 1000);
+	});
+
+	it("gives the focused player (highest tier) a larger buffer than a thumbnail", () => {
+		expect(bufferCapsForLevel(2).maxBufferLength).toBeGreaterThan(
+			bufferCapsForLevel(0).maxBufferLength,
+		);
 	});
 });
 

--- a/packages/frontend/src/Applications/TV/staggerLoad.test.ts
+++ b/packages/frontend/src/Applications/TV/staggerLoad.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { STAGGER_THRESHOLD, computeConcurrency } from "./staggerLoad";
+import { type LoadPhase, markLoaded, reconcile, shouldMount } from "./staggerLoad";
 
 describe("computeConcurrency", () => {
 	it("does not stagger at or below the threshold (mount all)", () => {
@@ -31,3 +32,71 @@ describe("computeConcurrency", () => {
 		expect(computeConcurrency(23, { hardwareConcurrency: 0 })).toBe(2);
 	});
 });
+
+const phases = (entries: [number, LoadPhase][]) => new Map(entries);
+
+describe("reconcile", () => {
+	it("promotes up to `concurrency` visible idle players to loading", () => {
+		const next = reconcile(new Map(), {
+			visibleIds: [1, 2, 3, 4, 5],
+			priorityIds: [],
+			concurrency: 2,
+		});
+		const loading = [...next].filter(([, p]) => p === "loading").map(([id]) => id);
+		expect(loading.sort()).toEqual([1, 2]);
+	});
+
+	it("does not exceed the budget while players are still loading", () => {
+		const prev = phases([[1, "loading"], [2, "loading"]]);
+		const next = reconcile(prev, { visibleIds: [1, 2, 3, 4], priorityIds: [], concurrency: 2 });
+		expect([...next].filter(([, p]) => p === "loading").length).toBe(2);
+		expect(next.get(3)).toBe("idle");
+	});
+
+	it("frees capacity once a player has loaded, promoting the next", () => {
+		const prev = phases([[1, "loaded"], [2, "loading"]]);
+		const next = reconcile(prev, { visibleIds: [1, 2, 3, 4], priorityIds: [], concurrency: 2 });
+		// 1 loaded (doesn't count), 2 still loading -> 1 slot free -> promote 3
+		expect(next.get(3)).toBe("loading");
+		expect(next.get(4)).toBe("idle");
+	});
+
+	it("promotes priority ids before other visible thumbnails", () => {
+		const next = reconcile(new Map(), {
+			visibleIds: [1, 2, 3, 4, 5],
+			priorityIds: [5],
+			concurrency: 1,
+		});
+		expect(next.get(5)).toBe("loading");
+		expect(next.get(1)).toBe("idle");
+	});
+
+	it("prunes players that are no longer visible back to idle (unmount)", () => {
+		const prev = phases([[1, "loaded"], [2, "loading"]]);
+		const next = reconcile(prev, { visibleIds: [2], priorityIds: [], concurrency: 4 });
+		expect(next.has(1)).toBe(false);
+		expect(next.get(2)).toBe("loading");
+	});
+});
+
+describe("markLoaded", () => {
+	it("moves a loading player to loaded", () => {
+		expect(markLoaded(phases([[1, "loading"]]), 1).get(1)).toBe("loaded");
+	});
+	it("is a no-op for ids that are not loading", () => {
+		const prev = phases([[1, "idle"]]);
+		expect(markLoaded(prev, 1).get(1)).toBe("idle");
+		expect(markLoaded(prev, 99).has(99)).toBe(false);
+	});
+});
+
+describe("shouldMount", () => {
+	it("mounts loading and loaded players, not idle/unknown", () => {
+		const p = phases([[1, "loading"], [2, "loaded"], [3, "idle"]]);
+		expect(shouldMount(p, 1)).toBe(true);
+		expect(shouldMount(p, 2)).toBe(true);
+		expect(shouldMount(p, 3)).toBe(false);
+		expect(shouldMount(p, 4)).toBe(false);
+	});
+});
+

--- a/packages/frontend/src/Applications/TV/staggerLoad.test.ts
+++ b/packages/frontend/src/Applications/TV/staggerLoad.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { STAGGER_THRESHOLD, computeConcurrency } from "./staggerLoad";
+
+describe("computeConcurrency", () => {
+	it("does not stagger at or below the threshold (mount all)", () => {
+		expect(computeConcurrency(4, {})).toBe(4);
+		expect(computeConcurrency(1, {})).toBe(1);
+		expect(STAGGER_THRESHOLD).toBe(4);
+	});
+
+	it("uses deviceMemory (GiB) as the cap above the threshold", () => {
+		expect(computeConcurrency(23, { deviceMemory: 8 })).toBe(8);
+		expect(computeConcurrency(23, { deviceMemory: 4 })).toBe(4);
+	});
+
+	it("clamps to the [2, 8] range", () => {
+		expect(computeConcurrency(23, { deviceMemory: 0.5 })).toBe(2);
+		expect(computeConcurrency(23, { deviceMemory: 64 })).toBe(8);
+	});
+
+	it("falls back to half the core count when deviceMemory is absent", () => {
+		expect(computeConcurrency(23, { hardwareConcurrency: 12 })).toBe(6);
+		expect(computeConcurrency(23, { hardwareConcurrency: 2 })).toBe(2);
+	});
+
+	it("falls back to the threshold when no signal is available", () => {
+		expect(computeConcurrency(23, {})).toBe(4);
+	});
+
+	it("handles a zero core count by clamping to the floor of the range", () => {
+		expect(computeConcurrency(23, { hardwareConcurrency: 0 })).toBe(2);
+	});
+});

--- a/packages/frontend/src/Applications/TV/staggerLoad.ts
+++ b/packages/frontend/src/Applications/TV/staggerLoad.ts
@@ -1,0 +1,22 @@
+// Below this channel count the TV app mounts every player at once; above it,
+// initial loading is bounded by a concurrency queue (see reconcile).
+export const STAGGER_THRESHOLD = 4;
+
+/** How many thumbnail players may load concurrently.
+ *  K = clamp(deviceMemory ?? floor(cores/2) ?? THRESHOLD, 2, 8).
+ *  deviceMemory (GiB, Chromium-only) is the best cheap proxy for memory
+ *  headroom; core count is the cross-browser fallback. Neither is a true
+ *  "max simultaneous decoders" signal — no such API exists — so this only
+ *  *tunes* the cap; the queue mechanism is the actual safety net. */
+export function computeConcurrency(
+	channelCount: number,
+	nav: { deviceMemory?: number; hardwareConcurrency?: number } = navigator,
+): number {
+	if (channelCount <= STAGGER_THRESHOLD) return channelCount;
+	const fromCores =
+		nav.hardwareConcurrency != null
+			? Math.floor(nav.hardwareConcurrency / 2)
+			: undefined;
+	const raw = nav.deviceMemory ?? fromCores ?? STAGGER_THRESHOLD;
+	return Math.min(8, Math.max(2, Math.round(raw)));
+}

--- a/packages/frontend/src/Applications/TV/staggerLoad.ts
+++ b/packages/frontend/src/Applications/TV/staggerLoad.ts
@@ -78,3 +78,20 @@ export function reconcile(
 	}
 	return next;
 }
+
+/** hls.js buffer caps per quality tier. Thumbnails hold only a few seconds and
+ *  no back-buffer so each idle instance's memory stays small; the focused
+ *  player gets a roomier forward buffer. Levels match TV.tsx's QUALITY_*. */
+export function bufferCapsForLevel(level: number): {
+	maxBufferLength: number;
+	backBufferLength: number;
+	maxBufferSize: number;
+} {
+	if (level >= 2) {
+		return { maxBufferLength: 30, backBufferLength: 10, maxBufferSize: 60 * 1000 * 1000 };
+	}
+	if (level === 1) {
+		return { maxBufferLength: 10, backBufferLength: 0, maxBufferSize: 20 * 1000 * 1000 };
+	}
+	return { maxBufferLength: 6, backBufferLength: 0, maxBufferSize: 10 * 1000 * 1000 };
+}

--- a/packages/frontend/src/Applications/TV/staggerLoad.ts
+++ b/packages/frontend/src/Applications/TV/staggerLoad.ts
@@ -20,3 +20,61 @@ export function computeConcurrency(
 	const raw = nav.deviceMemory ?? fromCores ?? STAGGER_THRESHOLD;
 	return Math.min(8, Math.max(2, Math.round(raw)));
 }
+
+export type LoadPhase = "idle" | "loading" | "loaded";
+
+/** True once a player should have a live <ReactPlayer> in the DOM. */
+export function shouldMount(phase: Map<number, LoadPhase>, id: number): boolean {
+	const p = phase.get(id);
+	return p === "loading" || p === "loaded";
+}
+
+/** Mark a player's initial load complete (called from onReady). */
+export function markLoaded(
+	prev: Map<number, LoadPhase>,
+	id: number,
+): Map<number, LoadPhase> {
+	if (prev.get(id) !== "loading") return prev;
+	const next = new Map(prev);
+	next.set(id, "loaded");
+	return next;
+}
+
+/** Recompute load phases. Prunes off-screen players to idle (unmount), keeps
+ *  `loading` within `concurrency`, and promotes visible idle players —
+ *  priority ids first — into freed slots. `loaded` players do not consume
+ *  budget; they have finished their initial fetch. */
+export function reconcile(
+	prev: Map<number, LoadPhase>,
+	opts: { visibleIds: number[]; priorityIds: number[]; concurrency: number },
+): Map<number, LoadPhase> {
+	const { visibleIds, priorityIds, concurrency } = opts;
+	const visible = new Set(visibleIds);
+	const next = new Map<number, LoadPhase>();
+
+	// Carry forward only still-visible players; drop the rest (they unmount).
+	let loadingCount = 0;
+	for (const id of visibleIds) {
+		const p = prev.get(id);
+		if (p === "loading" || p === "loaded") {
+			next.set(id, p);
+			if (p === "loading") loadingCount++;
+		} else {
+			next.set(id, "idle");
+		}
+	}
+
+	// Promote idle visible players into free slots, priority first.
+	const ordered = [
+		...priorityIds.filter((id) => visible.has(id)),
+		...visibleIds.filter((id) => !priorityIds.includes(id)),
+	];
+	for (const id of ordered) {
+		if (loadingCount >= concurrency) break;
+		if (next.get(id) === "idle") {
+			next.set(id, "loading");
+			loadingCount++;
+		}
+	}
+	return next;
+}

--- a/packages/frontend/src/Applications/TV/useStaggeredLoad.test.ts
+++ b/packages/frontend/src/Applications/TV/useStaggeredLoad.test.ts
@@ -1,0 +1,97 @@
+import { act, renderHook } from "@testing-library/react";
+import { createRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useStaggeredLoad } from "./useStaggeredLoad";
+
+// Minimal controllable IntersectionObserver mock: capture the callback and the
+// observed elements so tests can drive intersection events deterministically.
+type IOEntry = { target: Element; isIntersecting: boolean };
+let lastObserver: {
+	cb: (entries: IOEntry[]) => void;
+	elements: Set<Element>;
+} | null = null;
+
+beforeEach(() => {
+	lastObserver = null;
+	class MockIO {
+		cb: (entries: IOEntry[]) => void;
+		elements = new Set<Element>();
+		constructor(cb: (entries: IOEntry[]) => void) {
+			this.cb = cb;
+			lastObserver = this;
+		}
+		observe(el: Element) { this.elements.add(el); }
+		unobserve(el: Element) { this.elements.delete(el); }
+		disconnect() { this.elements.clear(); }
+	}
+	vi.stubGlobal("IntersectionObserver", MockIO);
+});
+afterEach(() => vi.unstubAllGlobals());
+
+/** Build a fake element carrying its channel id for assertions. */
+const elFor = (id: number) => {
+	const el = document.createElement("div");
+	(el as unknown as { __id: number }).__id = id;
+	return el;
+};
+
+describe("useStaggeredLoad", () => {
+	it("mounts all channels without staggering at/below the threshold", () => {
+		const rootRef = createRef<HTMLElement>();
+		const { result } = renderHook(() =>
+			useStaggeredLoad({ ids: [1, 2, 3, 4], priorityIds: [], rootRef }),
+		);
+		for (const id of [1, 2, 3, 4]) {
+			expect(result.current.shouldMount(id)).toBe(true);
+		}
+	});
+
+	it("bounds concurrent loads above the threshold and fills slots on load", () => {
+		vi.stubGlobal("navigator", { deviceMemory: 2 } as Navigator); // K = 2
+		const rootRef = createRef<HTMLElement>();
+		const ids = [1, 2, 3, 4, 5];
+		const { result } = renderHook(() =>
+			useStaggeredLoad({ ids, priorityIds: [], rootRef }),
+		);
+
+		// Register + reveal all five thumbnails.
+		act(() => {
+			for (const id of ids) result.current.observe(id, elFor(id));
+			lastObserver?.cb(
+				[...(lastObserver?.elements ?? [])].map((target) => ({
+					target,
+					isIntersecting: true,
+				})),
+			);
+		});
+
+		const mounted = () => ids.filter((id) => result.current.shouldMount(id));
+		expect(mounted().length).toBe(2);
+
+		// First two report ready -> next two should mount.
+		act(() => {
+			for (const id of mounted()) result.current.markLoaded(id);
+		});
+		expect(mounted().length).toBe(4);
+	});
+
+	it("unmounts thumbnails that scroll out of view", () => {
+		vi.stubGlobal("navigator", { deviceMemory: 8 } as Navigator);
+		const rootRef = createRef<HTMLElement>();
+		const ids = [1, 2, 3, 4, 5];
+		const { result } = renderHook(() =>
+			useStaggeredLoad({ ids, priorityIds: [], rootRef }),
+		);
+		const els = new Map(ids.map((id) => [id, elFor(id)]));
+		act(() => {
+			for (const id of ids) result.current.observe(id, els.get(id) ?? null);
+			lastObserver?.cb(ids.map((id) => ({ target: els.get(id)!, isIntersecting: true })));
+		});
+		expect(result.current.shouldMount(1)).toBe(true);
+
+		act(() => {
+			lastObserver?.cb([{ target: els.get(1)!, isIntersecting: false }]);
+		});
+		expect(result.current.shouldMount(1)).toBe(false);
+	});
+});

--- a/packages/frontend/src/Applications/TV/useStaggeredLoad.test.ts
+++ b/packages/frontend/src/Applications/TV/useStaggeredLoad.test.ts
@@ -14,11 +14,12 @@ let lastObserver: {
 beforeEach(() => {
 	lastObserver = null;
 	class MockIO {
-		cb: (entries: IOEntry[]) => void;
 		elements = new Set<Element>();
 		constructor(cb: (entries: IOEntry[]) => void) {
-			this.cb = cb;
-			lastObserver = this;
+			// Capture cb and the elements Set reference (not `this`) so tests can
+			// drive IO events; the Set is shared by reference so mutations via
+			// observe/unobserve are visible through lastObserver.
+			lastObserver = { cb, elements: this.elements };
 		}
 		observe(el: Element) { this.elements.add(el); }
 		unobserve(el: Element) { this.elements.delete(el); }

--- a/packages/frontend/src/Applications/TV/useStaggeredLoad.ts
+++ b/packages/frontend/src/Applications/TV/useStaggeredLoad.ts
@@ -1,0 +1,121 @@
+import type React from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+	STAGGER_THRESHOLD,
+	computeConcurrency,
+	type LoadPhase,
+	markLoaded as markLoadedPure,
+	reconcile,
+	shouldMount as shouldMountPure,
+} from "./staggerLoad";
+
+/** Drives which TV thumbnails are mounted: a concurrency-bounded load queue fed
+ *  by an IntersectionObserver on the scroll container. Below STAGGER_THRESHOLD
+ *  channels it mounts everything; above it, only visible thumbnails load, ≤ K at
+ *  a time, freeing a slot on each onReady.
+ *
+ *  Every state change goes through setPhase from an *event* (intersection,
+ *  markLoaded, or a list/priority/budget change) — never from a render — so
+ *  there is no reconcile-on-every-render feedback loop. "Promote the next
+ *  queued thumbnail" is folded into the same setPhase as markLoaded.
+ *
+ *  `rootRef` must be a STABLE ref (e.g. from useRef), not recreated per render,
+ *  since the observer effect keys on it. */
+export function useStaggeredLoad(opts: {
+	ids: number[];
+	priorityIds: number[];
+	rootRef: React.RefObject<HTMLElement | null>;
+}): {
+	shouldMount: (id: number) => boolean;
+	markLoaded: (id: number) => void;
+	observe: (id: number, el: HTMLElement | null) => void; // ref callback per thumbnail
+} {
+	const { ids, priorityIds, rootRef } = opts;
+	const [phase, setPhase] = useState<Map<number, LoadPhase>>(new Map());
+
+	const small = ids.length <= STAGGER_THRESHOLD;
+	const concurrency = small ? ids.length : computeConcurrency(ids.length);
+
+	// Stable mirror of the inputs so the event callbacks keep a fixed identity
+	// yet always read current values (no stale closures, no churn).
+	const cfg = useRef({ ids, priorityIds, concurrency, small });
+	cfg.current = { ids, priorityIds, concurrency, small };
+
+	// id <-> element bookkeeping for the observer and visibility set.
+	const elToId = useRef<Map<Element, number>>(new Map());
+	const idToEl = useRef<Map<number, HTMLElement>>(new Map());
+	const visible = useRef<Set<number>>(new Set());
+	const observerRef = useRef<IntersectionObserver | null>(null);
+
+	// Pure: recompute phases from a base map + current visibility/priority/budget.
+	const recompute = useCallback((base: Map<number, LoadPhase>) => {
+		const { ids, priorityIds, concurrency, small } = cfg.current;
+		const visibleIds = small ? ids : ids.filter((id) => visible.current.has(id));
+		return reconcile(base, { visibleIds, priorityIds, concurrency });
+	}, []);
+
+	// Build the observer once per root (and when crossing the stagger threshold);
+	// each intersection change re-reconciles.
+	useEffect(() => {
+		if (small) {
+			setPhase((prev) => recompute(prev));
+			return;
+		}
+		const obs = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) {
+					const id = elToId.current.get(entry.target);
+					if (id == null) continue;
+					if (entry.isIntersecting) visible.current.add(id);
+					else visible.current.delete(id);
+				}
+				setPhase((prev) => recompute(prev));
+			},
+			{ root: rootRef.current ?? null, rootMargin: "200px" },
+		);
+		observerRef.current = obs;
+		for (const el of elToId.current.keys()) obs.observe(el);
+		return () => {
+			obs.disconnect();
+			observerRef.current = null;
+		};
+	}, [rootRef, recompute, small]);
+
+	const idsKey = ids.join(",");
+	const priorityKey = priorityIds.join(",");
+	// Re-reconcile when the channel list, priority, or budget changes. Keyed on
+	// stable strings so it fires on real changes, not on every render.
+	useEffect(() => {
+		setPhase((prev) => recompute(prev));
+	}, [idsKey, priorityKey, concurrency, recompute]);
+
+	const observe = useCallback((id: number, el: HTMLElement | null) => {
+		const prevEl = idToEl.current.get(id);
+		if (prevEl && prevEl !== el) {
+			observerRef.current?.unobserve(prevEl);
+			elToId.current.delete(prevEl);
+			visible.current.delete(id);
+		}
+		if (el) {
+			idToEl.current.set(id, el);
+			elToId.current.set(el, id);
+			observerRef.current?.observe(el);
+		} else {
+			idToEl.current.delete(id);
+			visible.current.delete(id);
+		}
+	}, []);
+
+	// Mark loaded AND promote the next queued thumbnail in one update.
+	const markLoaded = useCallback(
+		(id: number) => setPhase((prev) => recompute(markLoadedPure(prev, id))),
+		[recompute],
+	);
+
+	const shouldMount = useCallback(
+		(id: number) => (cfg.current.small ? true : shouldMountPure(phase, id)),
+		[phase],
+	);
+
+	return { shouldMount, markLoaded, observe };
+}

--- a/packages/frontend/src/Applications/TV/useStaggeredLoad.ts
+++ b/packages/frontend/src/Applications/TV/useStaggeredLoad.ts
@@ -50,8 +50,13 @@ export function useStaggeredLoad(opts: {
 	// Pure: recompute phases from a base map + current visibility/priority/budget.
 	const recompute = useCallback((base: Map<number, LoadPhase>) => {
 		const { ids, priorityIds, concurrency, small } = cfg.current;
-		const visibleIds = small ? ids : ids.filter((id) => visible.current.has(id));
-		return reconcile(base, { visibleIds, priorityIds, concurrency });
+		// Priority IDs (e.g. the focused player) are treated as always-visible so
+		// they mount even when scrolled out of the strip's scroll rect — otherwise
+		// the active channel could be pruned if its thumbnail scrolls off-screen.
+		const effectiveVisible = small
+			? ids
+			: ids.filter((id) => visible.current.has(id) || priorityIds.includes(id));
+		return reconcile(base, { visibleIds: effectiveVisible, priorityIds, concurrency });
 	}, []);
 
 	// Build the observer once per root (and when crossing the stagger threshold);

--- a/packages/frontend/src/global.d.ts
+++ b/packages/frontend/src/global.d.ts
@@ -1,0 +1,5 @@
+// navigator.deviceMemory is a non-standard (Chromium-only) signal: approximate
+// device RAM in GiB, bucketed to 0.25/0.5/1/2/4/8. Absent on Firefox/Safari.
+interface Navigator {
+	readonly deviceMemory?: number;
+}


### PR DESCRIPTION
## Summary

- **Concurrency-bounded queue**: K players load concurrently (K from `deviceMemory` → `hardwareConcurrency/2` → 4, clamped to [2,8]). Below 4 channels, mounts everything with no queue.
- **IntersectionObserver virtualization**: thumbnails outside the strip viewport (+ 200px margin) are unmounted; priority channels (the focused player) are pinned visible even when scrolled off-screen.
- **Per-tier buffer caps**: focused player gets a 30s/60MB buffer; grid players 10s/20MB; thumbnails 6s/10MB — runtime-mutated via `capHlsLevel` alongside the existing ABR ceiling.

## Files

| File | Role |
|------|------|
| `staggerLoad.ts` | Pure state machine: `computeConcurrency`, `reconcile`, `markLoaded`, `shouldMount`, `bufferCapsForLevel` |
| `useStaggeredLoad.ts` | React hook: IntersectionObserver + queue, stable refs, no render-loop |
| `TV.tsx` | Wiring: `stripRef`, `priorityIds`, `channelIds`, gate `shouldMount`, `markLoaded` in `onReady`, buffer caps via `capHlsLevel` |

## Bugs caught and fixed during review

- **Buffer caps frozen at level 0**: `hlsConfigFor` caches config on first render (all players at level 0), so buffer tiers were never reachable. Fixed: `capHlsLevel` now mutates `el.api.config.{maxBufferLength,backBufferLength,maxBufferSize}` at runtime alongside `autoLevelCapping`.
- **Grid-mode queue jam**: `priorityIds = selectedPlayers` in grid mode caused selected channels (which render title-only, never mounting a `<ReactPlayer>`) to permanently occupy concurrency slots. Fixed: `priorityIds = []` in `multiSelectMode`.

## Test plan

- [ ] Open TV with ≥5 channels — confirm only K players load initially (watch Network tab: only K HLS fetches start)
- [ ] Scroll the thumbnail strip — off-screen thumbnails unmount, on-screen ones load
- [ ] Click a channel — it loads immediately (priority promotion); other slots fill behind it
- [ ] Enter grid/multi-select mode — all visible strip thumbnails load normally (no queue jam)
- [ ] `npx vitest run` in `packages/frontend` → 179/179 passing

## Stacked on

PR #142 (`feat/tv-graceful-quality`) — base is `feat/tv-graceful-quality`, not `main`. Merge #142 first, then this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnhE6P81JhB2ePneazHwMi