### PR TITLE
fix(video-grabber): self-heal transcribe workers instead of stalling on a crash

### DIFF
--- a/packages/tools/video-grabber/video_grabber/serve.py
+++ b/packages/tools/video-grabber/video_grabber/serve.py
@@ -18,6 +18,8 @@ avoids coupling pure modules to Prefect's runtime.
 """
 import subprocess
 import sys
+import threading
+import time
 
 import sqlalchemy as sa
 from prefect import serve
@@ -76,49 +78,100 @@ _USENET_DISPATCH_LIMIT = 4
 # Re-run the (bounded, idempotent) dispatcher every 5 minutes to keep the queue draining.
 _USENET_DISPATCH_INTERVAL = 300
 # Transcription shares the encode-1 iGPU with VAAPI video encode (whisper Vulkan
-# vs. h264_vaapi). Encode backlog is fully drained; encode-1 is at ~5% CPU / 2% RAM
-# so iGPU is idle. Raised to 6 concurrent slots. Revert if encode backlog returns.
-# scan/dispatch are serial; channel merge writes one shared per-channel SRT so keep at 1.
-_TRANSCRIBE_ITEM_LIMIT = 6
+# vs. h264_vaapi). 6 concurrent whisper-Vulkan instances destabilised the iGPU —
+# workers crashed silently (native SIGSEGV/SIGKILL, not OOM; the node had 96% RAM
+# free), each orphaning its job and losing its slot until all 6 were dead and the
+# pipeline stalled. Held at 3 to ease GPU contention; the supervisor below makes a
+# crash self-healing rather than terminal. scan/dispatch are serial; channel merge
+# writes one shared per-channel SRT so keep at 1.
+_TRANSCRIBE_ITEM_LIMIT = 3
 _TRANSCRIBE_SCAN_LIMIT = 1
-_TRANSCRIBE_DISPATCH_LIMIT = 6
+_TRANSCRIBE_DISPATCH_LIMIT = 3
 _BUILD_CHANNEL_SUBS_LIMIT = 1
+# A live worker heartbeats its claimed job's last_transition_at every minute, so a
+# 'transcribing' row untouched for this long means its worker died — recover it.
+# Well above the 60s heartbeat but far below the ~1h46m max real transcription, so
+# it never reclaims a job a slow-but-alive worker is still running.
+_TRANSCRIBE_STALE_MINUTES = 5
+_TRANSCRIBE_SUPERVISE_INTERVAL = 20
+_TRANSCRIBE_MAX_RETRIES = 3
 _THUMBNAIL_LIMIT = 1  # one batch run at a time; manually triggered from Prefect UI
 
 
-def _start_transcribe_workers() -> None:
-    """Reset stuck transcription jobs and spawn one dispatch worker per slot.
+def _recover_orphaned_transcribing(engine, stale_minutes: int) -> int:
+    """Re-queue 'transcribing' jobs whose worker died mid-transcription.
 
-    Called once at pod startup, before serve() blocks. Any job left in
-    'transcribing' from the previous pod session is reset to 'failed' so the
-    dispatcher retries it. Workers write to /tmp/transcribe-worker-N.log."""
+    A worker that crashes (native SIGSEGV / SIGKILL) never runs the flow's
+    except/finally, so its job is stuck in 'transcribing'. Live workers heartbeat
+    last_transition_at every minute, so a row untouched for ``stale_minutes`` has
+    no live worker → recover it: back to 'pending' to retry, or to 'failed' once
+    retries are exhausted (kept for diagnosis), bumping retry_count either way.
+    ``stale_minutes=0`` recovers every 'transcribing' row — used at boot, when no
+    worker is running yet so all of them are orphans."""
+    with engine.begin() as db:
+        res = db.execute(sa.text("""
+            UPDATE transcribe_jobs
+               SET stage = CASE WHEN retry_count < :max
+                                THEN CAST('pending' AS transcribe_stage)
+                                ELSE CAST('failed'  AS transcribe_stage) END,
+                   retry_count = retry_count + 1,
+                   error_message = 'recovered: worker died/stalled mid-transcription',
+                   last_transition_at = now()
+             WHERE stage = 'transcribing'
+               AND last_transition_at < now() - (:mins * interval '1 minute')
+            RETURNING id
+        """), {"max": _TRANSCRIBE_MAX_RETRIES, "mins": stale_minutes})
+        return res.rowcount
+
+
+def _spawn_transcribe_worker(i: int) -> subprocess.Popen:
+    log = open(f"/tmp/transcribe-worker-{i}.log", "w")  # noqa: SIM115
+    return subprocess.Popen(
+        [sys.executable, "-m", "video_grabber.transcribe.dispatch_worker", str(i)],
+        stdout=log,
+        stderr=log,
+    )
+
+
+def _start_transcribe_workers() -> None:
+    """Spawn one dispatch worker per slot and supervise them.
+
+    Called once at pod startup, before serve() blocks. A background supervisor
+    thread (a) respawns any worker that dies — a native whisper/Vulkan crash would
+    otherwise permanently lose a slot — and (b) periodically re-queues jobs orphaned
+    in 'transcribing' by such a crash. Workers write to /tmp/transcribe-worker-N.log."""
     from video_grabber.config import Config
     from video_grabber.transcribe.flows import _sync_db_url
 
     cfg = Config()
     engine = sa.create_engine(_sync_db_url(cfg.database_url))
-    with engine.connect() as db:
-        result = db.execute(sa.text("""
-            UPDATE transcribe_jobs
-            SET stage = CAST('failed' AS transcribe_stage),
-                error_message = 'reset: pod restarted'
-            WHERE stage = 'transcribing'
-            RETURNING id
-        """))
-        db.commit()
-        n = result.rowcount
-    engine.dispose()
-    if n:
-        print(f"[serve] reset {n} stuck transcribing job(s) to failed", flush=True)
 
+    # On boot no worker is running, so every 'transcribing' row is an orphan.
+    n = _recover_orphaned_transcribing(engine, 0)
+    if n:
+        print(f"[serve] recovered {n} orphaned transcribing job(s) at startup", flush=True)
+
+    procs = {}
     for i in range(_TRANSCRIBE_DISPATCH_LIMIT):
-        log = open(f"/tmp/transcribe-worker-{i}.log", "w")  # noqa: SIM115
-        proc = subprocess.Popen(
-            [sys.executable, "-m", "video_grabber.transcribe.dispatch_worker", str(i)],
-            stdout=log,
-            stderr=log,
-        )
-        print(f"[serve] started transcribe-worker-{i} pid={proc.pid}", flush=True)
+        procs[i] = _spawn_transcribe_worker(i)
+        print(f"[serve] started transcribe-worker-{i} pid={procs[i].pid}", flush=True)
+
+    def supervise() -> None:
+        while True:
+            time.sleep(_TRANSCRIBE_SUPERVISE_INTERVAL)
+            try:
+                for i, proc in list(procs.items()):
+                    if proc.poll() is not None:
+                        print(f"[serve] transcribe-worker-{i} died (exit={proc.returncode}); "
+                              "respawning", flush=True)
+                        procs[i] = _spawn_transcribe_worker(i)
+                recovered = _recover_orphaned_transcribing(engine, _TRANSCRIBE_STALE_MINUTES)
+                if recovered:
+                    print(f"[serve] recovered {recovered} stalled transcribing job(s)", flush=True)
+            except Exception as exc:  # noqa: BLE001 — supervisor must never die
+                print(f"[serve] transcribe supervisor error: {exc}", flush=True)
+
+    threading.Thread(target=supervise, daemon=True, name="transcribe-supervisor").start()
 
 
 def main() -> None:

--- a/packages/tools/video-grabber/video_grabber/transcribe/dispatch_worker.py
+++ b/packages/tools/video-grabber/video_grabber/transcribe/dispatch_worker.py
@@ -3,13 +3,26 @@
 Spawned as a subprocess by serve.main() — one process per concurrent transcription
 slot (_TRANSCRIBE_DISPATCH_LIMIT). Claims pending/failed transcribe_jobs one at a
 time and calls transcribe_item_flow directly (no Prefect run_deployment round-trip),
-then loops until the queue is empty.
+then loops forever.
 
 Running as a subprocess rather than a thread gives each worker a fully isolated
 Python interpreter: its own event loop, connection pool, and signal handlers. This
 avoids anyio / asyncio conflicts that arise when multiple threads each try to own
-a Prefect flow's event loop."""
+a Prefect flow's event loop. The trade-off is that a native whisper/Vulkan crash
+takes the whole process down — serve.py's supervisor respawns it, and the heartbeat
+below lets the supervisor tell a crashed claim apart from a live one.
+
+Two behaviours keep the pipeline self-healing:
+  - On an empty queue the worker SLEEPS and retries instead of exiting, so a drained
+    queue that scan-transcribe later refills is picked up without a pod restart.
+  - While a job is claimed, a heartbeat thread refreshes its last_transition_at every
+    minute. If the worker dies mid-transcription the heartbeat stops, the row goes
+    stale, and serve.py re-queues it. A live worker — even on a ~1h46m transcription —
+    keeps it fresh, so a slow job is never mistaken for a dead one.
+"""
 import sys
+import threading
+import time
 
 import sqlalchemy as sa
 
@@ -32,16 +45,44 @@ _CLAIM_SQL = sa.text("""
     RETURNING id
 """)
 
-_PREFIX = f"[transcribe-worker-{sys.argv[1] if len(sys.argv) > 1 else '?'}]"
+_IDLE_SLEEP = 30        # seconds to wait before re-polling an empty queue
+_HEARTBEAT_INTERVAL = 60  # seconds between last_transition_at refreshes (see serve._TRANSCRIBE_STALE_MINUTES)
+
+_WORKER = sys.argv[1] if len(sys.argv) > 1 else "?"
+_PREFIX = f"[transcribe-worker-{_WORKER}]"
+
+# The id of the job currently being transcribed (None while idle). Read by the
+# heartbeat thread; a plain dict is fine — single writer, CPython atomic reads.
+_current = {"id": None}
 
 
 def _log(msg: str) -> None:
     print(f"{_PREFIX} {msg}", flush=True)
 
 
+def _heartbeat(url: str) -> None:
+    """Refresh the claimed job's last_transition_at so the supervisor can tell a
+    live transcription from one whose worker has crashed."""
+    engine = sa.create_engine(url)
+    while True:
+        time.sleep(_HEARTBEAT_INTERVAL)
+        job_id = _current["id"]
+        if not job_id:
+            continue
+        try:
+            with engine.begin() as db:
+                db.execute(sa.text(
+                    "UPDATE transcribe_jobs SET last_transition_at = now() "
+                    "WHERE id = :id AND stage = 'transcribing'"
+                ), {"id": job_id})
+        except Exception as exc:  # noqa: BLE001 — heartbeat must not kill the worker
+            _log(f"heartbeat error: {exc}")
+
+
 def main() -> None:
     cfg = Config()
     url = _sync_db_url(cfg.database_url)
+    threading.Thread(target=_heartbeat, args=(url,), daemon=True).start()
     processed = 0
 
     while True:
@@ -52,18 +93,19 @@ def main() -> None:
         engine.dispose()
 
         if row is None:
-            _log(f"queue empty after {processed} runs")
-            break
+            time.sleep(_IDLE_SLEEP)  # stay alive; scan-transcribe may refill the queue
+            continue
 
         job_id = str(row[0])
+        _current["id"] = job_id
         _log(f"claimed {job_id} (run {processed + 1})")
         try:
             transcribe_item_flow(job_id=job_id)
         except Exception as exc:  # noqa: BLE001
             _log(f"error on {job_id}: {exc}")
+        finally:
+            _current["id"] = None
         processed += 1
-
-    _log(f"done after {processed} runs")
 
 
 if __name__ == "__main__":

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -856,36 +856,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -1334,36 +1340,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
@@ -2297,24 +2309,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2779,48 +2795,56 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: glibc
 
   sass-embedded-linux-arm@1.100.0:
     resolution: {integrity: sha512-9Ul7O1eKrc5YlhwWjkp8tZPSe3UEwSZ1uwUZOQom1HL0pRlBA6F/IlGZYFTLwnHMIP1fc77MMNaBRfc05mKMpw==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: glibc
 
   sass-embedded-linux-musl-arm64@1.100.0:
     resolution: {integrity: sha512-XpACJB2KjSLjf2e9uuvGVdOURsoNrFqgRiihhXyUHK9W0t3LIHb7z5MA/7XGPIT9bWSOO2zyw+rH/FHtDV/Yrg==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-musl-arm@1.100.0:
     resolution: {integrity: sha512-sl0JgbGloPyJg66XXx5UDSDScZ0oU85DpMQU4JU/sCUCFj1Z8zZ69SJWKTCNE4/jwnce7WI2zPCV5AG+RHOZJw==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-musl-riscv64@1.100.0:
     resolution: {integrity: sha512-ShvI0Kx04mwoCARwZ0UjiT97isQvzO80tAt91zmFyHLN9kelc/IrQi940farSm2xQVPCKdeVyeG0ekBsokSpYQ==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-musl-x64@1.100.0:
     resolution: {integrity: sha512-TDBCRWNuS4RDLQXvRc1gjZlWiWTWaWGp0Bwu/IKwJxov81lsvrCs3TihTyNXtW7V5aoN4Ky3r0QOkNb3mwmBnA==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-riscv64@1.100.0:
     resolution: {integrity: sha512-j4ENJGOheO+fm3j/yorLxCjBP6/XskrZx7dTLlT+lXYwN/qqCqoA/gsNLI0McS3DFM6GBwPiffzWsdWS8t6sEQ==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
+    libc: glibc
 
   sass-embedded-linux-x64@1.100.0:
     resolution: {integrity: sha512-0vUSN8j0WGtCJIOPh//EmUvYGHW0QOe5iul8qyhPk50MAcw49MA0r34AhftjDdx94ILPF6vApFs0gwHPQRlpVA==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: glibc
 
   sass-embedded-unknown-all@1.100.0:
     resolution: {integrity: sha512-c+naBgWId4MIpToXcI0DgqetjdAkwTTAxFAuOaBz7HUXLdyG1oZRrEvSsbe41nEdQOKH0vgofVFCeSQgoXOG9A==}


### PR DESCRIPTION
## Symptom
The transcribe pipeline silently stalled — **all 6 worker subprocesses dead** (0 running flows, ~5,500 jobs `pending`), with 6 jobs orphaned in `transcribing` (recovered manually).

## Root cause
6 concurrent whisper-Vulkan instances destabilise the shared iGPU and crash a worker **natively** (SIGSEGV/SIGKILL — *not* OOM; the node had 96% RAM free). A native crash skips the flow's `except/finally`, so the job sticks in `transcribing`. And `serve.py` spawned the 6 workers **once and never respawned** them, so each crash permanently lost a slot until none remained. The only recovery — `serve.py`'s startup reset — needs a pod restart that never came. (The `2→6` concurrency bump landed earlier the same day.)

## Fix — make a crash self-healing rather than terminal
- **Supervisor thread** (`serve.py`): respawns any dead worker and periodically re-queues jobs orphaned in `transcribing` → `pending`, or → `failed` once `retry_count` is exhausted (crash-looping files are kept for diagnosis, per project policy).
- **Heartbeat** (`dispatch_worker.py`): a live worker refreshes its job's `last_transition_at` every minute, so the supervisor distinguishes a live transcription (even the ~1h46m p100 measured from logs) from a dead worker's orphan via a 5-min staleness threshold — **no false reclaims** of running jobs.
- **Sleep-and-poll**: workers no longer exit on an empty queue, so a drained queue that `scan-transcribe` later refills resumes without a pod restart.
- **Concurrency 6→3** to ease iGPU contention; the supervisor covers any crashes that still slip through.

## Verification
- `ruff check` clean; 7 transcribe tests pass.
- Will verify live after deploy: workers stay at 3 and respawn on death, orphaned `transcribing` rows recover, and the ~5,500 `pending` backlog drains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)