### PR TITLE
fix(usenet): header-thread tiny archives instead of crashing on repack-zstd

### DIFF
--- a/packages/tools/video-grabber/tests/test_usenet_processor.py
+++ b/packages/tools/video-grabber/tests/test_usenet_processor.py
@@ -135,3 +135,44 @@ def test_process_archive_uses_header_threading_when_large(tmp_path, monkeypatch)
 
     assert called["thread_mbox"] is False                       # usenetarchive skipped (too large)
     assert any(m["parent_id"] == "0@x" for m in groups["ntl.talk"])  # header threading linked replies
+
+
+def test_process_archive_uses_header_threading_when_tiny(tmp_path, monkeypatch):
+    # Archives below the zstd dictionary-training floor (repack-zstd SIGSEGVs on
+    # too few samples) must skip the usenetarchive build and thread from headers.
+    monkeypatch.setattr(processor, "_MIN_THREADIFY_MESSAGES", 8)
+    records = [{"headers": {"newsgroups": "ntl.talk", "message-id": f"<{i}@x>",
+                            "references": "" if i == 0 else "<0@x>"}, "body": {}} for i in range(3)]
+    called = {"thread_mbox": False}
+
+    def boom(*a, **k):
+        called["thread_mbox"] = True
+        return {}
+
+    with mock.patch.object(processor, "run_mbox_parser", side_effect=_write_jsonl(records)), \
+         mock.patch.object(processor.threader, "thread_mbox", side_effect=boom):
+        groups = processor.process_archive("/in/x.mbox", "2001-09-21", str(tmp_path), "fb.k")
+
+    assert called["thread_mbox"] is False                       # usenetarchive skipped (too small)
+    assert any(m["parent_id"] == "0@x" for m in groups["ntl.talk"])  # header threading still linked replies
+
+
+def test_process_archive_falls_back_when_threader_crashes(tmp_path, monkeypatch):
+    # If the usenetarchive build crashes for any reason (a repack-zstd/lexicon
+    # SIGSEGV the count check didn't pre-empt), the job must degrade to header
+    # threading and still produce records — not fail the whole archive.
+    monkeypatch.setattr(processor, "_MIN_THREADIFY_MESSAGES", 0)
+    monkeypatch.setattr(processor, "_MAX_THREADIFY_MESSAGES", 10_000)
+    records = [{"headers": {"newsgroups": "ntl.talk", "message-id": f"<{i}@x>",
+                            "references": "" if i == 0 else "<0@x>"}, "body": {}} for i in range(20)]
+
+    def crash(*a, **k):
+        raise RuntimeError("repack-zstd failed (rc=-11): Building dictionary")
+
+    with mock.patch.object(processor, "run_mbox_parser", side_effect=_write_jsonl(records)), \
+         mock.patch.object(processor.threader, "thread_mbox", side_effect=crash):
+        groups = processor.process_archive("/in/x.mbox", "2001-09-21", str(tmp_path), "fb.k")
+
+    assert "ntl.talk" in groups
+    assert len(groups["ntl.talk"]) == 20                        # all messages survived the crash
+    assert any(m["parent_id"] == "0@x" for m in groups["ntl.talk"])  # header threading linked replies

--- a/packages/tools/video-grabber/video_grabber/usenet/processor.py
+++ b/packages/tools/video-grabber/video_grabber/usenet/processor.py
@@ -24,6 +24,14 @@ _TAG_RE = re.compile(r"<[^>]+>")
 # threading. Tunable without a rebuild.
 _MAX_THREADIFY_MESSAGES = int(os.getenv("USENET_MAX_THREADIFY_MESSAGES", "100000"))
 
+# Below this message count, repack-zstd's zstd dictionary trainer (ZDICT) SIGSEGVs:
+# it needs a minimum number of samples and crashes on tiny archives (empirically
+# ≤5 messages segfault, ≥7 are safe; default 8 clears the boundary with margin).
+# This was ~6.5k of the usenet failures — all tiny giganews groups. Such archives
+# have nothing for threadify's quote-matcher to recover anyway, so header-based
+# threading is a lossless substitute here. Tunable without a rebuild.
+_MIN_THREADIFY_MESSAGES = int(os.getenv("USENET_MIN_THREADIFY_MESSAGES", "8"))
+
 # A valid newsgroup name is dot-separated components, each starting and ending
 # alphanumeric (interior +, _, - allowed). Malformed Newsgroups: headers (seen in
 # bundled archives) yield junk like "-h", "!.!", ".blur", "1", "0000000001" — this
@@ -147,8 +155,22 @@ def process_archive(mbox_path, before: str, workdir, fallback_group: str, *, log
             logger.warning("usenet process: %d messages > %d — header-based threading (skipping usenetarchive)",
                            len(records), _MAX_THREADIFY_MESSAGES)
         thread_index = header_thread_index(records)
+    elif len(records) < _MIN_THREADIFY_MESSAGES:
+        if logger:
+            logger.warning("usenet process: %d messages < %d — header-based threading (repack-zstd SIGSEGVs on tiny archives)",
+                           len(records), _MIN_THREADIFY_MESSAGES)
+        thread_index = header_thread_index(records)
     else:
-        thread_index = threader.thread_mbox(str(mbox_path), str(work / "uat"), logger=logger)
+        # The usenetarchive C++ build can still crash on archives the count checks
+        # don't pre-empt (e.g. enough messages but too little total content for
+        # ZDICT, or a lexicon/repack SIGSEGV). Degrade to header threading rather
+        # than failing the whole archive — only the quote-restored links are lost.
+        try:
+            thread_index = threader.thread_mbox(str(mbox_path), str(work / "uat"), logger=logger)
+        except Exception as exc:  # noqa: BLE001 — any build crash falls back, by design
+            if logger:
+                logger.warning("usenet process: usenetarchive build failed (%s) — header-based threading", exc)
+            thread_index = header_thread_index(records)
 
     groups: dict[str, list[dict]] = {}
     skipped = 0


### PR DESCRIPTION
## Problem

**92% of `process-usenet-item` failures — 6,531 of ~7,050 — were a single error:**

```
repack-zstd failed (rc=-11): Building dictionary
```

`rc=-11` is **SIGSEGV**. zstd's dictionary trainer (`ZDICT`, the "Building dictionary" step of `repack-zstd`) segfaults when handed too few samples. These are all tiny single-day giganews groups.

## Root cause (reproduced)

Ran the real archive `usenet-alt.egujsove` (2 messages) through the build pipeline in the worker pod → `repack-zstd` exits 139 (SIGSEGV). Swept synthetic mboxes to find the boundary:

| messages | repack-zstd |
|---------:|:------------|
| 2, 3, 5  | **SEGV** |
| 7, 8, 10, 16, 32, 64 | OK |

The break at 7 is exactly zstd's `ZDICT` minimum-sample floor.

## Fix

Mirrors the existing **oversize**-archive path (which already falls back to header-based threading to dodge `repack-zstd` OOM):

1. **Symmetric lower bound** (`_MIN_THREADIFY_MESSAGES`, default 8, env-tunable): archives below the ZDICT floor skip the usenetarchive C++ build and thread from `References`/`In-Reply-To` headers. Tiny archives have nothing for `threadify`'s quote-matcher to recover, so header threading is **lossless** here.
2. **Defensive fallback**: if the build crashes anyway (a SIGSEGV the count check didn't pre-empt, or a `lexicon` crash), catch it and fall back to header threading rather than failing the whole archive — only the quote-restored links are lost.

Routing keys on the post-cutoff record count, which is a **lower bound** on the raw mbox sample count, so the threader is only invoked when ZDICT is safe.

## Tests

- `test_process_archive_uses_header_threading_when_tiny` — below the floor, the C++ build is skipped and headers still link replies.
- `test_process_archive_falls_back_when_threader_crashes` — a simulated `repack-zstd` SIGSEGV degrades to header threading; all 20 messages survive.

Full suite: **298 passed, 8 skipped** (12 `test_migrations.py` errors are the documented no-local-Postgres env gap). `ruff` clean.

## Follow-up (operational, after this deploys)

6,279 of the failed jobs are at `retry_count=3` (exhausted) and 1,040 are orphaned in `downloading`/`processing`. Once the new image is live I'll reset `retry_count`/stage so the dispatcher re-runs them under the fixed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)