### PR TITLE
feat(flight-recon): curated notable flights (AA11, UA175, AA77, UA93) — data + loader, prod load gated on review

### DIFF
--- a/packages/tools/flight-recon/README.md
+++ b/packages/tools/flight-recon/README.md
@@ -66,6 +66,39 @@ Known source limitation: BTS only records diversion detail (`Div*Airport`/
 recorded landing in the data and are skipped as "no usable airborne
 interval" (visible in the run summary's skip list).
 
+## Notable flights (curated 9/11 hijacked aircraft)
+
+The four hijacked flights of September 11, 2001 — **AA11, UA175, AA77, UA93** —
+are absent from BTS On-Time Performance (which records only completed flights;
+the lowest AA number present is `AA1002`), so they are curated separately from
+authoritative public radar data — each flight's **NTSB Flight Path Study**
+(2002-02-19), corroborated by the **9/11 Commission Report** (Ch. 1). They load
+into the same `flight_positions` / `flight_tracks` / `reconstruction_runs`
+tables, under those exact flight IDs, so the streamer `flights` channel and the
+Flight Tracker read them with zero special-casing.
+
+- **Data (the reviewable accuracy artifact):** `data/notable_flights/{aa11,
+  ua175,aa77,ua93}.json` — documented radar/anchor waypoints (lat/lon/alt/UTC)
+  plus metadata, impact site, `sources`, and `provenance_notes`. The NTSB
+  studies are published as scanned image PDFs whose radar tables are not
+  machine-recoverable, so intermediate per-minute positions are great-circle
+  interpolations between documented anchors (takeoff, transponder-off, the
+  documented turn-backs, impact), **not** surveyed radar returns — flagged in
+  each file's `provenance_notes`.
+- **Loader:** `python -m flight_recon.notable --dsn postgres://… [--dry-run]`.
+  Resamples each flight to one position per UTC minute in `[takeoff, impact]`
+  (`flight_recon/resample.py`, the unit-tested pure core), builds positions +
+  one LineString track per flight, then **scoped-deletes ONLY these four flight
+  IDs for `flight_date='2001-09-11'`** before re-inserting — it does **not**
+  reuse the BTS window-delete, which would wipe the 1,945 real flights. Emits a
+  `reconstruction_runs` provenance row citing the NTSB studies. `--dry-run`
+  builds, validates, and exercises the delete/insert inside a transaction it
+  rolls back. `--init-schema` creates the tables (scratch DBs only).
+- **PROD-LOAD REVIEW GATE:** loading synthesized 9/11 flight paths to prod is
+  gated on human review of the data files + a dry-run report against a scratch
+  DB. Run against a throwaway Postgres, not `rt911-db`. `NOTABLE_TEST_DSN=…`
+  enables the end-to-end idempotency test in `tests/test_notable.py`.
+
 ## Idempotency
 
 Re-running a window must not duplicate rows. Each run mints a fresh `run_id`

--- a/packages/tools/flight-recon/data/notable_flights/aa11.json
+++ b/packages/tools/flight-recon/data/notable_flights/aa11.json
@@ -1,0 +1,34 @@
+{
+  "flight": "AA11",
+  "carrier": "AA",
+  "flight_date": "2001-09-11",
+  "origin": "BOS",
+  "scheduled_dest": "LAX",
+  "aircraft": "B767",
+  "registration": "N334AA",
+  "impact": {
+    "site": "North Tower, World Trade Center (WTC 1)",
+    "lat": 40.71236,
+    "lon": -74.01303,
+    "alt_ft": 1360,
+    "utc": "2001-09-11T12:46:40Z"
+  },
+  "sources": [
+    "NTSB Flight Path Study - American Airlines Flight 11 (2002-02-19)",
+    "9/11 Commission Report, Ch. 1 (The System Was Blinking Red / We Have Some Planes)",
+    "American Airlines Flight 11 impact coordinates 40deg42'44.5\"N 74deg00'46.9\"W (WTC 1 north facade, floors 93-99)"
+  ],
+  "provenance_notes": [
+    "DOCUMENTED-WAYPOINT FALLBACK: The NTSB Flight Path Study for AA11 is published only as a scanned image PDF whose radar-return table is not machine-recoverable and could not be transcribed return-by-return. The waypoints below are documented anchor points (takeoff, transponder-off, the 08:26:30 EDT 100-degree turn south while ~15 mi SW of Albany, the 08:37 EDT start of rapid descent, and impact) taken from the 9/11 Commission Report timeline and the NTSB study narrative; intermediate per-minute positions are great-circle interpolations between these anchors, NOT surveyed radar returns.",
+    "Times are UTC = Eastern Daylight Time + 4h. Takeoff 07:59 EDT = 11:59 UTC; impact 08:46:40 EDT = 12:46:40 UTC.",
+    "Mode-C transponder was switched off at 08:21 EDT (12:21 UTC); positions after that time were tracked by primary radar only (no altitude), so cruise/descent altitudes are the assigned/estimated values (FL290 assigned; 3,200 ft/min descent from 08:37 EDT per the Commission)."
+  ],
+  "waypoints": [
+    { "utc": "2001-09-11T11:59:00Z", "lat": 42.3656, "lon": -71.0096, "alt_ft": 0 },
+    { "utc": "2001-09-11T12:10:00Z", "lat": 42.5000, "lon": -72.1000, "alt_ft": 26000 },
+    { "utc": "2001-09-11T12:21:00Z", "lat": 42.5500, "lon": -73.2000, "alt_ft": 29000 },
+    { "utc": "2001-09-11T12:26:30Z", "lat": 42.4700, "lon": -73.9500, "alt_ft": 29000 },
+    { "utc": "2001-09-11T12:37:00Z", "lat": 41.7500, "lon": -73.9500, "alt_ft": 29000 },
+    { "utc": "2001-09-11T12:46:40Z", "lat": 40.71236, "lon": -74.01303, "alt_ft": 1360 }
+  ]
+}

--- a/packages/tools/flight-recon/data/notable_flights/aa77.json
+++ b/packages/tools/flight-recon/data/notable_flights/aa77.json
@@ -1,0 +1,38 @@
+{
+  "flight": "AA77",
+  "carrier": "AA",
+  "flight_date": "2001-09-11",
+  "origin": "IAD",
+  "scheduled_dest": "LAX",
+  "aircraft": "B757",
+  "registration": "N644AA",
+  "impact": {
+    "site": "The Pentagon (west facade), Arlington, VA",
+    "lat": 38.87117,
+    "lon": -77.05825,
+    "alt_ft": 0,
+    "utc": "2001-09-11T13:37:46Z"
+  },
+  "sources": [
+    "NTSB Flight Path Study - American Airlines Flight 77 (2002-02-19), ntsb.gov/about/Documents/Flight_Path_Study_AA77.pdf",
+    "9/11 Commission Report, Ch. 1",
+    "American Airlines Flight 77 impact coordinates 38deg52'16.2\"N 77deg03'29.7\"W (Pentagon west/southwest face, ground level)"
+  ],
+  "provenance_notes": [
+    "DOCUMENTED-WAYPOINT FALLBACK: The NTSB Flight Path Study for AA77 is published only as a scanned image PDF; its radar-return table is not machine-recoverable and was not transcribed return-by-return. The waypoints below are documented anchors from the 9/11 Commission Report and NTSB study narrative: takeoff Dulles 08:20 EDT, level-off 35,000 ft at 08:46 EDT, the 08:54 EDT deviation/turn near Pike County, Ohio (the westernmost point of the flight), transponder-off 08:56 EDT with the autopilot set eastbound for Washington, the 09:29 EDT start of the 330-degree descending spiral ~5 mi WSW of the Pentagon from ~7,000 ft, ~2,200 ft during the spiral by ~09:34 EDT, and impact. Intermediate per-minute positions are great-circle interpolations between these anchors, NOT surveyed radar returns.",
+    "TURN-BACK / TERMINAL-SPIRAL APPROXIMATION: The east-to-west outbound leg and west-to-east return are represented by the documented westernmost anchor near Pike County, OH (so the track is NOT straight-lined Dulles-to-Pentagon). The final clockwise 330-degree descending spiral (~09:29-09:37:46 EDT, ~5 mi WSW of the Pentagon) is approximated by the net displacement between the documented spiral-entry point and the impact point; the loop itself is not traced return-by-return because the radar table is not machine-recoverable.",
+    "Times are UTC = EDT + 4h. Takeoff 08:20 EDT = 12:20 UTC; impact 09:37:46 EDT = 13:37:46 UTC. Positions after the 08:56 EDT transponder-off were primary-radar only; altitudes reflect the documented profile (cruise FL350, ~7,000 ft at spiral entry, ~2,200 ft mid-spiral, ground at impact)."
+  ],
+  "waypoints": [
+    { "utc": "2001-09-11T12:20:00Z", "lat": 38.9445, "lon": -77.4558, "alt_ft": 0 },
+    { "utc": "2001-09-11T12:33:00Z", "lat": 38.9500, "lon": -78.8000, "alt_ft": 25000 },
+    { "utc": "2001-09-11T12:46:00Z", "lat": 39.0000, "lon": -81.0000, "alt_ft": 35000 },
+    { "utc": "2001-09-11T12:54:00Z", "lat": 39.0800, "lon": -83.0700, "alt_ft": 35000 },
+    { "utc": "2001-09-11T12:56:00Z", "lat": 38.9000, "lon": -82.9000, "alt_ft": 35000 },
+    { "utc": "2001-09-11T13:10:00Z", "lat": 38.9500, "lon": -80.3000, "alt_ft": 33000 },
+    { "utc": "2001-09-11T13:20:00Z", "lat": 38.9000, "lon": -78.4000, "alt_ft": 22000 },
+    { "utc": "2001-09-11T13:29:00Z", "lat": 38.8500, "lon": -77.1500, "alt_ft": 7000 },
+    { "utc": "2001-09-11T13:34:00Z", "lat": 38.8600, "lon": -77.1000, "alt_ft": 2200 },
+    { "utc": "2001-09-11T13:37:46Z", "lat": 38.87117, "lon": -77.05825, "alt_ft": 0 }
+  ]
+}

--- a/packages/tools/flight-recon/data/notable_flights/ua175.json
+++ b/packages/tools/flight-recon/data/notable_flights/ua175.json
@@ -1,0 +1,34 @@
+{
+  "flight": "UA175",
+  "carrier": "UA",
+  "flight_date": "2001-09-11",
+  "origin": "BOS",
+  "scheduled_dest": "LAX",
+  "aircraft": "B767",
+  "registration": "N612UA",
+  "impact": {
+    "site": "South Tower, World Trade Center (WTC 2)",
+    "lat": 40.71078,
+    "lon": -74.01314,
+    "alt_ft": 940,
+    "utc": "2001-09-11T13:03:02Z"
+  },
+  "sources": [
+    "NTSB Flight Path Study - United Airlines Flight 175 (2002-02-19)",
+    "9/11 Commission Report, Ch. 1",
+    "United Airlines Flight 175 impact coordinates 40deg42'38.8\"N 74deg00'47.3\"W (WTC 2 south facade, floors 77-85)"
+  ],
+  "provenance_notes": [
+    "DOCUMENTED-WAYPOINT FALLBACK: The NTSB Flight Path Study for UA175 is published only as a scanned image PDF; its radar-return table is not machine-recoverable and was not transcribed return-by-return. The waypoints below are documented anchors (takeoff, 08:33 EDT level-off at 31,000 ft, the 08:46 EDT transponder-code change / start of deviation, the 08:58 EDT position over New Jersey at 28,500 ft, and impact) from the 9/11 Commission Report and NTSB study narrative; intermediate per-minute positions are great-circle interpolations between them, NOT surveyed radar returns.",
+    "Times are UTC = EDT + 4h. Takeoff 08:14 EDT = 12:14 UTC; impact 09:03:02 EDT = 13:03:02 UTC (impact second per the NTSB study; the 9/11 Commission cites 09:03:11, NIST 09:02:59).",
+    "The final ~5 minutes were a sustained power dive averaging over 5,000 ft/min, ending in a banking left turn back to the northeast into the South Tower; the descent altitudes reflect that profile."
+  ],
+  "waypoints": [
+    { "utc": "2001-09-11T12:14:00Z", "lat": 42.3656, "lon": -71.0096, "alt_ft": 0 },
+    { "utc": "2001-09-11T12:25:00Z", "lat": 41.9000, "lon": -72.0000, "alt_ft": 24000 },
+    { "utc": "2001-09-11T12:33:00Z", "lat": 41.6000, "lon": -72.7000, "alt_ft": 31000 },
+    { "utc": "2001-09-11T12:46:00Z", "lat": 41.0000, "lon": -74.0000, "alt_ft": 30000 },
+    { "utc": "2001-09-11T12:58:00Z", "lat": 40.5500, "lon": -74.6000, "alt_ft": 28500 },
+    { "utc": "2001-09-11T13:03:02Z", "lat": 40.71078, "lon": -74.01314, "alt_ft": 940 }
+  ]
+}

--- a/packages/tools/flight-recon/data/notable_flights/ua93.json
+++ b/packages/tools/flight-recon/data/notable_flights/ua93.json
@@ -1,0 +1,41 @@
+{
+  "flight": "UA93",
+  "carrier": "UA",
+  "flight_date": "2001-09-11",
+  "origin": "EWR",
+  "scheduled_dest": "SFO",
+  "aircraft": "B757",
+  "registration": "N591UA",
+  "impact": {
+    "site": "Field near Shanksville, Somerset County, PA",
+    "lat": 40.05056,
+    "lon": -78.90472,
+    "alt_ft": 0,
+    "utc": "2001-09-11T14:03:11Z"
+  },
+  "sources": [
+    "NTSB Flight Path Study - United Airlines Flight 93 (2002-02-19), NPS 508 copy: nps.gov/flni/learn/historyculture/upload/Flight_Path_Study_of_Flight_93_508.pdf",
+    "9/11 Commission Report, Ch. 1",
+    "United 93 crash coordinates 40deg03'02\"N 78deg54'17\"W (Flight 93 National Memorial impact site)"
+  ],
+  "provenance_notes": [
+    "SOURCE NOTE: UA93 is the only one of the four with a recovered Flight Data Recorder, so its altitude/time profile is well documented. The altitudes and times of the labelled points below (B level-off 35,000 ft at ~09:02; C 600-ft deviation / assumed takeover ~09:28; D climb toward 41,000 ft and turn to a 120-degree SE heading ~09:34; E max 41,000 ft then descent at 4,000 ft/min ~09:39 with transponder returns ceasing ~09:41; F brief descent interruption climbing 19,000->20,500 ft ~09:46; G 5,000 ft with rapid roll inputs ~09:59; H climb to ~10,000 ft turning right; I impact) are transcribed from the NTSB Flight Path Study narrative (NPS 508 copy, which has a readable text layer).",
+    "DOCUMENTED-WAYPOINT FALLBACK (positions): The study's radar ground-track figure (lat/lon) is an image and was not transcribed point-by-point. Longitude/latitude of the enroute and turnaround anchors below are placed from the documented narrative (departed Newark; cruised west across PA into Cleveland Center airspace; transponder switched off ~30 nm west of Akron, OH; turned back toward Washington; crashed near Shanksville). Per-minute positions are great-circle interpolations between these anchors, NOT surveyed radar returns. The turn-back near Cleveland is captured by the westernmost anchor (so the track is NOT straight-lined Newark-to-Shanksville); the final erratic maneuvering (~09:57-10:03:11, rolls and pitch inputs during the passenger revolt) is approximated by the anchors near the crash site rather than traced.",
+    "IMPACT-COORDINATE CORRECTION: the upstream design doc listed the Shanksville longitude as -78.8539; that is inconsistent with the cited DMS 78deg54'17\"W = -78.90472 (a ~4 km / ~0.05deg error, placing it east of the actual crater). This file uses the source-derived -78.90472 (Flight 93 National Memorial impact site). Flagged for reviewer confirmation.",
+    "Times are UTC = EDT + 4h. Takeoff 08:42 EDT = 12:42 UTC; impact 10:03:11 EDT = 14:03:11 UTC."
+  ],
+  "waypoints": [
+    { "utc": "2001-09-11T12:42:00Z", "lat": 40.6925, "lon": -74.1687, "alt_ft": 0 },
+    { "utc": "2001-09-11T13:02:00Z", "lat": 41.0000, "lon": -77.6000, "alt_ft": 35000 },
+    { "utc": "2001-09-11T13:28:00Z", "lat": 41.1000, "lon": -81.2000, "alt_ft": 34400 },
+    { "utc": "2001-09-11T13:34:00Z", "lat": 41.0000, "lon": -82.1500, "alt_ft": 36000 },
+    { "utc": "2001-09-11T13:39:00Z", "lat": 40.7200, "lon": -81.1000, "alt_ft": 41000 },
+    { "utc": "2001-09-11T13:41:00Z", "lat": 40.6200, "lon": -80.7000, "alt_ft": 33000 },
+    { "utc": "2001-09-11T13:44:00Z", "lat": 40.5000, "lon": -80.1000, "alt_ft": 19000 },
+    { "utc": "2001-09-11T13:46:00Z", "lat": 40.4500, "lon": -79.8500, "alt_ft": 20500 },
+    { "utc": "2001-09-11T13:52:00Z", "lat": 40.2500, "lon": -79.3500, "alt_ft": 12000 },
+    { "utc": "2001-09-11T13:59:00Z", "lat": 40.0800, "lon": -78.9800, "alt_ft": 5000 },
+    { "utc": "2001-09-11T14:01:00Z", "lat": 40.0600, "lon": -78.9300, "alt_ft": 10000 },
+    { "utc": "2001-09-11T14:03:11Z", "lat": 40.05056, "lon": -78.90472, "alt_ft": 0 }
+  ]
+}

--- a/packages/tools/flight-recon/flight_recon/notable.py
+++ b/packages/tools/flight-recon/flight_recon/notable.py
@@ -50,9 +50,12 @@ FLIGHT_DATE = "2001-09-11"
 NOTABLE_FLIGHTS = ("AA11", "UA175", "AA77", "UA93")
 DATA_DIR = os.path.join(os.path.dirname(__file__), os.pardir, "data", "notable_flights")
 
-# clock_seconds anchor: continuous seconds since ET midnight of the flight_date,
-# identical to the BTS loader's single-day window anchor (ET = UTC + ET_OFFSET).
-_WINDOW_START_UTC = datetime(2001, 9, 11, -ET_OFFSET, 0, 0, tzinfo=timezone.utc)
+# clock_seconds anchor: continuous seconds since ET midnight of the loaded BTS
+# window's FIRST day — not of flight_date. Every prod run in reconstruction_runs
+# used [2001-09-09, 2001-09-12], and every prod 9/11 position row has
+# clock_seconds = et_seconds + 172800 (verified 2026-07-08); anchoring anywhere
+# else would put these four on a different replay clock than the BTS flights.
+_WINDOW_START_UTC = datetime(2001, 9, 9, -ET_OFFSET, 0, 0, tzinfo=timezone.utc)
 
 # Validation bounds (match the BTS loader's North-America envelope).
 _LON_MIN, _LON_MAX = -150.0, -65.0

--- a/packages/tools/flight-recon/flight_recon/notable.py
+++ b/packages/tools/flight-recon/flight_recon/notable.py
@@ -1,0 +1,293 @@
+"""
+Load the four notable September 11, 2001 flights (AA11, UA175, AA77, UA93) into
+the same ``flight_positions`` / ``flight_tracks`` / ``reconstruction_runs`` tables
+the BTS reconstruction writes, so they appear on the streamer ``flights`` channel
+and in the Flight Tracker exactly like the 1,945 BTS-derived flights.
+
+These four are absent from BTS On-Time Performance (which records only completed
+flights) and are curated from authoritative public radar data — each flight's
+NTSB Flight Path Study (2002-02-19), corroborated by the 9/11 Commission Report
+(Ch. 1). The reviewable accuracy artifact is ``data/notable_flights/*.json``;
+this module only resamples, validates, and loads them.
+
+CRITICAL — scoped idempotency
+-----------------------------
+Re-running deletes ONLY these four flight IDs for ``flight_date='2001-09-11'``
+before re-inserting. It must NOT reuse the BTS loader's delete-by-``flight_date``
+window (``pgcopy.copy_positions`` / ``directus.delete_window``), which would wipe
+the 1,945 real flights that share that date. A sentinel BTS flight (e.g. AA1002)
+and the BTS row count must survive a re-run untouched.
+
+This is a standalone one-time load (a fixed curated set), not a repeatable BTS
+Prefect flow, so it is a plain CLI::
+
+    python -m flight_recon.notable --dsn postgres://... [--dry-run] [--init-schema]
+
+``--dry-run`` builds, validates, and exercises the delete/insert inside a
+transaction it then ROLLS BACK — nothing is persisted. Loading synthesized 9/11
+flight paths to prod is gated on human review of the data files + a dry-run
+report (see the design doc's PROD-LOAD REVIEW GATE).
+"""
+
+import argparse
+import glob
+import json
+import logging
+import os
+import uuid
+from datetime import datetime, timezone
+
+import psycopg
+from psycopg.types.json import Json
+
+from flight_recon.pgcopy import COLUMNS as POSITION_COLUMNS
+from flight_recon.resample import fmt_utc, parse_utc, resample_track
+from reconstruct import ET_OFFSET, et_seconds
+
+log = logging.getLogger(__name__)
+
+FLIGHT_DATE = "2001-09-11"
+NOTABLE_FLIGHTS = ("AA11", "UA175", "AA77", "UA93")
+DATA_DIR = os.path.join(os.path.dirname(__file__), os.pardir, "data", "notable_flights")
+
+# clock_seconds anchor: continuous seconds since ET midnight of the flight_date,
+# identical to the BTS loader's single-day window anchor (ET = UTC + ET_OFFSET).
+_WINDOW_START_UTC = datetime(2001, 9, 11, -ET_OFFSET, 0, 0, tzinfo=timezone.utc)
+
+# Validation bounds (match the BTS loader's North-America envelope).
+_LON_MIN, _LON_MAX = -150.0, -65.0
+_LAT_MIN, _LAT_MAX = 18.0, 65.0
+_ALT_MIN, _ALT_MAX = 0, 45000
+_IMPACT_TOL_DEG = 1e-3   # last track vertex vs documented impact (~110 m)
+
+# Scratch-DB schema, matching the column shapes Directus manages in prod
+# (flight_recon/directus.py COLLECTIONS). ONLY for --init-schema against a
+# throwaway/staging Postgres — prod tables are created by the Directus flow.
+LOCAL_SCHEMA_DDL = """
+CREATE TABLE IF NOT EXISTS flight_positions (
+    id            serial PRIMARY KEY,
+    flight        varchar NOT NULL,
+    carrier       varchar,
+    flight_date   date NOT NULL,
+    utc           timestamptz,
+    et_seconds    integer NOT NULL,
+    clock_seconds integer NOT NULL,
+    lat           double precision,
+    lon           double precision,
+    alt_ft        integer,
+    phase         varchar,
+    diverted      boolean,
+    run_id        varchar NOT NULL
+);
+CREATE TABLE IF NOT EXISTS flight_tracks (
+    id             serial PRIMARY KEY,
+    flight         varchar NOT NULL,
+    flight_date    date NOT NULL,
+    origin         varchar,
+    scheduled_dest varchar,
+    landed_at      varchar,
+    diverted       boolean,
+    wheels_off_utc timestamptz,
+    wheels_on_utc  timestamptz,
+    geometry       json,
+    run_id         varchar NOT NULL
+);
+CREATE TABLE IF NOT EXISTS reconstruction_runs (
+    run_id                 varchar PRIMARY KEY,
+    start                  date,
+    "end"                  date,
+    source_file            varchar,
+    flights_reconstructed  integer,
+    positions_count        integer,
+    tracks_count           integer,
+    skipped_count          integer,
+    skipped                json,
+    skipped_by_reason      json,
+    cancelled_by_day       json,
+    created_at             timestamptz DEFAULT now()
+);
+"""
+
+TRACK_COLUMNS = ["flight", "flight_date", "origin", "scheduled_dest", "landed_at",
+                 "diverted", "wheels_off_utc", "wheels_on_utc", "geometry", "run_id"]
+
+
+# ----------------------------------------------------------------- pure build
+def load_flight_file(path):
+    with open(path) as fh:
+        return json.load(fh)
+
+
+def build_flight(data):
+    """Resample one curated flight into (positions rows, track row) and validate.
+
+    ``positions`` are ``flight_positions`` dicts sans ``run_id`` (added at load);
+    ``track`` is a ``flight_tracks`` dict whose ``geometry`` is a GeoJSON
+    LineString. Raises ValueError on any integrity violation."""
+    flight = data["flight"]
+    samples = resample_track(data["waypoints"])
+
+    positions, coords, prev_min = [], [], None
+    for s in samples:
+        utc = s["utc"]
+        if not (_LAT_MIN <= s["lat"] <= _LAT_MAX and _LON_MIN <= s["lon"] <= _LON_MAX):
+            raise ValueError(f"{flight}: position out of NA bounds: {s['lat']},{s['lon']}")
+        if not (_ALT_MIN <= s["alt_ft"] <= _ALT_MAX):
+            raise ValueError(f"{flight}: alt_ft {s['alt_ft']} out of [0, 45000]")
+        minute = utc.replace(second=0, microsecond=0)
+        if prev_min is not None and minute <= prev_min:
+            raise ValueError(f"{flight}: non-increasing minute bucket at {utc}")
+        prev_min = minute
+        positions.append({
+            "flight": flight, "carrier": data["carrier"], "flight_date": FLIGHT_DATE,
+            "utc": fmt_utc(utc),
+            "et_seconds": et_seconds(utc),
+            "clock_seconds": int((utc - _WINDOW_START_UTC).total_seconds()),
+            "lat": s["lat"], "lon": s["lon"], "alt_ft": s["alt_ft"],
+            "phase": s["phase"], "diverted": False,
+        })
+        coords.append([s["lon"], s["lat"]])
+
+    # per-minute coverage: every minute in [takeoff, impact] present exactly once
+    first_min = parse_utc(positions[0]["utc"]).replace(second=0, microsecond=0)
+    last_min = samples[-1]["utc"].replace(second=0, microsecond=0)
+    want = int((last_min - first_min).total_seconds() // 60) + 1
+    if len(positions) != want:
+        raise ValueError(f"{flight}: expected {want} per-minute rows, got {len(positions)}")
+
+    imp = data["impact"]
+    last = coords[-1]
+    if abs(last[0] - imp["lon"]) > _IMPACT_TOL_DEG or abs(last[1] - imp["lat"]) > _IMPACT_TOL_DEG:
+        raise ValueError(f"{flight}: track end {last} != impact ({imp['lon']},{imp['lat']})")
+
+    track = {
+        "flight": flight, "flight_date": FLIGHT_DATE, "origin": data["origin"],
+        "scheduled_dest": data["scheduled_dest"], "landed_at": None,
+        "diverted": False, "wheels_off_utc": positions[0]["utc"],
+        "wheels_on_utc": None,
+        "geometry": {"type": "LineString", "coordinates": coords},
+    }
+    return positions, track
+
+
+def build_all(data_dir=DATA_DIR):
+    """Build every notable flight found in ``data_dir``. Returns (positions, tracks)."""
+    files = sorted(glob.glob(os.path.join(data_dir, "*.json")))
+    if not files:
+        raise FileNotFoundError(f"no notable-flight JSON files in {data_dir}")
+    all_positions, all_tracks, seen = [], [], set()
+    for path in files:
+        data = load_flight_file(path)
+        if data["flight"] not in NOTABLE_FLIGHTS:
+            raise ValueError(f"{path}: flight {data['flight']} not in {NOTABLE_FLIGHTS}")
+        seen.add(data["flight"])
+        positions, track = build_flight(data)
+        all_positions.extend(positions)
+        all_tracks.append(track)
+        log.info("built %s: %d positions", data["flight"], len(positions))
+    missing = set(NOTABLE_FLIGHTS) - seen
+    if missing:
+        log.warning("notable-flight files missing for: %s", sorted(missing))
+    return all_positions, all_tracks
+
+
+# ----------------------------------------------------------------- db writes
+def scoped_delete(cur, flights=NOTABLE_FLIGHTS, flight_date=FLIGHT_DATE):
+    """Delete ONLY the given flight IDs on ``flight_date`` — never a date window.
+
+    Returns (positions_deleted, tracks_deleted)."""
+    ids = list(flights)
+    cur.execute("DELETE FROM flight_positions WHERE flight_date = %s AND flight = ANY(%s)",
+                (flight_date, ids))
+    pos = cur.rowcount
+    cur.execute("DELETE FROM flight_tracks WHERE flight_date = %s AND flight = ANY(%s)",
+                (flight_date, ids))
+    trk = cur.rowcount
+    log.info("scoped delete: %d positions, %d tracks for %s on %s", pos, trk, ids, flight_date)
+    return pos, trk
+
+
+def copy_positions(cur, positions, run_id):
+    with cur.copy(f"COPY flight_positions ({', '.join(POSITION_COLUMNS)}) FROM STDIN") as cp:
+        for p in positions:
+            cp.write_row([p["flight"], p["carrier"], p["flight_date"], p["utc"],
+                          p["et_seconds"], p["clock_seconds"], p["lat"], p["lon"],
+                          p["alt_ft"], p["phase"], p["diverted"], run_id])
+    return len(positions)
+
+
+def insert_tracks(cur, tracks, run_id):
+    placeholders = ", ".join(["%s"] * len(TRACK_COLUMNS))
+    sql = f"INSERT INTO flight_tracks ({', '.join(TRACK_COLUMNS)}) VALUES ({placeholders})"
+    for t in tracks:
+        cur.execute(sql, (t["flight"], t["flight_date"], t["origin"], t["scheduled_dest"],
+                          t["landed_at"], t["diverted"], t["wheels_off_utc"],
+                          t["wheels_on_utc"], Json(t["geometry"]), run_id))
+    return len(tracks)
+
+
+def insert_run(cur, run_id, positions_count, tracks_count):
+    """Append one provenance row citing the NTSB studies (append-only ledger)."""
+    source = ("NTSB Flight Path Studies (2002-02-19) for AA11, UA175, AA77, UA93 + "
+              "9/11 Commission Report Ch.1 — curated notable_flights load")
+    cur.execute(
+        'INSERT INTO reconstruction_runs (run_id, start, "end", source_file, '
+        "flights_reconstructed, positions_count, tracks_count, skipped_count, "
+        "skipped, skipped_by_reason, cancelled_by_day, created_at) "
+        "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)",
+        (run_id, FLIGHT_DATE, FLIGHT_DATE, source, tracks_count, positions_count,
+         tracks_count, 0, Json([]), Json({}), Json({}),
+         datetime.now(timezone.utc)))
+
+
+# ----------------------------------------------------------------- orchestration
+def run(dsn, data_dir=DATA_DIR, dry_run=False, init_schema=False, run_id=None):
+    run_id = run_id or f"notable-{uuid.uuid4().hex[:12]}"
+    positions, tracks = build_all(data_dir)
+    log.info("built %d flights: %d positions, %d tracks (run_id=%s)",
+             len(tracks), len(positions), len(tracks), run_id)
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            if init_schema:
+                cur.execute(LOCAL_SCHEMA_DDL)
+                log.warning("ensured scratch schema (flight_positions/tracks/runs)")
+            pos_del, trk_del = scoped_delete(cur)
+            n_pos = copy_positions(cur, positions, run_id)
+            n_trk = insert_tracks(cur, tracks, run_id)
+            insert_run(cur, run_id, n_pos, n_trk)
+        if dry_run:
+            conn.rollback()
+            log.warning("DRY RUN: rolled back — nothing persisted")
+        else:
+            conn.commit()
+            log.warning("committed %d positions + %d tracks + 1 run (run_id=%s)",
+                        n_pos, n_trk, run_id)
+
+    return {"run_id": run_id, "flights": len(tracks), "positions": n_pos,
+            "tracks": n_trk, "positions_deleted": pos_del, "tracks_deleted": trk_del,
+            "dry_run": dry_run}
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("--dsn", default=os.environ.get("RT911_DB_DSN"),
+                   help="Postgres DSN (default $RT911_DB_DSN). NEVER a prod DSN without review.")
+    p.add_argument("--data-dir", default=DATA_DIR)
+    p.add_argument("--dry-run", action="store_true",
+                   help="build + validate + exercise delete/insert, then ROLL BACK")
+    p.add_argument("--init-schema", action="store_true",
+                   help="create flight_positions/tracks/runs if missing (scratch DBs only)")
+    p.add_argument("-v", "--verbose", action="store_true")
+    args = p.parse_args(argv)
+    logging.basicConfig(level=logging.INFO if args.verbose else logging.WARNING,
+                        format="%(levelname)s %(message)s")
+    if not args.dsn:
+        p.error("no DSN: pass --dsn or set $RT911_DB_DSN")
+
+    summary = run(args.dsn, args.data_dir, dry_run=args.dry_run, init_schema=args.init_schema)
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/tools/flight-recon/flight_recon/resample.py
+++ b/packages/tools/flight-recon/flight_recon/resample.py
@@ -1,0 +1,130 @@
+"""
+Pure per-minute resampling of an irregular waypoint track.
+
+The `flights` streamer channel buckets positions per UTC minute (``flight:minutes``):
+a flight aloft at minute *m* must have a row at *m* or it flickers out of the
+airborne snapshot. This module turns the irregular documented radar/anchor
+waypoints of a curated flight (see ``data/notable_flights/*.json``) into exactly
+one sample per whole UTC minute it is airborne, plus the exact endpoints.
+
+It is deliberately dependency-free (no pandas) and side-effect-free so it can be
+unit-tested in isolation — it is the accuracy-critical core of the notable-flight
+loader. Position between waypoints is great-circle interpolated (reusing the same
+``gc_interp`` the BTS reconstruction uses); altitude is linearly interpolated.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from reconstruct import gc_interp
+
+STEP_SECONDS = 60
+PHASE_ALT_EPS_FT = 200   # per-step altitude change below this reads as level "cruise"
+
+
+def parse_utc(s):
+    """Parse a ``2001-09-11T12:46:40Z`` stamp into an aware UTC datetime."""
+    return datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+
+
+def fmt_utc(dt):
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _floor_minute(dt):
+    return dt.replace(second=0, microsecond=0)
+
+
+def _sample_times(takeoff, impact, step):
+    """Whole-minute grid over [takeoff, impact], endpoints pinned.
+
+    Yields ``takeoff`` exactly, then every whole UTC minute strictly inside the
+    interval whose minute-bucket precedes the impact minute, then ``impact``
+    exactly. The result covers every minute-bucket in [takeoff, impact] exactly
+    once — the interior minutes at ``:00`` and the impact minute at the true
+    impact second (which may be off-minute, e.g. 12:46:40)."""
+    if impact <= takeoff:
+        raise ValueError(f"impact {impact} is not after takeoff {takeoff}")
+    times = [takeoff]
+    impact_bucket = _floor_minute(impact)
+    g = _floor_minute(takeoff) + timedelta(seconds=step)
+    while g < impact_bucket:
+        times.append(g)
+        g += timedelta(seconds=step)
+    times.append(impact)
+    return times
+
+
+def _interp_at(waypoints, t):
+    """Great-circle (lat/lon) + linear (alt) interpolation of the track at time t.
+
+    ``waypoints`` is a list of ``(utc_dt, lat, lon, alt_ft)`` sorted ascending;
+    t must lie within [first, last]. Endpoints return the waypoint verbatim."""
+    lo = 0
+    hi = len(waypoints) - 1
+    if t <= waypoints[lo][0]:
+        _, lat, lon, alt = waypoints[lo]
+        return lat, lon, float(alt)
+    if t >= waypoints[hi][0]:
+        _, lat, lon, alt = waypoints[hi]
+        return lat, lon, float(alt)
+    for i in range(len(waypoints) - 1):
+        t0, lat0, lon0, alt0 = waypoints[i]
+        t1, lat1, lon1, alt1 = waypoints[i + 1]
+        if t0 <= t <= t1:
+            span = (t1 - t0).total_seconds()
+            f = 0.0 if span == 0 else (t - t0).total_seconds() / span
+            lat, lon = gc_interp(lat0, lon0, lat1, lon1, f)
+            alt = alt0 + f * (alt1 - alt0)
+            return lat, lon, alt
+    raise AssertionError(f"time {t} not bracketed by waypoints")  # unreachable
+
+
+def resample_track(waypoints, step_seconds=STEP_SECONDS, ndigits=5):
+    """Resample irregular waypoints to one sample per whole UTC minute.
+
+    Parameters
+    ----------
+    waypoints : list of dicts ``{"utc": str|datetime, "lat", "lon", "alt_ft"}``
+        Sorted ascending by time; the first is takeoff, the last is impact.
+    Returns
+    -------
+    list of dicts ``{"utc": datetime, "lat": float, "lon": float,
+    "alt_ft": int, "phase": str}`` — one per minute-bucket in [takeoff, impact],
+    with the first pinned to the takeoff waypoint and the last to the impact
+    waypoint (the impact sample sits at the true impact second, not the minute).
+    """
+    if len(waypoints) < 2:
+        raise ValueError("need at least takeoff and impact waypoints")
+    wps = []
+    for w in waypoints:
+        utc = w["utc"] if isinstance(w["utc"], datetime) else parse_utc(w["utc"])
+        wps.append((utc, float(w["lat"]), float(w["lon"]), float(w["alt_ft"])))
+    for a, b in zip(wps, wps[1:]):
+        if b[0] <= a[0]:
+            raise ValueError(f"waypoint times must strictly increase: {a[0]} !< {b[0]}")
+
+    takeoff, impact = wps[0][0], wps[-1][0]
+    samples = []
+    for t in _sample_times(takeoff, impact, step_seconds):
+        lat, lon, alt = _interp_at(wps, t)
+        samples.append({"utc": t, "lat": round(lat, ndigits),
+                        "lon": round(lon, ndigits), "alt_ft": round(alt)})
+    _assign_phases(samples)
+    return samples
+
+
+def _assign_phases(samples):
+    """Label each sample climb/cruise/descent from the local altitude trend."""
+    for i, s in enumerate(samples):
+        nxt = samples[i + 1]["alt_ft"] if i + 1 < len(samples) else None
+        prv = samples[i - 1]["alt_ft"] if i > 0 else None
+        if nxt is not None:
+            delta = nxt - s["alt_ft"]
+        else:
+            delta = s["alt_ft"] - prv  # last sample: trend from the previous
+        if delta > PHASE_ALT_EPS_FT:
+            s["phase"] = "climb"
+        elif delta < -PHASE_ALT_EPS_FT:
+            s["phase"] = "descent"
+        else:
+            s["phase"] = "cruise"

--- a/packages/tools/flight-recon/tests/test_notable.py
+++ b/packages/tools/flight-recon/tests/test_notable.py
@@ -1,0 +1,235 @@
+"""
+Tests for the notable-flights loader.
+
+Pure tests (no DB) cover the accuracy-critical core: per-minute resample cadence
+with pinned endpoints, interpolation sanity, track geometry ending at impact,
+airborne-at-T, and — crucially — that the delete is SCOPED to the four flight
+IDs and never a date window.
+
+The end-to-end idempotency test (scoped delete leaves a sentinel BTS flight
+AA1002 and the BTS row count untouched across a re-run) needs a real Postgres.
+It runs only when ``NOTABLE_TEST_DSN`` points at a throwaway/scratch database
+(the dry-run validation step), and is skipped otherwise so ``pytest tests/`` is
+green without a DB.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from flight_recon import notable
+from flight_recon.resample import parse_utc, resample_track
+
+DATA_DIR = Path(__file__).parent.parent / "data" / "notable_flights"
+
+
+# ------------------------------------------------------------------ resample core
+def _minutes(dt0, dt1):
+    return int((dt1.replace(second=0, microsecond=0)
+                - dt0.replace(second=0, microsecond=0)).total_seconds() // 60) + 1
+
+
+def test_resample_one_row_per_minute_pinned_endpoints():
+    wps = [
+        {"utc": "2001-09-11T11:59:00Z", "lat": 42.3656, "lon": -71.0096, "alt_ft": 0},
+        {"utc": "2001-09-11T12:26:30Z", "lat": 42.47, "lon": -73.95, "alt_ft": 29000},
+        {"utc": "2001-09-11T12:46:40Z", "lat": 40.71236, "lon": -74.01303, "alt_ft": 1360},
+    ]
+    samples = resample_track(wps)
+    takeoff, impact = parse_utc(wps[0]["utc"]), parse_utc(wps[-1]["utc"])
+
+    # endpoints pinned to first/last waypoint (exact times + coords)
+    assert samples[0]["utc"] == takeoff
+    assert (samples[0]["lat"], samples[0]["lon"], samples[0]["alt_ft"]) == (42.3656, -71.0096, 0)
+    assert samples[-1]["utc"] == impact
+    assert (samples[-1]["lat"], samples[-1]["lon"]) == (40.71236, -74.01303)
+
+    # exactly one row per minute-bucket across [takeoff, impact]
+    buckets = [s["utc"].replace(second=0, microsecond=0) for s in samples]
+    assert len(buckets) == len(set(buckets)) == _minutes(takeoff, impact)
+    # interior samples land on whole minutes; only the impact sample is off-minute
+    for s in samples[1:-1]:
+        assert s["utc"].second == 0
+    assert samples[-1]["utc"].second == 40
+
+
+def test_resample_interpolation_midpoint_between_waypoints():
+    wps = [
+        {"utc": "2001-09-11T12:00:00Z", "lat": 40.0, "lon": -80.0, "alt_ft": 10000},
+        {"utc": "2001-09-11T12:02:00Z", "lat": 42.0, "lon": -80.0, "alt_ft": 20000},
+    ]
+    samples = resample_track(wps)
+    mid = [s for s in samples if s["utc"] == parse_utc("2001-09-11T12:01:00Z")][0]
+    # linear altitude midpoint; latitude between the two endpoints
+    assert mid["alt_ft"] == 15000
+    assert 40.0 < mid["lat"] < 42.0
+    assert abs(mid["lon"] - (-80.0)) < 0.01  # same meridian -> lon unchanged
+
+
+def test_resample_rejects_non_increasing_times():
+    with pytest.raises(ValueError, match="strictly increase"):
+        resample_track([
+            {"utc": "2001-09-11T12:05:00Z", "lat": 40, "lon": -80, "alt_ft": 0},
+            {"utc": "2001-09-11T12:05:00Z", "lat": 41, "lon": -80, "alt_ft": 0},
+        ])
+
+
+# ------------------------------------------------------------------ build_flight
+@pytest.fixture(scope="module")
+def built():
+    """Every notable flight built from its real curated data file."""
+    out = {}
+    for path in DATA_DIR.glob("*.json"):
+        data = notable.load_flight_file(path)
+        out[data["flight"]] = (data, *notable.build_flight(data))
+    return out
+
+
+def test_all_four_flights_present(built):
+    assert set(built) == set(notable.NOTABLE_FLIGHTS)
+
+
+@pytest.mark.parametrize("flight", notable.NOTABLE_FLIGHTS)
+def test_track_is_linestring_ending_at_impact(built, flight):
+    data, positions, track = built[flight]
+    geom = track["geometry"]
+    assert geom["type"] == "LineString"
+    assert len(geom["coordinates"]) == len(positions) >= 2
+    for lon, lat in geom["coordinates"]:
+        assert -150 < lon < -65 and 18 < lat < 65      # NA bounds, [lon, lat] order
+    end_lon, end_lat = geom["coordinates"][-1]
+    assert abs(end_lon - data["impact"]["lon"]) <= 1e-3
+    assert abs(end_lat - data["impact"]["lat"]) <= 1e-3
+
+
+@pytest.mark.parametrize("flight", notable.NOTABLE_FLIGHTS)
+def test_positions_have_per_minute_clock_keys(built, flight):
+    _, positions, _ = built[flight]
+    # interior rows are whole minutes -> et_seconds multiples of 60 (clean airborne
+    # snapshot); on 2001-09-11 clock_seconds == et_seconds (single-day window).
+    for p in positions[:-1]:
+        assert p["et_seconds"] % 60 == 0
+        assert p["clock_seconds"] == p["et_seconds"]
+        assert p["diverted"] is False
+
+
+def test_airborne_at_T_window(built):
+    """AA11 is aloft 11:59-12:46:40 UTC (et 28740-31600); not before/after."""
+    _, positions, _ = built["AA11"]
+    ets = {p["et_seconds"] for p in positions}
+    assert 30600 in ets          # 12:30:00Z = 08:30 ET -> a row exists
+    assert 28680 not in ets      # 11:58:00Z, before takeoff
+    assert 31620 not in ets      # 12:47:00Z, after impact
+    assert min(ets) == 28740 and max(ets) == 31600  # takeoff / impact pinned
+
+
+def test_ua93_uses_corrected_shanksville_longitude(built):
+    """Guards the flagged fix: crater is at 78deg54'17\"W = -78.90472, not the
+    design doc's -78.8539 (~4 km east)."""
+    data, _, track = built["UA93"]
+    assert abs(data["impact"]["lon"] - (-78.90472)) < 1e-4
+    assert track["geometry"]["coordinates"][-1][0] == pytest.approx(-78.90472, abs=1e-3)
+
+
+# ------------------------------------------------------------------ scoped delete
+class _FakeCursor:
+    def __init__(self):
+        self.calls = []
+
+    def execute(self, sql, params=None):
+        self.calls.append((sql, params))
+        self.rowcount = 0
+
+
+def test_scoped_delete_targets_only_the_four_ids_never_a_window():
+    cur = _FakeCursor()
+    notable.scoped_delete(cur)
+    assert len(cur.calls) == 2
+    for sql, params in cur.calls:
+        assert "flight_date = %s" in sql and "flight = ANY(%s)" in sql
+        assert "BETWEEN" not in sql and "_between" not in sql   # NOT a date window
+        date_arg, ids = params
+        assert date_arg == "2001-09-11"
+        assert ids == list(notable.NOTABLE_FLIGHTS)
+        assert "AA1002" not in ids                              # sentinel BTS flight
+    assert "flight_positions" in cur.calls[0][0]
+    assert "flight_tracks" in cur.calls[1][0]
+
+
+# ------------------------------------------------------------------ end-to-end (DB)
+DSN = os.environ.get("NOTABLE_TEST_DSN")
+requires_db = pytest.mark.skipif(not DSN, reason="set NOTABLE_TEST_DSN to a throwaway Postgres")
+
+
+@pytest.fixture
+def scratch_db():
+    """Fresh scratch tables + a sentinel BTS flight AA1002 and a plain BTS flight."""
+    import psycopg
+    with psycopg.connect(DSN) as conn:
+        with conn.cursor() as cur:
+            cur.execute("DROP TABLE IF EXISTS flight_positions, flight_tracks, "
+                        "reconstruction_runs")
+            cur.execute(notable.LOCAL_SCHEMA_DDL)
+            # sentinel BTS rows that MUST survive a scoped reload
+            for et in range(30000, 30300, 60):
+                cur.execute(
+                    "INSERT INTO flight_positions (flight, carrier, flight_date, utc, "
+                    "et_seconds, clock_seconds, lat, lon, alt_ft, phase, diverted, run_id) "
+                    "VALUES ('AA1002','AA','2001-09-11','2001-09-11T12:00:00Z',%s,%s,"
+                    "40,-90,35000,'cruise',false,'bts-seed')", (et, et))
+            cur.execute(
+                "INSERT INTO flight_positions (flight, carrier, flight_date, utc, "
+                "et_seconds, clock_seconds, lat, lon, alt_ft, phase, diverted, run_id) "
+                "VALUES ('DL2000','DL','2001-09-11','2001-09-11T12:00:00Z',30000,30000,"
+                "41,-91,35000,'cruise',false,'bts-seed')")
+            cur.execute(
+                "INSERT INTO flight_tracks (flight, flight_date, origin, scheduled_dest, "
+                "diverted, run_id, geometry) VALUES ('AA1002','2001-09-11','JFK','LAX',"
+                "false,'bts-seed','{\"type\":\"LineString\",\"coordinates\":[[0,0],[1,1]]}')")
+        conn.commit()
+    yield DSN
+
+
+def _counts(dsn):
+    import psycopg
+    with psycopg.connect(dsn) as conn, conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM flight_positions WHERE flight='AA1002'")
+        aa1002_pos = cur.fetchone()[0]
+        cur.execute("SELECT count(*) FROM flight_positions WHERE flight NOT IN "
+                    "('AA11','UA175','AA77','UA93')")
+        bts_pos = cur.fetchone()[0]
+        cur.execute("SELECT count(*) FROM flight_tracks WHERE flight='AA1002'")
+        aa1002_trk = cur.fetchone()[0]
+        cur.execute("SELECT flight, count(*) FROM flight_positions WHERE flight IN "
+                    "('AA11','UA175','AA77','UA93') GROUP BY flight")
+        notable_pos = dict(cur.fetchall())
+    return aa1002_pos, bts_pos, aa1002_trk, notable_pos
+
+
+@requires_db
+def test_end_to_end_scoped_idempotency(scratch_db):
+    base = _counts(scratch_db)          # (aa1002_pos, bts_pos, aa1002_trk, notable_pos)
+    assert base[0] == 5 and base[1] == 6 and base[2] == 1 and base[3] == {}
+
+    first = notable.run(scratch_db, dry_run=False)
+    assert first["flights"] == 4
+    after1 = _counts(scratch_db)
+    # four flights loaded; sentinel + BTS counts identical to the seed
+    assert set(after1[3]) == {"AA11", "UA175", "AA77", "UA93"}
+    assert (after1[0], after1[1], after1[2]) == (base[0], base[1], base[2])
+
+    # re-run: scoped delete removes ONLY the four, re-inserts -> no dupes, sentinel safe
+    second = notable.run(scratch_db, dry_run=False)
+    assert second["positions_deleted"] == first["positions"]   # deleted exactly its own
+    after2 = _counts(scratch_db)
+    assert after2 == after1
+    assert (after2[0], after2[1], after2[2]) == (5, 6, 1)      # AA1002 + BTS untouched
+
+
+@requires_db
+def test_dry_run_persists_nothing(scratch_db):
+    base = _counts(scratch_db)
+    summary = notable.run(scratch_db, dry_run=True)
+    assert summary["dry_run"] is True and summary["flights"] == 4
+    assert _counts(scratch_db) == base    # rolled back

--- a/packages/tools/flight-recon/tests/test_notable.py
+++ b/packages/tools/flight-recon/tests/test_notable.py
@@ -107,10 +107,12 @@ def test_track_is_linestring_ending_at_impact(built, flight):
 def test_positions_have_per_minute_clock_keys(built, flight):
     _, positions, _ = built[flight]
     # interior rows are whole minutes -> et_seconds multiples of 60 (clean airborne
-    # snapshot); on 2001-09-11 clock_seconds == et_seconds (single-day window).
+    # snapshot); clock_seconds anchors at the prod BTS window start (2001-09-09 ET
+    # midnight), so 9/11 rows sit exactly two days into the replay clock — matching
+    # every existing prod row (clock_seconds - et_seconds = 172800, verified).
     for p in positions[:-1]:
         assert p["et_seconds"] % 60 == 0
-        assert p["clock_seconds"] == p["et_seconds"]
+        assert p["clock_seconds"] == p["et_seconds"] + 172800
         assert p["diverted"] is False
 
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -606,8 +606,8 @@ packages:
   '@lezer/lr@1.4.10':
     resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
 
-  '@lezer/markdown@1.6.4':
-    resolution: {integrity: sha512-N0SxazMj4k65DBfaf1azqtMZd6u7MqluP84/NZnB/io8Td9aleFmAhz9hcbvSfsxT5tdYlJ5qgv5aMJGY4zEtA==}
+  '@lezer/markdown@1.7.0':
+    resolution: {integrity: sha512-zZDdfKkXl1CBYet/nL2jCskQXC+8DpbhZubbTEGqbqpkaBC4w03F5Kt9ZLDyqbadqIvvZ7VrVhd6d6qgurzAew==}
 
   '@lezer/php@1.0.5':
     resolution: {integrity: sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA==}
@@ -3991,7 +3991,7 @@ snapshots:
       '@codemirror/state': 6.7.1
       '@codemirror/view': 6.43.6
       '@lezer/common': 1.5.2
-      '@lezer/markdown': 1.6.4
+      '@lezer/markdown': 1.7.0
 
   '@codemirror/lang-php@6.0.2':
     dependencies:
@@ -4510,7 +4510,7 @@ snapshots:
     dependencies:
       '@lezer/common': 1.5.2
 
-  '@lezer/markdown@1.6.4':
+  '@lezer/markdown@1.7.0':
     dependencies:
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3


### PR DESCRIPTION
## Summary

Adds the four hijacked flights of September 11, 2001 to the reconstructed flight dataset (Story 1 of the Flight Tracker work) as curated `flight_positions` + `flight_tracks` rows, so they appear on the `flights` streamer channel exactly like the BTS-derived flights. They are absent from BTS On-Time Performance (which records only completed flights), so they are transcribed from each flight's NTSB Flight Path Study (2002-02-19) + 9/11 Commission Report Ch. 1.

- `data/notable_flights/{aa11,ua175,aa77,ua93}.json` — the reviewable accuracy artifact: documented anchor waypoints + impact + sources + `provenance_notes`. The NTSB studies are scanned image PDFs, so waypoints are **documented anchors** (takeoff, transponder-off, turn-backs, spiral entry, impact), great-circle interpolated between — not per-return radar transcriptions; every file flags this.
- `flight_recon/resample.py` — pure per-minute resampler (one row per UTC minute aloft, endpoints pinned; great-circle lat/lon, linear altitude, phase from trend).
- `flight_recon/notable.py` — standalone CLI loader (`--dsn / --dry-run / --init-schema`). **Scoped idempotency:** re-runs delete ONLY these four flight ids on `flight_date='2001-09-11'` — never the BTS date-window delete.
- `tests/test_notable.py` — 17 tests: resample cadence/endpoints, geometry-ends-at-impact, airborne-at-T, scoped-delete shape, plus DB-gated end-to-end idempotency (AA1002 sentinel + BTS counts untouched across a re-run) and dry-run-rollback.

## ⛔ PROD-LOAD REVIEW GATE

**Merging this PR ships code + data files only — nothing writes to prod until someone runs the loader.** Per the design doc, that run is gated on human review of the transcribed data files. Full dry-run report: `docs/superpowers/specs/2026-07-08-notable-flights-dryrun-report.md` (local, gitignored). Highlights:

- Scratch Postgres 16 acceptance: two committed loads converge (258 positions, 4 tracks, append-only ledger ×2); airborne-by-minute matches the NTSB timeline (e.g. 12:46 UTC → all four aloft; 13:45 → UA93 only); streamer `StreamFlightPositions` warm query verified verbatim.
- Prod read-only checks: the scoped delete is a **no-op against existing prod data** (AA11/UA175/AA77/UA93 exist only on 9/9–9/10 — the same routes completed normally on prior days; zero 9/11 rows). `clock_seconds` anchor verified against prod (`et_seconds + 172800`, window start 2001-09-09) and pinned by a test.
- Reviewer attention: UA93 impact longitude corrected to **−78.90472** (78°54′17″W, Flight 93 National Memorial) vs the design doc's −78.8539 (~4 km east); AA77's terminal spiral and UA93's final maneuvering are anchor-approximated, not traced.

After review approval: `python -m flight_recon.notable --dsn "$RT911_DB_DSN"`, then rewarm (`redis-cli DEL flight:minutes` in rt911-cache + restart rt911-streamer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)