### PR TITLE
feat(usenet): self-heal orphaned jobs (dispatch supervisor + heartbeat)

### DIFF
--- a/packages/tools/video-grabber/tests/test_usenet_flows.py
+++ b/packages/tools/video-grabber/tests/test_usenet_flows.py
@@ -1,4 +1,6 @@
 """Unit tests for usenet flow DB helpers. Imports prefect (CI-only, like test_flows.py)."""
+import time
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from video_grabber.usenet import flows
@@ -48,3 +50,52 @@ def test_get_usenet_job_shapes_namespace():
 def test_sync_db_url_rewrites_asyncpg():
     assert flows._sync_db_url("postgresql+asyncpg://u:p@h/db") == "postgresql+psycopg2://u:p@h/db"
     assert flows._sync_db_url("postgresql+psycopg2://u:p@h/db") == "postgresql+psycopg2://u:p@h/db"
+
+
+def test_reclaim_orphaned_requeues_stale_inflight_jobs():
+    db = FakeDB()
+    flows.reclaim_orphaned_usenet_jobs(db, stale_minutes=10, max_retries=3, logger=None)
+    sql, params = db.calls[0]
+    # Only in-flight stages, and only when the heartbeat has gone stale.
+    assert "stage IN ('downloading', 'downloaded', 'processing')" in sql
+    assert "last_transition_at < now() - (:mins * interval '1 minute')" in sql
+    # Retry if budget remains, else park in 'failed'; always spend a retry so a
+    # perpetually-orphaning job eventually stops.
+    assert "CAST('discovered' AS usenet_stage)" in sql
+    assert "CAST('failed' AS usenet_stage)" in sql
+    assert "retry_count = retry_count + 1" in sql
+    assert params == {"max": 3, "mins": 10}
+    assert db.commits == 1
+
+
+def test_job_heartbeat_refreshes_last_transition(monkeypatch):
+    """The heartbeat thread bumps last_transition_at for its job while running."""
+    calls = []
+
+    class _Ctx:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def execute(self, stmt, params=None):
+            calls.append((str(stmt), params))
+
+    class _Engine:
+        def begin(self):
+            return _Ctx()
+
+        def dispose(self):
+            pass
+
+    monkeypatch.setattr(flows.sa, "create_engine", lambda url: _Engine())
+    monkeypatch.setattr(flows, "Config", lambda: SimpleNamespace(database_url="postgresql+psycopg2://u:p@h/db"))
+
+    with flows._JobHeartbeat("job-1", interval=0.01, logger=None):
+        time.sleep(0.05)
+
+    assert calls, "heartbeat issued no update"
+    sql, params = calls[0]
+    assert "last_transition_at = now()" in sql
+    assert "stage IN" in sql and params == {"id": "job-1"}

--- a/packages/tools/video-grabber/video_grabber/config.py
+++ b/packages/tools/video-grabber/video_grabber/config.py
@@ -34,6 +34,11 @@ class Config:
     # Per-message cutoff passed to mbox_parser --before. Keep messages on or before
     # this date (exclusive of later), so the replay never reveals "future" posts.
     usenet_before: str = field(default_factory=lambda: os.getenv("USENET_BEFORE", "2001-09-21"))
+    # A usenet_jobs row untouched (no heartbeat / transition) this long while in an
+    # in-flight stage (downloading/downloaded/processing) is treated as orphaned by
+    # a dead process-usenet-item run and re-queued at the head of dispatch-usenet.
+    # Must exceed the heartbeat interval (60s) by a comfortable margin.
+    usenet_orphan_stale_minutes: int = field(default_factory=lambda: _int("USENET_ORPHAN_STALE_MINUTES", 10))
 
     # --- Channel thumbnail generation ---
     # Real-world UTC timestamp when the virtual clock was set to the channel window's

--- a/packages/tools/video-grabber/video_grabber/usenet/flows.py
+++ b/packages/tools/video-grabber/video_grabber/usenet/flows.py
@@ -12,6 +12,7 @@ drag in the video pipeline's boto/ffmpeg dependencies.
 """
 import os
 import shutil
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -72,6 +73,97 @@ def transition_usenet_job(db, job_id: str, to_stage: str, *, error: str = None, 
     db.commit()
 
 
+# Stages a job passes through while a process-usenet-item run is working it. If
+# that run's pod is killed (OOM / eviction / SIGKILL), the flow's except/finally
+# never runs, so the job is stranded here — invisible to the dispatcher, which
+# only claims 'discovered'/'failed'. reclaim_orphaned_usenet_jobs rescues these.
+_INFLIGHT_STAGES = ("downloading", "downloaded", "processing")
+
+# Seconds between a live process-usenet-item's last_transition_at refreshes.
+_HEARTBEAT_INTERVAL = 60
+
+
+def reclaim_orphaned_usenet_jobs(db, *, stale_minutes: int, max_retries: int, logger=None) -> int:
+    """Re-queue jobs stranded mid-flight by a killed process-usenet-item run.
+
+    A live run heartbeats its job's ``last_transition_at`` every minute (see
+    ``_JobHeartbeat``), so a job in an in-flight stage untouched for
+    ``stale_minutes`` has no live worker → recover it: back to 'discovered' to
+    retry, or to 'failed' once retries are exhausted (kept for diagnosis),
+    bumping ``retry_count`` either way so a job that keeps orphaning eventually
+    stops. Runs at the head of every dispatch-usenet — the periodic driver — so
+    no separate supervisor process is needed. Returns the number reclaimed.
+    """
+    res = db.execute(
+        sa.text(
+            """
+            UPDATE usenet_jobs
+               SET stage = CASE WHEN retry_count < :max
+                                THEN CAST('discovered' AS usenet_stage)
+                                ELSE CAST('failed' AS usenet_stage) END,
+                   retry_count = retry_count + 1,
+                   error_message = 'recovered: worker died/stalled mid-' || stage,
+                   last_transition_at = now()
+             WHERE stage IN ('downloading', 'downloaded', 'processing')
+               AND last_transition_at < now() - (:mins * interval '1 minute')
+            """
+        ),
+        {"max": max_retries, "mins": stale_minutes},
+    )
+    db.commit()
+    n = res.rowcount
+    if n and logger:
+        logger.warning("dispatch-usenet: reclaimed %d orphaned job(s) stale > %d min", n, stale_minutes)
+    return n
+
+
+class _JobHeartbeat:
+    """Refresh a job's ``last_transition_at`` every minute while it is in-flight.
+
+    Lets ``reclaim_orphaned_usenet_jobs`` distinguish a live-but-slow run (a big
+    mbox download or a long threading build) from one whose pod was killed. The
+    heartbeat runs its own short-lived engine on a daemon thread and is
+    best-effort: any error is logged, never raised, so it can't fail the job.
+    Once the job leaves the in-flight stages the UPDATE simply matches nothing.
+    """
+
+    def __init__(self, job_id: str, *, interval: int = _HEARTBEAT_INTERVAL, logger=None):
+        self._job_id = job_id
+        self._interval = interval
+        self._logger = logger
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def __enter__(self) -> "_JobHeartbeat":
+        self._thread.start()
+        return self
+
+    def _run(self) -> None:
+        engine = sa.create_engine(_sync_db_url(Config().database_url))
+        try:
+            while not self._stop.wait(self._interval):
+                try:
+                    with engine.begin() as db:
+                        db.execute(
+                            sa.text(
+                                "UPDATE usenet_jobs SET last_transition_at = now() "
+                                "WHERE id = :id AND stage IN "
+                                "('downloading', 'downloaded', 'processing')"
+                            ),
+                            {"id": self._job_id},
+                        )
+                except Exception as exc:  # noqa: BLE001 — heartbeat must not kill the job
+                    if self._logger:
+                        self._logger.warning("usenet heartbeat error: %s", exc)
+        finally:
+            engine.dispose()
+
+    def __exit__(self, *exc) -> bool:
+        self._stop.set()
+        self._thread.join(timeout=5)
+        return False
+
+
 @flow(name="scan-usenet")
 def scan_usenet_flow(collections: list[str] | None = None) -> None:
     logger = get_run_logger()
@@ -98,21 +190,24 @@ def process_usenet_item_flow(job_id: str) -> None:
     job = get_usenet_job(job_id)
     scratch = _SCRATCH / "usenet" / job.ia_identifier
     try:
-        transition_usenet_job(db, job_id, "downloading")
-        mbox_path = download_mbox(job, scratch / "dl", logger=logger)
-        transition_usenet_job(db, job_id, "downloaded")
+        # Heartbeat last_transition_at while in-flight so a killed pod's job is
+        # reclaimable but a slow-but-live one is never falsely reclaimed.
+        with _JobHeartbeat(job_id, logger=logger):
+            transition_usenet_job(db, job_id, "downloading")
+            mbox_path = download_mbox(job, scratch / "dl", logger=logger)
+            transition_usenet_job(db, job_id, "downloaded")
 
-        transition_usenet_job(db, job_id, "processing")
-        fallback_group = job.ia_identifier.removeprefix("usenet-")
-        groups = process_archive(mbox_path, cfg.usenet_before, scratch / "work", fallback_group, logger=logger)
+            transition_usenet_job(db, job_id, "processing")
+            fallback_group = job.ia_identifier.removeprefix("usenet-")
+            groups = process_archive(mbox_path, cfg.usenet_before, scratch / "work", fallback_group, logger=logger)
 
-        total = 0
-        for newsgroup, records in groups.items():
-            _, n = write_group(newsgroup, records, cfg)
-            total += n
-        transition_usenet_job(db, job_id, "processed", message_count=total)
-        logger.info("process-usenet-item: %s ingested %d messages in %d groups",
-                    job.ia_identifier, total, len(groups))
+            total = 0
+            for newsgroup, records in groups.items():
+                _, n = write_group(newsgroup, records, cfg)
+                total += n
+            transition_usenet_job(db, job_id, "processed", message_count=total)
+            logger.info("process-usenet-item: %s ingested %d messages in %d groups",
+                        job.ia_identifier, total, len(groups))
     except Exception as exc:  # noqa: BLE001 — record failure, then re-raise for retry
         transition_usenet_job(db, job_id, "failed", error=str(exc)[:2000])
         raise
@@ -132,6 +227,15 @@ def dispatch_usenet_flow(max_runs: int = 100, max_retries: int = 3) -> None:
     """
     logger = get_run_logger()
     db = get_db()
+    # Supervisor sweep: rescue jobs orphaned in-flight by a killed process run
+    # before claiming fresh work, so a crash self-heals within one dispatch cycle
+    # instead of stranding the job (and leaking its DB connection) indefinitely.
+    reclaim_orphaned_usenet_jobs(
+        db,
+        stale_minutes=Config().usenet_orphan_stale_minutes,
+        max_retries=max_retries,
+        logger=logger,
+    )
     processed = 0
     while processed < max_runs:
         row = db.execute(


### PR DESCRIPTION
## Problem
When a `process-usenet-item` pod is killed (OOM/eviction/SIGKILL), the flow's `except/finally` never runs, so its job is stranded in an in-flight stage (`downloading`/`downloaded`/`processing`). The dispatcher only claims `discovered`/`failed`, so the orphan sits **forever** — and its abandoned DB connection lingers. Enough of them saturated the **shared** rt911-db (99/100 connections), starving Directus/the whole app. This has now required **manual recovery twice** (2026-06-30 and 2026-07-09).

## Fix — port the transcribe self-healing pattern (PR #148) to usenet's flow model
- **`reclaim_orphaned_usenet_jobs()`** runs at the head of every `dispatch-usenet` (already scheduled every 5 min, so it *is* the periodic supervisor — no new process): jobs in an in-flight stage untouched past `USENET_ORPHAN_STALE_MINUTES` (default 10) → re-queued to `discovered`, or parked in `failed` once retries are exhausted, always spending a `retry_count` so a perpetually-orphaning job eventually stops.
- **`_JobHeartbeat`** refreshes `last_transition_at` every 60s while `process-usenet-item` is in-flight, so a slow-but-live run (big mbox download / long threading build) is **never** falsely reclaimed — only a dead pod's job goes stale. Mirrors the transcribe heartbeat.

Operationally backstopped by `ALTER DATABASE video_grabber SET idle_session_timeout='10min'` (already applied) which reaps leaked idle connections.

## Verification
- 17 usenet tests pass (2 new: reclaim SQL shape + heartbeat update); ruff clean.
- Reclaim SQL validated against **live Postgres** in a `BEGIN…ROLLBACK` (valid syntax; correctly matched 1 currently-orphaned job → `discovered`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)