### PR TITLE
Fix RadioScanner crash: react-fast-marquee CJS interop shim

### DIFF
--- a/packages/frontend/src/Applications/RadioScanner/NowPlayingList.test.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/NowPlayingList.test.tsx
@@ -8,7 +8,7 @@ afterEach(cleanup);
 // react-fast-marquee measures via ResizeObserver, which jsdom doesn't
 // implement. The marquee is purely presentational here, so render children
 // directly.
-vi.mock("react-fast-marquee", () => ({
+vi.mock("./marquee", () => ({
 	default: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
 }));
 

--- a/packages/frontend/src/Applications/RadioScanner/NowPlayingList.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/NowPlayingList.tsx
@@ -2,7 +2,7 @@ import { ClassicyIcons } from "classicy";
 import type React from "react";
 import type { MediaItem } from "../../Providers/MediaStream/MediaStreamContext";
 import styles from "./RadioScanner.module.scss";
-import Marquee from "react-fast-marquee";
+import Marquee from "./marquee";
 
 interface NowPlayingListProps {
 	segments: MediaItem[];
@@ -27,28 +27,28 @@ export const NowPlayingList: React.FC<NowPlayingListProps> = ({
 		return <p className={styles.rsNowPlayingEmpty}>—</p>;
 	}
 	return (
-		// react-fast-marquee re-measures via ResizeObserver, so the ticker keeps
-		// scrolling when the virtual clock promotes/expires segments (the old
-		// react-marquee-text measured once on mount and froze on content change).
-		<Marquee direction="right" speed={40} pauseOnHover>
-			<ul className={styles.rsNowPlaying}>
-				{segments.map((item) => {
-					const isMuted = mutedItems.includes(item.id);
-					return (
-						<li key={item.id} className={styles.rsNowPlayingRow}>
-							<button
-								type="button"
-								className={styles.rsNowPlayingBtn}
-								onMouseUp={() => onToggleMute(item.id)}
-								aria-pressed={isMuted}
-							>
-								<img src={isMuted ? soundMute : soundOn} alt={isMuted ? "Unmute" : "Mute"} />
-							</button>
-								<span className={styles.rsNowPlayingTitle}>{item.full_title || item.title}</span>
-						</li>
-					);
-				})}
-			</ul>
-		</Marquee>
+		<ul className={styles.rsNowPlaying}>
+			{segments.map((item) => {
+				const isMuted = mutedItems.includes(item.id);
+				return (
+					<li key={item.id} className={styles.rsNowPlayingRow}>
+						<button
+							type="button"
+							className={styles.rsNowPlayingBtn}
+							onMouseUp={() => onToggleMute(item.id)}
+							aria-pressed={isMuted}
+						>
+							<img src={isMuted ? soundMute : soundOn} alt={isMuted ? "Unmute" : "Mute"} />
+						</button>
+						{/* Per-title marquee; react-fast-marquee re-measures via
+						    ResizeObserver so it keeps scrolling when the clock swaps
+						    segments (react-marquee-text froze on content change). */}
+						<Marquee direction="right" speed={40} pauseOnHover>
+							<span className={styles.rsNowPlayingTitle}>{item.full_title || item.title}</span>
+						</Marquee>
+					</li>
+				);
+			})}
+		</ul>
 	);
 };

--- a/packages/frontend/src/Applications/RadioScanner/RadioScanner.module.scss
+++ b/packages/frontend/src/Applications/RadioScanner/RadioScanner.module.scss
@@ -139,6 +139,7 @@
   padding: var(--window-padding-size);
   gap: var(--window-control-size);
   width: 100%;
+  overflow: hidden;
 }
 
 .rsNowPlayingRow {

--- a/packages/frontend/src/Applications/RadioScanner/RadioScanner.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/RadioScanner.tsx
@@ -32,7 +32,7 @@ import {
     previousSegments,
     upcomingSegments,
 } from "./stationGrouping";
-import Marquee from "react-fast-marquee";
+import Marquee from "./marquee";
 
 type RadioScannerProps = Record<string, never>;
 
@@ -402,7 +402,9 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
                                             {station.label}
                                         </p>
                                         {!isOnline && (
-                                                <p
+                                                // div, not p: the marquee renders block divs inside,
+                                                // and <div> inside <p> is invalid HTML (React 19 errors)
+                                                <div
                                                     className={
                                                         styles.rsStationOffline
                                                     }
@@ -410,7 +412,7 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
                                                 <Marquee direction="right" speed={20}>
                                                         <span className={styles.rsOfflineText}>OFFLINE</span>
                                                 </Marquee>
-                                                </p>
+                                                </div>
                                         )}
                                     </ClassicyButton>
                                 );

--- a/packages/frontend/src/Applications/RadioScanner/marquee.test.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/marquee.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// jsdom has no ResizeObserver; the real component instantiates one on mount.
+vi.stubGlobal(
+	"ResizeObserver",
+	class {
+		observe() {}
+		unobserve() {}
+		disconnect() {}
+	},
+);
+
+import Marquee from "./marquee";
+
+describe("marquee interop shim", () => {
+	it("exports a renderable component whatever CJS interop shape Vite hands us", () => {
+		// With the raw default import under rolldown-vite this throws
+		// "Element type is invalid ... got: object" — the shim must unwrap it.
+		render(
+			<Marquee speed={40}>
+				<span>tick</span>
+			</Marquee>,
+		);
+		expect(screen.getAllByText("tick").length).toBeGreaterThan(0);
+	});
+});

--- a/packages/frontend/src/Applications/RadioScanner/marquee.ts
+++ b/packages/frontend/src/Applications/RadioScanner/marquee.ts
@@ -1,0 +1,12 @@
+import MarqueeImport from "react-fast-marquee";
+
+// react-fast-marquee ships CJS-only (main: dist/index.js, no exports map, no
+// ESM build). Vite 8's rolldown dep optimizer re-exports the raw CJS
+// namespace as the default export ({ __esModule, default: Marquee }), so a
+// plain default import reaches React as an object and crashes with
+// "Element type is invalid ... got: object". Unwrap defensively — this works
+// under every interop shape (vite dev, vite build, vitest).
+const Marquee = ((MarqueeImport as unknown as { default?: typeof MarqueeImport })
+	.default ?? MarqueeImport) as typeof MarqueeImport;
+
+export default Marquee;


### PR DESCRIPTION
RadioScanner crashed on open with `Element type is invalid ... got: object` in `NowPlayingList`.

**Root cause:** react-fast-marquee ships CJS-only (`main: dist/index.js`, no exports map). Vite 8's rolldown dep optimizer emits `export default require_dist()` — the raw CJS namespace `{__esModule, default: Marquee}` — so the default import reaches React as an object, not a component. The unit tests mocked the module, which is exactly how this got past the gates on #177.

**Fix:**
- New `RadioScanner/marquee.ts` shim that unwraps `.default` defensively (correct under dev, build, and vitest interop shapes); both call sites import it. A real-render test (ResizeObserver stubbed) now exercises the actual package instead of a mock.
- Restores the per-title marquee layout that the #177 merge clobbered (marquee wraps each title span, not the whole list).
- OFFLINE ticker wrapper `p` → `div` (the marquee renders block divs; div-in-p is invalid HTML and React 19 errors on it).

**Verified live** on a fresh vite dev server: RadioScanner opens, marquees scroll, console clean of both the crash and the DOM-nesting error. Gates: tsc, eslint, 375 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NMS1V2keS3pTbWRemCd9o