### PR TITLE
RadioScanner: click a now-playing title to solo it

### DIFF
--- a/packages/frontend/src/Applications/RadioScanner/NowPlayingList.test.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/NowPlayingList.test.tsx
@@ -7,9 +7,13 @@ afterEach(cleanup);
 
 // react-fast-marquee measures via ResizeObserver, which jsdom doesn't
 // implement. The marquee is purely presentational here, so render children
-// directly.
+// directly — recording the play prop so tests can assert pause-on-solo.
 vi.mock("./marquee", () => ({
-	default: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+	default: ({ children, play }: { children?: React.ReactNode; play?: boolean }) => (
+		<div data-testid="marquee" data-play={String(play ?? true)}>
+			{children}
+		</div>
+	),
 }));
 
 import type React from "react";
@@ -28,39 +32,78 @@ const segs = [
 	item({ id: 2, full_title: "", title: "ATC Ground" }),
 ];
 
+const noop = () => {};
+
+function renderList(over: Partial<React.ComponentProps<typeof NowPlayingList>> = {}) {
+	return render(
+		<NowPlayingList
+			segments={segs}
+			mutedItems={[]}
+			onToggleMute={noop}
+			soloItemId={null}
+			onToggleSolo={noop}
+			{...over}
+		/>,
+	);
+}
+
 describe("NowPlayingList", () => {
 	it("renders one row per segment showing full_title (title fallback)", () => {
-		const { getByText, getAllByRole } = render(
-			<NowPlayingList segments={segs} mutedItems={[]} onToggleMute={() => {}} />,
-		);
+		const { getByText, getAllByRole } = renderList();
 		expect(getByText("ATC Tower")).not.toBeNull();
 		expect(getByText("ATC Ground")).not.toBeNull(); // full_title empty → title
 		expect(getAllByRole("listitem")).toHaveLength(2);
 	});
 
-	it("calls onToggleMute with the file id when a row's button is clicked", () => {
+	it("calls onToggleMute with the file id when a row's icon button is clicked", () => {
 		const onToggle = vi.fn();
-		const { getAllByRole } = render(
-			<NowPlayingList segments={segs} mutedItems={[]} onToggleMute={onToggle} />,
-		);
-		fireEvent.mouseUp(getAllByRole("button")[0]);
+		const onSolo = vi.fn();
+		const { getAllByAltText } = renderList({ onToggleMute: onToggle, onToggleSolo: onSolo });
+		fireEvent.mouseUp(getAllByAltText("Mute")[0]);
 		expect(onToggle).toHaveBeenCalledWith(1);
+		expect(onSolo).not.toHaveBeenCalled(); // icon click never solos
 	});
 
 	it("shows the muted icon (alt 'Unmute') for files in mutedItems", () => {
-		const { getAllByRole } = render(
-			<NowPlayingList segments={segs} mutedItems={[2]} onToggleMute={() => {}} />,
-		);
+		const { getAllByRole } = renderList({ mutedItems: [2] });
 		const imgs = getAllByRole("img");
 		expect(imgs[0].getAttribute("alt")).toBe("Mute"); // id 1 unmuted → action Mute
 		expect(imgs[1].getAttribute("alt")).toBe("Unmute"); // id 2 muted → action Unmute
 	});
 
 	it("renders a placeholder and no rows when segments is empty", () => {
-		const { getByText, queryAllByRole } = render(
-			<NowPlayingList segments={[]} mutedItems={[]} onToggleMute={() => {}} />,
-		);
+		const { getByText, queryAllByRole } = renderList({ segments: [] });
 		expect(getByText("—")).not.toBeNull();
 		expect(queryAllByRole("listitem")).toHaveLength(0);
+	});
+
+	it("clicking a title solos that item; clicking it again un-solos", () => {
+		const onSolo = vi.fn();
+		const { getByText, unmount } = renderList({ onToggleSolo: onSolo });
+		fireEvent.click(getByText("ATC Tower"));
+		expect(onSolo).toHaveBeenCalledWith(1);
+		unmount();
+		// parent flips soloItemId; a second click reports the same id (toggle)
+		onSolo.mockClear();
+		const { getByText: getByText2 } = renderList({ soloItemId: 1, onToggleSolo: onSolo });
+		fireEvent.click(getByText2("ATC Tower"));
+		expect(onSolo).toHaveBeenCalledWith(1);
+	});
+
+	it("while soloed, other rows read as muted and the soloed row as audible", () => {
+		// manual mutes are ignored for display while solo is active — what you
+		// see is what you hear
+		const { getAllByRole } = renderList({ soloItemId: 2, mutedItems: [2] });
+		const imgs = getAllByRole("img");
+		expect(imgs[0].getAttribute("alt")).toBe("Unmute"); // id 1 silenced by solo
+		expect(imgs[1].getAttribute("alt")).toBe("Mute"); // id 2 audible (soloed)
+	});
+
+	it("pauses the marquee while a solo is active", () => {
+		const { getByTestId, unmount } = renderList({ soloItemId: 1 });
+		expect(getByTestId("marquee").getAttribute("data-play")).toBe("false");
+		unmount();
+		const { getByTestId: get2 } = renderList({ soloItemId: null });
+		expect(get2("marquee").getAttribute("data-play")).toBe("true");
 	});
 });

--- a/packages/frontend/src/Applications/RadioScanner/NowPlayingList.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/NowPlayingList.tsx
@@ -8,6 +8,10 @@ interface NowPlayingListProps {
 	segments: MediaItem[];
 	mutedItems: number[];
 	onToggleMute: (id: number) => void;
+	// Solo: clicking a title mutes every other playing item and pauses the
+	// marquee; clicking it again restores the manual mute state. null = off.
+	soloItemId: number | null;
+	onToggleSolo: (id: number) => void;
 }
 
 const soundOn = ClassicyIcons.controlPanels.soundManager.soundOn as string;
@@ -16,21 +20,32 @@ const soundMute = ClassicyIcons.controlPanels.soundManager.soundMute as string;
 /**
  * Lists the files currently playing for one station (its in-window segments),
  * each with a mute/unmute toggle. Purely presentational — the caller owns the
- * segment computation and the muted-id state.
+ * segment computation, the muted-id state, and the solo state.
  */
 export const NowPlayingList: React.FC<NowPlayingListProps> = ({
 	segments,
 	mutedItems,
 	onToggleMute,
+	soloItemId,
+	onToggleSolo,
 }) => {
 	if (segments.length === 0) {
 		return <p className={styles.rsNowPlayingEmpty}>—</p>;
 	}
+	const soloActive = soloItemId !== null;
 	return (
-		<Marquee direction="left" speed={40} pauseOnHover>
+		// react-fast-marquee re-measures via ResizeObserver so it keeps
+		// scrolling when the clock swaps segments; it pauses while a solo is
+		// active so the soloed row stays put.
+		<Marquee direction="left" speed={40} pauseOnHover play={!soloActive}>
 			<ul className={styles.rsNowPlaying}>
 				{segments.map((item) => {
-					const isMuted = mutedItems.includes(item.id);
+					// While soloed, display mirrors what's audible: only the soloed
+					// item plays, regardless of manual mutes (which stay untouched).
+					const isMuted = soloActive
+						? item.id !== soloItemId
+						: mutedItems.includes(item.id);
+					const isSoloed = soloItemId === item.id;
 					return (
 						<li key={item.id} className={styles.rsNowPlayingRow}>
 							<button
@@ -41,10 +56,15 @@ export const NowPlayingList: React.FC<NowPlayingListProps> = ({
 							>
 								<img src={isMuted ? soundMute : soundOn} alt={isMuted ? "Unmute" : "Mute"} />
 							</button>
-							{/* Per-title marquee; react-fast-marquee re-measures via
-								ResizeObserver so it keeps scrolling when the clock swaps
-								segments (react-marquee-text froze on content change). */}
+							<button
+								type="button"
+								className={`${styles.rsNowPlayingTitleBtn}${isSoloed ? ` ${styles.rsNowPlayingSolo}` : ""}`}
+								onClick={() => onToggleSolo(item.id)}
+								aria-pressed={isSoloed}
+								title={isSoloed ? "Unsolo (unmute the rest)" : "Solo (mute the rest)"}
+							>
 								<span className={styles.rsNowPlayingTitle}>{item.full_title || item.title}</span>
+							</button>
 						</li>
 					);
 				})}

--- a/packages/frontend/src/Applications/RadioScanner/RadioScanner.module.scss
+++ b/packages/frontend/src/Applications/RadioScanner/RadioScanner.module.scss
@@ -162,6 +162,22 @@
 	}
 }
 
+// Title is a click target (solo toggle) — strip button chrome so it reads
+// like the plain label it replaced.
+.rsNowPlayingTitleBtn {
+	background: transparent;
+	border: none;
+	cursor: pointer;
+	padding: 0;
+	text-align: left;
+	min-width: 0;
+}
+
+.rsNowPlayingSolo .rsNowPlayingTitle {
+	font-weight: bold;
+	text-decoration: underline;
+}
+
 .rsNowPlayingTitle {
 	font-family: var(--ui-font) ;
 	font-size: calc(var(--ui-font-size) * 1.25);

--- a/packages/frontend/src/Applications/RadioScanner/RadioScanner.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/RadioScanner.tsx
@@ -24,7 +24,11 @@ import { NowPlayingList } from "./NowPlayingList";
 import styles from "./RadioScanner.module.scss";
 import "./RadioScannerContext";
 import { trackAppToggle } from "../../openreplay";
-import { sanitizeActiveStation, sanitizeItemIds } from "./radioPlayback";
+import {
+    effectiveMutedIds,
+    sanitizeActiveStation,
+    sanitizeItemIds,
+} from "./radioPlayback";
 import { StationPlayer } from "./StationPlayer";
 import {
     activeSegments,
@@ -93,6 +97,10 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
         (appState?.showWaveform as boolean) ?? true,
     );
     const [focusedItem, setFocusedItem] = useState<MediaItem | null>(null);
+    // Solo (ephemeral, not persisted): while set, every other playing item is
+    // muted via effectiveMutedIds and the now-playing marquee pauses. Manual
+    // mutedItems stay untouched, so un-soloing restores them exactly.
+    const [soloItemId, setSoloItemId] = useState<number | null>(null);
 
     // Accumulate all mp3Items ever received so previousSegments can access them
     // even after they expire from the live stream.
@@ -165,6 +173,16 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
         );
     };
 
+    const toggleSoloItem = useCallback((id: number) => {
+        setSoloItemId((prev) => (prev === id ? null : id));
+    }, []);
+
+    // Solo is scoped to the station it was started on.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: reset-on-change effect
+    useEffect(() => {
+        setSoloItemId(null);
+    }, [activeStation]);
+
     const appMenu = [
         {
             id: "file",
@@ -185,6 +203,39 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
     ];
 
     const activeStationObj = stations.find((s) => s.key === activeStation);
+
+    // The active station's in-window segments — shared by the now-playing
+    // list, the solo lifecycle, and the effective-mute derivation. Memoized so
+    // the no-solo playerMutedItems keeps mutedItems' identity and the volume
+    // effect in StationPlayer doesn't re-fire on unrelated renders.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: nowMs is the clock dep
+    const playingSegments = useMemo(
+        () => (activeStationObj ? activeSegments(activeStationObj, nowMs) : []),
+        [activeStationObj, nowMs],
+    );
+
+    // A soloed clip that finishes (or expires on seek) releases the solo, so
+    // the rest of the mix comes back rather than staying silent.
+    useEffect(() => {
+        if (
+            soloItemId !== null &&
+            !playingSegments.some((i) => i.id === soloItemId)
+        ) {
+            setSoloItemId(null);
+        }
+    }, [playingSegments, soloItemId]);
+
+    // What the audio elements actually honor: manual mutes, or — while a solo
+    // is active — everything in the mix except the soloed item.
+    const playerMutedItems = useMemo(
+        () =>
+            effectiveMutedIds(
+                mutedItems,
+                soloItemId,
+                playingSegments.map((i) => i.id),
+            ),
+        [mutedItems, soloItemId, playingSegments],
+    );
 
     const showSchedule =
         activeStation !== "" && !CONTINUOUS_STATIONS.has(activeStation);
@@ -262,12 +313,11 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
                                             {activeStationObj.label}
                                         </p>
                                         <NowPlayingList
-                                            segments={activeSegments(
-                                                activeStationObj,
-                                                nowMs,
-                                            )}
+                                            segments={playingSegments}
                                             mutedItems={mutedItems}
                                             onToggleMute={toggleItemMute}
+                                            soloItemId={soloItemId}
+                                            onToggleSolo={toggleSoloItem}
                                         />
                                         <div style={{ display: "flex", flexDirection: "row", width: "100%", minHeight: "30%", maxHeight: "60%", gap: "var(--window-control-size)" }}>
                                                 <div
@@ -363,7 +413,7 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
                                         nowMs={nowMs}
                                         getNowMs={getNowMs}
                                         stationMuted={false}
-                                        mutedItems={mutedItems}
+                                        mutedItems={playerMutedItems}
                                         clockPaused={clockPaused}
                                         showWaveform={showWaveform}
                                         captionsOn={captionsOn}

--- a/packages/frontend/src/Applications/RadioScanner/radioPlayback.test.ts
+++ b/packages/frontend/src/Applications/RadioScanner/radioPlayback.test.ts
@@ -50,3 +50,23 @@ describe("sanitizeItemIds", () => {
 		expect(sanitizeItemIds("nope")).toEqual([]);
 	});
 });
+
+describe("effectiveMutedIds", () => {
+	const playing = [10, 11, 12];
+
+	it("returns manual mutes untouched when no solo is active", async () => {
+		const { effectiveMutedIds } = await import("./radioPlayback");
+		expect(effectiveMutedIds([11], null, playing)).toEqual([11]);
+	});
+
+	it("mutes every playing item except the soloed one, ignoring manual mutes", async () => {
+		const { effectiveMutedIds } = await import("./radioPlayback");
+		// 11 was manually muted but is the solo target -> audible
+		expect(effectiveMutedIds([11], 11, playing)).toEqual([10, 12]);
+	});
+
+	it("solo of an id not in the playing set mutes everything playing", async () => {
+		const { effectiveMutedIds } = await import("./radioPlayback");
+		expect(effectiveMutedIds([], 99, playing)).toEqual([10, 11, 12]);
+	});
+});

--- a/packages/frontend/src/Applications/RadioScanner/radioPlayback.ts
+++ b/packages/frontend/src/Applications/RadioScanner/radioPlayback.ts
@@ -27,3 +27,18 @@ export function sanitizeItemIds(value: unknown): number[] {
 		? value.filter((v): v is number => typeof v === "number" && Number.isFinite(v))
 		: [];
 }
+
+/**
+ * The muted ids that should actually reach the audio elements. With no solo
+ * active, manual mutes apply as-is. While an item is soloed, every OTHER
+ * playing item is muted and manual mutes are ignored — un-soloing therefore
+ * restores the manual state untouched.
+ */
+export function effectiveMutedIds(
+	mutedItems: number[],
+	soloItemId: number | null,
+	playingIds: number[],
+): number[] {
+	if (soloItemId === null) return mutedItems;
+	return playingIds.filter((id) => id !== soloItemId);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 18.1.0
       classicy:
         specifier: latest
-        version: 0.27.0(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30)
+        version: 0.27.1(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30)
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -1847,8 +1847,8 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
-  classicy@0.27.0:
-    resolution: {integrity: sha512-Y5T9BYW0cUynweG+J73gcet0OfyF/UYZr8V7lySRoG3eKE8h0CGRAePUvirLCet4DdHmFr2gRxYE+ffyzy99TQ==}
+  classicy@0.27.1:
+    resolution: {integrity: sha512-rZr9k8bJrTX5APiCmjIxnOoGDkbSAeHJOaSNgnWW0oYlhCcJ6HNe2H/EEwjVydEFoSh3Ba+HQbkNvr7KZ+yA3g==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -5842,7 +5842,7 @@ snapshots:
       readdirp: 5.0.0
     optional: true
 
-  classicy@0.27.0(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30):
+  classicy@0.27.1(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30):
     dependencies:
       '@analytics/google-tag-manager': 0.6.0
       '@mdxeditor/editor': 3.55.0(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30)


### PR DESCRIPTION
Clicking an item in the NowPlayingList solos it: every other playing item is muted and the marquee pauses; clicking it again un-solos and the rest come back. The mute icon keeps its existing per-item toggle.

Design notes:
- Solo is **derived, not destructive**: `effectiveMutedIds(mutedItems, soloItemId, playingIds)` feeds StationPlayer, so manual mutes are never rewritten and un-soloing restores them exactly (a manually-muted item that gets soloed is audible while soloed, muted again after).
- While soloed, the row icons mirror what's audible (others show muted) — what you see is what you hear.
- Solo is ephemeral (not persisted): it clears on station change, and auto-releases when the soloed clip ends or expires on a seek so the mix doesn't stay silent.
- Marquee gets `play={!soloActive}` — the soloed row stays put while reading.
- Title is now an unstyled `<button>` (valid HTML next to the icon button, keyboard-accessible), bold+underline when soloed.

Tests: 7 NowPlayingList cases (solo toggle, icon isolation, audible-state icons, marquee pause) + 3 for the pure derivation helper; 381 total green, build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NMS1V2keS3pTbWRemCd9o