### PR TITLE
fix(transcribe): open a fresh DB connection per job transition

### DIFF
--- a/packages/tools/video-grabber/tests/test_transcribe_flows.py
+++ b/packages/tools/video-grabber/tests/test_transcribe_flows.py
@@ -1,4 +1,10 @@
+import logging
 from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+import video_grabber.transcribe.flows as flows
 from video_grabber.transcribe.flows import build_channel_cues
 
 WS = datetime(2001, 9, 11, 0, 0, 0, tzinfo=timezone.utc)
@@ -24,6 +30,116 @@ def test_build_channel_cues_sorts_out_of_order_programs():
     b_air = datetime(2001, 9, 11, 1, 0, 0, tzinfo=timezone.utc)
     cues = build_channel_cues(WS, [(a_air, PROG_A), (b_air, PROG_B)])
     assert cues[0].text == "B opening"   # earlier air_date first
+
+
+# ---- per-transition DB connections -----------------------------------------
+#
+# rt911-db sets idle_session_timeout=10min on the video_grabber database (leak
+# protection), but whisper holds transcribe-item for 15-20 minutes. Any
+# connection opened before transcription is dead by the time the flow writes
+# stage='done' — so every transition must open its own fresh connection.
+
+
+class FakeConn:
+    """Stands in for sqlalchemy Connection; `dead` mimics the server having
+    closed the socket (idle_session_timeout)."""
+
+    def __init__(self, registry):
+        self.dead = False
+        self.executed = []
+        self.commits = 0
+        self.closed = False
+        registry.append(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.closed = True
+        return False
+
+    def _check(self):
+        if self.dead:
+            raise RuntimeError("server closed the connection unexpectedly")
+
+    def execute(self, stmt, params=None):
+        self._check()
+        self.executed.append((str(stmt), params or {}))
+
+    def commit(self):
+        self._check()
+        self.commits += 1
+
+
+def _stages(conns):
+    return [p["stage"] for c in conns for (_, p) in c.executed if "stage" in p]
+
+
+def test_transition_transcribe_job_opens_and_closes_its_own_connection(monkeypatch):
+    conns = []
+    monkeypatch.setattr(flows, "get_db", lambda: FakeConn(conns))
+    flows.transition_transcribe_job("j1", "done", srt_key="k")
+    assert len(conns) == 1
+    assert _stages(conns) == ["done"]
+    assert conns[0].commits == 1
+    assert conns[0].closed
+
+
+@pytest.fixture
+def flow_env(monkeypatch, tmp_path):
+    """Run transcribe_item_flow.fn with every external dependency stubbed and
+    a registry of every DB connection ever opened."""
+    conns = []
+    monkeypatch.setattr(flows, "_SCRATCH", tmp_path / "scratch")
+    monkeypatch.setattr(flows, "get_db", lambda: FakeConn(conns))
+    monkeypatch.setattr(flows, "get_run_logger", lambda: logging.getLogger("test"))
+    monkeypatch.setattr(
+        flows, "get_transcribe_job",
+        lambda job_id: SimpleNamespace(
+            id=job_id, kind="tv", source_key="TCN_test", source_url="http://x/audio.m3u8",
+        ),
+    )
+    monkeypatch.setattr(flows, "extract_audio", lambda url, dst: dst)
+    monkeypatch.setattr(
+        flows, "wasabi",
+        SimpleNamespace(upload_text=lambda text, key, cfg: None, list_keys=lambda *a: []),
+    )
+
+    def make_transcriber(fail=None):
+        def fake_transcribe(wav, out_base, cfg):
+            # idle_session_timeout fires mid-transcription: every connection
+            # opened before this point is now dead.
+            for c in conns:
+                c.dead = True
+            if fail is not None:
+                raise fail
+            out_base.parent.mkdir(parents=True, exist_ok=True)
+            srt = out_base.with_suffix(".srt")
+            srt.write_text("1\n00:00:01,000 --> 00:00:02,000\nhello\n")
+            return srt
+        return fake_transcribe
+
+    return SimpleNamespace(conns=conns, monkeypatch=monkeypatch, make_transcriber=make_transcriber)
+
+
+def test_transcribe_item_marks_done_after_connections_die_mid_transcription(flow_env):
+    flow_env.monkeypatch.setattr(flows, "transcribe_wav", flow_env.make_transcriber())
+    flows.transcribe_item_flow.fn("job-1")
+    assert _stages(flow_env.conns) == ["transcribing", "done"]
+
+
+def test_transcribe_item_marks_failed_on_fresh_connection(flow_env):
+    boom = RuntimeError("whisper exploded")
+    flow_env.monkeypatch.setattr(flows, "transcribe_wav", flow_env.make_transcriber(fail=boom))
+    with pytest.raises(RuntimeError, match="whisper exploded"):
+        flows.transcribe_item_flow.fn("job-1")
+    stages = _stages(flow_env.conns)
+    assert stages[0] == "transcribing"
+    assert stages[-1] == "failed"
+    failed_params = [
+        p for c in flow_env.conns for (_, p) in c.executed if p.get("stage") == "failed"
+    ]
+    assert "whisper exploded" in failed_params[0]["error"]
 
 
 def test_build_channel_cues_mixed_tzinfo_naive_window_start_aware_air_date():

--- a/packages/tools/video-grabber/video_grabber/ia/channel_map.py
+++ b/packages/tools/video-grabber/video_grabber/ia/channel_map.py
@@ -28,6 +28,9 @@ KNOWN_CHANNELS: dict[str, str] = {
     "univision": "univision",
     "telemundo": "telemundo",
     "cctv4": "cctv4",
+    # The IA archive's identifier prefix stayed CCTV3_ after the slug was
+    # renamed to cctv4 (the stream is CCTV-4; see migration 004).
+    "cctv3": "cctv4",
 }
 
 # Local affiliate call-sign pattern: W/K followed by 3 uppercase letters

--- a/packages/tools/video-grabber/video_grabber/transcribe/flows.py
+++ b/packages/tools/video-grabber/video_grabber/transcribe/flows.py
@@ -62,7 +62,14 @@ def get_transcribe_job(job_id: str):
         return SimpleNamespace(**dict(row))
 
 
-def transition_transcribe_job(db, job_id, to_stage, *, error=None, srt_key=None) -> None:
+def transition_transcribe_job(job_id, to_stage, *, error=None, srt_key=None) -> None:
+    """Move a transcribe_jobs row to *to_stage* on a fresh, short-lived connection.
+
+    Opening a connection per transition (rather than holding one across the
+    flow) is load-bearing: rt911-db sets idle_session_timeout=10min on the
+    video_grabber database, and whisper keeps transcribe-item busy for 15-20
+    minutes — any connection opened before transcription is dead by the time
+    the flow records 'done'/'failed'."""
     sets = ["stage = CAST(:stage AS transcribe_stage)", "last_transition_at = now()"]
     params = {"stage": to_stage, "job_id": job_id}
     if error is not None:
@@ -73,8 +80,9 @@ def transition_transcribe_job(db, job_id, to_stage, *, error=None, srt_key=None)
     if srt_key is not None:
         sets.append("srt_key = :srt_key")
         params["srt_key"] = srt_key
-    db.execute(sa.text(f"UPDATE transcribe_jobs SET {', '.join(sets)} WHERE id = :job_id"), params)
-    db.commit()
+    with get_db() as db:
+        db.execute(sa.text(f"UPDATE transcribe_jobs SET {', '.join(sets)} WHERE id = :job_id"), params)
+        db.commit()
 
 
 # ---- pure merge helper (unit-tested) --------------------------------------
@@ -154,11 +162,10 @@ def transcribe_item_flow(job_id: str) -> None:
     its mp3_items row. TV's Directus write happens in build-channel-subtitles."""
     logger = get_run_logger()
     cfg = Config()
-    db = get_db()
     job = get_transcribe_job(job_id)
     scratch = _SCRATCH / "transcribe" / str(job.id)
     try:
-        transition_transcribe_job(db, job_id, "transcribing")
+        transition_transcribe_job(job_id, "transcribing")
         wav = extract_audio(job.source_url, scratch / "audio.wav")
         out_base = scratch / "out"
         srt_path = transcribe_wav(wav, out_base, cfg)
@@ -190,14 +197,13 @@ def transcribe_item_flow(job_id: str) -> None:
                     job.source_key,
                 )
 
-        transition_transcribe_job(db, job_id, "done", srt_key=srt_key)
+        transition_transcribe_job(job_id, "done", srt_key=srt_key)
         logger.info("transcribe-item: %s %s → %s", job.kind, job.source_key, srt_key)
     except Exception as exc:  # noqa: BLE001 — record failure then re-raise for retry
-        transition_transcribe_job(db, job_id, "failed", error=str(exc)[:2000])
+        transition_transcribe_job(job_id, "failed", error=str(exc)[:2000])
         raise
     finally:
         shutil.rmtree(scratch, ignore_errors=True)
-        db.close()
 
 
 @flow(name="build-channel-subtitles")


### PR DESCRIPTION
## Problem

Every `transcribe-item` run since 2026-07-09 fails with `PendingRollbackError` (186 failed runs). Root cause chain:

1. `rt911-db` sets `idle_session_timeout=10min` on the `video_grabber` database (added during the 2026-07-08 connection-leak firefight).
2. `transcribe_item_flow` opened one DB connection and held it idle for the 15–20 minutes whisper takes, so Postgres killed it before the final `stage='done'` UPDATE (`server closed the connection unexpectedly`).
3. The `except` path then reused the same invalidated connection → `PendingRollbackError`, so the job was never marked `done` **or** `failed` — it stayed in `transcribing`, the supervisor reclaimed it, and the GPU re-transcribed the same programs in a loop (the SRT/VTT uploads actually succeed; only the bookkeeping write dies).

## Fix

`transition_transcribe_job` now opens its own fresh, short-lived connection per transition instead of taking a held one, so no connection ever idles across transcription. The `idle_session_timeout` leak backstop stays in place.

Regression tests simulate the production failure: every connection opened before `transcribe_wav` is killed mid-transcription, and the flow must still record `done` (and `failed` on error) on fresh connections.

## Also: unblock red CI on main

`test_identifier_prefix_fallback_for_international_feed` has been failing on `main` since 3be9c05 (CCTV3→CCTV4 rename) — the test landed but the `CCTV3_` identifier-prefix alias didn't, which also blocked image builds. Added `"cctv3": "cctv4"` to `KNOWN_CHANNELS`.

## Verification

- `pytest tests/` — 303 passed, 8 skipped (only the documented live-Postgres `test_migrations` errors locally)
- `ruff check video_grabber/ tests/` — clean

Note: `process-item` and the usenet flows still hold a connection across long stages (a multi-GB IA download can idle >10min) — same latent bug class, follow-up candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)