### PR TITLE
fix(pipeline,usenet): open fresh DB connections per transition/claim

### DIFF
--- a/packages/tools/video-grabber/tests/test_flows.py
+++ b/packages/tools/video-grabber/tests/test_flows.py
@@ -33,6 +33,7 @@ def test_sync_db_url_passes_through_explicit_psycopg2():
 def _mock_db_returning(mapping):
     """Build a MagicMock db whose execute(...).mappings().fetchone() yields `mapping`."""
     db = MagicMock()
+    db.__enter__.return_value = db  # sqlalchemy Connection context manager returns self
     db.execute.return_value.mappings.return_value.fetchone.return_value = mapping
     return db
 
@@ -82,27 +83,155 @@ def test_get_job_raises_when_row_missing():
             get_job("nope")
 
 
-# --- transition_job ---
-
-def test_transition_job_updates_stage_and_logs():
-    from video_grabber.pipeline.flows import transition_job
-
-    db = MagicMock()
-    transition_job(db, "job-id-001", "metadata_extracted", from_stage="discovered")
-
-    db.execute.assert_called()
-    calls_sql = " ".join(str(c) for c in db.execute.call_args_list)
-    assert "video_jobs" in calls_sql or db.execute.called
+# --- transition_job / per-transition DB connections -------------------------
+#
+# rt911-db sets idle_session_timeout=10min on the video_grabber database (leak
+# protection), but download/encode can hold process-item for far longer, and
+# dispatch blocks on run_deployment for the whole job. Any connection opened
+# before a long stage is dead afterwards — so every DB touch must open its own
+# fresh connection (same fix as transcribe-item, PR #189).
 
 
-def test_transition_job_inserts_audit_row():
-    from video_grabber.pipeline.flows import transition_job
+class FakeConn:
+    """Stands in for a sqlalchemy Connection; `dead` mimics the server having
+    closed the socket (idle_session_timeout). Optional shared `results` deque
+    feeds execute(...).first() for dispatcher claim queries."""
 
-    db = MagicMock()
-    transition_job(db, "job-id-001", "downloading", from_stage="metadata_extracted")
+    def __init__(self, registry, results=None):
+        self.dead = False
+        self.executed = []
+        self.commits = 0
+        self.closed = False
+        self._results = results
+        registry.append(self)
 
-    # Two execute calls: UPDATE video_jobs + INSERT pipeline_transitions
-    assert db.execute.call_count >= 2
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.closed = True
+        return False
+
+    def _check(self):
+        if self.dead:
+            raise RuntimeError("server closed the connection unexpectedly")
+
+    def execute(self, stmt, params=None):
+        self._check()
+        self.executed.append((str(stmt), params or {}))
+        res = MagicMock()
+        if self._results is not None:
+            # Lazy pop: only a caller that actually calls .first() (the claim
+            # query) consumes a row; other queries must not eat the queue.
+            res.first = lambda: self._results.popleft() if self._results else None
+        return res
+
+    def commit(self):
+        self._check()
+        self.commits += 1
+
+
+def _stages(conns):
+    return [p["stage"] for c in conns for (_, p) in c.executed if "stage" in p]
+
+
+def _kill_all(conns):
+    """Simulate idle_session_timeout firing during a long stage."""
+    for c in conns:
+        c.dead = True
+
+
+def test_transition_job_opens_and_closes_its_own_connection():
+    from video_grabber.pipeline import flows
+
+    conns = []
+    with patch.object(flows, "get_db", lambda: FakeConn(conns)):
+        flows.transition_job("job-id-001", "downloading", from_stage="discovered")
+
+    assert len(conns) == 1
+    sqls = " ".join(s for s, _ in conns[0].executed)
+    assert "UPDATE video_jobs" in sqls
+    assert "INSERT INTO pipeline_transitions" in sqls
+    assert conns[0].commits == 1
+    assert conns[0].closed
+
+
+def test_get_job_closes_its_connection():
+    from video_grabber.pipeline.flows import get_job
+
+    db = _mock_db_returning(None)
+    with patch("video_grabber.pipeline.flows.get_db", return_value=db):
+        with pytest.raises(ValueError, match="not found"):
+            get_job("nope")
+    assert db.__exit__.called
+
+
+def test_process_item_flow_completes_after_connections_die_during_long_stages():
+    from video_grabber.pipeline import flows
+
+    job = MagicMock(id="job-001", ia_identifier="cnn-sep11-0800", stage="discovered")
+    conns = []
+
+    def slow_stage(*a, **k):
+        _kill_all(conns)
+        return MagicMock()
+
+    with patch.object(flows, "get_db", lambda: FakeConn(conns)), \
+         patch("video_grabber.pipeline.flows.get_job", return_value=job), \
+         patch("video_grabber.pipeline.flows.download_item", side_effect=slow_stage), \
+         patch("video_grabber.pipeline.flows.resolve_job", return_value=job), \
+         patch("video_grabber.pipeline.flows.encode_to_hls", side_effect=slow_stage), \
+         patch("video_grabber.pipeline.flows.upload_hls_package", return_value="some/key"), \
+         patch("video_grabber.pipeline.flows.write_media_item"), \
+         patch("video_grabber.pipeline.flows.shutil.rmtree"), \
+         patch("video_grabber.pipeline.flows.get_run_logger", return_value=MagicMock()):
+        flows.process_item_flow.fn("job-001")
+
+    stages = _stages(conns)
+    assert stages[0] == "downloading"
+    assert stages[-1] == "complete"
+
+
+def test_process_item_flow_marks_failed_on_fresh_connection():
+    from video_grabber.pipeline import flows
+
+    job = MagicMock(id="job-001", ia_identifier="cnn-sep11-0800", stage="discovered")
+    conns = []
+
+    def dying_download(*a, **k):
+        _kill_all(conns)
+        raise Exception("download fail")
+
+    with patch.object(flows, "get_db", lambda: FakeConn(conns)), \
+         patch("video_grabber.pipeline.flows.get_job", return_value=job), \
+         patch("video_grabber.pipeline.flows.download_item", side_effect=dying_download), \
+         patch("video_grabber.pipeline.flows.shutil.rmtree"), \
+         patch("video_grabber.pipeline.flows.get_run_logger", return_value=MagicMock()):
+        with pytest.raises(Exception, match="download fail"):
+            flows.process_item_flow.fn("job-001")
+
+    assert _stages(conns)[-1] == "failed"
+
+
+def test_dispatch_discovered_claims_each_job_on_a_fresh_connection():
+    from collections import deque
+    from types import SimpleNamespace
+    from video_grabber.pipeline import flows
+
+    rows = deque([SimpleNamespace(id="job-1"), None])
+    conns = []
+
+    def blocking_run(*a, **k):
+        _kill_all(conns)  # the dispatched job outlives idle_session_timeout
+
+    with patch.object(flows, "get_db", lambda: FakeConn(conns, results=rows)), \
+         patch("video_grabber.pipeline.flows.run_deployment", side_effect=blocking_run) as mock_run, \
+         patch("video_grabber.pipeline.flows.get_run_logger", return_value=MagicMock()):
+        flows.dispatch_discovered_flow.fn(max_runs=5)
+
+    assert mock_run.call_count == 1
+    claims = [s for c in conns for s, _ in c.executed if "UPDATE video_jobs" in s]
+    assert len(claims) == 2  # both claim attempts survived, second returned empty
 
 
 # --- scan_collections_flow ---
@@ -162,7 +291,7 @@ def test_process_item_flow_transitions_to_complete_on_success():
 
         process_item_flow.fn("job-001")
 
-    stages = [c[0][2] for c in mock_trans.call_args_list]
+    stages = [c[0][1] for c in mock_trans.call_args_list]  # transition_job(job_id, to_stage, ...)
     assert "complete" in stages
 
 
@@ -182,7 +311,7 @@ def test_process_item_flow_transitions_to_failed_on_download_error():
         with pytest.raises(Exception, match="download fail"):
             process_item_flow.fn("job-001")
 
-    stages = [c[0][2] for c in mock_trans.call_args_list]
+    stages = [c[0][1] for c in mock_trans.call_args_list]  # transition_job(job_id, to_stage, ...)
     assert "failed" in stages
 
 
@@ -241,7 +370,7 @@ def test_process_item_flow_transitions_through_all_stages():
 
         process_item_flow.fn("job-001")
 
-    stages = [c[0][2] for c in mock_trans.call_args_list]
+    stages = [c[0][1] for c in mock_trans.call_args_list]  # transition_job(job_id, to_stage, ...)
     assert "downloading" in stages
     assert "downloaded" in stages
     assert "encoding" in stages
@@ -264,6 +393,7 @@ def test_requeue_pending_review_promotes_only_resolvable_jobs():
          "ia_metadata": {"identifier": "20010911_0900_x", "title": ""}},
     ]
     db = MagicMock()
+    db.__enter__.return_value = db
     db.execute.return_value.mappings.return_value.all.return_value = rows
 
     with patch("video_grabber.pipeline.flows.get_db", return_value=db), \
@@ -282,6 +412,7 @@ def test_requeue_pending_review_dry_run_makes_no_changes():
     rows = [{"id": "j1", "ia_identifier": "NHK_20010914_010000_x",
              "ia_metadata": {"identifier": "NHK_20010914_010000_x"}}]
     db = MagicMock()
+    db.__enter__.return_value = db
     db.execute.return_value.mappings.return_value.all.return_value = rows
 
     with patch("video_grabber.pipeline.flows.get_db", return_value=db), \
@@ -299,6 +430,7 @@ def test_dispatch_discovered_flow_no_discovered_jobs_is_noop():
     from video_grabber.pipeline.flows import dispatch_discovered_flow
 
     db = MagicMock()
+    db.__enter__.return_value = db
     db.execute.return_value.first.return_value = None
 
     with patch("video_grabber.pipeline.flows.get_db", return_value=db), \
@@ -315,6 +447,7 @@ def test_dispatch_discovered_flow_dispatches_one_per_iteration():
     # Two discovered rows, then empty — flow should dispatch twice then exit.
     rows = [MagicMock(id="job-a"), MagicMock(id="job-b"), None]
     db = MagicMock()
+    db.__enter__.return_value = db
     db.execute.return_value.first.side_effect = rows
 
     with patch("video_grabber.pipeline.flows.get_db", return_value=db), \
@@ -332,6 +465,7 @@ def test_dispatch_discovered_flow_respects_max_runs_cap():
 
     # Endless supply of rows — flow must still stop at max_runs.
     db = MagicMock()
+    db.__enter__.return_value = db
     db.execute.return_value.first.return_value = MagicMock(id="job-x")
 
     with patch("video_grabber.pipeline.flows.get_db", return_value=db), \
@@ -349,6 +483,7 @@ def test_dispatch_claims_atomically_and_bumps_failed_retry():
     # dispatches it; the claim bumps retry_count for failed jobs via a CASE.
     claimed = MagicMock(id="job-f")
     db = MagicMock()
+    db.__enter__.return_value = db
     db.execute.return_value.first.side_effect = [claimed, None]
 
     with patch("video_grabber.pipeline.flows.get_db", return_value=db), \
@@ -371,6 +506,7 @@ def test_dispatch_skips_failed_jobs_over_retry_budget():
     # The SELECT itself filters out failed jobs at/over the retry cap, so an
     # exhausted job is simply never returned — modeled here as an empty queue.
     db = MagicMock()
+    db.__enter__.return_value = db
     db.execute.return_value.first.return_value = None
 
     with patch("video_grabber.pipeline.flows.get_db", return_value=db), \

--- a/packages/tools/video-grabber/tests/test_postgres_integration.py
+++ b/packages/tools/video-grabber/tests/test_postgres_integration.py
@@ -137,7 +137,7 @@ def test_upsert_job_unknown_channel_goes_to_pending_review(connection):
 
 # --- transition_job round-trip (catches stage-cast and audit-row bugs) ---
 
-def test_transition_job_updates_stage_and_writes_audit_row(connection):
+def test_transition_job_updates_stage_and_writes_audit_row(connection, engine, monkeypatch):
     upsert_job(
         connection,
         {"identifier": "int-test-trans", "title": "t", "creator": "CNN"},
@@ -149,7 +149,11 @@ def test_transition_job_updates_stage_and_writes_audit_row(connection):
         {"id": "int-test-trans"},
     ).scalar()
 
-    transition_job(connection, str(job_id), "downloading", from_stage="discovered")
+    # transition_job opens its own short-lived connection (idle_session_timeout
+    # safety); point its get_db at the test engine so it hits the same DB.
+    import video_grabber.pipeline.flows as flows_mod
+    monkeypatch.setattr(flows_mod, "get_db", lambda: engine.connect())
+    transition_job(str(job_id), "downloading", from_stage="discovered")
 
     stage = connection.execute(
         sa.text("SELECT stage FROM video_jobs WHERE id = :id"), {"id": job_id},
@@ -167,7 +171,7 @@ def test_transition_job_updates_stage_and_writes_audit_row(connection):
     assert str(audit.to_stage) == "downloading"
 
 
-def test_transition_job_failed_with_error_message_persists(connection):
+def test_transition_job_failed_with_error_message_persists(connection, engine, monkeypatch):
     upsert_job(
         connection,
         {"identifier": "int-test-fail", "title": "t", "creator": "CNN"},
@@ -179,7 +183,9 @@ def test_transition_job_failed_with_error_message_persists(connection):
         {"id": "int-test-fail"},
     ).scalar()
 
-    transition_job(connection, str(job_id), "failed", error="boom")
+    import video_grabber.pipeline.flows as flows_mod
+    monkeypatch.setattr(flows_mod, "get_db", lambda: engine.connect())
+    transition_job(str(job_id), "failed", error="boom")
 
     err, stage = connection.execute(
         sa.text("SELECT error_message, stage FROM video_jobs WHERE id = :id"),

--- a/packages/tools/video-grabber/tests/test_usenet_flows.py
+++ b/packages/tools/video-grabber/tests/test_usenet_flows.py
@@ -7,44 +7,80 @@ from video_grabber.usenet import flows
 
 
 class FakeDB:
-    def __init__(self):
+    """Context-manager connection double; `dead` mimics the server closing the
+    socket (rt911-db's idle_session_timeout=10min on the video_grabber DB).
+    Optional shared `results` deque feeds execute(...).first() for claims."""
+
+    def __init__(self, registry=None, results=None):
         self.calls = []
         self.commits = 0
+        self.dead = False
+        self.closed = False
+        self._results = results
+        if registry is not None:
+            registry.append(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.closed = True
+        return False
+
+    def _check(self):
+        if self.dead:
+            raise RuntimeError("server closed the connection unexpectedly")
 
     def execute(self, stmt, params=None):
+        self._check()
         self.calls.append((str(stmt), params or {}))
-        return MagicMock()
+        res = MagicMock()
+        if self._results is not None:
+            # Lazy pop: only a caller that actually calls .first() (the claim
+            # query) consumes a row; the reclaim sweep must not eat the queue.
+            res.first = lambda: self._results.popleft() if self._results else None
+        return res
 
     def commit(self):
+        self._check()
         self.commits += 1
 
 
-def test_transition_sets_stage_only():
+def _stages(conns):
+    return [p["stage"] for c in conns for (_, p) in c.calls if "stage" in p]
+
+
+def test_transition_opens_own_connection_and_sets_stage_only():
     db = FakeDB()
-    flows.transition_usenet_job(db, "j1", "processed")
+    with patch.object(flows, "get_db", return_value=db):
+        flows.transition_usenet_job("j1", "processed")
     sql, params = db.calls[0]
     assert "stage = CAST(:stage AS usenet_stage)" in sql
     assert params["stage"] == "processed" and params["job_id"] == "j1"
     assert "error_message = NULL" in sql       # stale error cleared on a clean transition
     assert ":error" not in sql and "message_count" not in sql
     assert db.commits == 1
+    assert db.closed  # short-lived: closed as soon as the transition commits
 
 
 def test_transition_with_error_and_count():
     db = FakeDB()
-    flows.transition_usenet_job(db, "j1", "failed", error="boom", message_count=42)
+    with patch.object(flows, "get_db", return_value=db):
+        flows.transition_usenet_job("j1", "failed", error="boom", message_count=42)
     sql, params = db.calls[0]
     assert "error_message = :error" in sql and "message_count = :mc" in sql
     assert params["error"] == "boom" and params["mc"] == 42
 
 
-def test_get_usenet_job_shapes_namespace():
+def test_get_usenet_job_shapes_namespace_and_closes_connection():
     row = {"id": "j1", "ia_identifier": "usenet-x", "stage": "discovered"}
     fake = MagicMock()
+    fake.__enter__.return_value = fake
     fake.execute.return_value.mappings.return_value.fetchone.return_value = row
     with patch.object(flows, "get_db", return_value=fake):
         job = flows.get_usenet_job("j1")
     assert job.ia_identifier == "usenet-x" and job.stage == "discovered"
+    assert fake.__exit__.called  # connection not leaked (the pre-fix leak source)
 
 
 def test_sync_db_url_rewrites_asyncpg():
@@ -66,6 +102,84 @@ def test_reclaim_orphaned_requeues_stale_inflight_jobs():
     assert "retry_count = retry_count + 1" in sql
     assert params == {"max": 3, "mins": 10}
     assert db.commits == 1
+
+
+class _NoHeartbeat:
+    def __init__(self, *a, **k):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _flow_env(monkeypatch, tmp_path, conns):
+    monkeypatch.setattr(flows, "get_db", lambda: FakeDB(conns))
+    monkeypatch.setattr(flows, "get_usenet_job",
+                        lambda jid: SimpleNamespace(id=jid, ia_identifier="usenet-alt.test"))
+    monkeypatch.setattr(flows, "_JobHeartbeat", _NoHeartbeat)
+    monkeypatch.setattr(flows, "get_run_logger", lambda: MagicMock())
+    monkeypatch.setattr(flows, "_SCRATCH", tmp_path)
+
+
+def _killer(conns, ret=None, raise_exc=None):
+    """A long stage during which idle_session_timeout kills every open conn."""
+    def _f(*a, **k):
+        for c in conns:
+            c.dead = True
+        if raise_exc is not None:
+            raise raise_exc
+        return ret
+    return _f
+
+
+def test_process_usenet_item_marks_processed_after_connections_die(monkeypatch, tmp_path):
+    conns = []
+    _flow_env(monkeypatch, tmp_path, conns)
+    monkeypatch.setattr(flows, "download_mbox", _killer(conns, ret=tmp_path / "a.mbox"))
+    monkeypatch.setattr(flows, "process_archive", _killer(conns, ret={"alt.test": [1, 2]}))
+    monkeypatch.setattr(flows, "write_group", lambda g, r, cfg: (g, len(r)))
+
+    flows.process_usenet_item_flow.fn("j1")
+
+    assert _stages(conns) == ["downloading", "downloaded", "processing", "processed"]
+    done = [p for c in conns for (_, p) in c.calls if p.get("stage") == "processed"]
+    assert done[0]["mc"] == 2
+
+
+def test_process_usenet_item_marks_failed_on_fresh_connection(monkeypatch, tmp_path):
+    import pytest
+
+    conns = []
+    _flow_env(monkeypatch, tmp_path, conns)
+    monkeypatch.setattr(flows, "download_mbox",
+                        _killer(conns, raise_exc=RuntimeError("mbox download died")))
+
+    with pytest.raises(RuntimeError, match="mbox download died"):
+        flows.process_usenet_item_flow.fn("j1")
+
+    assert _stages(conns)[-1] == "failed"
+
+
+def test_dispatch_usenet_claims_each_job_on_a_fresh_connection(monkeypatch):
+    from collections import deque
+
+    rows = deque([SimpleNamespace(id="j1"), None])
+    conns = []
+    monkeypatch.setattr(flows, "get_db", lambda: FakeDB(conns, results=rows))
+    monkeypatch.setattr(flows, "get_run_logger", lambda: MagicMock())
+    monkeypatch.setattr(flows, "Config",
+                        lambda: SimpleNamespace(usenet_orphan_stale_minutes=10))
+    run_dep = MagicMock(side_effect=_killer(conns))  # the run outlives the idle timeout
+    monkeypatch.setattr(flows, "run_deployment", run_dep)
+
+    flows.dispatch_usenet_flow.fn(max_runs=5)
+
+    assert run_dep.call_count == 1
+    claims = [s for c in conns for s, _ in c.calls if "UPDATE usenet_jobs SET" in s and "stage = 'downloading'" in s]
+    assert len(claims) == 2  # both claims survived; second saw an empty queue
 
 
 def test_job_heartbeat_refreshes_last_transition(monkeypatch):

--- a/packages/tools/video-grabber/video_grabber/pipeline/flows.py
+++ b/packages/tools/video-grabber/video_grabber/pipeline/flows.py
@@ -72,32 +72,32 @@ def get_job(job_id: str):
     ``pending_review`` stage. It gates Directus ``approved`` (0 = awaiting
     human sign-off, 1 = auto-approved).
     """
-    db = get_db()
-    row = db.execute(
-        sa.text(
-            """
-            SELECT
-                j.*,
-                c.slug             AS channel_slug,
-                c.display_name     AS channel_display_name,
-                c.timezone         AS channel_timezone,
-                p.title            AS program_title,
-                p.description      AS program_description,
-                p.air_date         AS program_air_date,
-                p.duration_seconds AS program_duration_seconds,
-                EXISTS (
-                    SELECT 1 FROM pipeline_transitions t
-                    WHERE t.job_id = j.id
-                      AND t.to_stage = 'pending_review'
-                ) AS passed_through_review
-            FROM video_jobs j
-            LEFT JOIN channels c ON c.id = j.channel_id
-            LEFT JOIN programs p ON p.id = j.program_id
-            WHERE j.id = :id
-            """
-        ),
-        {"id": job_id},
-    ).mappings().fetchone()
+    with get_db() as db:
+        row = db.execute(
+            sa.text(
+                """
+                SELECT
+                    j.*,
+                    c.slug             AS channel_slug,
+                    c.display_name     AS channel_display_name,
+                    c.timezone         AS channel_timezone,
+                    p.title            AS program_title,
+                    p.description      AS program_description,
+                    p.air_date         AS program_air_date,
+                    p.duration_seconds AS program_duration_seconds,
+                    EXISTS (
+                        SELECT 1 FROM pipeline_transitions t
+                        WHERE t.job_id = j.id
+                          AND t.to_stage = 'pending_review'
+                    ) AS passed_through_review
+                FROM video_jobs j
+                LEFT JOIN channels c ON c.id = j.channel_id
+                LEFT JOIN programs p ON p.id = j.program_id
+                WHERE j.id = :id
+                """
+            ),
+            {"id": job_id},
+        ).mappings().fetchone()
 
     if row is None:
         raise ValueError(f"video_jobs row not found: {job_id}")
@@ -117,45 +117,51 @@ def get_job(job_id: str):
     return SimpleNamespace(channel=channel, program=program, **m)
 
 
-def transition_job(db, job_id: str, to_stage: str, *, from_stage: str = None, error: str = None) -> None:
-    """Atomic stage transition: UPDATE video_jobs + INSERT pipeline_transitions audit row."""
+def transition_job(job_id: str, to_stage: str, *, from_stage: str = None, error: str = None) -> None:
+    """Atomic stage transition: UPDATE video_jobs + INSERT pipeline_transitions audit row.
+
+    Opens its own fresh, short-lived connection: rt911-db sets
+    idle_session_timeout=10min on the video_grabber database, and the stages
+    between transitions (a multi-GB IA download, an encode) routinely outlive
+    it — a connection held across them is dead by the next transition."""
     params = {
         "stage": to_stage,
         "job_id": job_id,
         "worker_id": os.getenv("HOSTNAME", "unknown"),
     }
-    if error:
-        db.execute(
-            sa.text(
-                "UPDATE video_jobs SET stage = CAST(:stage AS pipeline_stage), "
-                "error_message = :error, last_transition_at = now() "
-                "WHERE id = :job_id"
-            ),
-            {**params, "error": error},
-        )
-    else:
-        db.execute(
-            sa.text(
-                "UPDATE video_jobs SET stage = CAST(:stage AS pipeline_stage), "
-                "last_transition_at = now() WHERE id = :job_id"
-            ),
-            params,
-        )
+    with get_db() as db:
+        if error:
+            db.execute(
+                sa.text(
+                    "UPDATE video_jobs SET stage = CAST(:stage AS pipeline_stage), "
+                    "error_message = :error, last_transition_at = now() "
+                    "WHERE id = :job_id"
+                ),
+                {**params, "error": error},
+            )
+        else:
+            db.execute(
+                sa.text(
+                    "UPDATE video_jobs SET stage = CAST(:stage AS pipeline_stage), "
+                    "last_transition_at = now() WHERE id = :job_id"
+                ),
+                params,
+            )
 
-    db.execute(
-        sa.text(
-            "INSERT INTO pipeline_transitions (job_id, from_stage, to_stage, worker_id) "
-            "VALUES (:job_id, CAST(:from_stage AS pipeline_stage), "
-            "CAST(:to_stage AS pipeline_stage), :worker_id)"
-        ),
-        {
-            "job_id": job_id,
-            "from_stage": from_stage,
-            "to_stage": to_stage,
-            "worker_id": os.getenv("HOSTNAME", "unknown"),
-        },
-    )
-    db.commit()
+        db.execute(
+            sa.text(
+                "INSERT INTO pipeline_transitions (job_id, from_stage, to_stage, worker_id) "
+                "VALUES (:job_id, CAST(:from_stage AS pipeline_stage), "
+                "CAST(:to_stage AS pipeline_stage), :worker_id)"
+            ),
+            {
+                "job_id": job_id,
+                "from_stage": from_stage,
+                "to_stage": to_stage,
+                "worker_id": os.getenv("HOSTNAME", "unknown"),
+            },
+        )
+        db.commit()
 
 
 @flow(name="scan-collections")
@@ -164,14 +170,14 @@ def scan_collections_flow(collections: list[str] = ["sept_11_tv_archive", "911"]
     cfg = Config()
     sleep_sec = 1.0 / cfg.ia_rate_per_sec if cfg.ia_rate_per_sec > 0 else 0.0
     session = IASearch()
-    db = get_db()
-    for coll in collections:
-        crawl_collection(
-            session, coll, db,
-            visited=set(),
-            sleep_sec=sleep_sec,
-            logger=logger,
-        )
+    with get_db() as db:
+        for coll in collections:
+            crawl_collection(
+                session, coll, db,
+                visited=set(),
+                sleep_sec=sleep_sec,
+                logger=logger,
+            )
     logger.info("Scan complete")
 
 
@@ -193,44 +199,46 @@ def process_item_flow(job_id: str):
     Per-retry lists are a task-only feature.
     """
     logger = get_run_logger()
-    db = get_db()
     job = get_job(job_id)
     cfg = Config()
     scratch = _SCRATCH / job.ia_identifier
 
     try:
-        transition_job(db, job_id, "downloading", from_stage=str(job.stage))
+        transition_job(job_id, "downloading", from_stage=str(job.stage))
         local_path = download_item(job, scratch, cfg, logger=logger)
 
-        transition_job(db, job_id, "downloaded", from_stage="downloading")
+        transition_job(job_id, "downloaded", from_stage="downloading")
 
         # Bare video_jobs rows carry no channel/program. Derive and link them
         # from the IA metadata + downloaded media before any stage that needs
         # job.channel.* or job.program.* (upload prefix, Directus media_item).
-        job = resolve_job(job, db, media_path=local_path)
+        # Fresh connection: the download above can outlive idle_session_timeout.
+        with get_db() as db:
+            job = resolve_job(job, db, media_path=local_path)
 
         encode_dir = scratch / "encoded"
 
-        transition_job(db, job_id, "encoding", from_stage="downloaded")
+        transition_job(job_id, "encoding", from_stage="downloaded")
         encode_to_hls(local_path, encode_dir, logger=logger)
 
-        transition_job(db, job_id, "encoded", from_stage="encoding")
+        transition_job(job_id, "encoded", from_stage="encoding")
 
-        transition_job(db, job_id, "uploading", from_stage="encoded")
+        transition_job(job_id, "uploading", from_stage="encoded")
         wasabi_key = upload_hls_package(job, encode_dir, cfg)
 
-        db.execute(
-            sa.text("UPDATE video_jobs SET wasabi_key = :key WHERE id = :id"),
-            {"key": wasabi_key, "id": job_id},
-        )
-        db.commit()
+        with get_db() as db:
+            db.execute(
+                sa.text("UPDATE video_jobs SET wasabi_key = :key WHERE id = :id"),
+                {"key": wasabi_key, "id": job_id},
+            )
+            db.commit()
 
         write_media_item(job, wasabi_key, cfg)
-        transition_job(db, job_id, "complete", from_stage="uploading")
+        transition_job(job_id, "complete", from_stage="uploading")
         logger.info(f"Completed: {job.ia_identifier}")
 
     except Exception as exc:
-        transition_job(db, job_id, "failed", from_stage=None, error=str(exc))
+        transition_job(job_id, "failed", from_stage=None, error=str(exc))
         raise
     finally:
         # Reclaim the per-job scratch (downloaded source + encoded HLS). Without
@@ -262,19 +270,21 @@ def build_channel_flow(channel_id: str, window_start: str, window_end: str):
     ISO-8601 UTC strings, e.g. "2001-09-09T00:00:00+00:00".
     """
     logger = get_run_logger()
-    db = get_db()
     cfg = Config()
     ws = datetime.fromisoformat(window_start)
     we = datetime.fromisoformat(window_end)
-    channel = _load_channel(db, channel_id)
-
-    n_slots = build_schedule(channel_id, ws, we, db)
+    with get_db() as db:
+        channel = _load_channel(db, channel_id)
+        n_slots = build_schedule(channel_id, ws, we, db)
     logger.info("build-channel %s: %d slots scheduled", channel.slug, n_slots)
 
     # Shared sequenced blue gap pool (channel-independent); uploaded once.
+    # Generating + uploading it (first build only) can outlive
+    # idle_session_timeout, so assemble on a fresh connection afterwards.
     _ensure_gap_pool(cfg)
 
-    playlists, epg_channel = assemble_range(channel, ws, we, db, cfg=cfg)
+    with get_db() as db:
+        playlists, epg_channel = assemble_range(channel, ws, we, db, cfg=cfg)
 
     # HLS playlists under playlists/<slug>/ (the EPG JSON guide lives in epg/).
     base = f"playlists/{channel.slug}"
@@ -348,7 +358,6 @@ def dispatch_discovered_flow(max_runs: int = 100, max_retries: int = 3) -> None:
     a bug can stop, fix, and rerun.
     """
     logger = get_run_logger()
-    db = get_db()
     processed = 0
     while processed < max_runs:
         # Atomically claim the next job. A single UPDATE whose target is chosen
@@ -361,28 +370,33 @@ def dispatch_discovered_flow(max_runs: int = 100, max_retries: int = 3) -> None:
         # one retry (retry_count++ via the CASE on the OLD stage), which bounds
         # the retry loop. SKIP LOCKED means each concurrent dispatcher gets a
         # distinct row instead of blocking on the same one.
-        row = db.execute(
-            sa.text(
-                """
-                UPDATE video_jobs SET
-                    stage = 'downloading',
-                    retry_count = retry_count
-                        + CASE WHEN stage = 'failed' THEN 1 ELSE 0 END,
-                    last_transition_at = now()
-                WHERE id = (
-                    SELECT id FROM video_jobs
-                    WHERE stage = 'discovered'
-                       OR (stage = 'failed' AND retry_count < :max_retries)
-                    ORDER BY (stage = 'failed'), created_at
-                    FOR UPDATE SKIP LOCKED
-                    LIMIT 1
-                )
-                RETURNING id
-                """
-            ),
-            {"max_retries": max_retries},
-        ).first()
-        db.commit()
+        #
+        # Fresh connection per claim: the blocking run_deployment below outlives
+        # rt911-db's idle_session_timeout (10 min), so a connection held across
+        # it is dead by the next iteration.
+        with get_db() as db:
+            row = db.execute(
+                sa.text(
+                    """
+                    UPDATE video_jobs SET
+                        stage = 'downloading',
+                        retry_count = retry_count
+                            + CASE WHEN stage = 'failed' THEN 1 ELSE 0 END,
+                        last_transition_at = now()
+                    WHERE id = (
+                        SELECT id FROM video_jobs
+                        WHERE stage = 'discovered'
+                           OR (stage = 'failed' AND retry_count < :max_retries)
+                        ORDER BY (stage = 'failed'), created_at
+                        FOR UPDATE SKIP LOCKED
+                        LIMIT 1
+                    )
+                    RETURNING id
+                    """
+                ),
+                {"max_retries": max_retries},
+            ).first()
+            db.commit()
         if row is None:
             logger.info("dispatch-discovered: queue empty after %d runs", processed)
             return
@@ -412,51 +426,51 @@ def requeue_pending_review_flow(max_jobs: int = 20000, dry_run: bool = False) ->
     changing anything. Returns ``{"promoted": n, "evaluated": m}``.
     """
     logger = get_run_logger()
-    db = get_db()
-    rows = db.execute(
-        sa.text(
-            "SELECT id, ia_identifier, ia_metadata FROM video_jobs "
-            "WHERE stage = 'pending_review' ORDER BY created_at LIMIT :n"
-        ),
-        {"n": max_jobs},
-    ).mappings().all()
-
-    to_promote: list[str] = []
-    for r in rows:
-        meta = r["ia_metadata"] or {}
-        if isinstance(meta, str):
-            try:
-                meta = json.loads(meta)
-            except json.JSONDecodeError:
-                meta = {}
-        # The stored blob carries "identifier", but fall back to the column so
-        # the identifier-prefix rule still fires on older/sparse metadata.
-        meta.setdefault("identifier", r["ia_identifier"])
-        if normalize_slug(meta):
-            to_promote.append(str(r["id"]))
-
-    logger.info(
-        "requeue-pending-review: %d of %d evaluated jobs now resolve to a channel%s",
-        len(to_promote), len(rows), " (dry run — no changes made)" if dry_run else "",
-    )
-    if to_promote and not dry_run:
-        worker = os.getenv("HOSTNAME", "unknown")
-        db.execute(
+    with get_db() as db:
+        rows = db.execute(
             sa.text(
-                "UPDATE video_jobs SET stage = 'discovered', last_transition_at = now() "
-                "WHERE id = ANY(CAST(:ids AS uuid[]))"
+                "SELECT id, ia_identifier, ia_metadata FROM video_jobs "
+                "WHERE stage = 'pending_review' ORDER BY created_at LIMIT :n"
             ),
-            {"ids": to_promote},
+            {"n": max_jobs},
+        ).mappings().all()
+
+        to_promote: list[str] = []
+        for r in rows:
+            meta = r["ia_metadata"] or {}
+            if isinstance(meta, str):
+                try:
+                    meta = json.loads(meta)
+                except json.JSONDecodeError:
+                    meta = {}
+            # The stored blob carries "identifier", but fall back to the column so
+            # the identifier-prefix rule still fires on older/sparse metadata.
+            meta.setdefault("identifier", r["ia_identifier"])
+            if normalize_slug(meta):
+                to_promote.append(str(r["id"]))
+
+        logger.info(
+            "requeue-pending-review: %d of %d evaluated jobs now resolve to a channel%s",
+            len(to_promote), len(rows), " (dry run — no changes made)" if dry_run else "",
         )
-        # Audit trail, mirroring transition_job but in one bulk insert.
-        db.execute(
-            sa.text(
-                "INSERT INTO pipeline_transitions (job_id, from_stage, to_stage, worker_id) "
-                "SELECT unnest(CAST(:ids AS uuid[])), "
-                "CAST('pending_review' AS pipeline_stage), "
-                "CAST('discovered' AS pipeline_stage), :worker"
-            ),
-            {"ids": to_promote, "worker": worker},
-        )
-        db.commit()
+        if to_promote and not dry_run:
+            worker = os.getenv("HOSTNAME", "unknown")
+            db.execute(
+                sa.text(
+                    "UPDATE video_jobs SET stage = 'discovered', last_transition_at = now() "
+                    "WHERE id = ANY(CAST(:ids AS uuid[]))"
+                ),
+                {"ids": to_promote},
+            )
+            # Audit trail, mirroring transition_job but in one bulk insert.
+            db.execute(
+                sa.text(
+                    "INSERT INTO pipeline_transitions (job_id, from_stage, to_stage, worker_id) "
+                    "SELECT unnest(CAST(:ids AS uuid[])), "
+                    "CAST('pending_review' AS pipeline_stage), "
+                    "CAST('discovered' AS pipeline_stage), :worker"
+                ),
+                {"ids": to_promote, "worker": worker},
+            )
+            db.commit()
     return {"promoted": len(to_promote), "evaluated": len(rows)}

--- a/packages/tools/video-grabber/video_grabber/usenet/flows.py
+++ b/packages/tools/video-grabber/video_grabber/usenet/flows.py
@@ -48,17 +48,22 @@ def get_db():
 
 def get_usenet_job(job_id: str):
     """Load a usenet_jobs row as a SimpleNamespace of its columns."""
-    db = get_db()
-    row = db.execute(
-        sa.text("SELECT * FROM usenet_jobs WHERE id = :id"), {"id": job_id}
-    ).mappings().fetchone()
+    with get_db() as db:
+        row = db.execute(
+            sa.text("SELECT * FROM usenet_jobs WHERE id = :id"), {"id": job_id}
+        ).mappings().fetchone()
     if row is None:
         raise ValueError(f"usenet_jobs row not found: {job_id}")
     return SimpleNamespace(**dict(row))
 
 
-def transition_usenet_job(db, job_id: str, to_stage: str, *, error: str = None, message_count: int = None) -> None:
-    """Set a usenet_jobs row's stage (+ optional error / message_count). Commits."""
+def transition_usenet_job(job_id: str, to_stage: str, *, error: str = None, message_count: int = None) -> None:
+    """Set a usenet_jobs row's stage (+ optional error / message_count). Commits.
+
+    Opens its own fresh, short-lived connection: rt911-db sets
+    idle_session_timeout=10min on the video_grabber database, and the stages
+    between transitions (mbox download, threading) can outlive it — a
+    connection held across them is dead by the next transition."""
     sets = ["stage = CAST(:stage AS usenet_stage)", "last_transition_at = now()"]
     params = {"stage": to_stage, "job_id": job_id}
     if error is not None:
@@ -69,8 +74,9 @@ def transition_usenet_job(db, job_id: str, to_stage: str, *, error: str = None, 
     if message_count is not None:
         sets.append("message_count = :mc")
         params["mc"] = message_count
-    db.execute(sa.text(f"UPDATE usenet_jobs SET {', '.join(sets)} WHERE id = :job_id"), params)
-    db.commit()
+    with get_db() as db:
+        db.execute(sa.text(f"UPDATE usenet_jobs SET {', '.join(sets)} WHERE id = :job_id"), params)
+        db.commit()
 
 
 # Stages a job passes through while a process-usenet-item run is working it. If
@@ -171,8 +177,8 @@ def scan_usenet_flow(collections: list[str] | None = None) -> None:
     collections = collections or cfg.usenet_collection_list()
     sleep_sec = 1.0 / cfg.ia_rate_per_sec if cfg.ia_rate_per_sec > 0 else 0.0
     session = IASearch()
-    db = get_db()
-    total = scan_collections(session, collections, db, sleep_sec=sleep_sec, logger=logger)
+    with get_db() as db:
+        total = scan_collections(session, collections, db, sleep_sec=sleep_sec, logger=logger)
     logger.info("scan-usenet: complete, %d items enumerated", total)
 
 
@@ -186,18 +192,17 @@ def process_usenet_item_flow(job_id: str) -> None:
     """
     logger = get_run_logger()
     cfg = Config()
-    db = get_db()
     job = get_usenet_job(job_id)
     scratch = _SCRATCH / "usenet" / job.ia_identifier
     try:
         # Heartbeat last_transition_at while in-flight so a killed pod's job is
         # reclaimable but a slow-but-live one is never falsely reclaimed.
         with _JobHeartbeat(job_id, logger=logger):
-            transition_usenet_job(db, job_id, "downloading")
+            transition_usenet_job(job_id, "downloading")
             mbox_path = download_mbox(job, scratch / "dl", logger=logger)
-            transition_usenet_job(db, job_id, "downloaded")
+            transition_usenet_job(job_id, "downloaded")
 
-            transition_usenet_job(db, job_id, "processing")
+            transition_usenet_job(job_id, "processing")
             fallback_group = job.ia_identifier.removeprefix("usenet-")
             groups = process_archive(mbox_path, cfg.usenet_before, scratch / "work", fallback_group, logger=logger)
 
@@ -205,11 +210,11 @@ def process_usenet_item_flow(job_id: str) -> None:
             for newsgroup, records in groups.items():
                 _, n = write_group(newsgroup, records, cfg)
                 total += n
-            transition_usenet_job(db, job_id, "processed", message_count=total)
+            transition_usenet_job(job_id, "processed", message_count=total)
             logger.info("process-usenet-item: %s ingested %d messages in %d groups",
                         job.ia_identifier, total, len(groups))
     except Exception as exc:  # noqa: BLE001 — record failure, then re-raise for retry
-        transition_usenet_job(db, job_id, "failed", error=str(exc)[:2000])
+        transition_usenet_job(job_id, "failed", error=str(exc)[:2000])
         raise
     finally:
         shutil.rmtree(scratch, ignore_errors=True)
@@ -226,40 +231,44 @@ def dispatch_usenet_flow(max_runs: int = 100, max_retries: int = 3) -> None:
     job spends one retry, bounding the loop at max_retries.
     """
     logger = get_run_logger()
-    db = get_db()
     # Supervisor sweep: rescue jobs orphaned in-flight by a killed process run
     # before claiming fresh work, so a crash self-heals within one dispatch cycle
     # instead of stranding the job (and leaking its DB connection) indefinitely.
-    reclaim_orphaned_usenet_jobs(
-        db,
-        stale_minutes=Config().usenet_orphan_stale_minutes,
-        max_retries=max_retries,
-        logger=logger,
-    )
+    with get_db() as db:
+        reclaim_orphaned_usenet_jobs(
+            db,
+            stale_minutes=Config().usenet_orphan_stale_minutes,
+            max_retries=max_retries,
+            logger=logger,
+        )
     processed = 0
     while processed < max_runs:
-        row = db.execute(
-            sa.text(
-                """
-                UPDATE usenet_jobs SET
-                    stage = 'downloading',
-                    retry_count = retry_count
-                        + CASE WHEN stage = 'failed' THEN 1 ELSE 0 END,
-                    last_transition_at = now()
-                WHERE id = (
-                    SELECT id FROM usenet_jobs
-                    WHERE stage = 'discovered'
-                       OR (stage = 'failed' AND retry_count < :max_retries)
-                    ORDER BY (stage = 'failed'), created_at
-                    FOR UPDATE SKIP LOCKED
-                    LIMIT 1
-                )
-                RETURNING id
-                """
-            ),
-            {"max_retries": max_retries},
-        ).first()
-        db.commit()
+        # Fresh connection per claim: the blocking run_deployment below outlives
+        # rt911-db's idle_session_timeout (10 min), so a connection held across
+        # it is dead by the next iteration.
+        with get_db() as db:
+            row = db.execute(
+                sa.text(
+                    """
+                    UPDATE usenet_jobs SET
+                        stage = 'downloading',
+                        retry_count = retry_count
+                            + CASE WHEN stage = 'failed' THEN 1 ELSE 0 END,
+                        last_transition_at = now()
+                    WHERE id = (
+                        SELECT id FROM usenet_jobs
+                        WHERE stage = 'discovered'
+                           OR (stage = 'failed' AND retry_count < :max_retries)
+                        ORDER BY (stage = 'failed'), created_at
+                        FOR UPDATE SKIP LOCKED
+                        LIMIT 1
+                    )
+                    RETURNING id
+                    """
+                ),
+                {"max_retries": max_retries},
+            ).first()
+            db.commit()
         if row is None:
             logger.info("dispatch-usenet: queue empty after %d runs", processed)
             return


### PR DESCRIPTION
## Problem

Follow-up to #189, which fixed `transcribe-item`. The video pipeline and usenet flows have the same latent bug class: `rt911-db` sets `idle_session_timeout=10min` on the `video_grabber` database, but these flows hold a single DB connection across stages that routinely outlive it:

- `process-item`: a multi-GB IA download or an encode between transitions
- `process-usenet-item`: mbox download / threading build between transitions
- `dispatch-discovered` / `dispatch-usenet`: a **blocking `run_deployment`** for the whole job between claim queries — guaranteed to exceed 10 minutes for any real job, killing the dispatcher loop after its first dispatch
- `get_job` / `get_usenet_job`: opened a connection and **never closed it** — one leaked connection per job processed, the likely source of the 2026-07-08 connection-pool exhaustion (99/100) that motivated the timeout in the first place

## Fix

Every DB touch opens its own fresh, short-lived connection:

- `transition_job(job_id, ...)` / `transition_usenet_job(job_id, ...)` open their own connection (held-db param dropped; live-Postgres integration tests updated to exercise the real path via the test engine)
- `process-item` runs `resolve_job` and the `wasabi_key` UPDATE on fresh connections after the long stages
- both dispatchers claim each job on a per-iteration connection
- `get_job` / `get_usenet_job` close their connection via context manager
- `scan-collections` / `scan-usenet` / `build-channel` / `requeue-pending-review` wrap connections in context managers (no more leaks on flow exit)

## Tests

New regression tests simulate the production failure: every connection opened before a long stage (download, encode, threading, `run_deployment`) is killed mid-stage, and the flow must still record its terminal stage — `complete`/`processed` on success, `failed` on error — on fresh connections. Dispatcher tests verify each claim survives the previous iteration's blocking run.

- `pytest tests/` — 309 passed, 8 skipped (up from 303)
- `ruff check video_grabber/ tests/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)