### PR TITLE
feat(weather-recon): Phase 2b — radar mirror, 1,152 frames on Wasabi (#184)

### DIFF
--- a/packages/tools/weather-recon/Dockerfile
+++ b/packages/tools/weather-recon/Dockerfile
@@ -6,7 +6,7 @@ ENV PYTHONUNBUFFERED=1 PIP_NO_CACHE_DIR=1
 WORKDIR /app
 
 # Deps first (stable layer), pinned to the in-cluster Prefect server version.
-RUN pip install "prefect==3.7.4" "prefect-kubernetes>=0.5" "httpx>=0.27"
+RUN pip install "prefect==3.7.4" "prefect-kubernetes>=0.5" "httpx>=0.27" "boto3>=1.34"
 
 COPY pyproject.toml ./
 COPY weather_recon ./weather_recon

--- a/packages/tools/weather-recon/README.md
+++ b/packages/tools/weather-recon/README.md
@@ -1,17 +1,26 @@
 # weather-recon
 
-Loads September 2001 weather data into Directus for the rt911 Weather app
-(issue #184; design spec: `plans/weather-app-design.md`). Phase 1 ships the
-curated station reference table and the three collections; observation /
-radar / forecast / almanac flows follow in Phase 2.
+Loads September 2001 weather data into Directus/Wasabi for the rt911 Weather app
+(issue #184; design spec: `plans/weather-app-design.md`). Shipped so far: the
+curated station reference table + collections (Phase 1), the observations
+pipeline (Phase 2a, ~19k METARs), and the radar frame mirror (Phase 2b).
+Forecast and almanac flows follow in Phase 2c/2d.
 
 ## Layout
 
 - `scripts/build_stations.py` — dev-run: NOAA `isd-history.csv` + curated ICAO
-  list → `data/stations.csv` (committed). Re-run only to change the curation.
+  list (+ `ISD_OVERRIDES` for stations whose primary ids lack 2001-09 data)
+  → `data/stations.csv` (committed). Re-run only to change the curation.
 - `weather_recon/flow.py` — `load-weather-stations`: validates the CSV, ensures
   the `weather_stations` / `weather_observations` / `weather_forecasts`
   collections, reloads `weather_stations` (delete-all + insert; ICAO-keyed).
+- `weather_recon/obs.py` + `fetch_ncei.py` + `flow_observations.py` —
+  `load-weather-observations`: NCEI global-hourly METAR/SPECI subset per
+  station (disk-cached) → parsed/deduped rows → idempotent reload of
+  `weather_observations`.
+- `weather_recon/radar.py` + `wasabi.py` + `flow_radar.py` —
+  `load-weather-radar`: IEM archived NEXRAD CONUS composites (5-min PNGs)
+  → Wasabi `weather/radar/` + `index.json` (bounds, frame list, gaps).
 - `weather_recon/directus.py` — REST client + collection specs (ported from
   flight-recon; same 1 MB payload batching and cast-json rules).
 
@@ -20,6 +29,8 @@ radar / forecast / almanac flows follow in Phase 2.
     pip install -e ".[dev]"
     export DIRECTUS_URL=...            # e.g. port-forwarded rt911-api
     export DIRECTUS_API_TOKEN=...      # from the rt911 namespace secret
+    export WASABI_ACCESS_KEY_ID=...
+    export WASABI_SECRET_ACCESS_KEY=...
     python -m weather_recon.flow data/stations.csv
 
 ## Cluster deployment (mirrors flight-recon; see its k8s/ for templates)

--- a/packages/tools/weather-recon/pyproject.toml
+++ b/packages/tools/weather-recon/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Load Sept 2001 weather stations/observations/forecasts into Directus (Prefect flows)"
 requires-python = ">=3.12"
 dependencies = [
+    "boto3>=1.34",
     "prefect>=3.7,<4",
     "prefect-kubernetes>=0.5",
     "httpx>=0.27",

--- a/packages/tools/weather-recon/tests/test_radar.py
+++ b/packages/tools/weather-recon/tests/test_radar.py
@@ -1,0 +1,73 @@
+import struct
+
+from weather_recon.radar import (build_index, corners, frame_times, iem_frame_url,
+                                 iem_wld_url, parse_wld, png_dimensions,
+                                 wasabi_frame_key)
+
+# Real values from n0r_200109111740 (captured 2026-07-12)
+WLD = "0.01\n0.0\n0.0\n-0.01\n-126.0\n50.0\n"
+
+
+def _png_bytes(width, height):
+    return (b"\x89PNG\r\n\x1a\n" + b"\x00\x00\x00\rIHDR"
+            + struct.pack(">II", width, height) + b"\x08\x03" + b"\x00" * 20)
+
+
+def test_frame_times_five_minute_steps_inclusive():
+    times = frame_times("2001-09-09", "2001-09-12")
+    assert len(times) == 4 * 288
+    assert times[0] == "200109090000"
+    assert times[1] == "200109090005"
+    assert times[-1] == "200109122355"
+
+
+def test_frame_times_single_day():
+    times = frame_times("2001-09-11", "2001-09-11")
+    assert len(times) == 288
+    assert times[212] == "200109111740"
+
+
+def test_iem_urls_embed_date_path_and_stamp():
+    assert iem_frame_url("200109111740") == (
+        "https://mesonet.agron.iastate.edu/archive/data/2001/09/11/GIS/uscomp/"
+        "n0r_200109111740.png")
+    assert iem_wld_url("200109111740").endswith("uscomp/n0r_200109111740.wld")
+
+
+def test_wasabi_frame_key():
+    assert wasabi_frame_key("200109111740") == "weather/radar/n0r_200109111740.png"
+
+
+def test_png_dimensions_reads_ihdr():
+    assert png_dimensions(_png_bytes(6000, 2600)) == (6000, 2600)
+
+
+def test_png_dimensions_rejects_non_png():
+    try:
+        png_dimensions(b"<html>error page</html>")
+        raise AssertionError("expected ValueError")
+    except ValueError:
+        pass
+
+
+def test_parse_wld():
+    assert parse_wld(WLD) == {"dx": 0.01, "dy": -0.01, "ulx": -126.0, "uly": 50.0}
+
+
+def test_corners_maplibre_order():
+    got = corners(parse_wld(WLD), 6000, 2600)
+    assert got == [[-126.0, 50.0], [-66.0, 50.0], [-66.0, 24.0], [-126.0, 24.0]]
+
+
+def test_build_index_shape():
+    idx = build_index(["200109090000", "200109090010"], ["200109090005"],
+                      [[-126.0, 50.0], [-66.0, 50.0], [-66.0, 24.0], [-126.0, 24.0]],
+                      "2001-09-09", "2001-09-12")
+    assert idx == {
+        "product": "n0r", "interval_seconds": 300,
+        "start": "2001-09-09", "end": "2001-09-12",
+        "bounds": [[-126.0, 50.0], [-66.0, 50.0], [-66.0, 24.0], [-126.0, 24.0]],
+        "key_prefix": "weather/radar/", "key_pattern": "n0r_{stamp}.png",
+        "frames": ["200109090000", "200109090010"],
+        "missing": ["200109090005"],
+    }

--- a/packages/tools/weather-recon/tests/test_radar.py
+++ b/packages/tools/weather-recon/tests/test_radar.py
@@ -65,6 +65,7 @@ def test_build_index_shape():
                       "2001-09-09", "2001-09-12")
     assert idx == {
         "product": "n0r", "interval_seconds": 300,
+        "timezone": "UTC",
         "start": "2001-09-09", "end": "2001-09-12",
         "bounds": [[-126.0, 50.0], [-66.0, 50.0], [-66.0, 24.0], [-126.0, 24.0]],
         "key_prefix": "weather/radar/", "key_pattern": "n0r_{stamp}.png",

--- a/packages/tools/weather-recon/tests/test_wasabi.py
+++ b/packages/tools/weather-recon/tests/test_wasabi.py
@@ -1,0 +1,52 @@
+import pytest
+
+from weather_recon import wasabi
+
+
+def test_make_client_fails_fast_without_creds(monkeypatch):
+    monkeypatch.delenv("WASABI_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("WASABI_SECRET_ACCESS_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="WASABI_ACCESS_KEY_ID"):
+        wasabi.make_client()
+
+
+def test_make_client_config(monkeypatch):
+    monkeypatch.setenv("WASABI_ACCESS_KEY_ID", "k")
+    monkeypatch.setenv("WASABI_SECRET_ACCESS_KEY", "s")
+    client = wasabi.make_client()
+    # Wasabi compat knobs ported from video_grabber.storage.wasabi (verified
+    # against a live bucket there): path addressing + when_required checksums.
+    cfg = client._client_config
+    assert cfg.s3["addressing_style"] == "path"
+    assert cfg.request_checksum_calculation == "when_required"
+    assert client.meta.endpoint_url == "https://s3.us-central-1.wasabisys.com"
+
+
+def test_upload_bytes_passes_metadata(monkeypatch):
+    calls = []
+
+    class FakeS3:
+        def put_object(self, **kw):
+            calls.append(kw)
+
+    wasabi.upload_bytes(FakeS3(), "weather/radar/x.png", b"png", "image/png",
+                        "max-age=31536000")
+    assert calls == [{"Bucket": wasabi.BUCKET, "Key": "weather/radar/x.png",
+                      "Body": b"png", "ContentType": "image/png",
+                      "CacheControl": "max-age=31536000"}]
+
+
+def test_existing_keys_paginates():
+    class FakeS3:
+        def __init__(self):
+            self.pages = [
+                {"Contents": [{"Key": "weather/radar/a.png"}],
+                 "IsTruncated": True, "NextContinuationToken": "t"},
+                {"Contents": [{"Key": "weather/radar/b.png"}], "IsTruncated": False},
+            ]
+
+        def list_objects_v2(self, **kw):
+            return self.pages.pop(0)
+
+    assert wasabi.existing_keys(FakeS3(), "weather/radar/") == {
+        "weather/radar/a.png", "weather/radar/b.png"}

--- a/packages/tools/weather-recon/weather_recon/flow_radar.py
+++ b/packages/tools/weather-recon/weather_recon/flow_radar.py
@@ -1,0 +1,124 @@
+"""
+Prefect flow: mirror IEM archived NEXRAD CONUS composites to Wasabi.
+
+Per frame: download PNG (+ .wld once per run for geometry), verify the
+geometry matches every other frame, upload weather/radar/n0r_<stamp>.png.
+404s are recorded as missing (real gaps exist in the 2001 archive).
+Finishes by writing weather/radar/index.json (bounds + frame list + gaps).
+
+skip_existing=True (default) makes re-runs resumable: already-uploaded keys
+are skipped via one list_objects sweep, so a crashed run just re-runs.
+
+Secrets: WASABI_ACCESS_KEY_ID / WASABI_SECRET_ACCESS_KEY env-only.
+"""
+
+import json
+from pathlib import Path
+
+import httpx
+from prefect import flow, get_run_logger, task
+
+from weather_recon.flow import NETWORK_RETRIES
+from weather_recon.radar import (build_index, corners, frame_times, iem_frame_url,
+                                 iem_wld_url, parse_wld, png_dimensions,
+                                 wasabi_frame_key)
+from weather_recon.wasabi import existing_keys, make_client, upload_bytes
+
+FETCH_TIMEOUT = 60.0
+FRAME_CACHE_CONTROL = "max-age=31536000"   # immutable history
+INDEX_KEY = "weather/radar/index.json"
+
+
+def _fetch_frame(client, stamp, cache_dir):
+    """PNG bytes for stamp, disk-cached; None on 404 (archive gap)."""
+    cache_file = cache_dir / f"n0r_{stamp}.png" if cache_dir else None
+    if cache_file is not None and cache_file.is_file():
+        return cache_file.read_bytes()
+    r = client.get(iem_frame_url(stamp))
+    if r.status_code == 404:
+        return None
+    r.raise_for_status()
+    if cache_file is not None:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_file.write_bytes(r.content)
+    return r.content
+
+
+@task(**NETWORK_RETRIES)
+def mirror_frames(start, end, cache_dir, skip_existing):
+    log = get_run_logger()
+    stamps = frame_times(start, end)
+    cache = Path(cache_dir) if cache_dir else None
+    s3 = make_client()
+    have = existing_keys(s3, "weather/radar/n0r_") if skip_existing else set()
+    if have:
+        log.info("skip_existing: %d frames already on Wasabi", len(have))
+
+    uploaded, skipped, missing, present = 0, 0, [], []
+    bounds = None
+    with httpx.Client(timeout=FETCH_TIMEOUT, follow_redirects=True) as client:
+        wld = parse_wld(client.get(iem_wld_url(stamps[0])).raise_for_status().text)
+        for i, stamp in enumerate(stamps, 1):
+            key = wasabi_frame_key(stamp)
+            if key in have:
+                skipped += 1
+                present.append(stamp)
+                continue
+            data = _fetch_frame(client, stamp, cache)
+            if data is None:
+                missing.append(stamp)
+                continue
+            dims = png_dimensions(data)
+            frame_bounds = corners(wld, *dims)
+            if bounds is None:
+                bounds = frame_bounds
+                log.info("mosaic geometry: %dx%d px, bounds %s", *dims, bounds)
+            elif frame_bounds != bounds:
+                raise RuntimeError(f"geometry mismatch at {stamp}: "
+                                   f"{frame_bounds} != {bounds}")
+            upload_bytes(s3, key, data, "image/png", FRAME_CACHE_CONTROL)
+            uploaded += 1
+            present.append(stamp)
+            if i % 100 == 0:
+                log.info("frames %d/%d (uploaded %d, skipped %d, missing %d)",
+                         i, len(stamps), uploaded, skipped, len(missing))
+    if bounds is None:
+        # every frame either existed already or is missing; recompute bounds
+        # from the wld + the sample dims of the first cached/present frame
+        bounds = corners(wld, 6000, 2600)
+        log.warning("no new frames uploaded; using wld-derived default bounds %s",
+                    bounds)
+    return present, missing, bounds, uploaded, skipped
+
+
+@task(**NETWORK_RETRIES)
+def write_index(present, missing, bounds, start, end):
+    log = get_run_logger()
+    s3 = make_client()
+    index = build_index(sorted(present), sorted(missing), bounds, start, end)
+    upload_bytes(s3, INDEX_KEY, json.dumps(index).encode("utf-8"),
+                 "application/json", "max-age=300")
+    log.info("%s written: %d frames, %d missing", INDEX_KEY,
+             len(index["frames"]), len(index["missing"]))
+
+
+@flow(name="load-weather-radar", log_prints=True)
+def load_weather_radar(
+    start: str = "2001-09-09",
+    end: str = "2001-09-12",
+    cache_dir: str | None = "/tmp/iem-radar-cache",
+    skip_existing: bool = True,
+):
+    log = get_run_logger()
+    present, missing, bounds, uploaded, skipped = mirror_frames(
+        start, end, cache_dir, skip_existing)
+    write_index(present, missing, bounds, start, end)
+    log.info("done: %d uploaded, %d skipped, %d missing of %d",
+             uploaded, skipped, len(missing), len(present) + len(missing))
+    return {"uploaded": uploaded, "skipped_existing": skipped,
+            "missing": len(missing), "frames_total": len(present) + len(missing),
+            "bounds": bounds}
+
+
+if __name__ == "__main__":
+    load_weather_radar()

--- a/packages/tools/weather-recon/weather_recon/radar.py
+++ b/packages/tools/weather-recon/weather_recon/radar.py
@@ -1,0 +1,72 @@
+"""
+Pure helpers for mirroring IEM's archived NEXRAD CONUS composites (n0r).
+
+The 2001 archive serves 5-minute mosaic PNGs + ESRI world files in a plain
+EPSG:4326 grid (verified live: 6000x2600 px, 0.01 deg/px from -126,50).
+Gaps exist in the 2001 archive; callers treat a 404 frame as "missing", never
+fatal. Geometry consistency across frames is a hard requirement — the index
+carries ONE bounds for every frame.
+"""
+
+import struct
+from datetime import date, datetime, timedelta
+
+IEM_BASE = "https://mesonet.agron.iastate.edu/archive/data"
+FRAME_INTERVAL = timedelta(minutes=5)
+KEY_PREFIX = "weather/radar/"
+
+
+def frame_times(start_date, end_date):
+    """5-minute 'YYYYMMDDHHMM' stamps from start 00:00 through end 23:55 UTC."""
+    start = datetime.combine(date.fromisoformat(start_date), datetime.min.time())
+    stop = datetime.combine(date.fromisoformat(end_date),
+                            datetime.min.time()) + timedelta(days=1)
+    out, t = [], start
+    while t < stop:
+        out.append(t.strftime("%Y%m%d%H%M"))
+        t += FRAME_INTERVAL
+    return out
+
+
+def iem_frame_url(stamp):
+    return f"{IEM_BASE}/{stamp[:4]}/{stamp[4:6]}/{stamp[6:8]}/GIS/uscomp/n0r_{stamp}.png"
+
+
+def iem_wld_url(stamp):
+    return iem_frame_url(stamp).removesuffix(".png") + ".wld"
+
+
+def wasabi_frame_key(stamp):
+    return f"{KEY_PREFIX}n0r_{stamp}.png"
+
+
+def png_dimensions(data):
+    """(width, height) from the IHDR chunk; ValueError on non-PNG bytes."""
+    if len(data) < 24 or data[:8] != b"\x89PNG\r\n\x1a\n":
+        raise ValueError("not a PNG")
+    return struct.unpack(">II", data[16:24])
+
+
+def parse_wld(text):
+    """ESRI world file -> {dx, dy, ulx, uly} (skew lines 2-3 ignored: always 0)."""
+    lines = [float(x) for x in text.split()]
+    return {"dx": lines[0], "dy": lines[3], "ulx": lines[4], "uly": lines[5]}
+
+
+def corners(wld, width, height):
+    """MapLibre image-source corner order: TL, TR, BR, BL as [lon, lat]."""
+    left, top = wld["ulx"], wld["uly"]
+    right = left + wld["dx"] * width
+    bottom = top + wld["dy"] * height
+    return [[left, top], [right, top], [right, bottom], [left, bottom]]
+
+
+def build_index(frames_present, missing, bounds, start, end):
+    return {
+        "product": "n0r", "interval_seconds": 300,
+        "start": start, "end": end,
+        "bounds": bounds,
+        "key_prefix": KEY_PREFIX, "key_pattern": "n0r_{stamp}.png",
+        "frames": frames_present,
+        "missing": missing,
+    }

--- a/packages/tools/weather-recon/weather_recon/radar.py
+++ b/packages/tools/weather-recon/weather_recon/radar.py
@@ -64,6 +64,7 @@ def corners(wld, width, height):
 def build_index(frames_present, missing, bounds, start, end):
     return {
         "product": "n0r", "interval_seconds": 300,
+        "timezone": "UTC",   # frame stamps are UTC YYYYMMDDHHMM
         "start": start, "end": end,
         "bounds": bounds,
         "key_prefix": KEY_PREFIX, "key_pattern": "n0r_{stamp}.png",

--- a/packages/tools/weather-recon/weather_recon/wasabi.py
+++ b/packages/tools/weather-recon/weather_recon/wasabi.py
@@ -1,0 +1,57 @@
+"""
+Slim Wasabi S3 helper for radar frame mirroring.
+
+Client settings ported from video_grabber/storage/wasabi.py (proven against
+this exact bucket): SigV4, path addressing, and when_required checksum mode
+(boto3 >= 1.36 injects checksum headers Wasabi rejects).
+"""
+
+import os
+
+import boto3
+from botocore.config import Config as BotoCoreConfig
+
+BUCKET = os.environ.get("WASABI_BUCKET", "files.911realtime.org")
+
+
+def make_client():
+    key = os.environ.get("WASABI_ACCESS_KEY_ID")
+    secret = os.environ.get("WASABI_SECRET_ACCESS_KEY")
+    if not key:
+        raise RuntimeError("WASABI_ACCESS_KEY_ID is not set in the environment")
+    if not secret:
+        raise RuntimeError("WASABI_SECRET_ACCESS_KEY is not set in the environment")
+    return boto3.client(
+        "s3",
+        endpoint_url=os.environ.get("WASABI_ENDPOINT_URL",
+                                    "https://s3.us-central-1.wasabisys.com"),
+        aws_access_key_id=key,
+        aws_secret_access_key=secret,
+        region_name="us-central-1",
+        config=BotoCoreConfig(
+            signature_version="s3v4",
+            s3={"addressing_style": "path"},
+            request_checksum_calculation="when_required",
+            response_checksum_validation="when_required",
+            retries={"max_attempts": 10, "mode": "adaptive"},
+        ),
+    )
+
+
+def upload_bytes(s3, key, body, content_type, cache_control):
+    s3.put_object(Bucket=BUCKET, Key=key, Body=body,
+                  ContentType=content_type, CacheControl=cache_control)
+
+
+def existing_keys(s3, prefix):
+    """All object keys under prefix (paginated), as a set."""
+    keys, token = set(), None
+    while True:
+        kw = {"Bucket": BUCKET, "Prefix": prefix}
+        if token:
+            kw["ContinuationToken"] = token
+        resp = s3.list_objects_v2(**kw)
+        keys.update(o["Key"] for o in resp.get("Contents", []))
+        if not resp.get("IsTruncated"):
+            return keys
+        token = resp.get("NextContinuationToken")


### PR DESCRIPTION
Phase 2b of the Weather app (#184): the radar mirror. **All 1,152 five-minute NEXRAD CONUS composite frames for 2001-09-09..12 are now on Wasabi** under `weather/radar/` — zero gaps in the IEM archive for our window (Hurricane Erin included).

## What's in here

- **`weather_recon/radar.py`** — pure helpers: 5-min frame-stamp enumeration, IEM archive URLs, ESRI world-file → MapLibre corner geometry ([[-126,50],[-66,50],[-66,24],[-126,24]] verified), PNG dimension reads, index builder.
- **`weather_recon/wasabi.py`** — slim uploader with video-grabber's proven Wasabi client settings (SigV4, path addressing, when_required checksums).
- **`weather_recon/flow_radar.py`** — `load-weather-radar`: download-with-cache → per-frame geometry verification (hard error on mismatch) → upload-if-absent (resumable via one `list_objects` sweep) → `weather/radar/index.json` (bounds, frame list, gaps, `"timezone": "UTC"`, key pattern — the frontend reads the pattern instead of hardcoding).
- README refresh; boto3 added to pyproject + the image dep layer.

## Verification

- 63/63 pytest, ruff clean.
- **Live on Wasabi**: 1,152 frames (~130 MB), `image/png` + `max-age=31536000`, index bounds exact; sample frame 6000×2600 px / 114 KB. Resumability proven twice for real — two mid-run kills resumed cleanly with `skip_existing` (85-frame tail completed on the final resume, then a full re-run uploaded 0).

## Follow-ups

- **Infra (Phase 4 prerequisite):** `weather/` prefix needs a file-proxy allow-list entry (Traefik Ingress path rule in the infra repo) before the frontend can fetch frames via files.911realtime.org.
- Phase 2c (forecasts) next: IEM AFOS archive verified serving real Sept-2001 ZFP products.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W179bqEPFP92a3JrsPkD5c
