### PR TITLE
feat(weather-recon): Phase 2d — almanac, 188/188 stations on Wasabi (#184)

### DIFF
--- a/packages/tools/weather-recon/tests/test_ghcn.py
+++ b/packages/tools/weather-recon/tests/test_ghcn.py
@@ -1,0 +1,63 @@
+from weather_recon.ghcn import (compute_almanac, derive_ghcn_id, nearest_ghcn,
+                                parse_daily_rows, parse_ghcnd_stations)
+
+GHCND_STATIONS = (
+    "USW00094846  41.9950  -87.9336  201.8 IL CHICAGO OHARE INTL AP        \n"
+    "USW00014819  41.7861  -87.7522  185.9 IL CHICAGO MIDWAY AP 3SW        \n"
+    "CA006158733  43.6772  -79.6306  173.4    TORONTO LESTER B. PEARSON INT\n"
+)
+
+DAILY_CSV = ('"STATION","DATE","PRCP","TMAX","TMIN"\n'
+             '"USW00094846","1971-09-09","    5","  278","  133"\n'
+             '"USW00094846","1972-09-09","    0","  333","  100"\n'
+             '"USW00094846","1999-09-09","   25","  333","   89"\n'
+             '"USW00094846","2001-09-08","    0","  250","  120"\n'
+             '"USW00094846","2001-09-09","    0","  400","  200"\n'   # after cutoff!
+             '"USW00094846","1980-09-10","","  289",""\n')
+
+
+def test_derive_ghcn_id():
+    assert derive_ghcn_id("725300-94846") == "USW00094846"
+    assert derive_ghcn_id("716270-99999") is None
+
+
+def test_parse_ghcnd_stations():
+    st = parse_ghcnd_stations(GHCND_STATIONS)
+    assert st[0] == {"id": "USW00094846", "lat": 41.9950, "lon": -87.9336,
+                     "name": "IL CHICAGO OHARE INTL AP"}
+    assert st[2]["id"] == "CA006158733"
+
+
+def test_nearest_ghcn_within_radius():
+    st = parse_ghcnd_stations(GHCND_STATIONS)
+    assert nearest_ghcn(43.68, -79.63, st) == "CA006158733"
+    assert nearest_ghcn(41.995, -87.934, st) == "USW00094846"
+
+
+def test_nearest_ghcn_none_when_too_far():
+    st = parse_ghcnd_stations(GHCND_STATIONS)
+    assert nearest_ghcn(19.43, -99.07, st) is None   # Mexico City vs this tiny list
+
+
+def test_parse_daily_rows_units_and_missing():
+    rows = parse_daily_rows(DAILY_CSV)
+    assert rows[0] == {"date": "1971-09-09", "prcp_mm": 0.5, "tmax_c": 27.8,
+                       "tmin_c": 13.3}
+    assert rows[5]["prcp_mm"] is None and rows[5]["tmin_c"] is None
+
+
+def test_compute_almanac_records_normals_and_cutoff():
+    rows = parse_daily_rows(DAILY_CSV)
+    alm = compute_almanac(rows, ["09-09", "09-10"])
+    d = alm["09-09"]
+    # record high 33.3 shared by 1972 and 1999 -> latest year wins
+    assert d["record_high_c"] == 33.3 and d["record_high_year"] == 1999
+    assert d["record_low_c"] == 8.9 and d["record_low_year"] == 1999
+    # 2001-09-09 (40.0C, after cutoff) MUST be excluded
+    assert d["record_high_c"] != 40.0
+    # normals over 1971-2000 rows present: (27.8+33.3+33.3)/3 = 31.5 (1dp)
+    assert d["normal_high_c"] == 31.5
+    assert d["record_precip_mm"] == 2.5 and d["record_precip_year"] == 1999
+    d10 = alm["09-10"]
+    assert d10["record_high_c"] == 28.9 and d10["record_high_year"] == 1980
+    assert d10["record_low_c"] is None and d10["record_precip_mm"] is None

--- a/packages/tools/weather-recon/tests/test_ghcn.py
+++ b/packages/tools/weather-recon/tests/test_ghcn.py
@@ -8,13 +8,15 @@ GHCND_STATIONS = (
     "CA006158733  43.6772  -79.6306  173.4    TORONTO LESTER B. PEARSON INT\n"
 )
 
-# Three stations near Chicago O'Hare at increasing distance (0, 6.72, 12.62 km),
-# plus one far away (Toronto, ~702 km) that must be excluded by max_km.
+# Three stations near Chicago O'Hare at 0, 6.72 and 12.62 km, deliberately
+# listed OUT of distance order so the ordering assertions discriminate a
+# true sorted k-nearest from naive file-order collection; plus one far
+# station (Toronto, ~702 km) that must be excluded by max_km.
 NEARBY_STATIONS = (
-    "USW00094846  41.9950  -87.9336  201.8 IL CHICAGO OHARE INTL AP        \n"
-    "USC00111577  42.0500  -87.9000  190.0 IL EVANSTON                    \n"
     "USW00014819  41.9000  -87.8500  185.9 IL CHICAGO MIDWAY AP 3SW        \n"
+    "USW00094846  41.9950  -87.9336  201.8 IL CHICAGO OHARE INTL AP        \n"
     "CA006158733  43.6772  -79.6306  173.4    TORONTO LESTER B. PEARSON INT\n"
+    "USC00111577  42.0500  -87.9000  190.0 IL EVANSTON                    \n"
 )
 
 DAILY_CSV = ('"STATION","DATE","PRCP","TMAX","TMIN"\n'

--- a/packages/tools/weather-recon/tests/test_ghcn.py
+++ b/packages/tools/weather-recon/tests/test_ghcn.py
@@ -61,3 +61,12 @@ def test_compute_almanac_records_normals_and_cutoff():
     d10 = alm["09-10"]
     assert d10["record_high_c"] == 28.9 and d10["record_high_year"] == 1980
     assert d10["record_low_c"] is None and d10["record_precip_mm"] is None
+
+
+def test_compute_almanac_zero_precip_tie_goes_to_latest_year():
+    csv_text = ('"STATION","DATE","PRCP","TMAX","TMIN"\n'
+                '"USW00094846","1975-09-11","    0","  250","  120"\n'
+                '"USW00094846","1988-09-11","    0","  260","  130"\n')
+    alm = compute_almanac(parse_daily_rows(csv_text), ["09-11"])
+    d = alm["09-11"]
+    assert d["record_precip_mm"] == 0.0 and d["record_precip_year"] == 1988

--- a/packages/tools/weather-recon/tests/test_ghcn.py
+++ b/packages/tools/weather-recon/tests/test_ghcn.py
@@ -1,9 +1,19 @@
 from weather_recon.ghcn import (compute_almanac, derive_ghcn_id, nearest_ghcn,
-                                parse_daily_rows, parse_ghcnd_stations)
+                                nearest_ghcn_candidates, parse_daily_rows,
+                                parse_ghcnd_stations)
 
 GHCND_STATIONS = (
     "USW00094846  41.9950  -87.9336  201.8 IL CHICAGO OHARE INTL AP        \n"
     "USW00014819  41.7861  -87.7522  185.9 IL CHICAGO MIDWAY AP 3SW        \n"
+    "CA006158733  43.6772  -79.6306  173.4    TORONTO LESTER B. PEARSON INT\n"
+)
+
+# Three stations near Chicago O'Hare at increasing distance (0, 6.72, 12.62 km),
+# plus one far away (Toronto, ~702 km) that must be excluded by max_km.
+NEARBY_STATIONS = (
+    "USW00094846  41.9950  -87.9336  201.8 IL CHICAGO OHARE INTL AP        \n"
+    "USC00111577  42.0500  -87.9000  190.0 IL EVANSTON                    \n"
+    "USW00014819  41.9000  -87.8500  185.9 IL CHICAGO MIDWAY AP 3SW        \n"
     "CA006158733  43.6772  -79.6306  173.4    TORONTO LESTER B. PEARSON INT\n"
 )
 
@@ -37,6 +47,20 @@ def test_nearest_ghcn_within_radius():
 def test_nearest_ghcn_none_when_too_far():
     st = parse_ghcnd_stations(GHCND_STATIONS)
     assert nearest_ghcn(19.43, -99.07, st) is None   # Mexico City vs this tiny list
+
+
+def test_nearest_ghcn_candidates_orders_by_distance_and_excludes_far():
+    st = parse_ghcnd_stations(NEARBY_STATIONS)
+    ids = nearest_ghcn_candidates(41.9950, -87.9336, st)
+    # nearest-first: self (0 km), then Evanston (6.72 km), then Midway (12.62 km);
+    # Toronto (~702 km) excluded by the 20 km default max_km.
+    assert ids == ["USW00094846", "USC00111577", "USW00014819"]
+
+
+def test_nearest_ghcn_candidates_respects_limit():
+    st = parse_ghcnd_stations(NEARBY_STATIONS)
+    ids = nearest_ghcn_candidates(41.9950, -87.9336, st, limit=2)
+    assert ids == ["USW00094846", "USC00111577"]
 
 
 def test_parse_daily_rows_units_and_missing():

--- a/packages/tools/weather-recon/weather_recon/flow_almanac.py
+++ b/packages/tools/weather-recon/weather_recon/flow_almanac.py
@@ -1,0 +1,127 @@
+"""
+Prefect flow: GHCN-Daily -> per-station almanac JSON on Wasabi.
+
+GHCN id resolution (flow-internal by design — see the phase plan): derive
+USW000+WBAN, else nearest ghcnd-stations.txt entry within 20 km, else
+GHCN_OVERRIDES, else recorded gap. A derived/matched id that returns zero
+daily rows demotes to the next strategy rather than publishing an empty
+almanac. All math cuts off at 2001-09-08 (anachronism rule).
+"""
+
+import json
+import uuid
+from pathlib import Path
+
+import httpx
+from prefect import flow, get_run_logger, task
+
+from weather_recon.flow import NETWORK_RETRIES
+from weather_recon.ghcn import (compute_almanac, derive_ghcn_id, nearest_ghcn,
+                                parse_daily_rows, parse_ghcnd_stations)
+from weather_recon.stations import load_stations
+from weather_recon.wasabi import make_client, upload_bytes
+
+GHCND_STATIONS_URL = "https://www.ncei.noaa.gov/pub/data/ghcn/daily/ghcnd-stations.txt"
+DAILY_URL = "https://www.ncei.noaa.gov/access/services/data/v1"
+MONTH_DAYS = ["09-09", "09-10", "09-11", "09-12"]
+KEY_PREFIX = "weather/almanac/"
+
+# Hand-curated GHCN ids for stations neither derivation nor 20 km matching
+# resolves. Populate only with ids verified to return daily data.
+GHCN_OVERRIDES: dict[str, str] = {}
+
+
+def _fetch_daily(client, ghcn_id, cutoff, cache_dir):
+    cache_file = cache_dir / f"daily_{ghcn_id}.csv" if cache_dir else None
+    if cache_file is not None and cache_file.is_file():
+        return cache_file.read_text(encoding="utf-8")
+    r = client.get(DAILY_URL, params={
+        "dataset": "daily-summaries", "stations": ghcn_id,
+        "startDate": "1900-01-01", "endDate": cutoff,
+        "dataTypes": "TMAX,TMIN,PRCP", "format": "csv"}, timeout=180)
+    r.raise_for_status()
+    if cache_file is not None:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_file.write_text(r.text, encoding="utf-8")
+    return r.text
+
+
+def _ghcnd_station_list(client, cache_dir):
+    cache_file = cache_dir / "ghcnd-stations.txt" if cache_dir else None
+    if cache_file is not None and cache_file.is_file():
+        text = cache_file.read_text(encoding="utf-8")
+    else:
+        r = client.get(GHCND_STATIONS_URL, timeout=300)
+        r.raise_for_status()
+        text = r.text
+        if cache_file is not None:
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            cache_file.write_text(text, encoding="utf-8")
+    return parse_ghcnd_stations(text)
+
+
+@task(**NETWORK_RETRIES)
+def build_and_publish(stations_path, cache_dir, cutoff, run_id):
+    log = get_run_logger()
+    stations = load_stations(stations_path)
+    cache = Path(cache_dir) if cache_dir else None
+    s3 = make_client()
+    published, gaps = [], []
+    with httpx.Client(follow_redirects=True) as client:
+        ghcnd = _ghcnd_station_list(client, cache)
+        for i, st in enumerate(stations, 1):
+            sid = st["station_id"]
+            candidates = []
+            if sid in GHCN_OVERRIDES:
+                candidates.append(GHCN_OVERRIDES[sid])
+            derived = derive_ghcn_id(st["isd_id"])
+            if derived:
+                candidates.append(derived)
+            near = nearest_ghcn(st["lat"], st["lon"], ghcnd)
+            if near and near not in candidates:
+                candidates.append(near)
+            almanac, used = None, None
+            for gid in candidates:
+                rows = parse_daily_rows(_fetch_daily(client, gid, cutoff, cache))
+                if sum(1 for r in rows if r["tmax_c"] is not None) >= 300:
+                    almanac, used = compute_almanac(rows, MONTH_DAYS, cutoff), gid
+                    break
+            if almanac is None:
+                gaps.append(sid)
+                continue
+            body = json.dumps({"station_id": sid, "ghcn_id": used,
+                               "cutoff": cutoff, "days": almanac,
+                               "run_id": run_id}).encode("utf-8")
+            upload_bytes(s3, f"{KEY_PREFIX}{sid}.json", body,
+                         "application/json", "max-age=31536000")
+            published.append(sid)
+            if i % 25 == 0:
+                log.info("almanac %d/%d (published %d, gaps %d)",
+                         i, len(stations), len(published), len(gaps))
+    index = {"stations": sorted(published), "gaps": sorted(gaps),
+             "cutoff": cutoff, "key_prefix": KEY_PREFIX,
+             "key_pattern": "{station_id}.json"}
+    upload_bytes(s3, f"{KEY_PREFIX}index.json", json.dumps(index).encode("utf-8"),
+                 "application/json", "max-age=300")
+    log.info("published %d almanacs, %d gaps (%s)", len(published), len(gaps),
+             ", ".join(gaps) or "none")
+    return len(published), gaps
+
+
+@flow(name="load-weather-almanac", log_prints=True)
+def load_weather_almanac(
+    stations_path: str = "/app/data/stations.csv",
+    cache_dir: str | None = "/tmp/ghcn-cache",
+    cutoff: str = "2001-09-08",
+):
+    log = get_run_logger()
+    run_id = uuid.uuid4().hex
+    n, gaps = build_and_publish(stations_path, cache_dir, cutoff, run_id)
+    log.info("done: %d almanacs on Wasabi, run_id=%s", n, run_id)
+    return {"published": n, "gaps": gaps, "run_id": run_id}
+
+
+if __name__ == "__main__":
+    import sys
+    path = sys.argv[1] if len(sys.argv) > 1 else "data/stations.csv"
+    load_weather_almanac(stations_path=path)

--- a/packages/tools/weather-recon/weather_recon/flow_almanac.py
+++ b/packages/tools/weather-recon/weather_recon/flow_almanac.py
@@ -4,9 +4,9 @@ Prefect flow: GHCN-Daily -> per-station almanac JSON on Wasabi.
 GHCN id resolution (flow-internal by design — see the phase plan):
 GHCN_OVERRIDES first (hand-verified ids preempt automation, as in 2c's
 ZONE_OVERRIDES), else derived USW000+WBAN, else nearest ghcnd-stations.txt
-entry within 20 km, else recorded gap. A derived/matched id that returns zero
-daily rows demotes to the next strategy rather than publishing an empty
-almanac. All math cuts off at 2001-09-08 (anachronism rule).
+entries (k=5) within 20 km, else recorded gap. A derived/matched id that
+returns zero daily rows demotes to the next strategy rather than publishing
+an empty almanac. All math cuts off at 2001-09-08 (anachronism rule).
 """
 
 import json
@@ -17,8 +17,9 @@ import httpx
 from prefect import flow, get_run_logger, task
 
 from weather_recon.flow import NETWORK_RETRIES
-from weather_recon.ghcn import (compute_almanac, derive_ghcn_id, nearest_ghcn,
-                                parse_daily_rows, parse_ghcnd_stations)
+from weather_recon.ghcn import (compute_almanac, derive_ghcn_id,
+                                nearest_ghcn_candidates, parse_daily_rows,
+                                parse_ghcnd_stations)
 from weather_recon.stations import load_stations
 from weather_recon.wasabi import make_client, upload_bytes
 
@@ -78,9 +79,9 @@ def build_and_publish(stations_path, cache_dir, cutoff, run_id):
             derived = derive_ghcn_id(st["isd_id"])
             if derived:
                 candidates.append(derived)
-            near = nearest_ghcn(st["lat"], st["lon"], ghcnd)
-            if near and near not in candidates:
-                candidates.append(near)
+            for near in nearest_ghcn_candidates(st["lat"], st["lon"], ghcnd):
+                if near not in candidates:
+                    candidates.append(near)
             almanac, used = None, None
             for gid in candidates:
                 rows = parse_daily_rows(_fetch_daily(client, gid, cutoff, cache))

--- a/packages/tools/weather-recon/weather_recon/flow_almanac.py
+++ b/packages/tools/weather-recon/weather_recon/flow_almanac.py
@@ -1,9 +1,10 @@
 """
 Prefect flow: GHCN-Daily -> per-station almanac JSON on Wasabi.
 
-GHCN id resolution (flow-internal by design — see the phase plan): derive
-USW000+WBAN, else nearest ghcnd-stations.txt entry within 20 km, else
-GHCN_OVERRIDES, else recorded gap. A derived/matched id that returns zero
+GHCN id resolution (flow-internal by design — see the phase plan):
+GHCN_OVERRIDES first (hand-verified ids preempt automation, as in 2c's
+ZONE_OVERRIDES), else derived USW000+WBAN, else nearest ghcnd-stations.txt
+entry within 20 km, else recorded gap. A derived/matched id that returns zero
 daily rows demotes to the next strategy rather than publishing an empty
 almanac. All math cuts off at 2001-09-08 (anachronism rule).
 """

--- a/packages/tools/weather-recon/weather_recon/ghcn.py
+++ b/packages/tools/weather-recon/weather_recon/ghcn.py
@@ -94,10 +94,9 @@ def compute_almanac(rows, month_days, cutoff="2001-09-08",
                 entry["record_precip_mm"] is None
                 or r["prcp_mm"] >= entry["record_precip_mm"]
             ):
-                if r["prcp_mm"] > 0 or entry["record_precip_mm"] is None:
-                    entry["record_precip_mm"], entry["record_precip_year"] = (
-                        r["prcp_mm"], year
-                    )
+                entry["record_precip_mm"], entry["record_precip_year"] = (
+                    r["prcp_mm"], year
+                )
         if highs:
             entry["normal_high_c"] = round(sum(highs) / len(highs), 1)
         if lows:

--- a/packages/tools/weather-recon/weather_recon/ghcn.py
+++ b/packages/tools/weather-recon/weather_recon/ghcn.py
@@ -40,14 +40,20 @@ def _haversine_km(lat1, lon1, lat2, lon2):
     return 2 * EARTH_RADIUS_KM * math.asin(math.sqrt(a))
 
 
-def nearest_ghcn(lat, lon, stations, max_km=20.0):
-    """Haversine-nearest station id within max_km, or None if none qualify."""
-    best, best_km = None, max_km
+def nearest_ghcn_candidates(lat, lon, stations, max_km=20.0, limit=5):
+    """Ids of up to `limit` nearest stations within max_km, nearest first."""
+    within = []
     for st in stations:
         km = _haversine_km(lat, lon, st["lat"], st["lon"])
-        if km <= best_km:
-            best, best_km = st["id"], km
-    return best
+        if km <= max_km:
+            within.append((km, st["id"]))
+    within.sort(key=lambda pair: pair[0])
+    return [sid for _, sid in within[:limit]]
+
+
+def nearest_ghcn(lat, lon, stations, max_km=20.0):
+    """Haversine-nearest station id within max_km, or None if none qualify."""
+    return (nearest_ghcn_candidates(lat, lon, stations, max_km=max_km, limit=1) or [None])[0]
 
 
 def _tenths(v):

--- a/packages/tools/weather-recon/weather_recon/ghcn.py
+++ b/packages/tools/weather-recon/weather_recon/ghcn.py
@@ -1,0 +1,106 @@
+"""
+GHCN-Daily helpers for the almanac flow.
+
+Values from NCEI daily-summaries CSV are tenths (degC*10 / mm*10), padded
+with whitespace, empty when missing (verified live). All almanac math
+honors the cutoff date -- records set during the replay window must not
+appear (anachronism rule).
+"""
+
+import csv
+import io
+import math
+
+EARTH_RADIUS_KM = 6371.0
+
+
+def derive_ghcn_id(isd_id):
+    """US WBAN-based GHCN id; None when the WBAN is the 99999 placeholder."""
+    wban = isd_id.split("-")[1]
+    if wban == "99999":
+        return None
+    return f"USW000{wban}"
+
+
+def parse_ghcnd_stations(text):
+    """Fixed-width ghcnd-stations.txt -> [{id, lat, lon, name}]."""
+    out = []
+    for line in text.splitlines():
+        if len(line) < 40:
+            continue
+        out.append({"id": line[0:11].strip(), "lat": float(line[12:20]),
+                    "lon": float(line[21:30]), "name": line[38:71].strip()})
+    return out
+
+
+def _haversine_km(lat1, lon1, lat2, lon2):
+    p1, p2 = math.radians(lat1), math.radians(lat2)
+    dp, dl = math.radians(lat2 - lat1), math.radians(lon2 - lon1)
+    a = math.sin(dp / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dl / 2) ** 2
+    return 2 * EARTH_RADIUS_KM * math.asin(math.sqrt(a))
+
+
+def nearest_ghcn(lat, lon, stations, max_km=20.0):
+    """Haversine-nearest station id within max_km, or None if none qualify."""
+    best, best_km = None, max_km
+    for st in stations:
+        km = _haversine_km(lat, lon, st["lat"], st["lon"])
+        if km <= best_km:
+            best, best_km = st["id"], km
+    return best
+
+
+def _tenths(v):
+    v = (v or "").strip()
+    return round(int(v) / 10.0, 1) if v not in ("", "9999", "-9999") else None
+
+
+def parse_daily_rows(text):
+    """NCEI daily-summaries CSV -> [{date, prcp_mm, tmax_c, tmin_c}]."""
+    return [{"date": r["DATE"], "prcp_mm": _tenths(r.get("PRCP")),
+             "tmax_c": _tenths(r.get("TMAX")), "tmin_c": _tenths(r.get("TMIN"))}
+            for r in csv.DictReader(io.StringIO(text))]
+
+
+def compute_almanac(rows, month_days, cutoff="2001-09-08",
+                    normal_start=1971, normal_end=2000):
+    """Per MM-DD: record high/low/precip (ties -> latest year) + normal means."""
+    out = {}
+    for md in month_days:
+        day_rows = sorted(
+            (r for r in rows if r["date"][5:] == md and r["date"] <= cutoff),
+            key=lambda r: r["date"],
+        )
+        entry = {"record_high_c": None, "record_high_year": None,
+                 "record_low_c": None, "record_low_year": None,
+                 "normal_high_c": None, "normal_low_c": None,
+                 "record_precip_mm": None, "record_precip_year": None}
+        highs, lows = [], []
+        for r in day_rows:
+            year = int(r["date"][:4])
+            if r["tmax_c"] is not None:
+                if (entry["record_high_c"] is None
+                        or r["tmax_c"] >= entry["record_high_c"]):
+                    entry["record_high_c"], entry["record_high_year"] = r["tmax_c"], year
+                if normal_start <= year <= normal_end:
+                    highs.append(r["tmax_c"])
+            if r["tmin_c"] is not None:
+                if (entry["record_low_c"] is None
+                        or r["tmin_c"] <= entry["record_low_c"]):
+                    entry["record_low_c"], entry["record_low_year"] = r["tmin_c"], year
+                if normal_start <= year <= normal_end:
+                    lows.append(r["tmin_c"])
+            if r["prcp_mm"] is not None and (
+                entry["record_precip_mm"] is None
+                or r["prcp_mm"] >= entry["record_precip_mm"]
+            ):
+                if r["prcp_mm"] > 0 or entry["record_precip_mm"] is None:
+                    entry["record_precip_mm"], entry["record_precip_year"] = (
+                        r["prcp_mm"], year
+                    )
+        if highs:
+            entry["normal_high_c"] = round(sum(highs) / len(highs), 1)
+        if lows:
+            entry["normal_low_c"] = round(sum(lows) / len(lows), 1)
+        out[md] = entry
+    return out


### PR DESCRIPTION
Phase 2d of the Weather app (#184): the almanac — and with it, **all four datasets of the data pipeline are now live**. 188/188 stations have almanac JSON on Wasabi under `weather/almanac/`: record high/low (with years), 1971–2000 normal high/low, and record precip for Sept 9–12, computed from GHCN-Daily **using only data through 2001-09-08** (a record set during the replay window can never appear — belt-and-suspenders: the fetch is cutoff-bounded AND the math re-filters).

## What's in here

- **`weather_recon/ghcn.py`** — GHCN id derivation (`USW000`+WBAN), ghcnd-stations.txt parsing, haversine k-nearest matching, almanac computation (tenths→1 dp °C/mm, ties→latest year).
- **`weather_recon/flow_almanac.py`** — candidate ladder (overrides → derived → k-nearest), cached fetches, per-station JSON + `index.json` (same key_prefix/key_pattern shape as the radar index).
- **k-nearest fallback (found live):** the single nearest GHCN gauge near airports is often precip-only — first run gapped 12 of 17 Canadian stations. Trying the 5 nearest in distance order rescued **all 13 gaps with zero manual overrides** (CYYZ→CA006158733, CYUL→CA007025250, MMVA→MXN00027054).

## Verification

- 90/90 pytest, ruff clean; final review independently verified the k-nearest sort, hand-checked the fixture geometry, and reordered the test fixture so the ordering assertion can actually fail an unsorted implementation.
- **Live on Wasabi**: 188 almanacs + index (0 gaps); sampled KORD/KJFK/CYYZ/MMMX/KLAX/KDCA — all record years ≤ 2001, normals plausible (Toronto Sept-9 normal high 23.3 °C, KORD record high 35.0 °C/1983).

## ⚠️ Pre-Phase-3 blocker (infra repo)

The whole `weather/` prefix currently **404s through files.911realtime.org** — the file-proxy allow-list (Traefik Ingress path rules in Keeping-History/infra) needs a `weather/` entry before the frontend can fetch radar frames, almanacs, or any of it. Objects are confirmed present via the S3 API.

## What's next

Phase 3: the `weather` streamer channel (observations + forecasts, flights-style). Phase 4: the Classicy Weather app itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W179bqEPFP92a3JrsPkD5c
