### PR TITLE
feat(streamer): weather subscription channel — obs snapshot + windowed tick + on-demand forecasts (#184)

### DIFF
--- a/packages/backend/docs/websocket-protocol.md
+++ b/packages/backend/docs/websocket-protocol.md
@@ -41,12 +41,13 @@ Every client message is a JSON object with at least a `type` field. Additional f
 | `seek`        | `time`            | Move the virtual clock to a new instant.      |
 | `heartbeat`   | `time`            | Report client's current virtual time.         |
 | `filter`      | `formats[]`       | Whitelist media formats.                      |
-| `subscribe`   | `channel`         | Opt into a side channel (`pager`/`mp3`/`news`/`usenet`/`flights`). |
+| `subscribe`   | `channel`         | Opt into a side channel (`pager`/`mp3`/`news`/`usenet`/`flights`/`weather`). |
 | `unsubscribe` | `channel`         | Leave a side channel.                         |
 | `usenet_filter` | `newsgroups[]`  | Set the newsgroup(s) the client is viewing; the `usenet` channel delivers only these. |
 | `usenet_more` | `newsgroups[]`, `before` | Request the page of messages older than `before` for the viewed group(s) (backlog pagination). |
 | `usenet_body` | `id`              | Request the full body of one message by id (bodies are no longer in list frames). |
 | `flights_history` | `minutes`, `id` | Request the trailing `minutes` (30 or 90) of flight positions for loop playback. Requires an active `flights` subscription. `id` is echoed on every reply chunk. |
+| `weather_forecast` | `zone`, `id` | Request the forecast product covering NWS UGC `zone` (e.g. `"NYZ076"`) at the client's virtual time. Requires an active `weather` subscription. `id` is echoed on the reply. |
 | `pause`       | —                 | Stop advancing virtual time.                  |
 | `resume`      | —                 | Resume advancing virtual time.                |
 
@@ -72,6 +73,8 @@ All unknown `type` values produce an `error` reply but do not terminate the sess
 | `usenet`          | `time`, `usenet[]`            | Usenet messages for the viewed newsgroup(s): backlog snapshot (most recent ≤500 up to `t`) on subscribe/`usenet_filter`/init/seek, plus a forward **window** (default 600 s) per refill. Delivered **only** for the groups set via `usenet_filter`. |
 | `flights`         | `time`, `flights[]`           | Flights snapshot (airborne picture covering `[t−90s, t]`) on subscribe/init/seek, plus a forward **window** (default 300 s) per refill while subscribed. |
 | `flights_history` | `id`, `time`, `flights[]`, `done` | Chunked reply to a `flights_history` request (~10 minute-buckets per frame). The final frame carries `done: true` (and may be empty). `id` echoes the request. |
+| `weather`         | `time`, `weather[]`, `weather_forecasts[]` | Weather snapshot (latest observation per station ≤ `t`, no age limit) on subscribe/init/seek, plus a forward **window** (default 600 s) per refill while subscribed — windowed observations plus any forecast products newly issued in the window. One frame carries both lists; suppressed when both are empty. |
+| `weather_forecast` | `id`, `time`, `weather_forecasts[]` | Reply to `weather_forecast`: the forecast product covering the requested zone at the clock, or an explicit empty `weather_forecasts` when none exists. `id` echoes the request. |
 | `usenet_filter_ack` | —                           | Reply to `usenet_filter`.                              |
 | `usenet_body`     | `id`, `body` *or* `id`, `message` | Reply to `usenet_body`: the article body, or an empty body with `message` set when the id is missing/unapproved or the query fails. |
 | `sources`         | `sources`                     | Sent once after `init_ack`: the time-independent set of selectable sources per filter (`sources.video`, `sources.pager`, `sources.usenet`). Not resent on `seek`. |
@@ -230,8 +233,8 @@ in bulk on the wire, the **client reveal-gate** holds each page until its `start
 still render paced by the virtual clock rather than all at once. This pacing invariant is enforced
 client-side; consumer apps never receive a not-yet-due page.
 
-Valid channels are `"pager"`, `"mp3"`, `"news"`, `"usenet"` and `"flights"`; any other value yields
-`{"type":"error","message":"unknown channel \"…\""}`. (HTML is planned.)
+Valid channels are `"pager"`, `"mp3"`, `"news"`, `"usenet"`, `"flights"` and `"weather"`; any other
+value yields `{"type":"error","message":"unknown channel \"…\""}`. (HTML is planned.)
 Subscriptions are not remembered across reconnects — re-`subscribe` after reconnecting.
 
 The `mp3` channel (Radio app) behaves the same but carries `MediaItem`s on `mp3`-typed frames
@@ -257,6 +260,23 @@ reveals it immediately since every row's `start_date ≤ t`. Forward refills use
 as media. See [`flights` field reference](#server-initiated--snapshot-flights) below for the shape
 of `FlightPosition`, and [`flight_tracks` is not streamed](#flight_tracks-is-not-on-the-wire) for how
 per-flight route geometry is fetched instead.
+
+The `weather` channel carries `WeatherObservation`s and `WeatherForecast`s on `weather`-typed frames
+(its own `weather`/`weather_forecasts` fields, not a reuse of `items`). Observations are sparse —
+one per station per hour, versus a media item every few seconds — so unlike pager/flights the
+subscribe/init/seek **snapshot has no age limit**: it is the single most recent observation at or
+before `t` for **every** station (a point-in-time `DISTINCT ON`), so a station that has been silent
+for hours still shows its last reading, timestamped with its own `start_date` rather than `t`.
+Forecast products are **not** part of the snapshot — they're delivered on demand only, via
+`weather_forecast` below. Forward refills use a 600 s window (usenet/news scale, reflecting how
+sparse the data is) and carry both the observations newly in-window and any forecast products newly
+*issued* in that window, in a single frame; the frame is suppressed when both lists are empty. Like
+`usenet`, the `weather` channel reads Postgres directly on the tick rather than Redis — observations
+and forecasts are sparse enough that a Redis cache isn't worth building, so `Session` uses its
+`*pgxpool.Pool` the same way (`packages/backend/CLAUDE.md` hard rule #4's usenet exception; weather
+is a second exception under it). See [`weather` field reference](#server-initiated--snapshot-weather)
+below for the frame shape, and [radar and almanac are not on the wire](#radar-and-almanac-are-not-on-the-wire)
+for how the rest of the Weather app's data (map imagery, per-station normals) is fetched instead.
 
 ### `usenet_filter` and the `usenet` channel
 
@@ -434,6 +454,137 @@ Per-flight route geometry (`flight_tracks.geometry`, a GeoJSON LineString) is **
 `flights` channel. It's static per-flight metadata, not a time-windowed stream, so apps that need a
 flight's full track (e.g. drawing a route on a map) fetch it on demand from Directus REST —
 `GET /items/flight_tracks?filter[flight][_eq]=AA11` — rather than having the streamer replay it.
+
+### Server-initiated / snapshot `weather`
+
+```json
+{
+  "type": "weather",
+  "time": "2001-09-11T08:51:00Z",
+  "weather": [
+    {
+      "id": 88213,
+      "station_id": "KLGA",
+      "start_date": "2001-09-11T08:51:00Z",
+      "temp_c": 22.8,
+      "dewpoint_c": 15.6,
+      "wind_dir_deg": 250,
+      "wind_speed_kt": 8,
+      "pressure_hpa": 1015.2,
+      "sky_condition": "CLR",
+      "visibility_km": 16.1,
+      "raw_metar": "KLGA 110851Z 25008KT 10SM CLR 23/16 A2998"
+    }
+  ],
+  "weather_forecasts": [
+    {
+      "id": 512,
+      "wfo": "OKX",
+      "zone": "NYZ072,NYZ073,NYZ076",
+      "product_type": "ZFP",
+      "start_date": "2001-09-11T08:35:00Z",
+      "raw_text": "NEW YORK CITY ZONE FORECAST PRODUCT..."
+    }
+  ]
+}
+```
+
+`WeatherObservation` fields (mirrors `internal/model/weather.go`; field names are its `json` tags):
+
+| Field           | Type      | Notes                                                                 |
+| --------------- | --------- | ---------------------------------------------------------------------- |
+| `id`            | int       | Row id (`weather_observations.id`).                                    |
+| `station_id`    | string    | Station identifier (`weather_stations.station_id`), e.g. `"KLGA"`.     |
+| `start_date`    | timestamp | `observed_at`, UTC.                                                    |
+| `temp_c`        | float?    | **Absent when the station didn't report it** — not COALESCEd to 0.     |
+| `dewpoint_c`    | float?    | Absent when not reported.                                              |
+| `wind_dir_deg`  | int?      | Absent when not reported.                                              |
+| `wind_speed_kt` | float?    | Absent when not reported. A real `0` kt is sent as `0`, distinguishable from absence. |
+| `gust_kt`       | float?    | Absent when not reported.                                              |
+| `pressure_hpa`  | float?    | Absent when not reported.                                              |
+| `sky_condition` | string?   | Absent when empty.                                                     |
+| `present_weather` | string? | Absent when empty.                                                     |
+| `visibility_km` | float?    | Absent when not reported.                                              |
+| `raw_metar`     | string?   | Absent when empty; the raw encoded METAR/SPECI line.                   |
+
+`WeatherObservation`'s nullable numeric fields scan as Go pointers (`*float64`/`*int`) rather than
+being COALESCEd to `0` in SQL, and the wire encoding (msgpack `omitempty` via the `json` struct tag)
+drops the field entirely when the pointer is `nil` — so "not reported" and "reported as zero" stay
+distinguishable on the wire, not just in Postgres.
+
+`WeatherForecast` fields (mirrors `internal/model/weather.go`):
+
+| Field          | Type      | Notes                                                              |
+| -------------- | --------- | -------------------------------------------------------------------- |
+| `id`           | int       | Row id (`weather_forecasts.id`).                                     |
+| `wfo`          | string    | Issuing NWS Weather Forecast Office, e.g. `"OKX"`.                    |
+| `zone`         | string    | Comma-joined 6-char UGC zone ids the product covers, e.g. `"NYZ072,NYZ073,NYZ076"`. |
+| `product_type` | string    | e.g. `"ZFP"`, `"AFD"`.                                                |
+| `start_date`   | timestamp | `issued_at`, UTC.                                                    |
+| `raw_text`     | string    | The full archived forecast text.                                     |
+
+Like `pager`/`flights`, `weather` frames are sent once per **window refill** (or snapshot) and only
+when at least one of `weather[]`/`weather_forecasts[]` is non-empty — an empty batch on both produces
+no frame. Because the subscribe/init/seek snapshot and the first forward window can both cover a
+station's most recent observation, the client should **dedup by `id`**, same as `flights`.
+
+### `weather_forecast`
+
+Request:
+
+```json
+{ "type": "weather_forecast", "zone": "NYZ076", "id": 7 }
+```
+
+`zone` must match `^[A-Z]{2}Z\d{3}$` (an NWS UGC zone code, validated server-side before it ever
+reaches a SQL `LIKE` clause). If the zone fails that pattern, **or** the session has no active
+`weather` subscription, the request is **silently dropped** — no reply, no `error` frame — mirroring
+`flights_history`'s silent-drop gating for an unsubscribed request; neither condition is something
+the user needs surfaced as an error.
+
+A valid, subscribed request always gets a reply on `weather_forecast`, echoing `id`:
+
+```json
+{
+  "type": "weather_forecast",
+  "id": 7,
+  "time": "2001-09-11T08:51:00Z",
+  "weather_forecasts": [ { "id": 512, "wfo": "OKX", "zone": "NYZ072,NYZ073,NYZ076", "product_type": "ZFP", "start_date": "2001-09-11T08:35:00Z", "raw_text": "..." } ]
+}
+```
+
+When no forecast product covers the zone at or before the client's virtual time, the reply is still
+sent, with `weather_forecasts` empty/omitted:
+
+```json
+{ "type": "weather_forecast", "id": 7, "time": "2001-09-11T08:51:00Z" }
+```
+
+This is an **explicit** "no forecast for this zone yet" answer, not silence — unlike the
+unsubscribed/invalid-zone case above, a request that clears both gates always resolves the client's
+`id`, so "no product" and "still waiting" are never ambiguous.
+
+The zone lookup is a **containment** match, not an exact-string match: a forecast product's `zone`
+column holds a comma-joined list of every UGC zone it covers (e.g. `"NYZ072,NYZ073,NYZ076"`), and the
+server matches the requested zone as a substring of that list (`zone LIKE '%'||$1||'%'`), picking the
+most recently issued match at or before the clock. Each UGC zone id is a fixed 6 characters, so a
+prefix/suffix collision across adjacent zone ids in the joined list is not possible. The Weather app
+determines *which* zone to request by reading its selected station's `nws_zone` column from the
+`weather_stations` Directus collection — that mapping is static reference data, not part of this
+wire protocol.
+
+#### Radar and almanac are not on the wire
+
+NEXRAD radar composite imagery and per-station almanac (normals/records) are **not** part of the
+`weather` channel, or any WebSocket frame — like `flight_tracks`, they're static per-instant or
+per-station assets, not a time-windowed stream of database rows. `packages/tools/weather-recon`
+mirrors radar composites into Wasabi under `weather/radar/`, alongside an `index.json` manifest
+(mosaic bounds, the frame list, and any gaps) that the client uses to compute the frame URL for a
+given virtual-clock 5-minute bucket, served through `files.911realtime.org/weather/...` — the same
+static-asset path every other media type in this repo uses (see the top-level CLAUDE.md's "Media
+assets live outside this repo"). Almanac data follows the same pattern (one static JSON per station).
+See `plans/weather-app-design.md` for the full pipeline/frontend design and
+`packages/tools/weather-recon/README.md` for the shipped/pending pipeline phases.
 
 ### `pause`
 

--- a/packages/backend/internal/db/postgres.go
+++ b/packages/backend/internal/db/postgres.go
@@ -653,3 +653,125 @@ func StreamFlightPositions(ctx context.Context, pool *pgxpool.Pool, fn func(minu
 	}
 	return rows.Err()
 }
+
+// --- weather (weather channel) ---
+
+// weatherObsSelectFrom is the shared SELECT clause for weather_observations
+// rows (packages/tools/weather-recon). Numeric fields are nullable in the
+// NCEI source data — a station can report temp without gust, or vice versa —
+// so they scan straight into the model's *float64/*int fields rather than
+// COALESCEing to 0 (see model.WeatherObservation).
+const weatherObsSelectFrom = `
+	SELECT id, station_id, observed_at, temp_c, dewpoint_c,
+	       wind_dir_deg, wind_speed_kt, gust_kt, pressure_hpa,
+	       sky_condition, present_weather, visibility_km, raw_metar
+	FROM weather_observations`
+
+// WeatherObsInRange returns observations whose observed_at falls in the
+// half-open interval [lo, hi), ordered by observed_at — the forward window a
+// tick fetches for the weather channel.
+func WeatherObsInRange(ctx context.Context, pool *pgxpool.Pool, lo, hi time.Time) ([]model.WeatherObservation, error) {
+	return queryWeatherObs(ctx, pool,
+		weatherObsSelectFrom+`
+		 WHERE observed_at >= $1 AND observed_at < $2
+		 ORDER BY observed_at`, lo, hi)
+}
+
+// CurrentWeatherObs returns the most recent observation at or before t for
+// every station — the per-station snapshot a client sees on init/seek.
+func CurrentWeatherObs(ctx context.Context, pool *pgxpool.Pool, t time.Time) ([]model.WeatherObservation, error) {
+	return queryWeatherObs(ctx, pool,
+		`SELECT DISTINCT ON (station_id) id, station_id, observed_at, temp_c, dewpoint_c,
+		        wind_dir_deg, wind_speed_kt, gust_kt, pressure_hpa,
+		        sky_condition, present_weather, visibility_km, raw_metar
+		 FROM weather_observations
+		 WHERE observed_at <= $1
+		 ORDER BY station_id, observed_at DESC`, t)
+}
+
+func queryWeatherObs(ctx context.Context, pool *pgxpool.Pool, q string, args ...any) ([]model.WeatherObservation, error) {
+	rows, err := pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query: %w", err)
+	}
+	defer rows.Close()
+
+	var out []model.WeatherObservation
+	for rows.Next() {
+		var it model.WeatherObservation
+		// sky_condition/present_weather/raw_metar are nullable text — the derefStr
+		// pattern; the numeric fields are already *float64/*int on the model, so
+		// they scan directly (see item.go's CalcDuration/Sort for precedent).
+		var skyCondition, presentWeather, rawMetar *string
+		if err := rows.Scan(
+			&it.ID, &it.StationID, &it.StartDate, &it.TempC, &it.DewpointC,
+			&it.WindDirDeg, &it.WindSpeedKt, &it.GustKt, &it.PressureHpa,
+			&skyCondition, &presentWeather, &it.VisibilityKm, &rawMetar,
+		); err != nil {
+			return nil, fmt.Errorf("scan: %w", err)
+		}
+		derefStr(&it.SkyCondition, skyCondition)
+		derefStr(&it.PresentWeather, presentWeather)
+		derefStr(&it.RawMetar, rawMetar)
+		out = append(out, it)
+	}
+	return out, rows.Err()
+}
+
+// weatherForecastSelectFrom is the shared SELECT clause for weather_forecasts
+// rows (archived NWS ZFP/AFD zone forecast text products).
+const weatherForecastSelectFrom = `
+	SELECT id, wfo, zone, product_type, issued_at, raw_text
+	FROM weather_forecasts`
+
+// WeatherForecastsInRange returns forecasts whose issued_at falls in the
+// half-open interval [lo, hi), ordered by issued_at.
+func WeatherForecastsInRange(ctx context.Context, pool *pgxpool.Pool, lo, hi time.Time) ([]model.WeatherForecast, error) {
+	return queryWeatherForecasts(ctx, pool,
+		weatherForecastSelectFrom+`
+		 WHERE issued_at >= $1 AND issued_at < $2
+		 ORDER BY issued_at`, lo, hi)
+}
+
+// CurrentWeatherForecast returns the most recently issued forecast at or
+// before t whose comma-joined zone list contains zone, or (nil, nil) if none
+// exists. zone is matched with a substring LIKE since a single product can
+// cover many UGC zones.
+func CurrentWeatherForecast(ctx context.Context, pool *pgxpool.Pool, zone string, t time.Time) (*model.WeatherForecast, error) {
+	items, err := queryWeatherForecasts(ctx, pool,
+		weatherForecastSelectFrom+`
+		 WHERE zone LIKE '%'||$1||'%' AND issued_at <= $2
+		 ORDER BY issued_at DESC
+		 LIMIT 1`, zone, t)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, nil
+	}
+	return &items[0], nil
+}
+
+func queryWeatherForecasts(ctx context.Context, pool *pgxpool.Pool, q string, args ...any) ([]model.WeatherForecast, error) {
+	rows, err := pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query: %w", err)
+	}
+	defer rows.Close()
+
+	var out []model.WeatherForecast
+	for rows.Next() {
+		var it model.WeatherForecast
+		var wfo, productType, rawText *string
+		if err := rows.Scan(
+			&it.ID, &wfo, &it.Zone, &productType, &it.StartDate, &rawText,
+		); err != nil {
+			return nil, fmt.Errorf("scan: %w", err)
+		}
+		derefStr(&it.Wfo, wfo)
+		derefStr(&it.ProductType, productType)
+		derefStr(&it.RawText, rawText)
+		out = append(out, it)
+	}
+	return out, rows.Err()
+}

--- a/packages/backend/internal/db/postgres.go
+++ b/packages/backend/internal/db/postgres.go
@@ -727,9 +727,12 @@ const weatherForecastSelectFrom = `
 // WeatherForecastsInRange returns forecasts whose issued_at falls in the
 // half-open interval [lo, hi), ordered by issued_at.
 func WeatherForecastsInRange(ctx context.Context, pool *pgxpool.Pool, lo, hi time.Time) ([]model.WeatherForecast, error) {
+	// zone IS NOT NULL: Zone scans as a plain string; the loader never writes
+	// NULL zones, but the column is nullable — one bad row would otherwise
+	// fail the scan and black out the whole tick window.
 	return queryWeatherForecasts(ctx, pool,
 		weatherForecastSelectFrom+`
-		 WHERE issued_at >= $1 AND issued_at < $2
+		 WHERE zone IS NOT NULL AND issued_at >= $1 AND issued_at < $2
 		 ORDER BY issued_at`, lo, hi)
 }
 

--- a/packages/backend/internal/handler/ws.go
+++ b/packages/backend/internal/handler/ws.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"time"
 
 	"classicy/streamer/internal/cache"
@@ -17,6 +18,10 @@ import (
 	goredis "github.com/redis/go-redis/v9"
 	"golang.org/x/time/rate"
 )
+
+// weatherZoneRe validates a client-supplied NWS UGC zone code (e.g. "NYZ072")
+// before it feeds a SQL LIKE in db.CurrentWeatherForecast.
+var weatherZoneRe = regexp.MustCompile(`^[A-Z]{2}Z\d{3}$`)
 
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
@@ -39,7 +44,7 @@ type filterMsg struct {
 }
 
 // channelMsg carries the channel name for subscribe/unsubscribe. Valid channels
-// are "pager", "mp3", "news" and "usenet".
+// are "pager", "mp3", "news", "usenet", "flights" and "weather".
 type channelMsg struct {
 	Type    string `json:"type"`
 	Channel string `json:"channel"`
@@ -74,6 +79,15 @@ type flightsHistoryMsg struct {
 	Type    string `json:"type"`
 	Minutes int    `json:"minutes"`
 	ID      int    `json:"id"`
+}
+
+// weatherForecastMsg requests the current forecast product for a single NWS
+// zone (UGC code, e.g. "NYZ072") at the client's virtual time. id is echoed
+// on the reply so the client can match it to the request.
+type weatherForecastMsg struct {
+	Type string `json:"type"`
+	Zone string `json:"zone"`
+	ID   int    `json:"id"`
 }
 
 // NewWSHandler returns an http.HandlerFunc that upgrades connections to WebSocket
@@ -288,6 +302,24 @@ func NewWSHandler(hub *session.Hub, rdb *goredis.Client, pool *pgxpool.Pool, log
 					sendFlightsHistory(r, sess, rdb, fmsg.ID, t, fmsg.Minutes, logger)
 				}
 
+			case "weather_forecast":
+				var wmsg weatherForecastMsg
+				if err := json.Unmarshal(raw, &wmsg); err != nil {
+					sess.SendError("malformed weather_forecast message")
+					continue
+				}
+				// The forecast lookup is a weather-channel feature, and the zone feeds
+				// a SQL LIKE, so both gates return before touching the pool. Neither
+				// case sends an error frame — an unsubscribed client or a stale/mistyped
+				// zone selection isn't something the user needs to see as an error,
+				// mirroring flights_history's silent-drop gating for the unsubscribed case.
+				if !sess.Subscribed(session.ChannelWeather) || !weatherZoneRe.MatchString(wmsg.Zone) {
+					continue
+				}
+				if t, ok := sess.VirtualTime(); ok {
+					sendWeatherForecast(r, sess, pool, wmsg.ID, wmsg.Zone, t, logger)
+				}
+
 			case "pause":
 				sess.Pause()
 
@@ -494,6 +526,40 @@ func sendFlightsHistory(r *http.Request, sess *session.Session, rdb *goredis.Cli
 	sess.SendFlightsHistory(reqID, t, nil, true)
 }
 
+// sendWeatherSnapshot delivers the latest observation at or before t for every
+// station to the session if it is subscribed to the weather channel. Called
+// from init, seek, and subscribe. Unlike the tick path's windowed reads, this
+// is a point-in-time DISTINCT ON lookup with no lookback bound baked in — a
+// station silent for hours still shows its last observation, labeled by its
+// own timestamp; forecasts are not part of the snapshot (on-demand only, via
+// weather_forecast).
+func sendWeatherSnapshot(r *http.Request, sess *session.Session, pool *pgxpool.Pool, t time.Time, logger *slog.Logger) {
+	if !sess.Subscribed(session.ChannelWeather) {
+		return
+	}
+	obs, err := db.CurrentWeatherObs(r.Context(), pool, t)
+	if err != nil {
+		logger.Warn("current weather obs query failed", "error", err)
+		return
+	}
+	sess.SendWeather(t, obs, nil)
+}
+
+// sendWeatherForecast looks up the forecast product covering zone at t and
+// replies on the weather_forecast frame, echoing reqID. Unlike
+// sendWeatherSnapshot, this always sends — CurrentWeatherForecast returning
+// (nil, nil) (no product covers the zone) or a query error still gets a
+// reply (empty forecast field) so the client's request doesn't hang.
+func sendWeatherForecast(r *http.Request, sess *session.Session, pool *pgxpool.Pool, reqID int, zone string, t time.Time, logger *slog.Logger) {
+	fc, err := db.CurrentWeatherForecast(r.Context(), pool, zone, t)
+	if err != nil {
+		logger.Warn("current weather forecast query failed", "zone", zone, "error", err)
+		sess.SendWeatherForecast(reqID, t, nil)
+		return
+	}
+	sess.SendWeatherForecast(reqID, t, fc)
+}
+
 // sendSources delivers the time-independent available-source lists for client
 // filters (TV channels, RadioScanner audio stations, pager providers, newsgroups). Called once per init —
 // sources don't change with virtual time, so seek does not resend them. Failures
@@ -522,7 +588,7 @@ func sendSources(r *http.Request, sess *session.Session, pool *pgxpool.Pool, log
 func knownChannel(ch string) bool {
 	return ch == session.ChannelPager || ch == session.ChannelMp3 ||
 		ch == session.ChannelNews || ch == session.ChannelUsenet ||
-		ch == session.ChannelFlights
+		ch == session.ChannelFlights || ch == session.ChannelWeather
 }
 
 // sendChannelSnapshot delivers the subscribe-time snapshot for a single channel.
@@ -538,6 +604,8 @@ func sendChannelSnapshot(r *http.Request, sess *session.Session, pool *pgxpool.P
 		sendUsenetSnapshot(r, sess, pool, t, logger)
 	case session.ChannelFlights:
 		sendFlightsSnapshot(r, sess, rdb, t, logger)
+	case session.ChannelWeather:
+		sendWeatherSnapshot(r, sess, pool, t, logger)
 	}
 }
 
@@ -549,4 +617,5 @@ func sendSubscribedSnapshots(r *http.Request, sess *session.Session, pool *pgxpo
 	sendNewsSnapshot(r, sess, pool, t, logger)
 	sendUsenetSnapshot(r, sess, pool, t, logger)
 	sendFlightsSnapshot(r, sess, rdb, t, logger)
+	sendWeatherSnapshot(r, sess, pool, t, logger)
 }

--- a/packages/backend/internal/handler/ws_test.go
+++ b/packages/backend/internal/handler/ws_test.go
@@ -148,7 +148,7 @@ func TestParseTimeInvalid(t *testing.T) {
 // --- knownChannel ---
 
 func TestKnownChannels(t *testing.T) {
-	for _, ch := range []string{"pager", "mp3", "news", "usenet", "flights"} {
+	for _, ch := range []string{"pager", "mp3", "news", "usenet", "flights", "weather"} {
 		if !knownChannel(ch) {
 			t.Errorf("knownChannel(%q) = false, want true", ch)
 		}
@@ -263,16 +263,25 @@ func TestWSHandlerHeartbeatInvalidTime(t *testing.T) {
 	}
 }
 
+// TestWSHandlerAllChannelsSubscribeIndependently proves every known channel
+// can subscribe/unsubscribe on its own. It uses a nil pool and rdb (like the
+// other handler tests above) and never sends init/heartbeat/seek, so the
+// session's virtual time stays zero — sendChannelSnapshot is gated behind
+// sess.VirtualTime()'s ok flag and is therefore never invoked here, meaning
+// even the Postgres- and Redis-backed channels (weather, flights) are safe to
+// exercise without a real pool/rdb. Snapshot DB paths are covered separately
+// (or, per repo convention, left untested where they require Postgres).
 func TestWSHandlerAllChannelsSubscribeIndependently(t *testing.T) {
 	conn := dialWS(t, newTestServer(t, nil))
-	for _, ch := range []string{"pager", "mp3", "news", "usenet"} {
+	channels := []string{"pager", "mp3", "news", "usenet", "flights", "weather"}
+	for _, ch := range channels {
 		sendJSON(t, conn, map[string]string{"type": "subscribe", "channel": ch})
 		f := readFrame(t, conn)
 		if f.Type != "subscribe_ack" || f.Channel != ch {
 			t.Fatalf("channel %q: expected subscribe_ack, got %+v", ch, f)
 		}
 	}
-	for _, ch := range []string{"pager", "mp3", "news", "usenet"} {
+	for _, ch := range channels {
 		sendJSON(t, conn, map[string]string{"type": "unsubscribe", "channel": ch})
 		f := readFrame(t, conn)
 		if f.Type != "unsubscribe_ack" || f.Channel != ch {
@@ -353,5 +362,42 @@ func TestWSHandlerFlightsHistoryIgnoredWhenUnsubscribed(t *testing.T) {
 	sendJSON(t, conn, map[string]string{"type": "pause"})
 	if f := readFrame(t, conn); f.Type != "pause_ack" {
 		t.Fatalf("expected pause_ack (history silently ignored), got %+v", f)
+	}
+}
+
+// --- weather_forecast gating ---
+//
+// Both paths below return before touching the pool (invalid zone shape and
+// missing subscription), so a nil pool is safe — same technique as
+// TestWSHandlerFlightsHistoryIgnoredWhenUnsubscribed. The DB-backed success
+// path (valid zone + subscribed) needs Postgres and stays untested here by
+// repo convention (see sendUsenetSnapshot's siblings, none of which are
+// exercised end-to-end in this file either).
+
+func TestWSHandlerWeatherForecastIgnoredWhenUnsubscribed(t *testing.T) {
+	conn := dialWS(t, newTestServer(t, nil))
+	sendJSON(t, conn, map[string]any{"type": "weather_forecast", "zone": "NYZ072", "id": 1})
+	// A follow-up round-trip proves the request produced no frames at all.
+	sendJSON(t, conn, map[string]string{"type": "pause"})
+	if f := readFrame(t, conn); f.Type != "pause_ack" {
+		t.Fatalf("expected pause_ack (forecast request silently ignored), got %+v", f)
+	}
+}
+
+func TestWSHandlerWeatherForecastIgnoredWhenZoneInvalid(t *testing.T) {
+	conn := dialWS(t, newTestServer(t, nil))
+	sendJSON(t, conn, map[string]string{"type": "subscribe", "channel": "weather"})
+	if f := readFrame(t, conn); f.Type != "subscribe_ack" {
+		t.Fatalf("expected subscribe_ack, got %+v", f)
+	}
+
+	for _, zone := range []string{"", "nyz072", "NYZ72", "NYZ0721", "NY072", "NYZ07A", "NYZ072;DROP"} {
+		sendJSON(t, conn, map[string]any{"type": "weather_forecast", "zone": zone, "id": 2})
+		// A follow-up round-trip proves the request produced no frames at all —
+		// it never reached the pool (which is nil here and would panic).
+		sendJSON(t, conn, map[string]string{"type": "pause"})
+		if f := readFrame(t, conn); f.Type != "pause_ack" {
+			t.Fatalf("zone %q: expected pause_ack (forecast request silently ignored), got %+v", zone, f)
+		}
 	}
 }

--- a/packages/backend/internal/model/weather.go
+++ b/packages/backend/internal/model/weather.go
@@ -1,0 +1,38 @@
+package model
+
+import "time"
+
+// WeatherObservation is one hourly METAR/ISD surface observation for a station
+// (packages/tools/weather-recon, weather_observations). StartDate carries
+// observed_at — named StartDate to match every other channel's reveal-gating
+// field. Most numeric fields are nullable in the NCEI source data (a station
+// may report temp but not gust, or vice versa), so they scan as pointers
+// rather than COALESCEing to 0 — a real 0 kt gust and "not reported" must stay
+// distinguishable to the client.
+type WeatherObservation struct {
+	ID             int       `json:"id"`
+	StationID      string    `json:"station_id"`
+	StartDate      time.Time `json:"start_date"`
+	TempC          *float64  `json:"temp_c,omitempty"`
+	DewpointC      *float64  `json:"dewpoint_c,omitempty"`
+	WindDirDeg     *int      `json:"wind_dir_deg,omitempty"`
+	WindSpeedKt    *float64  `json:"wind_speed_kt,omitempty"`
+	GustKt         *float64  `json:"gust_kt,omitempty"`
+	PressureHpa    *float64  `json:"pressure_hpa,omitempty"`
+	SkyCondition   string    `json:"sky_condition,omitempty"`
+	PresentWeather string    `json:"present_weather,omitempty"`
+	VisibilityKm   *float64  `json:"visibility_km,omitempty"`
+	RawMetar       string    `json:"raw_metar,omitempty"`
+}
+
+// WeatherForecast is one archived NWS zone forecast text product (ZFP/AFD)
+// (packages/tools/weather-recon, weather_forecasts). StartDate carries
+// issued_at. Zone is the comma-joined 6-char UGC zone ids the product covers.
+type WeatherForecast struct {
+	ID          int       `json:"id"`
+	Wfo         string    `json:"wfo"`
+	Zone        string    `json:"zone"`
+	ProductType string    `json:"product_type"`
+	StartDate   time.Time `json:"start_date"`
+	RawText     string    `json:"raw_text"`
+}

--- a/packages/backend/internal/session/session.go
+++ b/packages/backend/internal/session/session.go
@@ -31,6 +31,7 @@ const (
 	ChannelNews    = "news"
 	ChannelUsenet  = "usenet"
 	ChannelFlights = "flights"
+	ChannelWeather = "weather"
 )
 
 // Look-ahead windowing. Instead of one Redis lookup + frame per virtual second,
@@ -54,12 +55,15 @@ const (
 	// flights are dense — ~600-900 airborne rows/min — so they get media's
 	// shorter window, keeping refill frames at ~300-450 KB.
 	windowFlights = 300 * time.Second
+	// weather is sparse (hourly obs per station, occasional forecast products),
+	// so it gets usenet/news scale rather than flights' shorter window.
+	windowWeather = 600 * time.Second
 )
 
-// usenetTickTimeout bounds a single windowed usenet Postgres read on the tick path
-// — the tick's only DB dependency (hard rule #4 exception). A slow query is
-// abandoned rather than allowed to pile up tick after tick.
-const usenetTickTimeout = 5 * time.Second
+// pgTickTimeout bounds a single windowed Postgres read on the tick path — the
+// usenet and weather channels' DB dependency (hard rule #4 exception). A slow
+// query is abandoned rather than allowed to pile up tick after tick.
+const pgTickTimeout = 5 * time.Second
 
 // SourceList carries the time-independent set of selectable sources for each
 // client-side filter. The sources table does not record which media type a source
@@ -80,8 +84,12 @@ type outMsg struct {
 	Pager   []model.PagerItem      `json:"pager,omitempty"`
 	Usenet  []model.UsenetItem     `json:"usenet,omitempty"`
 	Flights []model.FlightPosition `json:"flights,omitempty"`
-	Sources *SourceList            `json:"sources,omitempty"`
-	Msg     string                 `json:"message,omitempty"`
+	// Weather/WeatherForecasts carry the weather channel's tick batch
+	// (SendWeather) and the on-demand weather_forecast reply (SendWeatherForecast).
+	Weather          []model.WeatherObservation `json:"weather,omitempty"`
+	WeatherForecasts []model.WeatherForecast    `json:"weather_forecasts,omitempty"`
+	Sources          *SourceList                `json:"sources,omitempty"`
+	Msg              string                     `json:"message,omitempty"`
 	// ID/Body carry a single on-demand Usenet article body (usenet_body frame).
 	ID   int    `json:"id,omitempty"`
 	Body string `json:"body,omitempty"`
@@ -95,9 +103,11 @@ type Session struct {
 	id  string
 	hub *Hub
 	rdb *goredis.Client
-	// pool backs the usenet channel only: usenet messages are too large to cache in
-	// Redis, so its windowed delivery reads Postgres directly (see UsenetItemsInRange).
-	// Every other channel uses Redis via the tick path (hard rule #4).
+	// pool backs the usenet and weather channels: usenet messages are too large to
+	// cache in Redis, and weather data is sparse enough that a Redis cache isn't
+	// worth building, so both read Postgres directly on the tick (see
+	// UsenetItemsInRange / WeatherObsInRange / WeatherForecastsInRange). Every
+	// other channel uses Redis via the tick path (hard rule #4).
 	pool   *pgxpool.Pool
 	logger *slog.Logger
 
@@ -116,6 +126,7 @@ type Session struct {
 	newsHorizon    time.Time
 	usenetHorizon  time.Time
 	flightsHorizon time.Time
+	weatherHorizon time.Time
 
 	// usenetGroups is the set of newsgroups the client is currently viewing. The
 	// usenet channel is delivered only for these groups — a group can hold millions
@@ -230,6 +241,8 @@ func (s *Session) horizonFor(channel string) *time.Time {
 		return &s.usenetHorizon
 	case ChannelFlights:
 		return &s.flightsHorizon
+	case ChannelWeather:
+		return &s.weatherHorizon
 	}
 	return nil
 }
@@ -335,6 +348,30 @@ func (s *Session) SendFlightsHistory(reqID int, t time.Time, items []model.Fligh
 	s.send_(outMsg{Type: "flights_history", ID: reqID, Time: t.Format(time.RFC3339), Flights: items, Done: done})
 }
 
+// SendWeather delivers a batch of weather observations and forecasts at time t
+// on the weather channel. Sparse data (hourly obs, occasional forecast
+// products) rides one frame carrying both lists, following the usenet Postgres
+// exception. No frame is sent when both batches are empty.
+func (s *Session) SendWeather(t time.Time, obs []model.WeatherObservation, forecasts []model.WeatherForecast) {
+	if len(obs) == 0 && len(forecasts) == 0 {
+		return
+	}
+	s.send_(outMsg{Type: "weather", Time: t.Format(time.RFC3339), Weather: obs, WeatherForecasts: forecasts})
+}
+
+// SendWeatherForecast delivers a single on-demand forecast lookup for a zone,
+// echoing the client's request id. Unlike SendWeather, this always sends —
+// even when fc is nil, the client must see an explicit "no forecast for this
+// zone" reply (WeatherForecasts empty) rather than silence being ambiguous
+// with "still loading."
+func (s *Session) SendWeatherForecast(reqID int, t time.Time, fc *model.WeatherForecast) {
+	var forecasts []model.WeatherForecast
+	if fc != nil {
+		forecasts = []model.WeatherForecast{*fc}
+	}
+	s.send_(outMsg{Type: "weather_forecast", ID: reqID, Time: t.Format(time.RFC3339), WeatherForecasts: forecasts})
+}
+
 // SetUsenetGroups replaces the set of newsgroups the client is viewing on the
 // usenet channel and acks. Resetting the usenet horizon to the current virtual time
 // makes the next tick refill a fresh forward window for the new group(s); the
@@ -417,6 +454,7 @@ func (s *Session) resetHorizons(t time.Time) {
 	s.newsHorizon = t
 	s.usenetHorizon = t
 	s.flightsHorizon = t
+	s.weatherHorizon = t
 }
 
 // Pause freezes the client's virtual clock.
@@ -479,6 +517,7 @@ func (s *Session) RunTimePump() {
 			newsLo, newsHi, doNews := s.planChannelRefill(ChannelNews, &s.newsHorizon, t, windowNews)
 			usenetLo, usenetHi, doUsenet := s.planChannelRefill(ChannelUsenet, &s.usenetHorizon, t, windowUsenet)
 			flightsLo, flightsHi, doFlights := s.planChannelRefill(ChannelFlights, &s.flightsHorizon, t, windowFlights)
+			weatherLo, weatherHi, doWeather := s.planChannelRefill(ChannelWeather, &s.weatherHorizon, t, windowWeather)
 			var usenetGroups []string
 			if doUsenet {
 				usenetGroups = s.usenetGroupsLocked()
@@ -529,7 +568,7 @@ func (s *Session) RunTimePump() {
 			if doUsenet && len(usenetGroups) > 0 && s.pool != nil {
 				// Bound the per-tick Postgres reads so a slow query is abandoned
 				// rather than piling up across ticks.
-				qctx, cancel := context.WithTimeout(ctx, usenetTickTimeout)
+				qctx, cancel := context.WithTimeout(ctx, pgTickTimeout)
 				var batch []model.UsenetItem
 				for _, g := range usenetGroups {
 					items, err := db.UsenetItemsInRange(qctx, s.pool, g, usenetLo, usenetHi)
@@ -541,6 +580,22 @@ func (s *Session) RunTimePump() {
 				}
 				cancel()
 				s.SendUsenet(t, batch)
+			}
+			// weather refills read Postgres directly (not Redis), the same exception
+			// as usenet: observations/forecasts are sparse enough that per-tick query
+			// volume is low, so there is no Redis cache/listener/warm to build.
+			if doWeather && s.pool != nil {
+				qctx, cancel := context.WithTimeout(ctx, pgTickTimeout)
+				obs, obsErr := db.WeatherObsInRange(qctx, s.pool, weatherLo, weatherHi)
+				if obsErr != nil {
+					s.logger.Warn("weather obs range lookup failed", "error", obsErr)
+				}
+				forecasts, fcErr := db.WeatherForecastsInRange(qctx, s.pool, weatherLo, weatherHi)
+				if fcErr != nil {
+					s.logger.Warn("weather forecast range lookup failed", "error", fcErr)
+				}
+				cancel()
+				s.SendWeather(t, obs, forecasts)
 			}
 		}
 	}

--- a/packages/backend/internal/session/session_test.go
+++ b/packages/backend/internal/session/session_test.go
@@ -719,3 +719,99 @@ func TestSendFlightsHistoryDoneFrameSentEvenWhenEmpty(t *testing.T) {
 		t.Fatalf("done marker should carry no flights, got %d", len(m.Flights))
 	}
 }
+
+func TestSendWeatherEmitsFrame(t *testing.T) {
+	s := newTestSession(t)
+	at := time.Date(2001, 9, 11, 12, 51, 0, 0, time.UTC)
+	tempC := 21.1
+
+	s.SendWeather(at,
+		[]model.WeatherObservation{{ID: 1, StationID: "KJFK", StartDate: at, TempC: &tempC}},
+		[]model.WeatherForecast{{ID: 2, Wfo: "OKX", Zone: "NYZ072", StartDate: at, RawText: "Sunny."}},
+	)
+
+	m := recvType(t, s)
+	if m.Type != "weather" {
+		t.Fatalf("expected weather frame, got %q", m.Type)
+	}
+	if len(m.Weather) != 1 || m.Weather[0].StationID != "KJFK" || m.Weather[0].TempC == nil || *m.Weather[0].TempC != 21.1 {
+		t.Fatalf("expected one weather observation, got %+v", m.Weather)
+	}
+	if len(m.WeatherForecasts) != 1 || m.WeatherForecasts[0].Zone != "NYZ072" || m.WeatherForecasts[0].RawText != "Sunny." {
+		t.Fatalf("expected one weather forecast, got %+v", m.WeatherForecasts)
+	}
+	if len(m.Items) != 0 || len(m.Flights) != 0 {
+		t.Fatalf("weather frame must not carry other payloads, got %+v", m)
+	}
+}
+
+func TestSendWeatherSuppressesEmptyBatch(t *testing.T) {
+	s := newTestSession(t)
+	s.SendWeather(time.Date(2001, 9, 11, 3, 0, 0, 0, time.UTC), nil, nil)
+
+	select {
+	case data := <-s.send:
+		t.Fatalf("expected no frame for empty weather batch, got %d bytes", len(data))
+	default:
+	}
+}
+
+func TestWeatherHorizonResetOnSubscribeInitAndSeek(t *testing.T) {
+	s := newTestSession(t)
+	t0 := time.Date(2001, 9, 11, 12, 40, 0, 0, time.UTC)
+
+	s.Init(t0, nil)
+	if !s.weatherHorizon.Equal(t0) {
+		t.Fatalf("Init must reset weatherHorizon to t, got %v", s.weatherHorizon)
+	}
+
+	s.Subscribe(ChannelWeather)
+	if !s.Subscribed(ChannelWeather) {
+		t.Fatal("expected weather subscription after Subscribe")
+	}
+
+	t1 := t0.Add(2 * time.Hour)
+	s.Seek(t1, nil)
+	if !s.weatherHorizon.Equal(t1) {
+		t.Fatalf("Seek must reset weatherHorizon to t, got %v", s.weatherHorizon)
+	}
+}
+
+func TestWeatherRefillRequiresSubscription(t *testing.T) {
+	s := newTestSession(t)
+	t0 := time.Date(2001, 9, 11, 12, 40, 0, 0, time.UTC)
+	s.mu.Lock()
+	s.virtualTime = t0
+	s.weatherHorizon = t0
+	if _, _, due := s.planChannelRefill(ChannelWeather, &s.weatherHorizon, t0, windowWeather); due {
+		s.mu.Unlock()
+		t.Fatal("unsubscribed weather channel must never refill")
+	}
+	s.mu.Unlock()
+
+	s.Subscribe(ChannelWeather)
+	s.mu.Lock()
+	lo, hi, due := s.planChannelRefill(ChannelWeather, &s.weatherHorizon, t0, windowWeather)
+	s.mu.Unlock()
+	if !due || !lo.Equal(t0) || !hi.Equal(t0.Add(windowWeather)) {
+		t.Fatalf("expected [t, t+window) refill after subscribe, got lo=%v hi=%v due=%v", lo, hi, due)
+	}
+}
+
+func TestSendWeatherForecastNilStillSends(t *testing.T) {
+	s := newTestSession(t)
+	at := time.Date(2001, 9, 11, 12, 51, 0, 0, time.UTC)
+
+	s.SendWeatherForecast(42, at, nil)
+
+	m := recvType(t, s)
+	if m.Type != "weather_forecast" {
+		t.Fatalf("expected weather_forecast frame, got %q", m.Type)
+	}
+	if m.ID != 42 {
+		t.Fatalf("expected echoed request id 42, got %d", m.ID)
+	}
+	if len(m.WeatherForecasts) != 0 {
+		t.Fatalf("nil forecast must send an empty list, got %+v", m.WeatherForecasts)
+	}
+}


### PR DESCRIPTION
Phase 3 of the Weather app (#184): the streamer's `weather` subscription channel. Clock-synced conditions and forecasts now flow over the WebSocket — **live-verified end-to-end against production data** (all 8 checks, including KJFK's 9/11 morning at 21.1 °C / FEW / 16 km and the real OKX zone forecast text).

## What's in here

- **`model/weather.go` + 4 Postgres queries** — pointer-nullable scanning throughout (no COALESCE-to-zero: 0 °C is a real temperature), `DISTINCT ON` latest-per-station snapshot, NULL-zone guard on the tick query.
- **Session wiring** — `weather` channel const, 600 s window, usenet-shaped Postgres tick branch (lock discipline: plan under `mu`, query and send outside), one combined `weather` frame (windowed obs + newly-issued forecast segments), suppressed when empty.
- **Handler** — subscribe/init/seek snapshot (latest obs per station ≤ clock, no age limit); on-demand `{"type":"weather_forecast","zone","id"}` request with `^[A-Z]{2}Z\d{3}$` validation (also blocks LIKE-wildcard injection), silent drop on invalid/unsubscribed, explicit empty reply when no product exists. Also fixes a latent test omission: `flights` (and `weather`) added to the all-channels subscribe test.
- **Protocol doc** — full wire contract, accuracy-audited claim-by-claim against the code; radar/almanac "not on the wire" callout (static Wasabi + index.json).

## ⚠️ Two deviations from the design doc (`plans/weather-app-design.md`) — flagging for review

1. **Postgres-only, no Redis hour buckets.** The data is ~34k immutable rows (vs flights' 3.5M); the repo's own usenet precedent (backend CLAUDE.md hard-rule-4 exception) covers exactly this case, and it eliminates the warm/rewarm-after-reload operational surface entirely.
2. **Forecasts are on-demand per zone**, not a latest-per-zone snapshot broadcast (~800 KB saved per subscribe; the app shows one station's forecast at a time; newly-issued products still stream forward on the tick, ~2/min).

## Verification

`go test ./...`, `-race` on the weather tests, vet, gofmt all clean; final review traced mid-tick-seek ordering, Close-during-query, and horizon races (duplicates-only-never-gaps, matching existing channels). Existing frontend untouched — additive-only wire changes (`omitempty` on both new fields), confirmed no new frames reach clients that don't subscribe.

## Phase-4 client contract notes (carried to the frontend PR)

Clear weather state on seek and keep max-`start_date` per station (late stale windows carry fresh ids); start request ids at 1 (`id:0` is omitted by the envelope); pre-init requests silently drop (existing convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W179bqEPFP92a3JrsPkD5c
