### PR TITLE
fix(frontend): hide "Coming Up" on WINS/WCBS continuous stations

### DIFF
--- a/packages/frontend/src/Applications/RadioScanner/RadioScanner.test.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/RadioScanner.test.tsx
@@ -1,0 +1,147 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { MediaItem } from "../../Providers/MediaStream/MediaStreamContext";
+import {
+	MediaStreamContext,
+	type MediaStreamContextValue,
+} from "../../Providers/MediaStream/MediaStreamContext";
+
+// Stub the playback-heavy children — this suite only asserts the schedule
+// (Coming Up / Previous) chrome around them.
+vi.mock("./StationPlayer", () => ({
+	StationPlayer: () => <div data-testid="station-player" />,
+}));
+vi.mock("./NowPlayingList", () => ({
+	NowPlayingList: () => <div data-testid="now-playing" />,
+}));
+vi.mock("./FocusedItemPlayer", () => ({
+	FocusedItemPlayer: () => <div data-testid="focused-player" />,
+}));
+vi.mock("../../openreplay", () => ({
+	trackAppToggle: () => {},
+}));
+
+const mockAppData = vi.hoisted(
+	() => ({ current: {} as Record<string, unknown> }),
+);
+
+vi.mock("classicy", () => ({
+	ClassicyApp: ({ children }: { children: React.ReactNode }) => (
+		<div>{children}</div>
+	),
+	ClassicyWindow: ({ children }: { children?: React.ReactNode }) => (
+		<div>{children}</div>
+	),
+	ClassicyButton: ({
+		children,
+		onClickFunc,
+	}: {
+		children?: React.ReactNode;
+		onClickFunc?: () => void;
+	}) => (
+		<button type="button" onClick={onClickFunc}>
+			{children}
+		</button>
+	),
+	ClassicyIcons: {
+		applications: { radio: { app: "radio.png" } },
+		controlPanels: { soundManager: { sound33: "sound.png" } },
+	},
+	quitMenuItemHelper: () => ({}),
+	registerAppEventHandler: () => {},
+	useAppManager: (sel: (s: unknown) => unknown) =>
+		sel({
+			System: {
+				Manager: {
+					Applications: {
+						apps: {
+							"RadioScanner.app": {
+								open: true,
+								data: mockAppData.current,
+							},
+						},
+					},
+				},
+			},
+		}),
+	useAppManagerDispatch: () => () => {},
+	useClassicyDateTime: () => ({
+		dateTime: "2001-09-11T12:40:00.000Z",
+		paused: true,
+	}),
+}));
+
+import { RadioScanner } from "./RadioScanner";
+
+const NOW = "2001-09-11T12:40:00.000Z";
+
+function item(id: number, source: string, start: string): MediaItem {
+	return {
+		id,
+		title: `${source} clip ${id}`,
+		full_title: `${source} clip ${id}`,
+		source,
+		start_date: start,
+		calc_duration: 3600,
+		url: `https://example.test/${id}.mp3`,
+		format: "mp3",
+		approved: 1,
+		mute: 0,
+		volume: 1,
+		jump: 0,
+		trim: 0,
+	};
+}
+
+function renderScanner(activeStation: string): void {
+	mockAppData.current = { activeStation };
+	const ctx: Partial<MediaStreamContextValue> = {
+		mp3Items: [
+			item(1, "WINS", "2001-09-11T12:30:00.000Z"),
+			item(2, "WCBS", "2001-09-11T12:30:00.000Z"),
+			item(3, "ATC", "2001-09-11T12:30:00.000Z"),
+		],
+		mp3History: [],
+		sources: {
+			video: [],
+			audio: ["WINS", "WCBS", "ATC"],
+			pager: [],
+			usenet: [],
+		},
+		subscribeMp3: () => {},
+		unsubscribeMp3: () => {},
+		// Every station has a pending item, so any Coming Up section that
+		// renders would have content — the label's presence is purely the
+		// continuous-station gate under test.
+		getUpcomingMp3Items: () => [
+			item(11, "WINS", "2001-09-11T12:45:00.000Z"),
+			item(12, "WCBS", "2001-09-11T12:45:00.000Z"),
+			item(13, "ATC", "2001-09-11T12:45:00.000Z"),
+		],
+	};
+	render(
+		<MediaStreamContext.Provider value={ctx as MediaStreamContextValue}>
+			<RadioScanner />
+		</MediaStreamContext.Provider>,
+	);
+}
+
+describe("RadioScanner schedule visibility", () => {
+	afterEach(cleanup);
+
+	it(`shows Coming Up for a scheduled station (now=${NOW})`, () => {
+		renderScanner("ATC");
+		expect(screen.getByText("Coming Up")).toBeTruthy();
+	});
+
+	it("hides Coming Up on WINS (continuous broadcast)", () => {
+		renderScanner("WINS");
+		expect(screen.queryByText("Coming Up")).toBeNull();
+	});
+
+	it("hides Coming Up on WCBS (continuous broadcast)", () => {
+		renderScanner("WCBS");
+		expect(screen.queryByText("Coming Up")).toBeNull();
+	});
+});

--- a/packages/frontend/src/Applications/RadioScanner/RadioScanner.test.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/RadioScanner.test.tsx
@@ -69,6 +69,7 @@ vi.mock("classicy", () => ({
 	useClassicyDateTime: () => ({
 		dateTime: "2001-09-11T12:40:00.000Z",
 		paused: true,
+		tzOffset: -4,
 	}),
 }));
 
@@ -76,7 +77,12 @@ import { RadioScanner } from "./RadioScanner";
 
 const NOW = "2001-09-11T12:40:00.000Z";
 
-function item(id: number, source: string, start: string): MediaItem {
+function item(
+	id: number,
+	source: string,
+	start: string,
+	over: Partial<MediaItem> = {},
+): MediaItem {
 	return {
 		id,
 		title: `${source} clip ${id}`,
@@ -91,6 +97,7 @@ function item(id: number, source: string, start: string): MediaItem {
 		volume: 1,
 		jump: 0,
 		trim: 0,
+		...over,
 	};
 }
 
@@ -102,7 +109,11 @@ function renderScanner(activeStation: string): void {
 			item(2, "WCBS", "2001-09-11T12:30:00.000Z"),
 			item(3, "ATC", "2001-09-11T12:30:00.000Z"),
 		],
-		mp3History: [],
+		// One already-ended ATC clip (12:00–12:10 UTC, now is 12:40) for the
+		// Previous list.
+		mp3History: [
+			item(21, "ATC", "2001-09-11T12:00:00.000Z", { calc_duration: 600 }),
+		],
 		sources: {
 			video: [],
 			audio: ["WINS", "WCBS", "ATC"],
@@ -143,5 +154,12 @@ describe("RadioScanner schedule visibility", () => {
 	it("hides Coming Up on WCBS (continuous broadcast)", () => {
 		renderScanner("WCBS");
 		expect(screen.queryByText("Coming Up")).toBeNull();
+	});
+
+	it("labels each Previous item with its start time in the display timezone", () => {
+		renderScanner("ATC");
+		expect(screen.getByText("Previous")).toBeTruthy();
+		// 12:00 UTC shifted by the -4 display offset.
+		expect(screen.getByText("9/11, 8:00 AM")).toBeTruthy();
 	});
 });

--- a/packages/frontend/src/Applications/RadioScanner/RadioScanner.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/RadioScanner.tsx
@@ -36,6 +36,7 @@ import {
     mergeWithSources,
     previousSegments,
     sortStations,
+    startTimeLabel,
     upcomingSegments,
 } from "./stationGrouping";
 import { StationButtonContent } from "./StationButtonContent";
@@ -86,7 +87,7 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
         return () => unsubscribeMp3(appId);
     }, [subscribeMp3, unsubscribeMp3, appId]);
 
-    const { dateTime, paused: clockPaused } = useClassicyDateTime();
+    const { dateTime, paused: clockPaused, tzOffset } = useClassicyDateTime();
 
     const [captionsOn, setCaptionsOn] = useState<boolean>(false);
     const [activeStation, setActiveStation] = useState<string>(
@@ -394,6 +395,16 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
                                                                     }
                                                                 >
 																	<img src={ ClassicyIcons.controlPanels.soundManager.sound33} alt={item.title} />
+                                                                    <span
+                                                                        className={
+                                                                            styles.rsCountdown
+                                                                        }
+                                                                    >
+                                                                        {startTimeLabel(
+                                                                            item,
+                                                                            tzOffset,
+                                                                        )}
+                                                                    </span>
                                                                     <button
                                                                         type="button"
                                                                         className={

--- a/packages/frontend/src/Applications/RadioScanner/RadioScanner.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/RadioScanner.tsx
@@ -316,6 +316,7 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
                                             soloItemId={soloItemId}
                                             onToggleSolo={toggleSoloItem}
                                         />
+                                        {showSchedule && (
                                         <div style={{ display: "flex", flexDirection: "row", width: "100%", minHeight: "30%", maxHeight: "60%", gap: "var(--window-control-size)" }}>
                                                 <div
                                                     className={
@@ -413,7 +414,8 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
                                                     </ul>
                                                 </div>
                                             )}
-                                        </div>{" "}
+                                        </div>
+                                        )}
                                     </div>
                                     <StationPlayer
                                         station={activeStationObj}

--- a/packages/frontend/src/Applications/RadioScanner/stationGrouping.test.ts
+++ b/packages/frontend/src/Applications/RadioScanner/stationGrouping.test.ts
@@ -9,6 +9,7 @@ import {
 	previousSegments,
 	primarySegment,
 	sortStations,
+	startTimeLabel,
 	type Station,
 	upcomingSegments,
 } from "./stationGrouping";
@@ -141,6 +142,24 @@ describe("countdownLabel", () => {
 	it("clamps to 00:00 once the start has passed", () => {
 		const it1 = item({ start_date: "2001-09-11T12:30:00Z" });
 		expect(countdownLabel(it1, t("2001-09-11T12:31:00Z"))).toBe("00:00");
+	});
+});
+
+describe("startTimeLabel", () => {
+	it("formats the start instant in the display timezone", () => {
+		const it1 = item({ start_date: "2001-09-11T12:52:00.000Z" });
+		expect(startTimeLabel(it1, -4)).toBe("9/11, 8:52 AM");
+	});
+
+	it("treats a tz-less Directus datetime as UTC", () => {
+		const it1 = item({ start_date: "2001-09-11 12:52:00" });
+		expect(startTimeLabel(it1, -4)).toBe("9/11, 8:52 AM");
+	});
+
+	it("crosses the date line when the shift lands on another day", () => {
+		const it1 = item({ start_date: "2001-09-12T01:30:00.000Z" });
+		expect(startTimeLabel(it1, -4)).toBe("9/11, 9:30 PM");
+		expect(startTimeLabel(it1, 0)).toBe("9/12, 1:30 AM");
 	});
 });
 

--- a/packages/frontend/src/Applications/RadioScanner/stationGrouping.ts
+++ b/packages/frontend/src/Applications/RadioScanner/stationGrouping.ts
@@ -49,6 +49,24 @@ export function countdownLabel(item: MediaItem, nowMs: number): string {
 	return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
 }
 
+/**
+ * Short "M/D, h:mm AM" label for an item's start instant, rendered in the
+ * desktop's display timezone: shift the UTC epoch by tzOffsetHours and format
+ * as UTC — the same trick as lib/loopClock.ts's formatPlayhead, so the label
+ * matches the menu-bar clock for every visitor regardless of browser locale.
+ */
+export function startTimeLabel(item: MediaItem, tzOffsetHours: number): string {
+	return new Date(
+		toMs(item.start_date) + tzOffsetHours * 3_600_000,
+	).toLocaleString("en-US", {
+		timeZone: "UTC",
+		month: "numeric",
+		day: "numeric",
+		hour: "numeric",
+		minute: "2-digit",
+	});
+}
+
 /** Group items into stations keyed by source (title fallback), first-seen order. */
 export function groupStations(items: MediaItem[]): Station[] {
 	const order: string[] = [];


### PR DESCRIPTION
## Summary
RadioScanner improvements:

1. **Fixes #201 — hide "Coming Up" on WINS/WCBS.** `showSchedule` correctly excluded `CONTINUOUS_STATIONS` but only emptied the list data; the "Coming Up" label and schedule row rendered unconditionally. The whole schedule row is now gated on `showSchedule`.
2. **Previous items show their start time.** Each Previous entry leads with a short "M/D, h:mm AM" label in the desktop's display timezone (same shift-then-format-as-UTC idiom as `lib/loopClock.formatPlayhead`).
3. **Click-to-start-audio overlay.** A new `audioBlocked.ts` store aggregates everything still waiting for a user gesture, and RadioScanner shows a themed scrim + "Click anywhere to start audio" box while anything is blocked. The dismissing click is itself the unlock gesture.
4. **Safari-shaped detection.** Safari's blocked states are not all rejection-shaped: muted `play()` resolves, then the gesture-less unmute is punished with a silent `pause` event (no `NotAllowedError` anywhere). Detection is now transition-based — `onPause` marks any pause the player didn't initiate (clock pause, natural end, and unmount teardown excluded), and `captureAudioElement` follows the context's `statechange` events instead of a one-shot creation-time state check.

## Testing
- 679 frontend tests / 70 files pass; `tsc -b` and `eslint .` clean.
- Unit/component coverage: schedule visibility, `startTimeLabel`, `audioBlocked` store semantics, suspended-context marking incl. late `statechange`, `NotAllowedError` marking + unmount clearing, unmute-pause marking with clock-pause/ended exclusions, overlay show/hide.
- Runtime-verified in Chromium with `--autoplay-policy=user-gesture-required` (deterministic stand-in for Safari's gesture requirement): gesture-less reload with WINS restored → element `paused: true`, overlay visible within ~3s; one click → overlay gone, playback unmuted. Station switching while unlocked shows no spurious overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)