### PR TITLE
feat(frontend): RadioScanner click-to-start-audio overlay (Safari autoplay)

### DIFF
--- a/packages/frontend/src/Applications/RadioScanner/RadioScanner.module.scss
+++ b/packages/frontend/src/Applications/RadioScanner/RadioScanner.module.scss
@@ -326,3 +326,42 @@
   align-items: center;
   z-index: 9;
 }
+
+/* Scrim shown while the browser's autoplay policy is holding audio back —
+   any click anywhere doubles as the unlock gesture, so the overlay needs no
+   handler of its own. Sits above the display panels (z-index 9). */
+.rsUnlockOverlay {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+}
+
+.rsUnlockOverlayBox {
+  background: var(--color-theme-07);
+  border: 2px solid var(--color-theme-01);
+  box-shadow: 2px 2px 0 var(--color-theme-01);
+  padding: calc(var(--window-padding-size) * 4);
+  margin: calc(var(--window-padding-size) * 4);
+  text-align: center;
+}
+
+.rsUnlockOverlayTitle {
+  font-family: var(--ui-font);
+  font-size: calc(var(--ui-font-size) * 1.2);
+  color: var(--color-theme-01);
+  margin: 0 0 var(--window-padding-size) 0;
+}
+
+.rsUnlockOverlayHint {
+  font-family: var(--ui-font);
+  font-size: calc(var(--ui-font-size) * 0.85);
+  color: var(--color-theme-02);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin: 0;
+}

--- a/packages/frontend/src/Applications/RadioScanner/RadioScanner.test.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/RadioScanner.test.tsx
@@ -1,6 +1,7 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import type React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { clearAudioBlocked, markAudioBlocked } from "./audioBlocked";
 import type { MediaItem } from "../../Providers/MediaStream/MediaStreamContext";
 import {
 	MediaStreamContext,
@@ -161,5 +162,27 @@ describe("RadioScanner schedule visibility", () => {
 		expect(screen.getByText("Previous")).toBeTruthy();
 		// 12:00 UTC shifted by the -4 display offset.
 		expect(screen.getByText("9/11, 8:00 AM")).toBeTruthy();
+	});
+});
+
+describe("RadioScanner audio-unlock overlay", () => {
+	afterEach(() => {
+		clearAudioBlocked("test-gate");
+		cleanup();
+	});
+
+	it("appears while audio is gesture-blocked and leaves once unblocked", () => {
+		renderScanner("ATC");
+		expect(screen.queryByText(/click anywhere to start audio/i)).toBeNull();
+		act(() => markAudioBlocked("test-gate"));
+		expect(screen.getByText(/click anywhere to start audio/i)).toBeTruthy();
+		act(() => clearAudioBlocked("test-gate"));
+		expect(screen.queryByText(/click anywhere to start audio/i)).toBeNull();
+	});
+
+	it("is already visible on mount when audio was blocked before render", () => {
+		markAudioBlocked("test-gate");
+		renderScanner("WINS");
+		expect(screen.getByText(/click anywhere to start audio/i)).toBeTruthy();
 	});
 });

--- a/packages/frontend/src/Applications/RadioScanner/RadioScanner.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/RadioScanner.tsx
@@ -16,6 +16,7 @@ import {
     useMemo,
     useRef,
     useState,
+    useSyncExternalStore,
 } from "react";
 import { MediaStreamContext } from "../../Providers/MediaStream/MediaStreamContext";
 import type { MediaItem } from "../../Providers/MediaStream/MediaStreamContext";
@@ -24,6 +25,7 @@ import { NowPlayingList } from "./NowPlayingList";
 import styles from "./RadioScanner.module.scss";
 import "./RadioScannerContext";
 import { trackAppToggle } from "../../openreplay";
+import { isAudioBlocked, subscribeAudioBlocked } from "./audioBlocked";
 import {
     effectiveMutedIds,
     sanitizeActiveStation,
@@ -243,6 +245,15 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
     const showSchedule =
         activeStation !== "" && !CONTINUOUS_STATIONS.has(activeStation);
 
+    // True while the browser's autoplay policy is holding audio back (Safari
+    // refuses gesture-less sound on page load). The document-level unlock
+    // listeners in audioCapture.ts / StationPlayer.tsx make any click the fix,
+    // so the overlay below only has to ask for one.
+    const audioBlocked = useSyncExternalStore(
+        subscribeAudioBlocked,
+        isAudioBlocked,
+    );
+
     const upcomingList =
         showSchedule && activeStationObj
             ? upcomingSegments(activeStationObj, upcomingItems, nowMs)
@@ -296,6 +307,19 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
                 appMenu={appMenu}
             >
                 <div className={styles.rsContainer}>
+                    {audioBlocked && (
+                        <div className={styles.rsUnlockOverlay}>
+                            <div className={styles.rsUnlockOverlayBox}>
+                                <p className={styles.rsUnlockOverlayTitle}>
+                                    Click anywhere to start audio
+                                </p>
+                                <p className={styles.rsUnlockOverlayHint}>
+                                    Your browser paused sound until you
+                                    interact with the page
+                                </p>
+                            </div>
+                        </div>
+                    )}
                     <div className={styles.rsMainArea}>
                         {focusedItem ? (
                             <FocusedItemPlayer

--- a/packages/frontend/src/Applications/RadioScanner/StationPlayer.test.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/StationPlayer.test.tsx
@@ -1,6 +1,7 @@
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { MediaItem } from "../../Providers/MediaStream/MediaStreamContext";
+import { isAudioBlocked } from "./audioBlocked";
 import { setAudioSilenced } from "./audioCapture";
 import { StationPlayer } from "./StationPlayer";
 import type { Station } from "./stationGrouping";
@@ -199,6 +200,59 @@ describe("StationPlayer", () => {
 			playSpy.mockClear();
 			document.dispatchEvent(new Event("click"));
 			expect(playSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	// Safari's blocked states are not all rejection-shaped: muted play() can
+	// RESOLVE (muted autoplay is allowed) and the gesture-less unmute is then
+	// punished with a silent pause event. The audioBlocked signal must catch
+	// both shapes so the click-to-start overlay actually appears.
+	describe("blocked-audio signal", () => {
+		it("attempts play() at mount, before canplay (surfaces iOS-style refusals)", () => {
+			playSpy.mockClear();
+			render(<StationPlayer {...base} />);
+			expect(playSpy).toHaveBeenCalledTimes(2); // both in-window segments
+		});
+
+		it("marks blocked when play() rejects with NotAllowedError, clears on unmount", async () => {
+			playSpy.mockRejectedValue(
+				new DOMException("autoplay blocked", "NotAllowedError"),
+			);
+			const { unmount } = render(<StationPlayer {...base} />);
+			await act(async () => {});
+			expect(isAudioBlocked()).toBe(true);
+			unmount();
+			expect(isAudioBlocked()).toBe(false);
+			playSpy.mockResolvedValue(undefined);
+		});
+
+		it("marks blocked on a pause it did not initiate (Safari unmute-pause)", () => {
+			const { container, unmount } = render(<StationPlayer {...base} />);
+			const audio = container.querySelector('audio[src="a.mp3"]') as HTMLAudioElement;
+			expect(isAudioBlocked()).toBe(false);
+			fireEvent(audio, new Event("pause"));
+			expect(isAudioBlocked()).toBe(true);
+			unmount();
+			expect(isAudioBlocked()).toBe(false);
+		});
+
+		it("ignores the pause caused by the clock pausing", () => {
+			const { container, rerender } = render(<StationPlayer {...base} />);
+			const audio = container.querySelector('audio[src="a.mp3"]') as HTMLAudioElement;
+			rerender(<StationPlayer {...base} clockPaused={true} />);
+			fireEvent(audio, new Event("pause"));
+			expect(isAudioBlocked()).toBe(false);
+		});
+
+		it("ignores the pause of a naturally ended element", () => {
+			const endedSpy = vi
+				.spyOn(window.HTMLMediaElement.prototype, "ended", "get")
+				.mockReturnValue(true);
+			const { container } = render(<StationPlayer {...base} />);
+			const audio = container.querySelector('audio[src="a.mp3"]') as HTMLAudioElement;
+			fireEvent(audio, new Event("pause"));
+			expect(isAudioBlocked()).toBe(false);
+			endedSpy.mockRestore();
 		});
 	});
 });

--- a/packages/frontend/src/Applications/RadioScanner/StationPlayer.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/StationPlayer.tsx
@@ -229,6 +229,18 @@ export const StationPlayer: React.FC<StationPlayerProps> = ({
 						if (clockPausedRef.current) return;
 						tryPlay(item.id, el);
 					}}
+					onPause={(e) => {
+						const el = e.currentTarget;
+						// A pause we didn't initiate is the autoplay policy speaking —
+						// Safari lets muted play() RESOLVE, then punishes the gesture-less
+						// unmute with a silent pause (no rejection anywhere). Our own
+						// pauses are excluded: clock pause (guarded), natural end
+						// (el.ended), unmount teardown (element already out of audioRefs
+						// when the queued event fires).
+						if (clockPausedRef.current || el.ended) return;
+						if (!audioRefs.current.has(item.id)) return;
+						markAudioBlocked(`play-${item.id}`);
+					}}
 				>
 					{captionsOn && vttUrl(item.subtitles) && (
 						<track

--- a/packages/frontend/src/Applications/RadioScanner/StationPlayer.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/StationPlayer.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { vttUrl } from "../../Providers/MediaStream/MediaStreamContext";
+import { clearAudioBlocked, markAudioBlocked } from "./audioBlocked";
 import { setAudioSilenced } from "./audioCapture";
 import {
 	activeSegments,
@@ -62,14 +63,37 @@ export const StationPlayer: React.FC<StationPlayerProps> = ({
 	// not enough — Safari ignores it once the visualizer's
 	// createMediaElementSource captures the element (every clip is captured
 	// while it's the newest), and iOS ignores it always.
-	const unlockAndApplyMuteState = (id: number, el: HTMLAudioElement) => {
-		unlockedRef.current.add(id);
-		const silenced =
-			stationMutedRef.current || mutedItemsRef.current.includes(id);
-		el.muted = silenced;
-		el.volume = silenced ? 0 : 1;
-		setAudioSilenced(el, silenced);
-	};
+	const unlockAndApplyMuteState = useCallback(
+		(id: number, el: HTMLAudioElement) => {
+			unlockedRef.current.add(id);
+			const silenced =
+				stationMutedRef.current || mutedItemsRef.current.includes(id);
+			el.muted = silenced;
+			el.volume = silenced ? 0 : 1;
+			setAudioSilenced(el, silenced);
+		},
+		[],
+	);
+
+	// Every play() goes through here so the shared audioBlocked signal tracks
+	// which elements the autoplay policy is holding back: a NotAllowedError
+	// means a user gesture will fix it (the overlay tells the user to click);
+	// any success clears the element's token.
+	const tryPlay = useCallback(
+		(id: number, el: HTMLAudioElement) => {
+			el.play()
+				.then(() => {
+					clearAudioBlocked(`play-${id}`);
+					unlockAndApplyMuteState(id, el);
+				})
+				.catch((err: unknown) => {
+					if ((err as DOMException | null)?.name === "NotAllowedError") {
+						markAudioBlocked(`play-${id}`);
+					}
+				});
+		},
+		[unlockAndApplyMuteState],
+	);
 
 	// Health check: keep each mounted element playing and within 30s of expected.
 	useEffect(() => {
@@ -83,31 +107,26 @@ export const StationPlayer: React.FC<StationPlayerProps> = ({
 					// A late unlock (initial autoplay was blocked; a user gesture has
 					// since granted audio) must also clear the autoplay mute, or the
 					// element resumes playing but stays silent forever.
-					el.play()
-						.then(() => unlockAndApplyMuteState(segId, el))
-						.catch(() => {});
+					tryPlay(segId, el);
 				}
 				const expected = calcSeekSeconds(item, now);
 				if (Math.abs(el.currentTime - expected) > 30) el.currentTime = expected;
 			}
 		}, 15_000);
 		return () => clearInterval(id);
-	}, [station]);
+	}, [station, tryPlay]);
 
 	// A user gesture is the first moment blocked playback can start: Safari
 	// refuses gesture-less play() on page load, so a restored session autoplays
 	// into a blocked state — and clicking the already-selected station changes
 	// no React state, so without this nothing would retry until the health
 	// check above. Any click or keypress retries immediately.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: unlockAndApplyMuteState reads refs only
 	useEffect(() => {
 		const retryBlockedPlayback = () => {
 			if (clockPausedRef.current) return;
 			for (const [segId, el] of audioRefs.current) {
 				if (el.paused || el.ended) {
-					el.play()
-						.then(() => unlockAndApplyMuteState(segId, el))
-						.catch(() => {});
+					tryPlay(segId, el);
 				}
 			}
 		};
@@ -117,7 +136,7 @@ export const StationPlayer: React.FC<StationPlayerProps> = ({
 			document.removeEventListener("click", retryBlockedPlayback, true);
 			document.removeEventListener("keydown", retryBlockedPlayback, true);
 		};
-	}, []);
+	}, [tryPlay]);
 
 	// Apply mute state immediately: a file is silenced if its station is muted
 	// or the file itself is muted. Muting is always safe, but unmuting via
@@ -138,13 +157,9 @@ export const StationPlayer: React.FC<StationPlayerProps> = ({
 	useEffect(() => {
 		for (const [id, el] of audioRefs.current) {
 			if (clockPaused) el.pause();
-			else
-				el.play()
-					.then(() => unlockAndApplyMuteState(id, el))
-					.catch(() => {});
+			else tryPlay(id, el);
 		}
-		// biome-ignore lint/correctness/useExhaustiveDependencies: unlockAndApplyMuteState reads refs only
-	}, [clockPaused]);
+	}, [clockPaused, tryPlay]);
 
 	// Reseek on a clock scrub (a large jump), not on natural per-second advance.
 	const prevNowRef = useRef(nowMs);
@@ -180,6 +195,8 @@ export const StationPlayer: React.FC<StationPlayerProps> = ({
 					// A remount of the same id gets a fresh element that must redo
 					// the autoplay dance from its muted starting state.
 					unlockedRef.current.delete(id);
+					// A gone element no longer needs a gesture.
+					clearAudioBlocked(`play-${id}`);
 				}
 			};
 			refCallbacks.current.set(id, cb);
@@ -210,9 +227,7 @@ export const StationPlayer: React.FC<StationPlayerProps> = ({
 					onCanPlay={(e) => {
 						const el = e.currentTarget;
 						if (clockPausedRef.current) return;
-						el.play()
-							.then(() => unlockAndApplyMuteState(item.id, el))
-							.catch(() => {});
+						tryPlay(item.id, el);
 					}}
 				>
 					{captionsOn && vttUrl(item.subtitles) && (

--- a/packages/frontend/src/Applications/RadioScanner/audioBlocked.test.ts
+++ b/packages/frontend/src/Applications/RadioScanner/audioBlocked.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	clearAudioBlocked,
+	isAudioBlocked,
+	markAudioBlocked,
+	subscribeAudioBlocked,
+} from "./audioBlocked";
+
+describe("audioBlocked store", () => {
+	it("is unblocked until something is marked", () => {
+		expect(isAudioBlocked()).toBe(false);
+	});
+
+	it("tracks distinct tokens and clears when the last one is removed", () => {
+		markAudioBlocked("a");
+		markAudioBlocked("b");
+		expect(isAudioBlocked()).toBe(true);
+		clearAudioBlocked("a");
+		expect(isAudioBlocked()).toBe(true);
+		clearAudioBlocked("b");
+		expect(isAudioBlocked()).toBe(false);
+	});
+
+	it("notifies subscribers only when the blocked state flips", () => {
+		const cb = vi.fn();
+		const unsubscribe = subscribeAudioBlocked(cb);
+		markAudioBlocked("x");
+		expect(cb).toHaveBeenCalledTimes(1);
+		markAudioBlocked("y"); // still blocked — no flip
+		expect(cb).toHaveBeenCalledTimes(1);
+		clearAudioBlocked("y");
+		expect(cb).toHaveBeenCalledTimes(1);
+		clearAudioBlocked("x"); // last token — flips to unblocked
+		expect(cb).toHaveBeenCalledTimes(2);
+		unsubscribe();
+		markAudioBlocked("z");
+		expect(cb).toHaveBeenCalledTimes(2);
+		clearAudioBlocked("z");
+	});
+
+	it("ignores clearing a token that was never marked", () => {
+		const cb = vi.fn();
+		const unsubscribe = subscribeAudioBlocked(cb);
+		clearAudioBlocked("ghost");
+		expect(cb).not.toHaveBeenCalled();
+		expect(isAudioBlocked()).toBe(false);
+		unsubscribe();
+	});
+});

--- a/packages/frontend/src/Applications/RadioScanner/audioBlocked.ts
+++ b/packages/frontend/src/Applications/RadioScanner/audioBlocked.ts
@@ -1,0 +1,41 @@
+// Shared "audio is waiting for a user gesture" signal for the Radio Scanner.
+//
+// Safari (and Chrome's autoplay policy) refuse to start sound on a page that
+// has seen no user interaction: a restored session autoplays into silence —
+// suspended AudioContexts and rejected play() calls — until the first click
+// or keypress. The unlock retries themselves live in audioCapture.ts and
+// StationPlayer.tsx; this module only aggregates "is anything still waiting?"
+// so the UI can tell the user that a click is needed.
+//
+// Each blocked thing registers an arbitrary token (a context, an element id);
+// the signal is simply "any tokens present". Subscribers are notified on
+// blocked/unblocked flips only, which makes the store directly usable with
+// useSyncExternalStore.
+
+const tokens = new Set<unknown>();
+const listeners = new Set<() => void>();
+
+function notify(): void {
+	for (const cb of listeners) cb();
+}
+
+export function isAudioBlocked(): boolean {
+	return tokens.size > 0;
+}
+
+export function markAudioBlocked(token: unknown): void {
+	const wasBlocked = tokens.size > 0;
+	tokens.add(token);
+	if (!wasBlocked && tokens.size > 0) notify();
+}
+
+export function clearAudioBlocked(token: unknown): void {
+	const wasBlocked = tokens.size > 0;
+	tokens.delete(token);
+	if (wasBlocked && tokens.size === 0) notify();
+}
+
+export function subscribeAudioBlocked(cb: () => void): () => void {
+	listeners.add(cb);
+	return () => listeners.delete(cb);
+}

--- a/packages/frontend/src/Applications/RadioScanner/audioCapture.test.ts
+++ b/packages/frontend/src/Applications/RadioScanner/audioCapture.test.ts
@@ -107,6 +107,30 @@ describe("resume on first user gesture", () => {
 		await Promise.resolve();
 		expect(isAudioBlocked()).toBe(false);
 	});
+
+	it("tracks a context that only reports suspended AFTER creation (statechange)", () => {
+		class StatefulAudioContext extends FakeAudioContext {
+			state = "running";
+			listeners: Array<() => void> = [];
+			addEventListener(_t: string, l: () => void) {
+				this.listeners.push(l);
+			}
+			removeEventListener() {}
+			fireStateChange() {
+				for (const l of this.listeners) l();
+			}
+		}
+		vi.stubGlobal("AudioContext", StatefulAudioContext);
+		const entry = captureAudioElement(el());
+		const ctx = entry?.ctx as unknown as InstanceType<typeof StatefulAudioContext>;
+		expect(isAudioBlocked()).toBe(false);
+		ctx.state = "suspended";
+		ctx.fireStateChange();
+		expect(isAudioBlocked()).toBe(true);
+		ctx.state = "running";
+		ctx.fireStateChange();
+		expect(isAudioBlocked()).toBe(false);
+	});
 });
 
 describe("setAudioSilenced", () => {

--- a/packages/frontend/src/Applications/RadioScanner/audioCapture.test.ts
+++ b/packages/frontend/src/Applications/RadioScanner/audioCapture.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { isAudioBlocked } from "./audioBlocked";
 import { captureAudioElement, setAudioSilenced } from "./audioCapture";
 
 class FakeGain {
@@ -94,6 +95,17 @@ describe("resume on first user gesture", () => {
 		await Promise.resolve(); // flush resume().then(...) removal
 		document.dispatchEvent(new Event("click"));
 		expect(entry?.ctx.resume).toHaveBeenCalledTimes(1);
+	});
+
+	it("reports blocked audio while a context awaits a gesture, clear after", async () => {
+		vi.stubGlobal("AudioContext", SuspendedAudioContext);
+		expect(isAudioBlocked()).toBe(false);
+		const entry = captureAudioElement(el());
+		expect(isAudioBlocked()).toBe(true);
+		if (entry) (entry.ctx as unknown as { state: string }).state = "running";
+		document.dispatchEvent(new Event("click"));
+		await Promise.resolve();
+		expect(isAudioBlocked()).toBe(false);
 	});
 });
 

--- a/packages/frontend/src/Applications/RadioScanner/audioCapture.ts
+++ b/packages/frontend/src/Applications/RadioScanner/audioCapture.ts
@@ -12,6 +12,8 @@
 // with its el.volume/el.muted muting. The WeakMaps let entries be collected
 // with their audio elements.
 
+import { clearAudioBlocked, markAudioBlocked } from "./audioBlocked";
+
 export interface CapturedAudio {
 	ctx: AudioContext;
 	source: MediaElementAudioSourceNode;
@@ -31,14 +33,19 @@ const desiredSilenced = new WeakMap<HTMLAudioElement, boolean>();
 // plays in silence.
 const awaitingGesture = new Set<CapturedAudio["ctx"]>();
 
+function releaseContext(ctx: CapturedAudio["ctx"]): void {
+	awaitingGesture.delete(ctx);
+	clearAudioBlocked(ctx);
+}
+
 function resumeAwaitingContexts(): void {
 	for (const ctx of awaitingGesture) {
 		if (ctx.state !== "suspended") {
-			awaitingGesture.delete(ctx);
+			releaseContext(ctx);
 			continue;
 		}
 		ctx.resume()
-			.then(() => awaitingGesture.delete(ctx))
+			.then(() => releaseContext(ctx))
 			.catch(() => {});
 	}
 }
@@ -64,7 +71,10 @@ export function captureAudioElement(el: HTMLAudioElement): CapturedAudio | null 
 		}
 		entry.gain.gain.value = desiredSilenced.get(el) ? 0 : 1;
 		captured.set(el, entry);
-		if (entry.ctx.state === "suspended") awaitingGesture.add(entry.ctx);
+		if (entry.ctx.state === "suspended") {
+			awaitingGesture.add(entry.ctx);
+			markAudioBlocked(entry.ctx);
+		}
 	}
 	return entry;
 }

--- a/packages/frontend/src/Applications/RadioScanner/audioCapture.ts
+++ b/packages/frontend/src/Applications/RadioScanner/audioCapture.ts
@@ -71,10 +71,21 @@ export function captureAudioElement(el: HTMLAudioElement): CapturedAudio | null 
 		}
 		entry.gain.gain.value = desiredSilenced.get(el) ? 0 : 1;
 		captured.set(el, entry);
-		if (entry.ctx.state === "suspended") {
-			awaitingGesture.add(entry.ctx);
-			markAudioBlocked(entry.ctx);
-		}
+		// Track the suspended state via statechange, not just a creation-time
+		// snapshot: Safari can report a fresh context as running and only settle
+		// on suspended later (and a tab-hide suspension should also re-arm the
+		// gesture listeners).
+		const ctx = entry.ctx;
+		const syncBlocked = () => {
+			if (ctx.state === "suspended") {
+				awaitingGesture.add(ctx);
+				markAudioBlocked(ctx);
+			} else {
+				releaseContext(ctx);
+			}
+		};
+		ctx.addEventListener?.("statechange", syncBlocked);
+		syncBlocked();
 	}
 	return entry;
 }

--- a/packages/frontend/src/Applications/TimeMachine/TimeMachine.tsx
+++ b/packages/frontend/src/Applications/TimeMachine/TimeMachine.tsx
@@ -9,6 +9,8 @@ import {
 	ClassicyWindow,
 	quitMenuItemHelper,
 	registerClassicyIcons,
+	useAppManager,
+	useAppManagerDispatch,
 	useClassicyDateTime,
 } from "classicy";
 import appIconPng from "./app.png";
@@ -18,10 +20,13 @@ import { trackPauseResume, trackVirtualTimeSet } from "../../openreplay";
 import { BookmarksWindow } from "./BookmarksWindow";
 import { setDateTimeFromUtc } from "./setVirtualClock";
 import styles from "./TimeMachine.module.scss";
+import {
+	DEFAULT_TIME_MACHINE_SETTINGS,
+	readTimeMachineSettings,
+	TIME_MACHINE_APP_ID,
+	timeMachineSetSettings,
+} from "./timeMachineSettings";
 import type { Bookmark } from "./useBookmarks";
-
-const DEFAULT_SKIP_MINUTES = 30;
-const DEFAULT_STEP_SECONDS = 300; // 5 minutes
 
 // This app's own icon, registered into the shared registry at
 // ClassicyIcons.applications.timeMachine.app. registerClassicyIcons assigns
@@ -41,19 +46,29 @@ function formatSeconds(s: number): string {
 	return sec > 0 ? `${min} min ${sec} sec` : `${min} min`;
 }
 
-export const TimeMachine: React.FC = () => {
-	const appName = "Time Machine";
-	const appId = "TimeMachine.app";
-	const appIcon = ICONS.applications.timeMachine.app;
+const appName = "Time Machine";
+const appId = TIME_MACHINE_APP_ID;
+const appIcon = ICONS.applications.timeMachine.app;
 
-	const [skipMinutes, setSkipMinutes] = useState(DEFAULT_SKIP_MINUTES);
-	const [stepSeconds, setStepSeconds] = useState(DEFAULT_STEP_SECONDS);
+export const TimeMachine: React.FC = () => {
+
+	// Skip/step durations persist in Classicy app data (the Settings window
+	// writes them); the settings draft below stays local until Save.
+	const desktopEventDispatch = useAppManagerDispatch();
+	const appData = useAppManager(
+		(s) =>
+			s.System.Manager.Applications.apps[appId]?.data as
+				| Record<string, unknown>
+				| undefined,
+	);
+	const { skipMinutes, stepSeconds } = useMemo(
+		() => readTimeMachineSettings(appData),
+		[appData],
+	);
+
 	const [showSettings, setShowSettings] = useState(false);
 	const [showBookmarks, setShowBookmarks] = useState(false);
-	const [settingsForm, setSettingsForm] = useState({
-		skipMinutes: DEFAULT_SKIP_MINUTES,
-		stepSeconds: DEFAULT_STEP_SECONDS,
-	});
+	const [settingsForm, setSettingsForm] = useState(DEFAULT_TIME_MACHINE_SETTINGS);
 
 	const openSettings = useCallback(() => {
 		setSettingsForm({ skipMinutes, stepSeconds });
@@ -61,10 +76,9 @@ export const TimeMachine: React.FC = () => {
 	}, [skipMinutes, stepSeconds]);
 
 	const saveSettings = useCallback(() => {
-		setSkipMinutes(settingsForm.skipMinutes);
-		setStepSeconds(settingsForm.stepSeconds);
+		desktopEventDispatch(timeMachineSetSettings(settingsForm));
 		setShowSettings(false);
-	}, [settingsForm]);
+	}, [settingsForm, desktopEventDispatch]);
 
 	const openBookmarks = useCallback(() => setShowBookmarks(true), []);
 
@@ -88,7 +102,7 @@ export const TimeMachine: React.FC = () => {
 				],
 			},
 		],
-		[appIcon, openBookmarks, openSettings],
+		[openBookmarks, openSettings],
 	);
 
 	const { dateTime, setDateTime, tzOffset, paused, pause, resume } = useClassicyDateTime({ tick: true });

--- a/packages/frontend/src/Applications/TimeMachine/timeMachineSettings.test.ts
+++ b/packages/frontend/src/Applications/TimeMachine/timeMachineSettings.test.ts
@@ -1,0 +1,85 @@
+import type { ClassicyStore } from "classicy";
+import { describe, expect, it } from "vitest";
+import {
+	classicyTimeMachineEventHandler,
+	DEFAULT_TIME_MACHINE_SETTINGS,
+	readTimeMachineSettings,
+	timeMachineSetSettings,
+} from "./timeMachineSettings";
+
+describe("readTimeMachineSettings", () => {
+	it("returns defaults for absent app data", () => {
+		expect(readTimeMachineSettings(undefined)).toEqual({
+			skipMinutes: 30,
+			stepSeconds: 300,
+		});
+	});
+
+	it("merges partial stored settings over defaults (no migration needed)", () => {
+		expect(readTimeMachineSettings({ settings: { skipMinutes: 15 } })).toEqual({
+			...DEFAULT_TIME_MACHINE_SETTINGS,
+			skipMinutes: 15,
+		});
+	});
+
+	it("falls back to defaults for non-finite or out-of-range stored values", () => {
+		expect(
+			readTimeMachineSettings({
+				settings: { skipMinutes: Number.NaN, stepSeconds: -5 },
+			}),
+		).toEqual(DEFAULT_TIME_MACHINE_SETTINGS);
+		expect(
+			readTimeMachineSettings({
+				settings: { skipMinutes: 999, stepSeconds: 999_999 },
+			}),
+		).toEqual(DEFAULT_TIME_MACHINE_SETTINGS);
+	});
+});
+
+describe("timeMachineSetSettings", () => {
+	it("builds the namespaced action", () => {
+		const s = { skipMinutes: 10, stepSeconds: 60 };
+		expect(timeMachineSetSettings(s)).toEqual({
+			type: "ClassicyAppTimeMachineSetSettings",
+			settings: s,
+		});
+	});
+});
+
+describe("classicyTimeMachineEventHandler", () => {
+	function store(data: Record<string, unknown> | undefined): ClassicyStore {
+		return {
+			System: {
+				Manager: {
+					Applications: { apps: { "TimeMachine.app": { data } } },
+				},
+			},
+		} as unknown as ClassicyStore;
+	}
+
+	it("writes settings without clobbering other app data", () => {
+		const ds = store({ somethingElse: 42 });
+		const next = classicyTimeMachineEventHandler(
+			ds,
+			timeMachineSetSettings({ skipMinutes: 5, stepSeconds: 120 }),
+		);
+		const data = next.System.Manager.Applications.apps["TimeMachine.app"]
+			.data as Record<string, unknown>;
+		expect(data.somethingElse).toBe(42);
+		expect(data.settings).toEqual({ skipMinutes: 5, stepSeconds: 120 });
+	});
+
+	it("ignores unknown actions and a missing app entry", () => {
+		const ds = store({ keep: 1 });
+		expect(classicyTimeMachineEventHandler(ds, { type: "SomethingElse" })).toBe(ds);
+		const empty = {
+			System: { Manager: { Applications: { apps: {} } } },
+		} as unknown as ClassicyStore;
+		expect(
+			classicyTimeMachineEventHandler(
+				empty,
+				timeMachineSetSettings(DEFAULT_TIME_MACHINE_SETTINGS),
+			),
+		).toBe(empty);
+	});
+});

--- a/packages/frontend/src/Applications/TimeMachine/timeMachineSettings.ts
+++ b/packages/frontend/src/Applications/TimeMachine/timeMachineSettings.ts
@@ -1,0 +1,68 @@
+import type { ActionMessage, ClassicyStore } from "classicy";
+import { registerAppEventHandler } from "classicy";
+
+export const TIME_MACHINE_APP_ID = "TimeMachine.app";
+const appId = TIME_MACHINE_APP_ID;
+
+// Transport preferences (the Settings window's two sliders). Ephemeral UI
+// state (open windows, the H/M/S entry form, the settings draft) is NOT
+// persisted; only the user's choices are — same split as weatherSettings.ts.
+export interface TimeMachineSettings {
+	/** «/» skip distance, minutes. Slider range 1–60. */
+	skipMinutes: number;
+	/** ‹/› step distance, seconds. Slider range 1–600. */
+	stepSeconds: number;
+}
+
+export const DEFAULT_TIME_MACHINE_SETTINGS: TimeMachineSettings = {
+	skipMinutes: 30,
+	stepSeconds: 300, // 5 minutes
+};
+
+/** Persist the whole settings object in one dispatch. */
+export const timeMachineSetSettings = (
+	settings: TimeMachineSettings,
+): ActionMessage => ({
+	type: "ClassicyAppTimeMachineSetSettings",
+	settings,
+});
+
+// Stored state comes from localStorage, so a hand-edited or stale value could
+// be anything; anything outside the slider's own range falls back per-field.
+const inRange = (v: unknown, min: number, max: number): v is number =>
+	typeof v === "number" && Number.isFinite(v) && v >= min && v <= max;
+
+/** Per-field fallback to defaults, so absent/partial/invalid stored state needs no migration. */
+export const readTimeMachineSettings = (
+	data: Record<string, unknown> | undefined,
+): TimeMachineSettings => {
+	const stored =
+		(data?.settings as Partial<TimeMachineSettings> | undefined) ?? {};
+	return {
+		skipMinutes: inRange(stored.skipMinutes, 1, 60)
+			? stored.skipMinutes
+			: DEFAULT_TIME_MACHINE_SETTINGS.skipMinutes,
+		stepSeconds: inRange(stored.stepSeconds, 1, 600)
+			? stored.stepSeconds
+			: DEFAULT_TIME_MACHINE_SETTINGS.stepSeconds,
+	};
+};
+
+export const classicyTimeMachineEventHandler = (
+	ds: ClassicyStore,
+	action: ActionMessage,
+) => {
+	if (!ds.System.Manager.Applications.apps[appId]) return ds;
+	const appData = ds.System.Manager.Applications.apps[appId].data ?? {};
+	const apps = ds.System.Manager.Applications.apps;
+
+	switch (action.type) {
+		case "ClassicyAppTimeMachineSetSettings":
+			apps[appId].data = { ...appData, settings: action.settings };
+			return ds;
+		default:
+			return ds;
+	}
+};
+
+registerAppEventHandler("ClassicyAppTimeMachine", classicyTimeMachineEventHandler);


### PR DESCRIPTION
## Summary
Follow-on to #202 (merged before these commits landed on the branch). Contains:

1. **Click-to-start-audio overlay** (`0038efd`). Safari refuses gesture-less sound, so a restored session loads into silence until the user happens to click. A new `audioBlocked.ts` store aggregates everything still waiting for a user gesture — `audioCapture.ts` marks suspended AudioContexts, `StationPlayer` marks blocked `play()` attempts — and RadioScanner shows a themed scrim + "Click anywhere to start audio" box over the window while anything is blocked. The dismissing click is itself the unlock gesture (the existing document-level retry listeners handle it), so the overlay needs no handler.
2. **Safari-shaped detection** (`ac6d073`). Safari's blocked states are not all rejection-shaped: muted `play()` resolves, then the gesture-less unmute is punished with a silent `pause` event — no `NotAllowedError` until the 15s health check, which is why the first version showed no overlay in Safari. Detection is now transition-based: `onPause` marks any pause the player didn't initiate (clock pause, natural end, unmount teardown excluded), and `captureAudioElement` follows the context's `statechange` events instead of a one-shot creation-time check.
3. **TM Settings Persist** (`5655674`, @robbiebyrd) — was on the branch when #202 merged.

## Testing
- 679 frontend tests / 70 files pass; `tsc -b` and `eslint .` clean.
- Coverage: `audioBlocked` store semantics, suspended-context marking incl. late `statechange`, `NotAllowedError` marking + unmount clearing, unmute-pause marking with clock-pause/ended exclusions, overlay show/hide incl. blocked-before-mount.
- Runtime-verified in Chromium with `--autoplay-policy=user-gesture-required` (deterministic stand-in for Safari's gesture requirement): gesture-less reload with WINS restored → element `paused: true`, overlay visible within ~3s; one click → overlay gone, playback unmuted. Station switching while unlocked shows no spurious overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)