### PR TITLE
Make TV ABR switch more aggressive (#149)

### DIFF
--- a/packages/frontend/src/Applications/TV/TV.embed.test.tsx
+++ b/packages/frontend/src/Applications/TV/TV.embed.test.tsx
@@ -1,9 +1,13 @@
-import { act, cleanup, render } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { MediaItem } from "../../Providers/MediaStream/MediaStreamContext";
 
 const captured = vi.hoisted(() => ({ props: [] as Record<string, unknown>[] }));
+// Seeded TV.app data handed to useAppManager; tests may override, reset in afterEach.
+const mockAppData = vi.hoisted(() => ({ value: {} as Record<string, unknown> }));
+// Optional items override for the useMediaStream mock (null → default [FAKE_ITEM]).
+const mockItems = vi.hoisted(() => ({ value: null as unknown[] | null }));
 
 const FAKE_ITEM = {
 	id: 7,
@@ -14,17 +18,29 @@ const FAKE_ITEM = {
 	subtitles: "https://files.example.org/wabc/subs.srt",
 } as unknown as MediaItem;
 
+const FAKE_ITEM_2 = {
+	id: 8,
+	url: "https://files.example.org/wnbc/index.m3u8",
+	source: "WNBC",
+	start_date: "2001-09-11T12:00:00",
+	jump: 0,
+	subtitles: "https://files.example.org/wnbc/subs.srt",
+} as unknown as MediaItem;
+
 vi.mock("classicy", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("classicy")>();
-	const FAKE_STATE = {
+	// Built per call so a test's mockAppData override is visible to the selector.
+	const fakeState = () => ({
 		System: {
 			Manager: {
 				Applications: {
-					apps: { "TV.app": { data: {}, open: true, windows: [] } },
+					apps: {
+						"TV.app": { data: mockAppData.value, open: true, windows: [] },
+					},
 				},
 			},
 		},
-	};
+	});
 	return {
 		...actual,
 		ClassicyApp: ({ children }: { children?: React.ReactNode }) => (
@@ -49,7 +65,7 @@ vi.mock("classicy", async (importOriginal) => {
 			captured.props.push(props);
 			return <div data-testid="qt-embed" />;
 		},
-		useAppManager: (selector: (s: unknown) => unknown) => selector(FAKE_STATE),
+		useAppManager: (selector: (s: unknown) => unknown) => selector(fakeState()),
 		useAppManagerDispatch: () => () => {},
 		useClassicyDateTime: () => ({
 			dateTime: "2001-09-11T12:40:00.000Z",
@@ -60,8 +76,8 @@ vi.mock("classicy", async (importOriginal) => {
 
 vi.mock("../../Providers/MediaStream/useMediaStream", () => ({
 	useMediaStream: () => ({
-		items: [FAKE_ITEM],
-		sources: { video: ["WABC"], audio: [], pager: [], usenet: [] },
+		items: mockItems.value ?? [FAKE_ITEM],
+		sources: { video: ["WABC", "WNBC"], audio: [], pager: [], usenet: [] },
 	}),
 }));
 
@@ -73,7 +89,11 @@ vi.mock("../../openreplay", () => ({
 import { TV } from "./TV";
 import { DEFAULT_CAPTION_STYLE } from "./TVContext";
 
-afterEach(cleanup);
+afterEach(() => {
+	cleanup();
+	mockAppData.value = {};
+	mockItems.value = null;
+});
 
 type FakeApi = {
 	autoLevelCapping: number;
@@ -161,6 +181,34 @@ describe("TV — props handed to QuickTimeVideoEmbed", () => {
 		});
 
 		expect(api.autoLevelCapping).toBe(2); // ceiling: single view = full
+		expect(api.bandwidthEstimate).toBe(5_000_000); // optimistic reset
+		expect(api.nextLevel).toBe(2); // forced switch (flushes low-res buffer)
+		handlers.hlsLevelSwitched[0]();
+		expect(api.nextLevel).toBe(-1); // auto restored — a nudge, not a pin
+	});
+
+	it("bumps an already-mounted grid player whose tier rises to HIGHEST when the grid shrinks to one", () => {
+		captured.props.length = 0;
+		mockAppData.value = { multiSelectMode: true, selectedPlayers: [7, 8] };
+		mockItems.value = [FAKE_ITEM, FAKE_ITEM_2];
+		render(<TV />);
+
+		// Two grid players mounted; register a fake hls element for item 7.
+		const p7 = captured.props.find((p) => p.name === "WABC");
+		if (!p7) throw new Error("WABC grid player not mounted");
+		const { el, api, handlers } = fakeHlsElement();
+		(p7.onMediaElement as (el: unknown) => void)(el);
+
+		// Two-player grid → item 7 sits at ONE_DOWN; no bump has fired yet.
+		expect(api.bandwidthEstimate).toBe(500_000);
+		expect(api.nextLevel).toBe(-1);
+
+		// Remove item 8 via its grid ✕ button (selectedPlayers order [7, 8] →
+		// second ✕). The grid shrinks to one WITHOUT remounting item 7, so the
+		// bump must come from the re-cap effect's rise detection, not onReady.
+		fireEvent.mouseUp(screen.getAllByText("✕")[1]);
+
+		expect(api.autoLevelCapping).toBe(2); // ceiling: grid of one = full
 		expect(api.bandwidthEstimate).toBe(5_000_000); // optimistic reset
 		expect(api.nextLevel).toBe(2); // forced switch (flushes low-res buffer)
 		handlers.hlsLevelSwitched[0]();

--- a/packages/frontend/src/Applications/TV/TV.embed.test.tsx
+++ b/packages/frontend/src/Applications/TV/TV.embed.test.tsx
@@ -94,6 +94,7 @@ afterEach(() => {
 	mockAppData.value = {};
 	mockItems.value = null;
 });
+afterEach(() => vi.useRealTimers());
 
 type FakeApi = {
 	autoLevelCapping: number;
@@ -213,5 +214,23 @@ describe("TV — props handed to QuickTimeVideoEmbed", () => {
 		expect(api.nextLevel).toBe(2); // forced switch (flushes low-res buffer)
 		handlers.hlsLevelSwitched[0]();
 		expect(api.nextLevel).toBe(-1); // auto restored — a nudge, not a pin
+	});
+
+	it("probes one level up from the 15s health check when parked below the ceiling", () => {
+		vi.useFakeTimers();
+		captured.props.length = 0;
+		render(<TV />);
+		const p = captured.props[captured.props.length - 1];
+		const { el, api } = fakeHlsElement();
+		(p.onMediaElement as (el: unknown) => void)(el);
+		// Deliberately no onReady: the player sits parked at loadLevel 0 with a
+		// healthy buffer (fakeHlsElement buffers to t=4000) — the stuck case.
+
+		act(() => {
+			vi.advanceTimersByTime(15_000);
+		});
+
+		expect(api.nextLoadLevel).toBe(1); // one-fragment probe toward the ceiling
+		expect(api.nextLevel).toBe(-1); // still fully in auto mode — no flush
 	});
 });

--- a/packages/frontend/src/Applications/TV/TV.embed.test.tsx
+++ b/packages/frontend/src/Applications/TV/TV.embed.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render } from "@testing-library/react";
+import { act, cleanup, render } from "@testing-library/react";
 import type React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { MediaItem } from "../../Providers/MediaStream/MediaStreamContext";
@@ -75,6 +75,44 @@ import { DEFAULT_CAPTION_STYLE } from "./TVContext";
 
 afterEach(cleanup);
 
+type FakeApi = {
+	autoLevelCapping: number;
+	autoLevelEnabled: boolean;
+	bandwidthEstimate: number;
+	currentLevel: number;
+	loadLevel: number;
+	nextLevel: number;
+	nextLoadLevel: number;
+	once: (event: string, cb: () => void) => void;
+};
+
+/** Plain-object stand-in for the <hls-video> element QuickTimeVideoEmbed
+ *  registers via onMediaElement — jsdom's HTMLMediaElement lacks play(). */
+function fakeHlsElement() {
+	const handlers: Record<string, (() => void)[]> = {};
+	const api: FakeApi = {
+		autoLevelCapping: -1,
+		autoLevelEnabled: true,
+		bandwidthEstimate: 500_000,
+		currentLevel: 0,
+		loadLevel: 0,
+		nextLevel: -1,
+		nextLoadLevel: 0,
+		once: (event, cb) => {
+			(handlers[event] ??= []).push(cb);
+		},
+	};
+	const el = {
+		api,
+		paused: false,
+		ended: false,
+		currentTime: 2400,
+		buffered: { length: 1, start: () => 0, end: () => 4000 },
+		play: () => Promise.resolve(),
+	} as unknown as HTMLVideoElement;
+	return { el, api, handlers };
+}
+
 describe("TV — props handed to QuickTimeVideoEmbed", () => {
 	it("drives the embed as a fully controlled, chrome-less, caption-styled player", () => {
 		render(<TV />);
@@ -109,5 +147,23 @@ describe("TV — props handed to QuickTimeVideoEmbed", () => {
 		// The pre-existing per-item fields must survive the spread.
 		expect(hls.startLevel).toBe(2); // single view starts at full
 		expect(typeof hls.startPosition).toBe("number");
+	});
+
+	it("aggressively bumps the focused single view to full on ready, then restores auto", () => {
+		captured.props.length = 0;
+		render(<TV />);
+		const p = captured.props[captured.props.length - 1];
+		const { el, api, handlers } = fakeHlsElement();
+
+		(p.onMediaElement as (el: unknown) => void)(el);
+		act(() => {
+			(p.onReady as () => void)();
+		});
+
+		expect(api.autoLevelCapping).toBe(2); // ceiling: single view = full
+		expect(api.bandwidthEstimate).toBe(5_000_000); // optimistic reset
+		expect(api.nextLevel).toBe(2); // forced switch (flushes low-res buffer)
+		handlers.hlsLevelSwitched[0]();
+		expect(api.nextLevel).toBe(-1); // auto restored — a nudge, not a pin
 	});
 });

--- a/packages/frontend/src/Applications/TV/TV.embed.test.tsx
+++ b/packages/frontend/src/Applications/TV/TV.embed.test.tsx
@@ -93,4 +93,21 @@ describe("TV — props handed to QuickTimeVideoEmbed", () => {
 		expect(typeof p.onMediaElement).toBe("function");
 		expect(typeof p.onReady).toBe("function");
 	});
+
+	it("hands every hls player the upward-biased ABR config", () => {
+		captured.props.length = 0;
+		render(<TV />);
+		const p = captured.props[captured.props.length - 1];
+		const hls = (p.options as { hls: Record<string, unknown> }).hls;
+
+		expect(hls).toMatchObject({
+			abrEwmaDefaultEstimate: 5_000_000,
+			abrBandWidthUpFactor: 0.9,
+			abrEwmaFastVoD: 2,
+			abrEwmaSlowVoD: 5,
+		});
+		// The pre-existing per-item fields must survive the spread.
+		expect(hls.startLevel).toBe(2); // single view starts at full
+		expect(typeof hls.startPosition).toBe("number");
+	});
 });

--- a/packages/frontend/src/Applications/TV/TV.tsx
+++ b/packages/frontend/src/Applications/TV/TV.tsx
@@ -37,7 +37,7 @@ import {
 	tvSetVolumeLimit,
 } from "./TVContext";
 import { trackAppToggle, trackChannelChange } from "../../openreplay";
-import { bumpToLevel, TV_ABR_CONFIG } from "./abr";
+import { bumpToLevel, maybeProbeUp, TV_ABR_CONFIG } from "./abr";
 import type { HlsAbrApi } from "./abr";
 import { resolveVirtualNowMs } from "./clockDrift";
 import { resolveGridVolume } from "./volume";
@@ -344,6 +344,17 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 				if (Math.abs(el.currentTime - expected) > 30) {
 					el.currentTime = expected;
 				}
+
+				// Quality watchdog: a player parked below its tier ceiling despite a
+				// healthy buffer is usually stuck on a stale low bandwidth estimate —
+				// probe one fragment upward so ABR gets an honest sample (maybeProbeUp).
+				if (!clockPausedRef.current && !tvPausedRef.current) {
+					maybeProbeUp(
+						el,
+						(el as HlsVideoEl).api,
+						levelForItemRef.current(item),
+					);
+				}
 			}
 		}, 15_000);
 
@@ -561,6 +572,11 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 		},
 		[multiSelectMode, selectedPlayers, activePlayer],
 	);
+
+	// Stable ref to levelForItem so the health-check interval (empty deps) sees
+	// the current tiering without re-registering the timer.
+	const levelForItemRef = useRef(levelForItem);
+	levelForItemRef.current = levelForItem;
 
 	// Re-cap every loaded player whenever the tiering inputs change (active channel,
 	// selection set, grid mode); ABR then glides toward the new ceiling. onReady

--- a/packages/frontend/src/Applications/TV/TV.tsx
+++ b/packages/frontend/src/Applications/TV/TV.tsx
@@ -37,7 +37,8 @@ import {
 	tvSetVolumeLimit,
 } from "./TVContext";
 import { trackAppToggle, trackChannelChange } from "../../openreplay";
-import { TV_ABR_CONFIG } from "./abr";
+import { bumpToLevel, TV_ABR_CONFIG } from "./abr";
+import type { HlsAbrApi } from "./abr";
 import { resolveVirtualNowMs } from "./clockDrift";
 import { resolveGridVolume } from "./volume";
 import { TVEPGPanel } from "./TVEPGPanel";
@@ -225,6 +226,9 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 	// Underlying video elements per item — QuickTimeVideoEmbed's onMediaElement
 	// hands back the native <video> element, so we set currentTime directly for seeking.
 	const videoRefs = useRef<Map<number, HTMLVideoElement>>(new Map());
+	// The <hls-video> element classicy renders exposes the hls.js instance as
+	// `.api` (absent on Safari's native-HLS path).
+	type HlsVideoEl = HTMLVideoElement & { api?: HlsAbrApi };
 	const prevDateTimeRef = useRef(dateTime);
 	// Stable ref to the latest UTC dateTime string for use in config callbacks.
 	const dateTimeRef = useRef(dateTime);
@@ -530,10 +534,17 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 	// Setting it just steers future fragment selection, so up/down moves smoothly
 	// at segment boundaries. Idempotent guard avoids redundant ABR re-evaluations.
 	const capHlsLevel = useCallback((id: number, level: number) => {
-		const el = videoRefs.current.get(id) as
-			| (HTMLVideoElement & { api?: { autoLevelCapping: number } })
-			| undefined;
+		const el = videoRefs.current.get(id) as HlsVideoEl | undefined;
 		if (el?.api && el.api.autoLevelCapping !== level) el.api.autoLevelCapping = level;
+	}, []);
+
+	// One-time aggressive bump when a channel gains single-view focus: reset
+	// the bandwidth estimate optimistically and force an immediate switch to
+	// the tier ceiling (flushing buffered low-res), then let ABR resume — see
+	// bumpToLevel. Complements capHlsLevel, which only sets the ceiling.
+	const bumpHlsLevel = useCallback((id: number, level: number) => {
+		const el = videoRefs.current.get(id) as HlsVideoEl | undefined;
+		if (el?.api) bumpToLevel(el.api, level);
 	}, []);
 
 	// The quality ceiling for a player: the single focused video (the active channel,
@@ -553,10 +564,28 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 
 	// Re-cap every loaded player whenever the tiering inputs change (active channel,
 	// selection set, grid mode); ABR then glides toward the new ceiling. onReady
-	// covers the initial cap for players that load after this runs.
+	// covers the initial cap for players that load after this runs. A player whose
+	// tier RISES to HIGHEST without remounting (grid shrinking to one) additionally
+	// gets the aggressive bump — remounting players get theirs from onReady.
+	const prevLevelsRef = useRef<Map<number, number>>(new Map());
 	useEffect(() => {
-		for (const item of items) capHlsLevel(item.id, levelForItem(item));
-	}, [items, levelForItem, capHlsLevel]);
+		const prev = prevLevelsRef.current;
+		const next = new Map<number, number>();
+		for (const item of items) {
+			const level = levelForItem(item);
+			next.set(item.id, level);
+			capHlsLevel(item.id, level);
+			const before = prev.get(item.id);
+			if (
+				level === QUALITY_HIGHEST &&
+				before !== undefined &&
+				before < QUALITY_HIGHEST
+			) {
+				bumpHlsLevel(item.id, level);
+			}
+		}
+		prevLevelsRef.current = next;
+	}, [items, levelForItem, capHlsLevel, bumpHlsLevel]);
 
 	// Re-sync the working copy from persisted state, reveal the window, and focus
 	// it so the modal is keyboard-ready the instant it opens (mirrors Browser).
@@ -785,7 +814,9 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 										onReady={() => {
 											setMainPlayerBuffering(false);
 											seekToCurrentTime(item);
-											capHlsLevel(item.id, levelForItem(item));
+											const level = levelForItem(item);
+											capHlsLevel(item.id, level);
+											if (level === QUALITY_HIGHEST) bumpHlsLevel(item.id, level);
 										}}
 										onWaiting={() => setMainPlayerBuffering(true)}
 										onPlaying={() => setMainPlayerBuffering(false)}
@@ -873,7 +904,9 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 												}}
 												onReady={() => {
 													seekToCurrentTime(item);
-													capHlsLevel(id, levelForItem(item));
+													const level = levelForItem(item);
+													capHlsLevel(id, level);
+													if (level === QUALITY_HIGHEST) bumpHlsLevel(id, level);
 												}}
 												playing={!clockPaused && !tvPaused}
 												muted={isGridMuted}

--- a/packages/frontend/src/Applications/TV/TV.tsx
+++ b/packages/frontend/src/Applications/TV/TV.tsx
@@ -37,6 +37,7 @@ import {
 	tvSetVolumeLimit,
 } from "./TVContext";
 import { trackAppToggle, trackChannelChange } from "../../openreplay";
+import { TV_ABR_CONFIG } from "./abr";
 import { resolveVirtualNowMs } from "./clockDrift";
 import { resolveGridVolume } from "./volume";
 import { TVEPGPanel } from "./TVEPGPanel";
@@ -270,6 +271,7 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 			);
 			config = {
 				hls: {
+					...TV_ABR_CONFIG,
 					startLevel: level,
 					startPosition: calcSeekSeconds(item, nowMs),
 				},

--- a/packages/frontend/src/Applications/TV/abr.test.ts
+++ b/packages/frontend/src/Applications/TV/abr.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
+	bumpToLevel,
 	bufferedAheadSeconds,
 	OPTIMISTIC_BANDWIDTH_ESTIMATE,
 	TV_ABR_CONFIG,
 	WATCHDOG_MIN_BUFFER_S,
 } from "./abr";
-import type { BufferedMedia } from "./abr";
+import type { BufferedMedia, HlsAbrApi } from "./abr";
 
 /** Build a minimal media element stand-in with the given buffered ranges. */
 export function fakeMedia(
@@ -53,5 +54,45 @@ describe("bufferedAheadSeconds", () => {
 		expect(
 			bufferedAheadSeconds(fakeMedia([[0, 10], [100, 160]], 150)),
 		).toBe(10);
+	});
+});
+
+/** Fake hls.js api that records once-handlers so tests can fire events. */
+export function fakeApi(over: Partial<HlsAbrApi> = {}) {
+	const handlers: Record<string, (() => void)[]> = {};
+	const api: HlsAbrApi = {
+		autoLevelCapping: -1,
+		autoLevelEnabled: true,
+		bandwidthEstimate: 500_000,
+		currentLevel: 0,
+		loadLevel: 0,
+		nextLevel: -1,
+		nextLoadLevel: 0,
+		once: (event, cb) => {
+			(handlers[event] ??= []).push(cb);
+		},
+		...over,
+	};
+	return { api, handlers };
+}
+
+describe("bumpToLevel", () => {
+	it("resets the estimate, forces the level, then restores auto on switch", () => {
+		const { api, handlers } = fakeApi();
+		bumpToLevel(api, 2);
+		expect(api.bandwidthEstimate).toBe(OPTIMISTIC_BANDWIDTH_ESTIMATE);
+		expect(api.nextLevel).toBe(2);
+		// hls.js fires hlsLevelSwitched once the forced switch lands.
+		expect(handlers.hlsLevelSwitched).toHaveLength(1);
+		handlers.hlsLevelSwitched[0]();
+		expect(api.nextLevel).toBe(-1); // back to auto — never frozen at full
+	});
+
+	it("only refreshes the estimate when already playing the target level", () => {
+		const { api, handlers } = fakeApi({ currentLevel: 2 });
+		bumpToLevel(api, 2);
+		expect(api.bandwidthEstimate).toBe(OPTIMISTIC_BANDWIDTH_ESTIMATE);
+		expect(api.nextLevel).toBe(-1); // no forced switch, no flush
+		expect(handlers.hlsLevelSwitched).toBeUndefined();
 	});
 });

--- a/packages/frontend/src/Applications/TV/abr.test.ts
+++ b/packages/frontend/src/Applications/TV/abr.test.ts
@@ -96,6 +96,14 @@ describe("bumpToLevel", () => {
 		expect(api.nextLevel).toBe(-1); // no forced switch, no flush
 		expect(handlers.hlsLevelSwitched).toBeUndefined();
 	});
+
+	it("only refreshes the estimate when nothing has played yet (fresh remount)", () => {
+		const { api, handlers } = fakeApi({ currentLevel: -1 });
+		bumpToLevel(api, 2);
+		expect(api.bandwidthEstimate).toBe(OPTIMISTIC_BANDWIDTH_ESTIMATE);
+		expect(api.nextLevel).toBe(-1); // no forced switch — startLevel already covers this
+		expect(handlers.hlsLevelSwitched).toBeUndefined();
+	});
 });
 
 describe("maybeProbeUp", () => {

--- a/packages/frontend/src/Applications/TV/abr.test.ts
+++ b/packages/frontend/src/Applications/TV/abr.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+	bufferedAheadSeconds,
+	OPTIMISTIC_BANDWIDTH_ESTIMATE,
+	TV_ABR_CONFIG,
+	WATCHDOG_MIN_BUFFER_S,
+} from "./abr";
+import type { BufferedMedia } from "./abr";
+
+/** Build a minimal media element stand-in with the given buffered ranges. */
+export function fakeMedia(
+	ranges: [number, number][],
+	currentTime: number,
+	over: Partial<BufferedMedia> = {},
+): BufferedMedia {
+	return {
+		buffered: {
+			length: ranges.length,
+			start: (i: number) => ranges[i][0],
+			end: (i: number) => ranges[i][1],
+		} as TimeRanges,
+		currentTime,
+		paused: false,
+		ended: false,
+		...over,
+	};
+}
+
+describe("TV_ABR_CONFIG", () => {
+	it("carries the exact upward-biased knobs from the design spec", () => {
+		expect(TV_ABR_CONFIG).toEqual({
+			abrEwmaDefaultEstimate: 5_000_000,
+			abrBandWidthUpFactor: 0.9,
+			abrEwmaFastVoD: 2,
+			abrEwmaSlowVoD: 5,
+		});
+		expect(OPTIMISTIC_BANDWIDTH_ESTIMATE).toBe(5_000_000);
+		expect(WATCHDOG_MIN_BUFFER_S).toBe(10);
+	});
+});
+
+describe("bufferedAheadSeconds", () => {
+	it("returns seconds remaining in the range containing the playhead", () => {
+		expect(bufferedAheadSeconds(fakeMedia([[100, 160]], 130))).toBe(30);
+	});
+
+	it("returns 0 when the playhead sits in no buffered range", () => {
+		expect(bufferedAheadSeconds(fakeMedia([[100, 160]], 200))).toBe(0);
+		expect(bufferedAheadSeconds(fakeMedia([], 42))).toBe(0);
+	});
+
+	it("picks the correct range among several", () => {
+		expect(
+			bufferedAheadSeconds(fakeMedia([[0, 10], [100, 160]], 150)),
+		).toBe(10);
+	});
+});

--- a/packages/frontend/src/Applications/TV/abr.test.ts
+++ b/packages/frontend/src/Applications/TV/abr.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	bumpToLevel,
 	bufferedAheadSeconds,
+	maybeProbeUp,
 	OPTIMISTIC_BANDWIDTH_ESTIMATE,
 	TV_ABR_CONFIG,
 	WATCHDOG_MIN_BUFFER_S,
@@ -94,5 +95,42 @@ describe("bumpToLevel", () => {
 		expect(api.bandwidthEstimate).toBe(OPTIMISTIC_BANDWIDTH_ESTIMATE);
 		expect(api.nextLevel).toBe(-1); // no forced switch, no flush
 		expect(handlers.hlsLevelSwitched).toBeUndefined();
+	});
+});
+
+describe("maybeProbeUp", () => {
+	const healthy = () => fakeMedia([[0, 100]], 50); // 50s buffered ahead
+
+	it("probes one level up via nextLoadLevel when below the ceiling with a healthy buffer", () => {
+		const { api } = fakeApi({ loadLevel: 0 });
+		expect(maybeProbeUp(healthy(), api, 2)).toBe(true);
+		expect(api.nextLoadLevel).toBe(1); // exactly one fragment, no flush
+	});
+
+	it("does nothing without an hls api (Safari native HLS)", () => {
+		expect(maybeProbeUp(healthy(), undefined, 2)).toBe(false);
+	});
+
+	it("does nothing in manual mode (a bump is in flight)", () => {
+		const { api } = fakeApi({ autoLevelEnabled: false, nextLoadLevel: 0 });
+		expect(maybeProbeUp(healthy(), api, 2)).toBe(false);
+		expect(api.nextLoadLevel).toBe(0);
+	});
+
+	it("never probes at or past the ceiling", () => {
+		const { api } = fakeApi({ loadLevel: 1, nextLoadLevel: 1 });
+		expect(maybeProbeUp(healthy(), api, 1)).toBe(false); // grid pinned at mid
+		expect(api.nextLoadLevel).toBe(1);
+	});
+
+	it("skips paused or ended players", () => {
+		const { api } = fakeApi();
+		expect(maybeProbeUp(fakeMedia([[0, 100]], 50, { paused: true }), api, 2)).toBe(false);
+		expect(maybeProbeUp(fakeMedia([[0, 100]], 50, { ended: true }), api, 2)).toBe(false);
+	});
+
+	it("skips when the buffer is thinner than WATCHDOG_MIN_BUFFER_S", () => {
+		const { api } = fakeApi();
+		expect(maybeProbeUp(fakeMedia([[0, 55]], 50), api, 2)).toBe(false); // 5s < 10s
 	});
 });

--- a/packages/frontend/src/Applications/TV/abr.ts
+++ b/packages/frontend/src/Applications/TV/abr.ts
@@ -1,0 +1,57 @@
+// Aggressive ABR helpers for TV.app (issue #149). The encoder ships a fixed
+// 3-rendition ladder (thumb 136k / mid 396k / full 2628k); hls.js defaults are
+// tuned for deep ladders and lazy up-switching, which parked players at thumb.
+// These helpers bias ABR strongly upward while keeping thumb selectable as a
+// genuine last resort — upward pressure, never a floor.
+
+/** Estimate handed to fresh/refocused players: assume a good connection until
+ *  measured otherwise. hls.js's 500k default is below the full rendition's
+ *  2628k, so an untouched player literally cannot pick full at start. */
+export const OPTIMISTIC_BANDWIDTH_ESTIMATE = 5_000_000;
+
+/** Minimum buffered seconds ahead of the playhead before the watchdog dares an
+ *  upward probe — a healthy buffer means the current level is comfortably
+ *  sustainable, so spending one fragment on a higher level is safe. */
+export const WATCHDOG_MIN_BUFFER_S = 10;
+
+/** Per-player hls.js config overrides, spread into each player's config. */
+export const TV_ABR_CONFIG = {
+	abrEwmaDefaultEstimate: OPTIMISTIC_BANDWIDTH_ESTIMATE,
+	// Up-switch to full at ~2.9Mbps measured instead of the default ~3.75Mbps.
+	abrBandWidthUpFactor: 0.9,
+	// Shorter EWMA half-lives (defaults 3/9): a transient dip stops dragging
+	// the estimate down within seconds instead of minutes.
+	abrEwmaFastVoD: 2,
+	abrEwmaSlowVoD: 5,
+} as const;
+
+/** The slice of the hls.js instance (exposed by hls-video-element as `.api`)
+ *  that the TV app's quality steering touches. */
+export type HlsAbrApi = {
+	autoLevelCapping: number;
+	autoLevelEnabled: boolean;
+	bandwidthEstimate: number;
+	currentLevel: number;
+	loadLevel: number;
+	nextLevel: number;
+	nextLoadLevel: number;
+	once(event: string, cb: () => void): void;
+};
+
+/** The slice of an HTMLMediaElement the buffer-health check reads. */
+export type BufferedMedia = Pick<
+	HTMLVideoElement,
+	"buffered" | "currentTime" | "paused" | "ended"
+>;
+
+/** Seconds of buffered media ahead of the playhead (0 if the playhead is
+ *  outside every buffered range). */
+export function bufferedAheadSeconds(el: BufferedMedia): number {
+	const { buffered, currentTime } = el;
+	for (let i = 0; i < buffered.length; i++) {
+		if (buffered.start(i) <= currentTime && currentTime <= buffered.end(i)) {
+			return buffered.end(i) - currentTime;
+		}
+	}
+	return 0;
+}

--- a/packages/frontend/src/Applications/TV/abr.ts
+++ b/packages/frontend/src/Applications/TV/abr.ts
@@ -71,3 +71,25 @@ export function bumpToLevel(api: HlsAbrApi, level: number): void {
 		api.nextLevel = -1;
 	});
 }
+
+/** Recurring watchdog probe: when a player is parked below its tier ceiling
+ *  despite a healthy buffer, force exactly ONE fragment at the next level up
+ *  (`nextLoadLevel` — no flush, auto mode preserved). The fragment's real
+ *  throughput sample feeds the EWMA, so if bandwidth is genuinely good ABR
+ *  keeps the higher level on its own; if not, it falls back and the watchdog
+ *  retries on the next health-check tick. This is what un-sticks a player
+ *  parked at thumb on a stale low estimate. Uses `loadLevel` (not
+ *  `currentLevel`) so a probe never drags an already-climbing loader back
+ *  down. Returns true when a probe was issued. */
+export function maybeProbeUp(
+	el: BufferedMedia,
+	api: HlsAbrApi | undefined,
+	ceiling: number,
+): boolean {
+	if (!api || !api.autoLevelEnabled) return false;
+	if (api.loadLevel >= ceiling) return false;
+	if (el.paused || el.ended) return false;
+	if (bufferedAheadSeconds(el) < WATCHDOG_MIN_BUFFER_S) return false;
+	api.nextLoadLevel = api.loadLevel + 1;
+	return true;
+}

--- a/packages/frontend/src/Applications/TV/abr.ts
+++ b/packages/frontend/src/Applications/TV/abr.ts
@@ -62,10 +62,19 @@ export function bufferedAheadSeconds(el: BufferedMedia): number {
  *  now, not after ~30s of buffer drains). Setting `nextLevel` puts hls.js in
  *  MANUAL mode, so auto is restored on the next level switch — the bump is a
  *  nudge, not a pin: if bandwidth can't sustain the level, ABR degrades as
- *  usual afterward. */
+ *  usual afterward.
+ *
+ *  A channel switch remounts the player embed, and `onReady` can fire before
+ *  hls.js has started anything — `currentLevel` still at its unset -1, with
+ *  nothing buffered to flush. Forcing `nextLevel` at that point strands
+ *  hls.js in manual mode with no fragment in flight, so `hlsLevelSwitched`
+ *  never fires and auto is never restored: the player wedges. Skip the force
+ *  whenever playback hasn't started yet — the per-player `startLevel`
+ *  config already loads a fresh mount at the ceiling, so there's nothing to
+ *  bump. */
 export function bumpToLevel(api: HlsAbrApi, level: number): void {
 	api.bandwidthEstimate = OPTIMISTIC_BANDWIDTH_ESTIMATE;
-	if (api.currentLevel === level) return; // already there — nothing to flush
+	if (api.currentLevel === level || api.currentLevel < 0) return; // already there, or nothing played yet — nothing to flush
 	api.nextLevel = level;
 	api.once("hlsLevelSwitched", () => {
 		api.nextLevel = -1;

--- a/packages/frontend/src/Applications/TV/abr.ts
+++ b/packages/frontend/src/Applications/TV/abr.ts
@@ -55,3 +55,19 @@ export function bufferedAheadSeconds(el: BufferedMedia): number {
 	}
 	return 0;
 }
+
+/** One-time aggressive bump used when a channel gains single-view focus:
+ *  optimistically reset the bandwidth estimate (future auto decisions), then
+ *  force `nextLevel` (flushes buffered low-res so the improvement is visible
+ *  now, not after ~30s of buffer drains). Setting `nextLevel` puts hls.js in
+ *  MANUAL mode, so auto is restored on the next level switch — the bump is a
+ *  nudge, not a pin: if bandwidth can't sustain the level, ABR degrades as
+ *  usual afterward. */
+export function bumpToLevel(api: HlsAbrApi, level: number): void {
+	api.bandwidthEstimate = OPTIMISTIC_BANDWIDTH_ESTIMATE;
+	if (api.currentLevel === level) return; // already there — nothing to flush
+	api.nextLevel = level;
+	api.once("hlsLevelSwitched", () => {
+		api.nextLevel = -1;
+	});
+}


### PR DESCRIPTION
Closes #149.

Users reported TV video quality degrading to the 136k thumbnail-grade rendition and sticking there. This biases hls.js ABR strongly upward while keeping the thumb rendition selectable as a genuine last resort (no hard floor — a starved connection still degrades instead of stalling).

## What changed (all in `packages/frontend/src/Applications/TV/`)

- **New pure module `abr.ts`** — ABR constants + three helpers, each unit-tested:
  - `TV_ABR_CONFIG`: `abrEwmaDefaultEstimate: 5_000_000` (the 500k default is *below* the full rendition's 2628k, so a fresh player literally couldn't pick full), `abrBandWidthUpFactor: 0.9` (up-switch at ~2.9Mbps measured instead of ~3.75Mbps), `abrEwmaFastVoD: 2` / `abrEwmaSlowVoD: 5` (transient dips stop dragging the estimate down within seconds).
  - `bumpToLevel`: one-time aggressive bump when a channel gains single-view focus — optimistic estimate reset + forced `nextLevel` (flushes buffered low-res so the improvement is visible now), auto restored on `hlsLevelSwitched`. Skipped before first playback (`currentLevel < 0`) — forcing a switch on a freshly remounted channel-switch player wedged hls.js in manual mode (found in runtime verification, covered by a regression test).
  - `maybeProbeUp`: 15s watchdog probe — when a player sits below its tier ceiling despite a healthy buffer (≥10s ahead), force exactly one fragment at the next level up via `nextLoadLevel` (no flush, auto preserved). The fragment's real throughput sample feeds the EWMA, un-sticking players parked on a stale low estimate.
- **`TV.tsx` wiring**: config spread into `hlsConfigFor`; bump on single-view `onReady` and on tier-rise-to-HIGHEST without remount (grid shrinking to one player); watchdog piggybacks the existing 15s health-check interval (no new timer).

## Verification

- 670/670 frontend tests (16 new: 13 unit + 3 component through the rendered TV app), eslint + tsc clean.
- Runtime-verified in a real browser against the dev server with CDP network throttling: knobs live in the hls instance; ~480kbps → loader drops to mid with watchdog up-probes each tick; ~200kbps → level 0 still reachable (last resort preserved); throttle lifted → recovery 0→1→2 in ~25s with auto ABR preserved throughout; channel switching A/B-identical to main after the regression fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)