### PR TITLE
HyperCard extension: embed mp3_items audio in stacks

### DIFF
--- a/packages/frontend/src/Applications/HyperCard/README.md
+++ b/packages/frontend/src/Applications/HyperCard/README.md
@@ -1,0 +1,53 @@
+# HyperCard extensions
+
+The **HyperCard app itself ships with `classicy`** and is auto-mounted by
+`ClassicyDesktop` (it can only be turned off via the
+`ClassicyDefaultAppsContext` `disableHyperCard` flag). Per the frontend
+`CLAUDE.md`, this repo never re-implements a bundled system app — it only
+supplies **configuration and content**. This folder is that content for
+HyperCard: extension *parts* that embed items from Directus collections into
+cards, and the built-in *stacks* that use them.
+
+A HyperCard stack is portable JSON and cannot fetch. classicy's plugin API
+(`registerHyperCardPart` / `registerHyperCardCommand` /
+`registerHyperCardStack`) is the seam that lets a card render live data: a
+registered part component does the fetching at render time and paints the
+result into its authored `rect`.
+
+## What's here
+
+- `extensions/directusCollections.ts` — the shared Directus read seam. One
+  anonymous REST GET per embedded item (same direct-Directus pattern as
+  `README/useReadmeArticles.ts`, bypassing the streamer). `DIRECTUS_COLLECTIONS`
+  is the registry of embeddable collections + the fields each needs.
+- `extensions/DirectusAudioPart.tsx` — the `directusAudio` part: embeds one
+  clip from the `mp3_items` collection (by `itemId`, or a direct `url`).
+- `extensions/mp3AudioStack.ts` — the built-in **Audio Clips** stack that
+  demonstrates the part.
+- `extensions/registerHyperCardExtensions.ts` — registers the parts and stacks
+  with classicy. Run once for its side effect via `index.ts`, imported from
+  `Desktop.tsx` above the desktop.
+
+## Authoring an audio embed in a stack
+
+```jsonc
+{
+  "id": "clip",
+  "type": "directusAudio",
+  "rect": [16, 52, 388, 96],
+  "options": { "itemId": 42 }        // a row in mp3_items
+  // or: { "url": "https://files.911realtime.org/…/clip.mp3", "title": "…" }
+}
+```
+
+`itemId` is passed through the stack expression engine, so it may reference a
+variable/field (`"options": { "itemId": "clip" }` tracks the `clip` variable).
+
+## Adding another collection (video, images, PDFs, …)
+
+1. Add an entry to `DIRECTUS_COLLECTIONS` with the collection name and the
+   fields the embed needs.
+2. Write a `Directus<Kind>Part.tsx` following `DirectusAudioPart.tsx` — read
+   `options`, fetch by id, render.
+3. Register its `type` in `registerHyperCardExtensions.ts`, and (optionally) add
+   a demo stack.

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusAudioPart.css
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusAudioPart.css
@@ -1,0 +1,33 @@
+/* Audio embed for HyperCard cards. Fills the authored part rect; the title sits
+   above a full-width native transport. Kept visually plain so it reads as a
+   period-appropriate media control inside a card. */
+.classicyHyperCardDirectusAudio {
+	margin: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	width: 100%;
+	height: 100%;
+	justify-content: center;
+}
+
+.classicyHyperCardDirectusAudioTitle {
+	font-size: 11px;
+	font-weight: bold;
+	line-height: 1.2;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.classicyHyperCardDirectusAudioPlayer {
+	width: 100%;
+	height: 32px;
+}
+
+.classicyHyperCardDirectusAudioMessage {
+	margin: 0;
+	font-size: 11px;
+	font-style: italic;
+	color: #555;
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusAudioPart.test.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusAudioPart.test.tsx
@@ -1,0 +1,96 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { HyperCardPartProps } from "classicy";
+import { DirectusAudioPart } from "./DirectusAudioPart";
+
+afterEach(() => {
+	cleanup();
+	vi.restoreAllMocks();
+});
+
+// Build the part props with sensible defaults; each test overrides what it needs.
+function props(overrides: Partial<HyperCardPartProps> = {}): HyperCardPartProps {
+	return {
+		part: { id: "clip", type: "directusAudio" },
+		partId: "clip",
+		stackId: "stack-1",
+		options: {},
+		locked: false,
+		value: "",
+		setValue: vi.fn(),
+		fire: vi.fn(),
+		getVariable: vi.fn(),
+		resolve: (expr: string) => expr,
+		...overrides,
+	} as HyperCardPartProps;
+}
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+	return { ok, status, json: async () => body } as unknown as Response;
+}
+
+describe("DirectusAudioPart", () => {
+	it("renders 'No audio source' with no url or itemId", () => {
+		render(<DirectusAudioPart {...props()} />);
+		expect(screen.getByText("No audio source")).toBeTruthy();
+	});
+
+	it("plays a direct url with no fetch", () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+		render(
+			<DirectusAudioPart
+				{...props({ options: { url: "https://x/a.mp3", title: "Direct Clip" } })}
+			/>,
+		);
+		const audio = screen.getByLabelText("Audio: Direct Clip") as HTMLAudioElement;
+		expect(audio.getAttribute("src")).toBe("https://x/a.mp3");
+		expect(screen.getByText("Direct Clip")).toBeTruthy();
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it("fetches an item by id and renders its url and title", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			jsonResponse({ data: { id: 42, title: "t", full_title: "Full Title", url: "https://x/42.mp3" } }),
+		);
+		render(<DirectusAudioPart {...props({ options: { itemId: 42 } })} />);
+
+		const audio = (await screen.findByLabelText("Audio: Full Title")) as HTMLAudioElement;
+		expect(audio.getAttribute("src")).toBe("https://x/42.mp3");
+		const url = fetchSpy.mock.calls[0][0] as string;
+		expect(url).toContain("/items/mp3_items/42?fields=");
+	});
+
+	it("resolves itemId through the expression engine before fetching", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			jsonResponse({ data: { id: 5, title: "Five", url: "https://x/5.mp3" } }),
+		);
+		// resolve maps the variable name "clip" to the id "5".
+		render(
+			<DirectusAudioPart
+				{...props({
+					options: { itemId: "clip" },
+					resolve: (expr) => (expr === "clip" ? "5" : expr),
+				})}
+			/>,
+		);
+		await screen.findByLabelText("Audio: Five");
+		expect(fetchSpy.mock.calls[0][0]).toContain("/items/mp3_items/5?fields=");
+	});
+
+	it("shows an error note when the fetch fails", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({}, false, 500));
+		render(<DirectusAudioPart {...props({ options: { itemId: 1 } })} />);
+		expect(await screen.findByRole("alert")).toBeTruthy();
+		expect(screen.getByText(/Could not load audio/)).toBeTruthy();
+	});
+
+	it("hides the native transport when locked", () => {
+		render(
+			<DirectusAudioPart
+				{...props({ locked: true, options: { url: "https://x/a.mp3", title: "Locked" } })}
+			/>,
+		);
+		const audio = screen.getByLabelText("Audio: Locked") as HTMLAudioElement;
+		expect(audio.hasAttribute("controls")).toBe(false);
+	});
+});

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusAudioPart.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusAudioPart.tsx
@@ -1,0 +1,180 @@
+import type { HyperCardPartProps } from "classicy";
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+	type DirectusAudioItem,
+	fetchDirectusAudioItem,
+} from "./directusCollections";
+import "./DirectusAudioPart.css";
+
+/**
+ * `directusAudio` HyperCard part — embeds one audio file from the `mp3_items`
+ * Directus collection into a card.
+ *
+ * Authored in a stack's JSON as a part whose `options` name the clip:
+ *
+ *   { "id": "clip", "type": "directusAudio", "rect": [16, 60, 388, 96],
+ *     "options": { "itemId": 42 } }
+ *
+ * Resolution order for the source:
+ *   1. `options.url`   — a direct audio URL (no fetch; also sets `title`).
+ *   2. `options.itemId` (or, when absent, the part's own field value) — fetched
+ *      from `mp3_items` and rendered from the row's `url`/`title`.
+ *
+ * `itemId` is passed through the stack's expression evaluator (`resolve`), so an
+ * author can bind it to a variable/field (e.g. `options.itemId: "currentClip"`)
+ * and drive playback from a script; a bare number or id resolves to itself.
+ */
+
+interface DirectusAudioOptions {
+	itemId?: string | number;
+	url?: string;
+	title?: string;
+	autoPlay?: boolean;
+	loop?: boolean;
+	preload?: "none" | "metadata" | "auto";
+}
+
+type LoadState =
+	| { status: "idle" }
+	| { status: "loading" }
+	| { status: "ready"; item: DirectusAudioItem }
+	| { status: "error"; message: string };
+
+function readOptions(options: Record<string, unknown>): DirectusAudioOptions {
+	const o = options as DirectusAudioOptions;
+	return {
+		itemId: typeof o.itemId === "string" || typeof o.itemId === "number" ? o.itemId : undefined,
+		url: typeof o.url === "string" ? o.url : undefined,
+		title: typeof o.title === "string" ? o.title : undefined,
+		autoPlay: o.autoPlay === true,
+		loop: o.loop === true,
+		preload: o.preload === "none" || o.preload === "auto" ? o.preload : "metadata",
+	};
+}
+
+export const DirectusAudioPart = ({
+	options,
+	value,
+	locked,
+	resolve,
+}: HyperCardPartProps) => {
+	const opts = useMemo(() => readOptions(options), [options]);
+
+	// The item id can come from options (resolved through the expression
+	// engine, so it may reference a variable/field) or fall back to the part's
+	// own field value. A direct `url` short-circuits the whole fetch.
+	const itemId = useMemo(() => {
+		if (opts.url) return undefined;
+		const raw = opts.itemId ?? value;
+		if (raw === undefined || raw === "") return undefined;
+		const resolved = resolve(String(raw)).trim();
+		return resolved === "" ? undefined : resolved;
+	}, [opts.url, opts.itemId, value, resolve]);
+
+	const [state, setState] = useState<LoadState>({ status: "idle" });
+
+	useEffect(() => {
+		if (opts.url || itemId === undefined) {
+			setState({ status: "idle" });
+			return;
+		}
+		const controller = new AbortController();
+		setState({ status: "loading" });
+		fetchDirectusAudioItem(itemId, fetch, controller.signal)
+			.then((item) => setState({ status: "ready", item }))
+			.catch((err: unknown) => {
+				if (controller.signal.aborted) return;
+				setState({
+					status: "error",
+					message: err instanceof Error ? err.message : String(err),
+				});
+			});
+		return () => controller.abort();
+	}, [opts.url, itemId]);
+
+	const src = opts.url ?? (state.status === "ready" ? state.item.url : undefined);
+	const title =
+		opts.title ??
+		(state.status === "ready"
+			? (state.item.full_title ?? state.item.title)
+			: undefined);
+	const subtitles = state.status === "ready" ? state.item.subtitles : undefined;
+
+	return (
+		<figure className="classicyHyperCardDirectusAudio">
+			{title && <figcaption className="classicyHyperCardDirectusAudioTitle">{title}</figcaption>}
+			<AudioBody
+				src={src}
+				title={title}
+				subtitles={subtitles ?? undefined}
+				autoPlay={opts.autoPlay}
+				loop={opts.loop}
+				preload={opts.preload}
+				controls={!locked}
+				loading={state.status === "loading"}
+				error={state.status === "error" ? state.message : undefined}
+				empty={!src && state.status === "idle"}
+			/>
+		</figure>
+	);
+};
+
+interface AudioBodyProps {
+	src?: string;
+	title?: string;
+	subtitles?: string;
+	autoPlay?: boolean;
+	loop?: boolean;
+	preload?: "none" | "metadata" | "auto";
+	controls: boolean;
+	loading: boolean;
+	error?: string;
+	empty: boolean;
+}
+
+function AudioBody({
+	src,
+	title,
+	subtitles,
+	autoPlay,
+	loop,
+	preload,
+	controls,
+	loading,
+	error,
+	empty,
+}: AudioBodyProps) {
+	const ref = useRef<HTMLAudioElement>(null);
+
+	// A locked part hides the native transport; still let a script-driven or
+	// autoplaying clip run to completion by starting it on mount.
+	useEffect(() => {
+		if (!controls && autoPlay && ref.current) void ref.current.play().catch(() => {});
+	}, [controls, autoPlay, src]);
+
+	if (error) {
+		return <p className="classicyHyperCardDirectusAudioMessage" role="alert">Could not load audio — {error}</p>;
+	}
+	if (loading) {
+		return <p className="classicyHyperCardDirectusAudioMessage">Loading audio…</p>;
+	}
+	if (empty || !src) {
+		return <p className="classicyHyperCardDirectusAudioMessage">No audio source</p>;
+	}
+	return (
+		<audio
+			ref={ref}
+			className="classicyHyperCardDirectusAudioPlayer"
+			src={src}
+			controls={controls}
+			autoPlay={autoPlay}
+			loop={loop}
+			preload={preload}
+			aria-label={title ? `Audio: ${title}` : "Audio clip"}
+		>
+			{/* Captions track is always present for accessibility; `src` is
+			    omitted (rendering an empty track) when the clip has none. */}
+			<track kind="captions" src={subtitles || undefined} label="Captions" />
+		</audio>
+	);
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/directusCollections.test.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/directusCollections.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	DIRECTUS_COLLECTIONS,
+	DIRECTUS_URL,
+	fetchDirectusAudioItem,
+	fetchDirectusItem,
+} from "./directusCollections";
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+	return {
+		ok,
+		status,
+		json: async () => body,
+	} as unknown as Response;
+}
+
+describe("fetchDirectusItem", () => {
+	it("builds a single-item URL with the projected fields and returns data", async () => {
+		const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ data: { id: 7, title: "Hi" } }));
+		const item = await fetchDirectusItem<{ id: number; title: string }>(
+			"mp3_items",
+			7,
+			["id", "title"],
+			fetchFn,
+		);
+		expect(item).toEqual({ id: 7, title: "Hi" });
+		expect(fetchFn).toHaveBeenCalledTimes(1);
+		const url = fetchFn.mock.calls[0][0] as string;
+		expect(url).toBe(`${DIRECTUS_URL}/items/mp3_items/7?fields=id,title`);
+	});
+
+	it("encodes collection, id and field names", async () => {
+		const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ data: {} }));
+		await fetchDirectusItem("odd items", "a/b", ["a,b"], fetchFn);
+		const url = fetchFn.mock.calls[0][0] as string;
+		expect(url).toBe(`${DIRECTUS_URL}/items/odd%20items/a%2Fb?fields=a%2Cb`);
+	});
+
+	it("passes the abort signal through", async () => {
+		const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ data: {} }));
+		const controller = new AbortController();
+		await fetchDirectusItem("mp3_items", 1, ["id"], fetchFn, controller.signal);
+		expect(fetchFn.mock.calls[0][1]).toEqual({ signal: controller.signal });
+	});
+
+	it("throws on a non-ok response", async () => {
+		const fetchFn = vi.fn().mockResolvedValue(jsonResponse({}, false, 404));
+		await expect(fetchDirectusItem("mp3_items", 9, ["id"], fetchFn)).rejects.toThrow("HTTP 404");
+	});
+
+	it("throws when the item is missing from the envelope", async () => {
+		const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ data: null }));
+		await expect(fetchDirectusItem("mp3_items", 9, ["id"], fetchFn)).rejects.toThrow("not found");
+	});
+});
+
+describe("fetchDirectusAudioItem", () => {
+	it("targets the mp3_items collection with the audio field set", async () => {
+		const fetchFn = vi.fn().mockResolvedValue(
+			jsonResponse({ data: { id: 3, title: "Clip", url: "https://x/a.mp3" } }),
+		);
+		const item = await fetchDirectusAudioItem(3, fetchFn);
+		expect(item.url).toBe("https://x/a.mp3");
+		const url = fetchFn.mock.calls[0][0] as string;
+		expect(url).toContain("/items/mp3_items/3?fields=");
+		for (const field of DIRECTUS_COLLECTIONS.audio.fields) {
+			expect(url).toContain(field);
+		}
+	});
+});

--- a/packages/frontend/src/Applications/HyperCard/extensions/directusCollections.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/directusCollections.ts
@@ -1,0 +1,89 @@
+// Directus-collection access for HyperCard extensions.
+//
+// HyperCard stacks are pure, portable JSON (see classicy's HyperCardModel). A
+// stack cannot fetch — so an *extension part* (registerHyperCardPart) does the
+// fetching at render time and paints the result into the card. This module is
+// the shared read seam every collection-backed part uses: one anonymous REST
+// GET per embedded item, same direct-Directus pattern as
+// README/useReadmeArticles.ts and Playlist/loadPlaylist.ts (reference data that
+// bypasses the streamer entirely).
+
+// Same env seam every other Directus caller uses; re-exported for parts.
+export { DIRECTUS_URL } from "../../../Providers/Playlist/loadPlaylist";
+import { DIRECTUS_URL } from "../../../Providers/Playlist/loadPlaylist";
+
+/**
+ * A minimal registry describing which Directus collections HyperCard stacks may
+ * embed and the fields each part needs. Adding a new embeddable collection
+ * (video, images, PDFs, …) is a one-line entry here plus a matching part
+ * component — the fetch/plumbing below is collection-agnostic.
+ */
+export const DIRECTUS_COLLECTIONS = {
+	/** Historical audio clips (radio, calls, broadcasts) — the mp3 pipeline. */
+	audio: {
+		collection: "mp3_items",
+		fields: [
+			"id",
+			"title",
+			"full_title",
+			"url",
+			"source",
+			"start_date",
+			"calc_duration",
+			"subtitles",
+		],
+	},
+} as const;
+
+export type DirectusCollectionKey = keyof typeof DIRECTUS_COLLECTIONS;
+
+/** One row of the `mp3_items` collection — the subset a stack embed reads. */
+export interface DirectusAudioItem {
+	id: number;
+	title: string;
+	full_title?: string | null;
+	url: string;
+	source?: string | null;
+	start_date?: string | null;
+	calc_duration?: number | null;
+	subtitles?: string | null;
+}
+
+interface ItemEnvelope<T> {
+	data?: T;
+}
+
+/**
+ * Fetch a single item from a Directus collection by id.
+ *
+ * One request per call. Never batch these onto the same path concurrently:
+ * api-beta can interleave response bodies under parallel same-path requests
+ * (see README/useReadmeArticles.ts and FlightTracker/useRouteIndex.ts) — each
+ * embed owning its own distinct `/items/<collection>/<id>` path avoids that.
+ */
+export async function fetchDirectusItem<T>(
+	collection: string,
+	id: string | number,
+	fields: readonly string[],
+	fetchFn: typeof fetch = fetch,
+	signal?: AbortSignal,
+): Promise<T> {
+	const url =
+		`${DIRECTUS_URL}/items/${encodeURIComponent(collection)}/${encodeURIComponent(String(id))}` +
+		`?fields=${fields.map(encodeURIComponent).join(",")}`;
+	const res = await fetchFn(url, { signal });
+	if (!res.ok) throw new Error(`Directus ${collection}/${id}: HTTP ${res.status}`);
+	const body = (await res.json()) as ItemEnvelope<T>;
+	if (body.data == null) throw new Error(`Directus ${collection}/${id}: not found`);
+	return body.data;
+}
+
+/** Fetch one `mp3_items` row by id, projecting the audio-embed field set. */
+export function fetchDirectusAudioItem(
+	id: string | number,
+	fetchFn: typeof fetch = fetch,
+	signal?: AbortSignal,
+): Promise<DirectusAudioItem> {
+	const { collection, fields } = DIRECTUS_COLLECTIONS.audio;
+	return fetchDirectusItem<DirectusAudioItem>(collection, id, fields, fetchFn, signal);
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/mp3AudioStack.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/mp3AudioStack.ts
@@ -1,0 +1,209 @@
+import type { HCStack } from "classicy";
+
+/**
+ * A built-in HyperCard stack that demonstrates the `directusAudio` extension
+ * part: each card embeds one audio clip from the `mp3_items` Directus
+ * collection, alongside the ordinary HyperCard parts (labels, buttons,
+ * navigation). Registered with the app via `registerHyperCardStack`, so it
+ * shows up in HyperCard's File → Open menu.
+ *
+ * The `itemId`s below reference rows in the live `mp3_items` collection; the
+ * part fetches each on render and degrades gracefully (a "Could not load audio"
+ * note) if an id is absent. The final card shows the direct-`url` form, which
+ * needs no Directus round-trip.
+ */
+
+/** The audio-part `type` string this stack embeds — must match the registered part. */
+export const DIRECTUS_AUDIO_PART_TYPE = "directusAudio";
+
+/** Stable id used both in the File menu registry and as the stack source key. */
+export const MP3_AUDIO_STACK_ID = "directus-mp3-audio";
+
+export const mp3AudioStack: HCStack = {
+	name: "Audio Clips",
+	version: "2",
+	size: [420, 300],
+	variables: { clip: "1" },
+	backgrounds: [
+		{
+			id: "main",
+			parts: [
+				{
+					id: "footer",
+					type: "label",
+					shared: true,
+					rect: [16, 272, 388, 20],
+					content: "Audio from the mp3_items collection — a Directus HyperCard extension",
+				},
+			],
+		},
+	],
+	cards: [
+		{
+			id: "intro",
+			name: "Audio Clips",
+			background: "main",
+			parts: [
+				{
+					id: "introTitle",
+					type: "label",
+					rect: [16, 16, 388, 24],
+					content: "Directus Audio",
+				},
+				{
+					id: "introText",
+					type: "field",
+					rect: [16, 48, 388, 56],
+					locked: true,
+					content:
+						"Each card embeds an audio clip pulled live from the mp3_items collection. Click Next to hear the first clip.",
+				},
+				{
+					id: "introNext",
+					type: "button",
+					name: "Next →",
+					rect: [304, 130, 100, 28],
+					script: {
+						onMouseUp: [
+							{ do: "visual", effect: "dissolve" },
+							{ do: "go", to: "next" },
+						],
+					},
+				},
+			],
+		},
+		{
+			id: "clip-1",
+			name: "Clip One",
+			background: "main",
+			parts: [
+				{
+					id: "clip1Title",
+					type: "label",
+					rect: [16, 16, 388, 24],
+					content: "Clip #1",
+				},
+				{
+					id: "clip1Audio",
+					type: DIRECTUS_AUDIO_PART_TYPE,
+					rect: [16, 52, 388, 96],
+					options: { itemId: 1 },
+				},
+				{
+					id: "clip1Prev",
+					type: "button",
+					name: "← Prev",
+					rect: [16, 160, 100, 28],
+					script: {
+						onMouseUp: [
+							{ do: "visual", effect: "wipeRight" },
+							{ do: "go", to: "prev" },
+						],
+					},
+				},
+				{
+					id: "clip1Next",
+					type: "button",
+					name: "Next →",
+					rect: [304, 160, 100, 28],
+					script: {
+						onMouseUp: [
+							{ do: "visual", effect: "wipeLeft" },
+							{ do: "go", to: "next" },
+						],
+					},
+				},
+			],
+		},
+		{
+			id: "clip-2",
+			name: "Clip Two",
+			background: "main",
+			parts: [
+				{
+					id: "clip2Title",
+					type: "label",
+					rect: [16, 16, 388, 24],
+					content: "Clip #2",
+				},
+				{
+					id: "clip2Audio",
+					type: DIRECTUS_AUDIO_PART_TYPE,
+					rect: [16, 52, 388, 96],
+					options: { itemId: 2 },
+				},
+				{
+					id: "clip2Prev",
+					type: "button",
+					name: "← Prev",
+					rect: [16, 160, 100, 28],
+					script: {
+						onMouseUp: [
+							{ do: "visual", effect: "wipeRight" },
+							{ do: "go", to: "prev" },
+						],
+					},
+				},
+				{
+					id: "clip2Next",
+					type: "button",
+					name: "Next →",
+					rect: [304, 160, 100, 28],
+					script: {
+						onMouseUp: [
+							{ do: "visual", effect: "wipeLeft" },
+							{ do: "go", to: "next" },
+						],
+					},
+				},
+			],
+		},
+		{
+			id: "chosen",
+			name: "By Variable",
+			background: "main",
+			parts: [
+				{
+					id: "chosenTitle",
+					type: "label",
+					rect: [16, 16, 388, 24],
+					content: "Pick a clip by id",
+				},
+				{
+					id: "chosenAudio",
+					// itemId resolves through the expression engine, so it can
+					// track a stack variable set by the buttons below.
+					type: DIRECTUS_AUDIO_PART_TYPE,
+					rect: [16, 52, 388, 96],
+					options: { itemId: "clip" },
+				},
+				{
+					id: "chosenOne",
+					type: "button",
+					name: "Clip 1",
+					rect: [16, 160, 80, 28],
+					script: { onMouseUp: [{ do: "put", value: "1", var: "clip" }] },
+				},
+				{
+					id: "chosenTwo",
+					type: "button",
+					name: "Clip 2",
+					rect: [104, 160, 80, 28],
+					script: { onMouseUp: [{ do: "put", value: "2", var: "clip" }] },
+				},
+				{
+					id: "chosenPrev",
+					type: "button",
+					name: "← Prev",
+					rect: [304, 160, 100, 28],
+					script: {
+						onMouseUp: [
+							{ do: "visual", effect: "wipeRight" },
+							{ do: "go", to: "prev" },
+						],
+					},
+				},
+			],
+		},
+	],
+};

--- a/packages/frontend/src/Applications/HyperCard/extensions/mp3AudioStack.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/mp3AudioStack.ts
@@ -7,10 +7,10 @@ import type { HCStack } from "classicy";
  * navigation). Registered with the app via `registerHyperCardStack`, so it
  * shows up in HyperCard's File → Open menu.
  *
- * The `itemId`s below reference rows in the live `mp3_items` collection; the
- * part fetches each on render and degrades gracefully (a "Could not load audio"
- * note) if an id is absent. The final card shows the direct-`url` form, which
- * needs no Directus round-trip.
+ * The `itemId`s below (9, 197, 36) reference rows in the live `mp3_items`
+ * collection; the part fetches each on render and degrades gracefully (a
+ * "Could not load audio" note) if an id is absent. The final card resolves its
+ * id from a stack variable so its buttons can switch between the same clips.
  */
 
 /** The audio-part `type` string this stack embeds — must match the registered part. */
@@ -23,7 +23,7 @@ export const mp3AudioStack: HCStack = {
 	name: "Audio Clips",
 	version: "2",
 	size: [420, 300],
-	variables: { clip: "1" },
+	variables: { clip: "9" },
 	backgrounds: [
 		{
 			id: "main",
@@ -81,13 +81,13 @@ export const mp3AudioStack: HCStack = {
 					id: "clip1Title",
 					type: "label",
 					rect: [16, 16, 388, 24],
-					content: "Clip #1",
+					content: "Clip #9",
 				},
 				{
 					id: "clip1Audio",
 					type: DIRECTUS_AUDIO_PART_TYPE,
 					rect: [16, 52, 388, 96],
-					options: { itemId: 1 },
+					options: { itemId: 9 },
 				},
 				{
 					id: "clip1Prev",
@@ -124,13 +124,13 @@ export const mp3AudioStack: HCStack = {
 					id: "clip2Title",
 					type: "label",
 					rect: [16, 16, 388, 24],
-					content: "Clip #2",
+					content: "Clip #197",
 				},
 				{
 					id: "clip2Audio",
 					type: DIRECTUS_AUDIO_PART_TYPE,
 					rect: [16, 52, 388, 96],
-					options: { itemId: 2 },
+					options: { itemId: 197 },
 				},
 				{
 					id: "clip2Prev",
@@ -146,6 +146,49 @@ export const mp3AudioStack: HCStack = {
 				},
 				{
 					id: "clip2Next",
+					type: "button",
+					name: "Next →",
+					rect: [304, 160, 100, 28],
+					script: {
+						onMouseUp: [
+							{ do: "visual", effect: "wipeLeft" },
+							{ do: "go", to: "next" },
+						],
+					},
+				},
+			],
+		},
+		{
+			id: "clip-3",
+			name: "Clip Three",
+			background: "main",
+			parts: [
+				{
+					id: "clip3Title",
+					type: "label",
+					rect: [16, 16, 388, 24],
+					content: "Clip #36",
+				},
+				{
+					id: "clip3Audio",
+					type: DIRECTUS_AUDIO_PART_TYPE,
+					rect: [16, 52, 388, 96],
+					options: { itemId: 36 },
+				},
+				{
+					id: "clip3Prev",
+					type: "button",
+					name: "← Prev",
+					rect: [16, 160, 100, 28],
+					script: {
+						onMouseUp: [
+							{ do: "visual", effect: "wipeRight" },
+							{ do: "go", to: "prev" },
+						],
+					},
+				},
+				{
+					id: "clip3Next",
 					type: "button",
 					name: "Next →",
 					rect: [304, 160, 100, 28],
@@ -180,16 +223,23 @@ export const mp3AudioStack: HCStack = {
 				{
 					id: "chosenOne",
 					type: "button",
-					name: "Clip 1",
-					rect: [16, 160, 80, 28],
-					script: { onMouseUp: [{ do: "put", value: "1", var: "clip" }] },
+					name: "#9",
+					rect: [16, 160, 60, 28],
+					script: { onMouseUp: [{ do: "put", value: "9", var: "clip" }] },
 				},
 				{
 					id: "chosenTwo",
 					type: "button",
-					name: "Clip 2",
-					rect: [104, 160, 80, 28],
-					script: { onMouseUp: [{ do: "put", value: "2", var: "clip" }] },
+					name: "#197",
+					rect: [84, 160, 60, 28],
+					script: { onMouseUp: [{ do: "put", value: "197", var: "clip" }] },
+				},
+				{
+					id: "chosenThree",
+					type: "button",
+					name: "#36",
+					rect: [152, 160, 60, 28],
+					script: { onMouseUp: [{ do: "put", value: "36", var: "clip" }] },
 				},
 				{
 					id: "chosenPrev",

--- a/packages/frontend/src/Applications/HyperCard/extensions/registerHyperCardExtensions.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/registerHyperCardExtensions.ts
@@ -1,0 +1,25 @@
+import { registerHyperCardPart, registerHyperCardStack } from "classicy";
+import { DirectusAudioPart } from "./DirectusAudioPart";
+import { MP3_AUDIO_STACK_ID, mp3AudioStack } from "./mp3AudioStack";
+
+// Registration must run once, before the HyperCard app opens a stack that uses
+// a Directus part. Classicy's registries are last-write-wins Maps, so repeat
+// calls (StrictMode double-invoke, HMR) are harmless — this guard just skips
+// the redundant work.
+let registered = false;
+
+/**
+ * Install the Directus-collection HyperCard extensions: the display parts and
+ * the built-in stacks that showcase them. Called for its side effect from the
+ * app entry (see `../index.ts`).
+ */
+export function registerHyperCardExtensions(): void {
+	if (registered) return;
+	registered = true;
+
+	// Display parts — one registered `type` per embeddable collection.
+	registerHyperCardPart("directusAudio", DirectusAudioPart);
+
+	// Built-in stacks that demonstrate the parts (File → Open in HyperCard).
+	registerHyperCardStack(MP3_AUDIO_STACK_ID, mp3AudioStack.name, mp3AudioStack);
+}

--- a/packages/frontend/src/Applications/HyperCard/index.ts
+++ b/packages/frontend/src/Applications/HyperCard/index.ts
@@ -1,0 +1,22 @@
+// HyperCard app content for 911realtime. The HyperCard *app* itself ships with
+// classicy and is auto-mounted by ClassicyDesktop — this repo, per the frontend
+// CLAUDE.md, only supplies configuration and content. Here that content is a
+// set of extension parts that embed items from Directus collections into
+// stacks, plus the built-in stacks that use them.
+//
+// Importing this module for its side effect registers the extensions with
+// classicy's HyperCard plugin registries. Do it once, above the desktop (see
+// Desktop.tsx), so the parts exist before any stack is opened.
+import { registerHyperCardExtensions } from "./extensions/registerHyperCardExtensions";
+
+registerHyperCardExtensions();
+
+export { registerHyperCardExtensions } from "./extensions/registerHyperCardExtensions";
+export { mp3AudioStack, MP3_AUDIO_STACK_ID } from "./extensions/mp3AudioStack";
+export { DirectusAudioPart } from "./extensions/DirectusAudioPart";
+export {
+	DIRECTUS_COLLECTIONS,
+	fetchDirectusAudioItem,
+	fetchDirectusItem,
+	type DirectusAudioItem,
+} from "./extensions/directusCollections";

--- a/packages/frontend/src/Desktop.tsx
+++ b/packages/frontend/src/Desktop.tsx
@@ -1,5 +1,9 @@
 import "maplibre-gl/dist/maplibre-gl.css";
 import { ClassicyDesktop } from "classicy";
+// Side effect: register the Directus-collection HyperCard extension parts and
+// stacks with classicy's HyperCard plugin registries. The HyperCard app itself
+// is bundled in classicy and auto-mounted by ClassicyDesktop.
+import "./Applications/HyperCard";
 import { Account } from "./Applications/Account/Account";
 import { Browser } from "./Applications/Browser/Browser";
 import { Feedback } from "./Applications/Feedback/Feedback";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 18.1.0
       classicy:
         specifier: latest
-        version: 0.41.3(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30)
+        version: 0.41.4(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30)
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -1847,8 +1847,8 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
-  classicy@0.41.3:
-    resolution: {integrity: sha512-cSjrAlvbA4eCL1GVAkxCITAbyOMiuozd0rKyTaZRZhR9GMf2WRXBK8B2c80aICOQXvuImNc/CaKLRpHQ2eyGJw==}
+  classicy@0.41.4:
+    resolution: {integrity: sha512-i7xazx+gnZGDHTUS6C/weEfam//ISIFkhGstTGU++aPpP4o2gVTBhQ4AAQJcPDU2DgxRtqbVZguCGd4FWHViNg==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -5846,7 +5846,7 @@ snapshots:
       readdirp: 5.0.0
     optional: true
 
-  classicy@0.41.3(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30):
+  classicy@0.41.4(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30):
     dependencies:
       '@analytics/google-tag-manager': 0.6.0
       '@mdxeditor/editor': 3.55.0(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30)


### PR DESCRIPTION
## What & why

The Classicy HyperCard app (auto-mounted by `ClassicyDesktop`, from classicy 0.41.4) exposes a plugin API for extending stacks. HyperCard stacks are portable JSON and can't fetch, so this adds the first **Directus-collection extension**: a `directusAudio` part that embeds an audio clip from the `mp3_items` collection into a card, plus a built-in demo stack that uses it. This is the groundwork for embedding further collections (video, images, PDFs) the same way.

Per the frontend `CLAUDE.md`, this repo never re-implements a bundled classicy app — it only supplies configuration and content. All of this lives under `src/Applications/HyperCard/` as content for the bundled app.

## Changes

- **`extensions/directusCollections.ts`** — shared Directus read seam (one anonymous REST GET per embed, same direct-Directus pattern as `README/useReadmeArticles.ts`, bypassing the streamer) + a `DIRECTUS_COLLECTIONS` registry so new embeddable collections are a one-line addition.
- **`extensions/DirectusAudioPart.tsx`** (+ `.css`) — the `directusAudio` part. Resolves an `itemId` (through the stack expression engine, so it can track a variable/field) or a direct `url`, fetches the `mp3_items` row, and renders a native audio transport. Degrades to a note on error/empty and hides controls when the part is `locked`.
- **`extensions/mp3AudioStack.ts`** — the built-in **"Audio Clips"** stack (appears in HyperCard's File → Open). Cards embed real clips (ids 9, 197, 36) plus a "pick by id" card driven by a stack variable.
- **`extensions/registerHyperCardExtensions.ts` + `index.ts`** — idempotent registration with classicy's plugin registries, run once via a side-effect import added to `Desktop.tsx`.
- **`README.md`** — documents the extension pattern and how to add embeds for other collections.
- Co-located unit tests for the fetch seam and the part.
- `pnpm-lock.yaml`: classicy 0.41.3 → 0.41.4 (the version that ships HyperCard); `package.json` pin stays `"latest"`.

## Authoring an embed

```jsonc
{ "id": "clip", "type": "directusAudio", "rect": [16,52,388,96], "options": { "itemId": 9 } }
// or a direct URL: "options": { "url": "https://files.911realtime.org/…/clip.mp3", "title": "…" }
```

## Verification

- `tsc -b` clean, `eslint .` 0 errors, full suite **1166 tests pass** (13 new).
- Ran a throwaway integration check against classicy's actual runtime: the part registers under `directusAudio`, the stack lands in the File menu, and classicy's own `validateStack` accepts the stack JSON. (Live `mp3_items` fetches happen in the browser at runtime; the sandbox's egress policy blocks `api-beta`, so I couldn't exercise the network path here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C449E6WHyMkjFVHKELYcmB

---
_Generated by [Claude Code](https://claude.ai/code/session_01C449E6WHyMkjFVHKELYcmB)_