### PR TITLE
HyperCard extension: embed tv_channels video (single + multiview)

### DIFF
--- a/packages/frontend/src/Applications/HyperCard/README.md
+++ b/packages/frontend/src/Applications/HyperCard/README.md
@@ -22,8 +22,17 @@ result into its authored `rect`.
   is the registry of embeddable collections + the fields each needs.
 - `extensions/DirectusAudioPart.tsx` — the `directusAudio` part: embeds one
   clip from the `mp3_items` collection (by `itemId`, or a direct `url`).
-- `extensions/mp3AudioStack.ts` — the built-in **Audio Clips** stack that
-  demonstrates the part.
+- `extensions/DirectusVideoPart.tsx` — the `directusVideo` part: embeds one TV
+  channel stream from `tv_channels`, optionally limited to a start/end segment,
+  using classicy's `QuickTimeVideoEmbed` (HLS) for controls/autoplay/captions.
+  Exports the reusable `DirectusVideo` body.
+- `extensions/DirectusMultiviewPart.tsx` — the `directusMultiview` part: a grid
+  ("video wall") of `DirectusVideo` tiles with solo/mute/all audio modes.
+- `extensions/videoOptions.ts` / `extensions/videoSegment.ts` — the video option
+  shape, and the pure start/end bound resolver (offset seconds, `M:SS`, or a
+  date-bearing wall-clock mapped via the channel `start_date`).
+- `extensions/mp3AudioStack.ts` / `extensions/tvChannelStack.ts` — the built-in
+  **Audio Clips** and **TV Channels** stacks that demonstrate the parts.
 - `extensions/registerHyperCardExtensions.ts` — registers the parts and stacks
   with classicy. Run once for its side effect via `index.ts`, imported from
   `Desktop.tsx` above the desktop.
@@ -43,7 +52,55 @@ result into its authored `rect`.
 `itemId` is passed through the stack expression engine, so it may reference a
 variable/field (`"options": { "itemId": "clip" }` tracks the `clip` variable).
 
-## Adding another collection (video, images, PDFs, …)
+## Authoring a TV video embed
+
+```jsonc
+{
+  "id": "tv",
+  "type": "directusVideo",
+  "rect": [12, 40, 416, 232],
+  "options": {
+    "channelId": 3,          // a row in tv_channels (or a direct HLS "url")
+    "start": 60, "end": 180, // stream-offset seconds, "M:SS", or a
+                             // date-bearing wall-clock ("2001-09-11T12:46:00")
+    "controls": true,        // native transport (default true); false = chromeless
+    "autoPlay": true,        // muted defaults to true when autoplaying
+    "loop": true,            // loop the [start, end] segment
+    "captions": true,        // captions on by default; the CC control still toggles
+    "muted": false, "volume": 0.8,
+    "poster": "https://…/frame.jpg",
+    "overlay": true          // channel-name + running-time bug
+  }
+}
+```
+
+Segment bounds resolve to a stream offset in seconds: a number or `M:SS` is an
+offset; a value carrying a calendar date is a 9/11 wall-clock instant mapped via
+the channel's `start_date`. A non-looping segment that reaches its `end` fires
+the part's own `script` (e.g. `go next`), so clips can chain.
+
+### Multiview (video wall)
+
+```jsonc
+{
+  "id": "wall",
+  "type": "directusMultiview",
+  "rect": [12, 40, 416, 232],
+  "options": {
+    "audio": "solo",         // "solo" (tap a tile to hear it) | "mute" | "all"
+    "columns": 2,            // omit for an automatic grid
+    "videos": [
+      { "channelId": 1, "autoPlay": true },
+      { "channelId": 2, "autoPlay": true },
+      { "channelId": 3, "start": "2001-09-11T12:46:00", "autoPlay": true }
+    ]
+  }
+}
+```
+
+Each tile takes the full `directusVideo` option set.
+
+## Adding another collection (images, PDFs, …)
 
 1. Add an entry to `DIRECTUS_COLLECTIONS` with the collection name and the
    fields the embed needs.

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusMultiviewPart.css
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusMultiviewPart.css
@@ -1,0 +1,35 @@
+/* Multiview "video wall" for HyperCard cards: an even grid of channel tiles
+   filling the authored part rect. Column count is set inline (author or auto). */
+.classicyHyperCardMultiview {
+	display: grid;
+	gap: 3px;
+	width: 100%;
+	height: 100%;
+	background: #000;
+	grid-auto-rows: 1fr;
+}
+
+.classicyHyperCardMultiviewTile {
+	position: relative;
+	min-width: 0;
+	min-height: 0;
+	overflow: hidden;
+	background: #000;
+}
+
+/* The audible tile in solo mode gets a highlighted border. */
+.classicyHyperCardMultiviewTileActive {
+	outline: 2px solid #fc0;
+	outline-offset: -2px;
+	z-index: 1;
+}
+
+.classicyHyperCardMultiviewEmpty {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: #ddd;
+	color: #333;
+	font-size: 11px;
+	font-style: italic;
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusMultiviewPart.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusMultiviewPart.tsx
@@ -1,0 +1,103 @@
+import type { HyperCardPartProps } from "classicy";
+import { useMemo, useState } from "react";
+import { DirectusVideo } from "./DirectusVideoPart";
+import { type DirectusVideoOptions, readVideoOptions } from "./videoOptions";
+import "./DirectusMultiviewPart.css";
+
+/**
+ * `directusMultiview` HyperCard part — a grid of TV channel streams (a "video
+ * wall"). Each tile takes the full `directusVideo` option set.
+ *
+ *   { "id": "wall", "type": "directusMultiview", "rect": [8, 32, 404, 236],
+ *     "options": {
+ *       "audio": "solo",          // "solo" | "all" | "mute"
+ *       "columns": 2,             // omit for an automatic grid
+ *       "videos": [
+ *         { "channelId": 1, "autoPlay": true },
+ *         { "channelId": 2, "autoPlay": true },
+ *         { "channelId": 3, "start": "2001-09-11T12:46:00", "autoPlay": true }
+ *       ]
+ *     } }
+ *
+ * Audio modes: `solo` plays one tile's audio (tap a tile to switch), `mute`
+ * silences every tile, `all` lets each tile use its own muted/volume options.
+ */
+
+type AudioMode = "solo" | "all" | "mute";
+
+interface MultiviewOptions {
+	videos: DirectusVideoOptions[];
+	columns?: number;
+	audio: AudioMode;
+	/** Index of the tile audible first in `solo` mode. */
+	active?: number;
+}
+
+function readMultiviewOptions(options: Record<string, unknown>): MultiviewOptions {
+	const rawVideos = Array.isArray(options.videos) ? options.videos : [];
+	const videos = rawVideos
+		.filter((v): v is Record<string, unknown> => typeof v === "object" && v !== null)
+		.map(readVideoOptions);
+	const audio: AudioMode =
+		options.audio === "all" || options.audio === "mute" ? options.audio : "solo";
+	const columns =
+		typeof options.columns === "number" && options.columns > 0
+			? Math.floor(options.columns)
+			: undefined;
+	const active = typeof options.active === "number" ? Math.floor(options.active) : 0;
+	return { videos, columns, audio, active };
+}
+
+/** Balanced column count for `n` tiles when the author doesn't set one. */
+function autoColumns(n: number): number {
+	return n <= 1 ? 1 : Math.ceil(Math.sqrt(n));
+}
+
+export const DirectusMultiviewPart = ({ options, partId, stackId }: HyperCardPartProps) => {
+	const { videos, columns, audio, active } = useMemo(
+		() => readMultiviewOptions(options),
+		[options],
+	);
+	const [activeIndex, setActiveIndex] = useState(active);
+
+	if (videos.length === 0) {
+		return (
+			<div className="classicyHyperCardMultiview classicyHyperCardMultiviewEmpty">
+				No videos configured
+			</div>
+		);
+	}
+
+	const cols = Math.min(columns ?? autoColumns(videos.length), videos.length);
+
+	return (
+		<div
+			className="classicyHyperCardMultiview"
+			style={{ gridTemplateColumns: `repeat(${cols}, 1fr)` }}
+		>
+			{videos.map((v, i) => {
+				const forceMuted = audio === "mute" ? true : audio === "solo" ? i !== activeIndex : undefined;
+				const solo = audio === "solo";
+				return (
+					<div
+						key={i}
+						className={
+							"classicyHyperCardMultiviewTile" +
+							(solo && i === activeIndex ? " classicyHyperCardMultiviewTileActive" : "")
+						}
+					>
+						<DirectusVideo
+							{...v}
+							appId={`hc-${stackId}-${partId}-${i}`}
+							// A muted wall usually wants the transport hidden unless the
+							// author explicitly asked for controls on a tile.
+							controls={v.controls === true}
+							forceMuted={forceMuted}
+							onActivate={solo ? () => setActiveIndex(i) : undefined}
+						/>
+					</div>
+				);
+			})}
+		</div>
+	);
+};

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusVideoPart.css
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusVideoPart.css
@@ -1,0 +1,57 @@
+/* TV channel video embed for HyperCard cards. Fills the authored part rect; the
+   classicy player sizes to this box. */
+.classicyHyperCardDirectusVideo {
+	position: relative;
+	width: 100%;
+	height: 100%;
+	min-height: 0;
+	background: #000;
+	overflow: hidden;
+	display: flex;
+}
+
+.classicyHyperCardDirectusVideo > * {
+	width: 100%;
+	height: 100%;
+}
+
+.classicyHyperCardDirectusVideoMessage {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: #ddd;
+	color: #333;
+	font-size: 11px;
+	font-style: italic;
+	text-align: center;
+	padding: 8px;
+}
+
+/* On-screen channel bug: name + running time, top-left over the video. */
+.classicyHyperCardDirectusVideoBug {
+	position: absolute;
+	top: 6px;
+	left: 6px;
+	display: flex;
+	gap: 6px;
+	align-items: baseline;
+	padding: 2px 6px;
+	background: rgba(0, 0, 0, 0.55);
+	color: #fff;
+	font-size: 10px;
+	line-height: 1.3;
+	pointer-events: none;
+	max-width: calc(100% - 12px);
+}
+
+.classicyHyperCardDirectusVideoBugName {
+	font-weight: bold;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.classicyHyperCardDirectusVideoBugTime {
+	font-variant-numeric: tabular-nums;
+	opacity: 0.85;
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusVideoPart.test.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusVideoPart.test.tsx
@@ -1,0 +1,207 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Capture every QuickTimeVideoEmbed render's props so tests can inspect what the
+// part passed and drive the onMediaElement segment hook.
+const embedProps = vi.hoisted(() => [] as Array<Record<string, unknown>>);
+vi.mock("classicy", () => ({
+	QuickTimeVideoEmbed: (props: Record<string, unknown>) => {
+		embedProps.push(props);
+		return (
+			<div
+				data-testid="qt-embed"
+				data-url={String(props.url ?? "")}
+				data-hide={String(props.hideControls ?? false)}
+				data-muted={String(props.muted ?? false)}
+				data-caps={String(props.captionsEnabled ?? false)}
+				data-subs={String(props.subtitlesUrl ?? "")}
+			/>
+		);
+	},
+	timeFriendly: (s: number) => `t${Math.floor(s)}`,
+}));
+
+import { DirectusVideo, DirectusVideoPart } from "./DirectusVideoPart";
+import { DirectusMultiviewPart } from "./DirectusMultiviewPart";
+import { readVideoOptions } from "./videoOptions";
+
+afterEach(() => {
+	cleanup();
+	vi.restoreAllMocks();
+	embedProps.length = 0;
+});
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+	return { ok, status, json: async () => body } as unknown as Response;
+}
+
+/** A minimal HTMLVideoElement stand-in that records listeners and can emit. */
+function makeFakeVideo() {
+	const listeners: Record<string, Array<() => void>> = {};
+	return {
+		currentTime: 0,
+		readyState: 1,
+		paused: false,
+		poster: "",
+		play: vi.fn(() => Promise.resolve()),
+		pause: vi.fn(function (this: { paused: boolean }) {
+			this.paused = true;
+		}),
+		addEventListener: (t: string, f: () => void) => {
+			(listeners[t] ||= []).push(f);
+		},
+		removeEventListener: (t: string, f: () => void) => {
+			listeners[t] = (listeners[t] || []).filter((x) => x !== f);
+		},
+		emit: (t: string) => (listeners[t] || []).forEach((f) => f()),
+	};
+}
+
+const lastEmbed = () => embedProps[embedProps.length - 1];
+
+describe("readVideoOptions", () => {
+	it("defaults controls on, reads channelId (and itemId alias)", () => {
+		expect(readVideoOptions({}).controls).toBe(true);
+		expect(readVideoOptions({ controls: false }).controls).toBe(false);
+		expect(readVideoOptions({ channelId: 5 }).channelId).toBe(5);
+		expect(readVideoOptions({ itemId: 7 }).channelId).toBe(7);
+	});
+});
+
+describe("DirectusVideoPart", () => {
+	it("shows 'No video source' with no url or channelId", () => {
+		render(<DirectusVideoPart {...partProps({})} />);
+		expect(screen.getByText("No video source")).toBeTruthy();
+	});
+
+	it("plays a direct url and hides controls when controls:false", () => {
+		render(<DirectusVideoPart {...partProps({ url: "https://x/a.m3u8", controls: false })} />);
+		const el = screen.getByTestId("qt-embed");
+		expect(el.getAttribute("data-url")).toBe("https://x/a.m3u8");
+		expect(el.getAttribute("data-hide")).toBe("true");
+	});
+
+	it("mutes by default when autoplaying", () => {
+		render(<DirectusVideoPart {...partProps({ url: "https://x/a.m3u8", autoPlay: true })} />);
+		expect(screen.getByTestId("qt-embed").getAttribute("data-muted")).toBe("true");
+	});
+
+	it("enables captions by default when captions:true", () => {
+		render(<DirectusVideoPart {...partProps({ url: "https://x/a.m3u8", captions: true })} />);
+		expect(screen.getByTestId("qt-embed").getAttribute("data-caps")).toBe("true");
+	});
+
+	it("fetches a channel and passes its url and derived vtt subtitles", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			jsonResponse({
+				data: {
+					id: 3,
+					title: "WNYW",
+					full_title: "WNYW Fox 5",
+					url: "https://x/ch3.m3u8",
+					start_date: "2001-09-11T12:40:00",
+					subtitles: "https://x/ch3.srt",
+				},
+			}),
+		);
+		render(<DirectusVideoPart {...partProps({ channelId: 3 })} />);
+		const el = await screen.findByTestId("qt-embed");
+		expect(el.getAttribute("data-url")).toBe("https://x/ch3.m3u8");
+		expect(el.getAttribute("data-subs")).toBe("https://x/ch3.vtt");
+	});
+
+	it("shows an error note when the fetch fails", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({}, false, 500));
+		render(<DirectusVideoPart {...partProps({ channelId: 1 })} />);
+		expect(await screen.findByRole("alert")).toBeTruthy();
+		expect(screen.getByText(/Could not load video/)).toBeTruthy();
+	});
+});
+
+describe("DirectusVideo segment enforcement", () => {
+	it("seeks to the start offset once the element is ready", () => {
+		render(<DirectusVideo appId="t" url="https://x/a.m3u8" start={10} end={20} />);
+		const video = makeFakeVideo();
+		act(() => {
+			(lastEmbed().onMediaElement as (el: unknown) => void)(video);
+		});
+		expect(video.currentTime).toBe(10);
+	});
+
+	it("pauses and fires onSegmentEnd at the end bound (no loop)", () => {
+		const onEnd = vi.fn();
+		render(<DirectusVideo appId="t" url="https://x/a.m3u8" start={10} end={20} onSegmentEnd={onEnd} />);
+		const video = makeFakeVideo();
+		act(() => {
+			(lastEmbed().onMediaElement as (el: unknown) => void)(video);
+		});
+		act(() => {
+			video.currentTime = 20.1;
+			video.emit("timeupdate");
+		});
+		expect(video.pause).toHaveBeenCalled();
+		expect(onEnd).toHaveBeenCalledTimes(1);
+	});
+
+	it("loops back to the start at the end bound when loop:true", () => {
+		render(<DirectusVideo appId="t" url="https://x/a.m3u8" start={10} end={20} loop />);
+		const video = makeFakeVideo();
+		act(() => {
+			(lastEmbed().onMediaElement as (el: unknown) => void)(video);
+		});
+		act(() => {
+			video.currentTime = 20.1;
+			video.emit("timeupdate");
+		});
+		expect(video.currentTime).toBe(10);
+		expect(video.play).toHaveBeenCalled();
+	});
+});
+
+describe("DirectusMultiviewPart", () => {
+	it("renders one tile per video and solos the active tile's audio", () => {
+		render(
+			<DirectusMultiviewPart
+				{...partProps({
+					audio: "solo",
+					columns: 2,
+					videos: [{ url: "https://x/1.m3u8" }, { url: "https://x/2.m3u8" }, { url: "https://x/3.m3u8" }],
+				})}
+			/>,
+		);
+		expect(screen.getAllByTestId("qt-embed")).toHaveLength(3);
+		// solo mode: exactly one tile unmuted (the active one).
+		const unmuted = embedProps.filter((p) => p.muted === false);
+		expect(unmuted).toHaveLength(1);
+	});
+
+	it("mutes every tile in 'mute' mode", () => {
+		render(
+			<DirectusMultiviewPart
+				{...partProps({ audio: "mute", videos: [{ url: "https://x/1.m3u8" }, { url: "https://x/2.m3u8" }] })}
+			/>,
+		);
+		expect(embedProps.every((p) => p.muted === true)).toBe(true);
+	});
+
+	it("shows a message when no videos are configured", () => {
+		render(<DirectusMultiviewPart {...partProps({ videos: [] })} />);
+		expect(screen.getByText("No videos configured")).toBeTruthy();
+	});
+});
+
+// Build HyperCardPartProps with the given options and sensible defaults.
+function partProps(options: Record<string, unknown>) {
+	return {
+		part: { id: "p", type: "directusVideo" },
+		partId: "p",
+		stackId: "s",
+		options,
+		locked: false,
+		value: "",
+		setValue: vi.fn(),
+		fire: vi.fn(),
+		getVariable: vi.fn(),
+		resolve: (e: string) => e,
+	} as unknown as Parameters<typeof DirectusVideoPart>[0];
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusVideoPart.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusVideoPart.tsx
@@ -1,0 +1,217 @@
+import type { HyperCardPartProps } from "classicy";
+import { QuickTimeVideoEmbed, timeFriendly } from "classicy";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { vttUrl } from "../../../Providers/MediaStream/MediaStreamContext";
+import {
+	type DirectusVideoItem,
+	fetchDirectusVideoItem,
+} from "./directusCollections";
+import { type DirectusVideoOptions, readVideoOptions } from "./videoOptions";
+import { resolveSegment, toUtcMs } from "./videoSegment";
+import "./DirectusVideoPart.css";
+
+/**
+ * `directusVideo` HyperCard part — embeds one TV channel stream from the
+ * `tv_channels` Directus collection, optionally limited to a start/end segment.
+ *
+ * Authored in a stack's JSON:
+ *
+ *   { "id": "tv", "type": "directusVideo", "rect": [16, 40, 388, 220],
+ *     "options": { "channelId": 3, "start": 120, "end": 240,
+ *                  "controls": true, "loop": true, "captions": true } }
+ *
+ * `channelId` picks the `tv_channels` row (or pass a direct HLS `url`).
+ * `start`/`end` bound the playback window — a number/"M:SS" is a stream offset,
+ * a date-bearing time (e.g. "2001-09-11T12:46:00") is a wall-clock instant
+ * mapped via the channel's `start_date` (see videoSegment.ts).
+ */
+
+type SourceState =
+	| { status: "idle" }
+	| { status: "loading" }
+	| { status: "ready"; url: string; title?: string; subtitlesUrl?: string; channelStartMs: number | null }
+	| { status: "error"; message: string };
+
+/** Resolve an embed's source: a direct `url`, or a fetched `tv_channels` row. */
+function useDirectusVideoSource(opts: DirectusVideoOptions): SourceState {
+	const { url, channelId, title } = opts;
+	const [state, setState] = useState<SourceState>({ status: "idle" });
+
+	useEffect(() => {
+		if (url) {
+			setState({ status: "ready", url, title, subtitlesUrl: undefined, channelStartMs: null });
+			return;
+		}
+		if (channelId === undefined || channelId === "") {
+			setState({ status: "idle" });
+			return;
+		}
+		const controller = new AbortController();
+		setState({ status: "loading" });
+		fetchDirectusVideoItem(channelId, fetch, controller.signal)
+			.then((item: DirectusVideoItem) =>
+				setState({
+					status: "ready",
+					url: item.url,
+					title: title ?? item.full_title ?? item.title,
+					subtitlesUrl: vttUrl(item.subtitles ?? undefined),
+					channelStartMs: toUtcMs(item.start_date ?? ""),
+				}),
+			)
+			.catch((err: unknown) => {
+				if (controller.signal.aborted) return;
+				setState({
+					status: "error",
+					message: err instanceof Error ? err.message : String(err),
+				});
+			});
+		return () => controller.abort();
+	}, [url, channelId, title]);
+
+	return state;
+}
+
+export interface DirectusVideoProps extends DirectusVideoOptions {
+	/** Unique id for the underlying player instance. */
+	appId: string;
+	/** Fired once when a non-looping segment reaches its end bound. */
+	onSegmentEnd?: () => void;
+	/** Multiview mutes every tile but the active one; a tap solos a tile. */
+	forceMuted?: boolean;
+	onActivate?: () => void;
+}
+
+/**
+ * The reusable video body: source resolution, the classicy HLS player, and
+ * start/end segment enforcement (seek to start, clamp/loop/stop at end). Used
+ * directly by the single-video part and by each multiview tile.
+ */
+export function DirectusVideo(props: DirectusVideoProps) {
+	const { appId, onSegmentEnd, forceMuted, onActivate, ...opts } = props;
+	const source = useDirectusVideoSource(opts);
+
+	const channelStartMs = source.status === "ready" ? source.channelStartMs : null;
+	const { startSec, endSec } = useMemo(
+		() => resolveSegment(opts.start, opts.end, channelStartMs),
+		[opts.start, opts.end, channelStartMs],
+	);
+
+	const [videoEl, setVideoEl] = useState<HTMLVideoElement | null>(null);
+	const [currentSec, setCurrentSec] = useState(startSec);
+	const endedRef = useRef(false);
+
+	// Enforce the [startSec, endSec] window on the raw media element.
+	useEffect(() => {
+		if (!videoEl) return;
+		endedRef.current = false;
+
+		const seekToStart = () => {
+			if (startSec > 0) videoEl.currentTime = startSec;
+		};
+		const onTime = () => {
+			setCurrentSec(videoEl.currentTime);
+			if (videoEl.currentTime < startSec - 0.5) {
+				videoEl.currentTime = startSec;
+				return;
+			}
+			if (endSec !== undefined && videoEl.currentTime >= endSec) {
+				if (opts.loop) {
+					videoEl.currentTime = startSec;
+					void videoEl.play().catch(() => {});
+				} else if (!endedRef.current) {
+					endedRef.current = true;
+					videoEl.pause();
+					onSegmentEnd?.();
+				}
+			}
+		};
+		if (videoEl.readyState >= 1) seekToStart();
+		videoEl.addEventListener("loadedmetadata", seekToStart);
+		videoEl.addEventListener("timeupdate", onTime);
+		return () => {
+			videoEl.removeEventListener("loadedmetadata", seekToStart);
+			videoEl.removeEventListener("timeupdate", onTime);
+		};
+	}, [videoEl, startSec, endSec, opts.loop, onSegmentEnd]);
+
+	// Poster is a plain <video> attribute the embed doesn't expose.
+	useEffect(() => {
+		if (videoEl && opts.poster) videoEl.poster = opts.poster;
+	}, [videoEl, opts.poster]);
+
+	// Captions default on/off; the CC control flips this at runtime.
+	const [captionsEnabled, setCaptionsEnabled] = useState(!!opts.captions);
+	useEffect(() => setCaptionsEnabled(!!opts.captions), [opts.captions]);
+
+	if (source.status === "error") {
+		return (
+			<div className="classicyHyperCardDirectusVideo classicyHyperCardDirectusVideoMessage" role="alert">
+				Could not load video — {source.message}
+			</div>
+		);
+	}
+	if (source.status === "loading") {
+		return <div className="classicyHyperCardDirectusVideo classicyHyperCardDirectusVideoMessage">Loading video…</div>;
+	}
+	if (source.status !== "ready") {
+		return <div className="classicyHyperCardDirectusVideo classicyHyperCardDirectusVideoMessage">No video source</div>;
+	}
+
+	const controls = opts.controls !== false;
+	const muted = forceMuted ?? opts.muted ?? (opts.autoPlay ? true : false);
+
+	return (
+		<div
+			className="classicyHyperCardDirectusVideo"
+			onClick={onActivate}
+			role={onActivate ? "button" : undefined}
+			tabIndex={onActivate ? 0 : undefined}
+			onKeyDown={
+				onActivate
+					? (e) => {
+							if (e.key === "Enter" || e.key === " ") {
+								e.preventDefault();
+								onActivate();
+							}
+						}
+					: undefined
+			}
+		>
+			<QuickTimeVideoEmbed
+				appId={appId}
+				name={source.title ?? "TV Channel"}
+				url={source.url}
+				type="video"
+				subtitlesUrl={source.subtitlesUrl}
+				autoPlay={opts.autoPlay}
+				hideControls={!controls}
+				muted={muted}
+				volume={opts.volume}
+				captionsEnabled={captionsEnabled}
+				onCaptionsEnabledChange={setCaptionsEnabled}
+				onMediaElement={setVideoEl}
+				playsInline
+			/>
+			{opts.overlay && (
+				<div className="classicyHyperCardDirectusVideoBug" aria-hidden="true">
+					{source.title && <span className="classicyHyperCardDirectusVideoBugName">{source.title}</span>}
+					<span className="classicyHyperCardDirectusVideoBugTime">{timeFriendly(currentSec)}</span>
+				</div>
+			)}
+		</div>
+	);
+}
+
+/** The registered HyperCard part: adapts part props to {@link DirectusVideo}. */
+export const DirectusVideoPart = ({ options, partId, stackId, fire }: HyperCardPartProps) => {
+	const opts = useMemo(() => readVideoOptions(options), [options]);
+	// Non-looping segment end fires the part's own script (e.g. `go next`).
+	const onSegmentEnd = useCallback(() => fire(), [fire]);
+	return (
+		<DirectusVideo
+			{...opts}
+			appId={`hc-${stackId}-${partId}`}
+			onSegmentEnd={opts.loop ? undefined : onSegmentEnd}
+		/>
+	);
+};

--- a/packages/frontend/src/Applications/HyperCard/extensions/directusCollections.test.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/directusCollections.test.ts
@@ -4,6 +4,7 @@ import {
 	DIRECTUS_URL,
 	fetchDirectusAudioItem,
 	fetchDirectusItem,
+	fetchDirectusVideoItem,
 } from "./directusCollections";
 
 function jsonResponse(body: unknown, ok = true, status = 200): Response {
@@ -64,6 +65,21 @@ describe("fetchDirectusAudioItem", () => {
 		const url = fetchFn.mock.calls[0][0] as string;
 		expect(url).toContain("/items/mp3_items/3?fields=");
 		for (const field of DIRECTUS_COLLECTIONS.audio.fields) {
+			expect(url).toContain(field);
+		}
+	});
+});
+
+describe("fetchDirectusVideoItem", () => {
+	it("targets the tv_channels collection with the video field set", async () => {
+		const fetchFn = vi.fn().mockResolvedValue(
+			jsonResponse({ data: { id: 3, title: "WNYW", url: "https://x/ch3.m3u8" } }),
+		);
+		const item = await fetchDirectusVideoItem(3, fetchFn);
+		expect(item.url).toBe("https://x/ch3.m3u8");
+		const url = fetchFn.mock.calls[0][0] as string;
+		expect(url).toContain("/items/tv_channels/3?fields=");
+		for (const field of DIRECTUS_COLLECTIONS.video.fields) {
 			expect(url).toContain(field);
 		}
 	});

--- a/packages/frontend/src/Applications/HyperCard/extensions/directusCollections.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/directusCollections.ts
@@ -33,6 +33,27 @@ export const DIRECTUS_COLLECTIONS = {
 			"subtitles",
 		],
 	},
+	/**
+	 * Stitched continuous TV channel streams (one HLS row per channel). The
+	 * `start_date`/`end_date` span the whole assembled broadcast window and the
+	 * stream is continuous across it, so a wall-clock instant inside that window
+	 * maps to a stream offset of `(instant − start_date)` seconds.
+	 */
+	video: {
+		collection: "tv_channels",
+		fields: [
+			"id",
+			"title",
+			"full_title",
+			"url",
+			"source",
+			"start_date",
+			"end_date",
+			"calc_duration",
+			"timezone",
+			"subtitles",
+		],
+	},
 } as const;
 
 export type DirectusCollectionKey = keyof typeof DIRECTUS_COLLECTIONS;
@@ -86,4 +107,30 @@ export function fetchDirectusAudioItem(
 ): Promise<DirectusAudioItem> {
 	const { collection, fields } = DIRECTUS_COLLECTIONS.audio;
 	return fetchDirectusItem<DirectusAudioItem>(collection, id, fields, fetchFn, signal);
+}
+
+/** One row of the `tv_channels` collection — the subset a video embed reads. */
+export interface DirectusVideoItem {
+	id: number;
+	title: string;
+	full_title?: string | null;
+	/** HLS (`.m3u8`) URL of the continuous channel stream. */
+	url: string;
+	source?: string | null;
+	/** Start of the assembled broadcast window (the offset origin for seeks). */
+	start_date?: string | null;
+	end_date?: string | null;
+	calc_duration?: number | null;
+	timezone?: string | null;
+	subtitles?: string | null;
+}
+
+/** Fetch one `tv_channels` row by id, projecting the video-embed field set. */
+export function fetchDirectusVideoItem(
+	id: string | number,
+	fetchFn: typeof fetch = fetch,
+	signal?: AbortSignal,
+): Promise<DirectusVideoItem> {
+	const { collection, fields } = DIRECTUS_COLLECTIONS.video;
+	return fetchDirectusItem<DirectusVideoItem>(collection, id, fields, fetchFn, signal);
 }

--- a/packages/frontend/src/Applications/HyperCard/extensions/registerHyperCardExtensions.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/registerHyperCardExtensions.ts
@@ -1,6 +1,9 @@
 import { registerHyperCardPart, registerHyperCardStack } from "classicy";
 import { DirectusAudioPart } from "./DirectusAudioPart";
+import { DirectusMultiviewPart } from "./DirectusMultiviewPart";
+import { DirectusVideoPart } from "./DirectusVideoPart";
 import { MP3_AUDIO_STACK_ID, mp3AudioStack } from "./mp3AudioStack";
+import { TV_CHANNEL_STACK_ID, tvChannelStack } from "./tvChannelStack";
 
 // Registration must run once, before the HyperCard app opens a stack that uses
 // a Directus part. Classicy's registries are last-write-wins Maps, so repeat
@@ -19,7 +22,10 @@ export function registerHyperCardExtensions(): void {
 
 	// Display parts — one registered `type` per embeddable collection.
 	registerHyperCardPart("directusAudio", DirectusAudioPart);
+	registerHyperCardPart("directusVideo", DirectusVideoPart);
+	registerHyperCardPart("directusMultiview", DirectusMultiviewPart);
 
 	// Built-in stacks that demonstrate the parts (File → Open in HyperCard).
 	registerHyperCardStack(MP3_AUDIO_STACK_ID, mp3AudioStack.name, mp3AudioStack);
+	registerHyperCardStack(TV_CHANNEL_STACK_ID, tvChannelStack.name, tvChannelStack);
 }

--- a/packages/frontend/src/Applications/HyperCard/extensions/tvChannelStack.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/tvChannelStack.ts
@@ -1,0 +1,215 @@
+import type { HCStack } from "classicy";
+
+/**
+ * A built-in HyperCard stack that demonstrates the TV video extensions:
+ * `directusVideo` (a single channel, optionally limited to a start/end segment,
+ * with controls/autoplay/loop/captions) and `directusMultiview` (a grid of
+ * channels — a "video wall"). Registered with the app via
+ * `registerHyperCardStack`, so it appears in HyperCard's File → Open menu.
+ *
+ * The `channelId`s below are PLACEHOLDERS (1, 2, 3) pending the real
+ * `tv_channels` row ids; the parts fetch each on render and degrade gracefully
+ * (a "Could not load video" note) if an id is absent.
+ */
+
+export const DIRECTUS_VIDEO_PART_TYPE = "directusVideo";
+export const DIRECTUS_MULTIVIEW_PART_TYPE = "directusMultiview";
+
+/** Stable id used both in the File menu registry and as the stack source key. */
+export const TV_CHANNEL_STACK_ID = "directus-tv-channels";
+
+export const tvChannelStack: HCStack = {
+	name: "TV Channels",
+	version: "2",
+	size: [440, 340],
+	backgrounds: [
+		{
+			id: "main",
+			parts: [
+				{
+					id: "footer",
+					type: "label",
+					shared: true,
+					rect: [12, 312, 416, 20],
+					content: "TV from the tv_channels collection — a Directus HyperCard extension",
+				},
+			],
+		},
+	],
+	cards: [
+		{
+			id: "intro",
+			name: "TV Channels",
+			background: "main",
+			parts: [
+				{
+					id: "introTitle",
+					type: "label",
+					rect: [12, 16, 416, 24],
+					content: "Directus TV",
+				},
+				{
+					id: "introText",
+					type: "field",
+					rect: [12, 48, 416, 90],
+					locked: true,
+					content:
+						"These cards embed live TV channel streams from the tv_channels collection: a single channel limited to a segment, an autoplaying looped segment, and a multiview video wall. Click Next to begin.",
+				},
+				{
+					id: "introNext",
+					type: "button",
+					name: "Next →",
+					rect: [324, 150, 104, 28],
+					script: {
+						onMouseUp: [
+							{ do: "visual", effect: "dissolve" },
+							{ do: "go", to: "next" },
+						],
+					},
+				},
+			],
+		},
+		{
+			id: "single",
+			name: "Single Channel",
+			background: "main",
+			parts: [
+				{
+					id: "singleTitle",
+					type: "label",
+					rect: [12, 14, 416, 22],
+					content: "Channel #1 — controls + captions, seconds 60–180",
+				},
+				{
+					id: "singleVideo",
+					type: DIRECTUS_VIDEO_PART_TYPE,
+					rect: [12, 40, 416, 232],
+					options: {
+						channelId: 1,
+						start: 60,
+						end: 180,
+						controls: true,
+						captions: true,
+						overlay: true,
+					},
+				},
+				{
+					id: "singlePrev",
+					type: "button",
+					name: "← Prev",
+					rect: [12, 280, 104, 26],
+					script: {
+						onMouseUp: [
+							{ do: "visual", effect: "wipeRight" },
+							{ do: "go", to: "prev" },
+						],
+					},
+				},
+				{
+					id: "singleNext",
+					type: "button",
+					name: "Next →",
+					rect: [324, 280, 104, 26],
+					script: {
+						onMouseUp: [
+							{ do: "visual", effect: "wipeLeft" },
+							{ do: "go", to: "next" },
+						],
+					},
+				},
+			],
+		},
+		{
+			id: "loop",
+			name: "Looped Segment",
+			background: "main",
+			parts: [
+				{
+					id: "loopTitle",
+					type: "label",
+					rect: [12, 14, 416, 22],
+					content: "Channel #1 — autoplay, muted, looping seconds 30–45",
+				},
+				{
+					id: "loopVideo",
+					type: DIRECTUS_VIDEO_PART_TYPE,
+					rect: [12, 40, 416, 232],
+					options: {
+						channelId: 1,
+						start: 30,
+						end: 45,
+						autoPlay: true,
+						loop: true,
+						controls: false,
+						muted: true,
+						overlay: true,
+					},
+				},
+				{
+					id: "loopPrev",
+					type: "button",
+					name: "← Prev",
+					rect: [12, 280, 104, 26],
+					script: {
+						onMouseUp: [
+							{ do: "visual", effect: "wipeRight" },
+							{ do: "go", to: "prev" },
+						],
+					},
+				},
+				{
+					id: "loopNext",
+					type: "button",
+					name: "Next →",
+					rect: [324, 280, 104, 26],
+					script: {
+						onMouseUp: [
+							{ do: "visual", effect: "wipeLeft" },
+							{ do: "go", to: "next" },
+						],
+					},
+				},
+			],
+		},
+		{
+			id: "wall",
+			name: "Multiview",
+			background: "main",
+			parts: [
+				{
+					id: "wallTitle",
+					type: "label",
+					rect: [12, 14, 416, 22],
+					content: "Multiview — tap a panel to hear its audio",
+				},
+				{
+					id: "wallGrid",
+					type: DIRECTUS_MULTIVIEW_PART_TYPE,
+					rect: [12, 40, 416, 232],
+					options: {
+						audio: "solo",
+						columns: 2,
+						videos: [
+							{ channelId: 1, autoPlay: true },
+							{ channelId: 2, autoPlay: true },
+							{ channelId: 3, autoPlay: true },
+						],
+					},
+				},
+				{
+					id: "wallPrev",
+					type: "button",
+					name: "← Prev",
+					rect: [12, 280, 104, 26],
+					script: {
+						onMouseUp: [
+							{ do: "visual", effect: "wipeRight" },
+							{ do: "go", to: "prev" },
+						],
+					},
+				},
+			],
+		},
+	],
+};

--- a/packages/frontend/src/Applications/HyperCard/extensions/tvChannelStack.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/tvChannelStack.ts
@@ -7,9 +7,9 @@ import type { HCStack } from "classicy";
  * channels — a "video wall"). Registered with the app via
  * `registerHyperCardStack`, so it appears in HyperCard's File → Open menu.
  *
- * The `channelId`s below are PLACEHOLDERS (1, 2, 3) pending the real
- * `tv_channels` row ids; the parts fetch each on render and degrade gracefully
- * (a "Could not load video" note) if an id is absent.
+ * The `channelId`s below (3, 6, 23) reference rows in the live `tv_channels`
+ * collection; the parts fetch each on render and degrade gracefully (a "Could
+ * not load video" note) if an id is absent.
  */
 
 export const DIRECTUS_VIDEO_PART_TYPE = "directusVideo";
@@ -79,14 +79,14 @@ export const tvChannelStack: HCStack = {
 					id: "singleTitle",
 					type: "label",
 					rect: [12, 14, 416, 22],
-					content: "Channel #1 — controls + captions, seconds 60–180",
+					content: "Channel #3 — controls + captions, seconds 60–180",
 				},
 				{
 					id: "singleVideo",
 					type: DIRECTUS_VIDEO_PART_TYPE,
 					rect: [12, 40, 416, 232],
 					options: {
-						channelId: 1,
+						channelId: 3,
 						start: 60,
 						end: 180,
 						controls: true,
@@ -129,14 +129,14 @@ export const tvChannelStack: HCStack = {
 					id: "loopTitle",
 					type: "label",
 					rect: [12, 14, 416, 22],
-					content: "Channel #1 — autoplay, muted, looping seconds 30–45",
+					content: "Channel #6 — autoplay, muted, looping seconds 30–45",
 				},
 				{
 					id: "loopVideo",
 					type: DIRECTUS_VIDEO_PART_TYPE,
 					rect: [12, 40, 416, 232],
 					options: {
-						channelId: 1,
+						channelId: 6,
 						start: 30,
 						end: 45,
 						autoPlay: true,
@@ -191,9 +191,9 @@ export const tvChannelStack: HCStack = {
 						audio: "solo",
 						columns: 2,
 						videos: [
-							{ channelId: 1, autoPlay: true },
-							{ channelId: 2, autoPlay: true },
 							{ channelId: 3, autoPlay: true },
+							{ channelId: 6, autoPlay: true },
+							{ channelId: 23, autoPlay: true },
 						],
 					},
 				},

--- a/packages/frontend/src/Applications/HyperCard/extensions/videoOptions.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/videoOptions.ts
@@ -1,0 +1,52 @@
+// Shared option shape for the video embeds. Kept in its own module (no React
+// component exports) so both DirectusVideoPart and DirectusMultiviewPart can
+// import it without tripping react-refresh's component-only rule.
+
+export interface DirectusVideoOptions {
+	channelId?: string | number;
+	/** Direct HLS URL; skips the Directus fetch. */
+	url?: string;
+	/** Title override (else the channel's title). */
+	title?: string;
+	/** Segment bounds — stream offset (number/"M:SS") or wall-clock datetime. */
+	start?: string | number;
+	end?: string | number;
+	/** Show the native transport (default true). */
+	controls?: boolean;
+	autoPlay?: boolean;
+	/** Loop the [start, end] segment. */
+	loop?: boolean;
+	/** Mute audio (defaults to true when autoPlay is set, so autoplay is allowed). */
+	muted?: boolean;
+	/** Initial volume, 0–1. */
+	volume?: number;
+	/** Captions shown by default; the CC control still toggles them at runtime. */
+	captions?: boolean;
+	/** Placeholder image shown before playback / while the stream buffers. */
+	poster?: string;
+	/** Draw a channel-name + running-time bug over the video. */
+	overlay?: boolean;
+}
+
+/** Coerce an untyped stack `options` object into {@link DirectusVideoOptions}. */
+export function readVideoOptions(options: Record<string, unknown>): DirectusVideoOptions {
+	const o = options;
+	const str = (v: unknown) => (typeof v === "string" ? v : undefined);
+	const numOrStr = (v: unknown) =>
+		typeof v === "number" || typeof v === "string" ? (v as string | number) : undefined;
+	return {
+		channelId: numOrStr(o.channelId ?? o.itemId),
+		url: str(o.url),
+		title: str(o.title),
+		start: numOrStr(o.start),
+		end: numOrStr(o.end),
+		controls: o.controls === undefined ? true : o.controls === true,
+		autoPlay: o.autoPlay === true,
+		loop: o.loop === true,
+		muted: typeof o.muted === "boolean" ? o.muted : undefined,
+		volume: typeof o.volume === "number" ? o.volume : undefined,
+		captions: o.captions === true,
+		poster: str(o.poster),
+		overlay: o.overlay === true,
+	};
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/videoSegment.test.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/videoSegment.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { parseBoundToSeconds, parseClock, resolveSegment, toUtcMs } from "./videoSegment";
+
+describe("toUtcMs", () => {
+	it("pins a naive datetime to UTC", () => {
+		expect(toUtcMs("2001-09-11T12:46:00")).toBe(Date.UTC(2001, 8, 11, 12, 46, 0));
+	});
+	it("honours an explicit zone", () => {
+		expect(toUtcMs("2001-09-11T12:46:00Z")).toBe(Date.UTC(2001, 8, 11, 12, 46, 0));
+	});
+	it("returns null on junk", () => {
+		expect(toUtcMs("not a date")).toBeNull();
+		expect(toUtcMs("")).toBeNull();
+	});
+});
+
+describe("parseClock", () => {
+	it("parses M:SS and H:MM:SS", () => {
+		expect(parseClock("2:00")).toBe(120);
+		expect(parseClock("1:02:03")).toBe(3723);
+		expect(parseClock("0:05")).toBe(5);
+	});
+	it("rejects non-clock strings", () => {
+		expect(parseClock("120")).toBeNull();
+		expect(parseClock("2001-09-11T12:46:00")).toBeNull();
+	});
+});
+
+describe("parseBoundToSeconds", () => {
+	it("treats a number as an offset in seconds", () => {
+		expect(parseBoundToSeconds(120, null)).toBe(120);
+		expect(parseBoundToSeconds(0, null)).toBe(0);
+	});
+	it("treats a numeric string as an offset", () => {
+		expect(parseBoundToSeconds("240", null)).toBe(240);
+	});
+	it("treats a clock string as an offset duration", () => {
+		expect(parseBoundToSeconds("2:00", null)).toBe(120);
+	});
+	it("maps a date-bearing wall-clock to an offset from the channel start", () => {
+		const start = toUtcMs("2001-09-11T12:40:00");
+		// 6 minutes after the channel start.
+		expect(parseBoundToSeconds("2001-09-11T12:46:00", start)).toBe(360);
+	});
+	it("needs the channel start to map wall-clock, else undefined", () => {
+		expect(parseBoundToSeconds("2001-09-11T12:46:00", null)).toBeUndefined();
+	});
+	it("returns undefined for absent/uninterpretable values", () => {
+		expect(parseBoundToSeconds(undefined, null)).toBeUndefined();
+		expect(parseBoundToSeconds("", null)).toBeUndefined();
+		expect(parseBoundToSeconds("nope", null)).toBeUndefined();
+	});
+});
+
+describe("resolveSegment", () => {
+	it("combines start and end", () => {
+		expect(resolveSegment(60, 180, null)).toEqual({ startSec: 60, endSec: 180 });
+	});
+	it("defaults start to 0", () => {
+		expect(resolveSegment(undefined, 30, null)).toEqual({ startSec: 0, endSec: 30 });
+	});
+	it("drops an end that is not after the start", () => {
+		expect(resolveSegment(100, 90, null)).toEqual({ startSec: 100 });
+		expect(resolveSegment(100, 100, null)).toEqual({ startSec: 100 });
+	});
+	it("maps wall-clock bounds against the channel start", () => {
+		const start = toUtcMs("2001-09-11T12:40:00");
+		expect(resolveSegment("2001-09-11T12:46:00", "2001-09-11T12:50:00", start)).toEqual({
+			startSec: 360,
+			endSec: 600,
+		});
+	});
+});

--- a/packages/frontend/src/Applications/HyperCard/extensions/videoSegment.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/videoSegment.ts
@@ -1,0 +1,94 @@
+// Segment-bound resolution for the video embeds. An authored `start`/`end`
+// bound may be written three ways; all resolve to a **stream offset in seconds**
+// (seconds from the start of the channel's HLS stream), which is what the
+// <video> element seeks to.
+//
+//   1. a number            → that many seconds into the stream (an offset)
+//   2. "M:SS" / "H:MM:SS"  → a duration offset into the stream
+//   3. a date-bearing time → a 9/11 wall-clock instant (e.g.
+//      "2001-09-11T12:46:00"), mapped to an offset of (instant − channelStart).
+//
+// Bare clock strings ("08:46") are treated as *offsets* (case 2), never
+// wall-clock — only a value carrying a calendar date (case 3) is mapped against
+// the channel start. Directus stores `start_date` as a naive-UTC string, so
+// wall-clock bounds must be written in that same UTC frame to line up.
+
+/** True when the string carries a calendar date (YYYY-MM-DD…). */
+const HAS_DATE = /\d{4}-\d{2}-\d{2}/;
+/** "M:SS" or "H:MM:SS" (optionally fractional seconds). */
+const CLOCK = /^(\d+):([0-5]?\d)(?::([0-5]?\d(?:\.\d+)?))?$/;
+
+/**
+ * Parse a naive datetime string as UTC. A trailing `Z`/offset is honoured; a
+ * naive value (Directus' convention) is pinned to UTC by appending `Z`.
+ * Returns null if unparseable.
+ */
+export function toUtcMs(value: string): number | null {
+	const trimmed = value.trim();
+	if (trimmed === "") return null;
+	const hasZone = /[zZ]$|[+-]\d{2}:?\d{2}$/.test(trimmed);
+	const ms = Date.parse(hasZone ? trimmed : `${trimmed}Z`);
+	return Number.isNaN(ms) ? null : ms;
+}
+
+/** Parse "M:SS" / "H:MM:SS" to seconds; null if it isn't a clock string. */
+export function parseClock(value: string): number | null {
+	const m = CLOCK.exec(value.trim());
+	if (!m) return null;
+	const h = m[3] !== undefined ? Number(m[1]) : 0;
+	const min = m[3] !== undefined ? Number(m[2]) : Number(m[1]);
+	const sec = m[3] !== undefined ? Number(m[3]) : Number(m[2]);
+	return h * 3600 + min * 60 + sec;
+}
+
+/**
+ * Resolve an authored bound to a stream offset in seconds, or `undefined` if it
+ * is absent/uninterpretable. `channelStartMs` is the channel `start_date` as
+ * UTC ms (from {@link toUtcMs}); it is only needed for wall-clock bounds.
+ */
+export function parseBoundToSeconds(
+	value: string | number | undefined | null,
+	channelStartMs: number | null,
+): number | undefined {
+	if (value === undefined || value === null || value === "") return undefined;
+	if (typeof value === "number") return Number.isFinite(value) ? Math.max(0, value) : undefined;
+
+	const str = value.trim();
+
+	// Wall-clock instant → offset from the channel start.
+	if (HAS_DATE.test(str)) {
+		const boundMs = toUtcMs(str);
+		if (boundMs === null || channelStartMs === null) return undefined;
+		return Math.max(0, (boundMs - channelStartMs) / 1000);
+	}
+
+	// Clock duration ("M:SS" / "H:MM:SS").
+	const clock = parseClock(str);
+	if (clock !== null) return clock;
+
+	// Plain numeric string.
+	const num = Number(str);
+	return Number.isFinite(num) ? Math.max(0, num) : undefined;
+}
+
+export interface ResolvedSegment {
+	/** Seek origin in seconds (clamped ≥ 0). */
+	startSec: number;
+	/** End of the window in seconds, or undefined = play to the end. */
+	endSec?: number;
+}
+
+/**
+ * Combine authored start/end bounds into a normalized segment. A start past the
+ * end (or non-positive span) drops the end so the clip just plays from start.
+ */
+export function resolveSegment(
+	start: string | number | undefined | null,
+	end: string | number | undefined | null,
+	channelStartMs: number | null,
+): ResolvedSegment {
+	const startSec = parseBoundToSeconds(start, channelStartMs) ?? 0;
+	const endSec = parseBoundToSeconds(end, channelStartMs);
+	if (endSec !== undefined && endSec <= startSec) return { startSec };
+	return { startSec, endSec };
+}

--- a/packages/frontend/src/Applications/HyperCard/index.ts
+++ b/packages/frontend/src/Applications/HyperCard/index.ts
@@ -13,10 +13,15 @@ registerHyperCardExtensions();
 
 export { registerHyperCardExtensions } from "./extensions/registerHyperCardExtensions";
 export { mp3AudioStack, MP3_AUDIO_STACK_ID } from "./extensions/mp3AudioStack";
+export { tvChannelStack, TV_CHANNEL_STACK_ID } from "./extensions/tvChannelStack";
 export { DirectusAudioPart } from "./extensions/DirectusAudioPart";
+export { DirectusVideo, DirectusVideoPart } from "./extensions/DirectusVideoPart";
+export { DirectusMultiviewPart } from "./extensions/DirectusMultiviewPart";
 export {
 	DIRECTUS_COLLECTIONS,
 	fetchDirectusAudioItem,
 	fetchDirectusItem,
+	fetchDirectusVideoItem,
 	type DirectusAudioItem,
+	type DirectusVideoItem,
 } from "./extensions/directusCollections";


### PR DESCRIPTION
## What & why

Follows the merged audio extension (#275) with the video counterpart: two HyperCard parts that embed TV channel streams from the `tv_channels` Directus collection into stacks, built on classicy's `QuickTimeVideoEmbed` (native HLS). Same pattern — the parts fetch at render time and paint into the card's `rect`; this repo only supplies content for the bundled HyperCard app.

## New parts

**`directusVideo`** — one channel stream, optionally limited to a segment:
- **Station** via `channelId` (a `tv_channels` row) or a direct HLS `url`.
- **Start/end segment** — bounds accept a number/`"M:SS"` (stream offset) or a date-bearing **9/11 wall-clock time** (e.g. `"2001-09-11T12:46:00"`) mapped to an offset via the channel's `start_date`.
- **`controls` vs `autoPlay`**, **`loop`** (loops the segment), **`muted`**+**`volume`**.
- **Captions on by default** (`captions`) with the player's built-in **CC toggle** still live at runtime.
- Extras: **`poster`**, a channel-name/running-time **`overlay`** bug, and **auto-advance** — a finished non-looping segment fires the part's own `script` (e.g. `go next`) so clips chain.
- Seek/clamp/loop/stop is enforced on the raw media element via `onMediaElement`.

**`directusMultiview`** — a grid "video wall" of tiles, each taking the full `directusVideo` option set. Auto or fixed **`columns`**, and **`audio`** mode `"solo"` (tap a tile to hear it) / `"mute"` / `"all"`.

## Changes

- `directusCollections.ts` — add the `video` (`tv_channels`) collection, `DirectusVideoItem`, `fetchDirectusVideoItem`.
- `videoSegment.ts` — pure start/end bound resolver (offset / `M:SS` / wall-clock → seconds) + `resolveSegment`.
- `videoOptions.ts` — shared per-video option shape + reader.
- `DirectusVideoPart.tsx` / `DirectusMultiviewPart.tsx` (+ CSS) — the two parts; `DirectusVideoPart` exports the reusable `DirectusVideo` body that each multiview tile uses.
- `tvChannelStack.ts` — the built-in **TV Channels** demo stack (single segment on channel 3, autoplay+loop on 6, a 3/6/23 multiview).
- Register the two parts + stack; co-located tests; README documents authoring both.

## Verification

- `tsc -b` clean, `eslint .` 0 errors, full suite **1195 tests pass** (29 new).
- Throwaway integration check against classicy's runtime: both parts register and `validateStack` accepts the demo stack. Live HLS fetches happen in the browser at runtime; the sandbox blocks `api-beta`, so the network path isn't exercised here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C449E6WHyMkjFVHKELYcmB

---
_Generated by [Claude Code](https://claude.ai/code/session_01C449E6WHyMkjFVHKELYcmB)_