### PR TITLE
Add camera-follow modes to Flight Tracker

### DIFF
--- a/packages/frontend/src/Applications/Account/ProfileEditor.test.tsx
+++ b/packages/frontend/src/Applications/Account/ProfileEditor.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import type { AuthUser } from "../../Providers/Auth/authApi";
 
 const mockUpdateProfile = vi.hoisted(() => vi.fn());
@@ -76,11 +76,11 @@ describe("ProfileEditor — about you (all optional)", () => {
 	});
 	it("round-trips educator role and toggled grade levels", async () => {
 		render(<ProfileEditor />);
-		// ClassicyPopUpMenu's label isn't htmlFor-associated (classicy quirk) —
-		// target the select by id.
-		fireEvent.change(document.getElementById("profile-educator-role") as HTMLSelectElement, {
-			target: { value: "librarian" },
-		});
+		// ClassicyPopUpMenu renders as a <button id=…> + a listbox that mounts on
+		// open (classicy quirk: the label isn't htmlFor-associated) — open it by id
+		// and click the option's visible label.
+		fireEvent.click(document.getElementById("profile-educator-role") as HTMLButtonElement);
+		fireEvent.click(within(screen.getByRole("listbox")).getByText("Librarian"));
 		fireEvent.click(screen.getByRole("button", { name: "High School" }));
 		fireEvent.click(screen.getByRole("button", { name: "College" }));
 		fireEvent.click(screen.getByRole("button", { name: "College" })); // toggle back off

--- a/packages/frontend/src/Applications/FlightTracker/FlightDetailPanel.test.tsx
+++ b/packages/frontend/src/Applications/FlightTracker/FlightDetailPanel.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { FlightPosition } from "../../Providers/MediaStream/MediaStreamContext";
 import type { FlightTrack } from "./useFlightTrack";
@@ -154,7 +154,9 @@ describe("FlightDetailPanel", () => {
 				<FlightDetailPanel selected={sel} track={null} loading={false} error={null}
 					nowMs={PRE_IMPACT} selectionOptions={[sel]} />,
 			);
-			expect(screen.queryByRole("combobox")).toBeNull();
+			// classicy renders ClassicyPopUpMenu as a <button id=…>, so a single-flight
+			// selection shows no selection popup at all.
+			expect(document.getElementById("flight_detail_selection")).toBeNull();
 			expect(screen.queryByText("Save as Filter")).toBeNull();
 		});
 
@@ -166,9 +168,10 @@ describe("FlightDetailPanel", () => {
 					nowMs={PRE_IMPACT} selectionOptions={[sel, other]}
 					onPickFlight={onPickFlight} onSaveAsFilter={onSaveAsFilter} />,
 			);
-			const dd = screen.getByRole("combobox") as HTMLSelectElement;
-			expect(dd.value).toBe("AA11");
-			fireEvent.change(dd, { target: { value: "DL404" } });
+			const dd = document.getElementById("flight_detail_selection") as HTMLButtonElement;
+			expect(dd.querySelector(".classicyPopUpMenuValue")?.textContent).toBe("AA11");
+			fireEvent.click(dd); // open the listbox
+			fireEvent.click(within(screen.getByRole("listbox")).getByText("DL404"));
 			expect(onPickFlight).toHaveBeenCalledWith("DL404");
 			fireEvent.click(screen.getByText("Save as Filter"));
 			expect(onSaveAsFilter).toHaveBeenCalledOnce();

--- a/packages/frontend/src/Applications/FlightTracker/FlightMap.test.tsx
+++ b/packages/frontend/src/Applications/FlightTracker/FlightMap.test.tsx
@@ -1145,6 +1145,95 @@ describe("FlightMap", () => {
 		expect(onAreaSelect).toHaveBeenCalledWith(["DL404"]); // UA9 outside box
 	});
 
+	describe("camera follow", () => {
+		const withRaf = () => {
+			let rafCb: FrameRequestCallback | null = null;
+			vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+				rafCb = cb;
+				return 1;
+			});
+			vi.stubGlobal("cancelAnimationFrame", () => {});
+			vi.spyOn(performance, "now").mockReturnValue(0);
+			return () => rafCb;
+		};
+		const common = {
+			basemapUrls: TEST_URLS, trackGeoJSON: null, nowMs: 0, playing: true as const,
+			onSelectFlight: () => {}, onClearSelection: () => {},
+			darkMap: false, mapStyle: "classic" as const, pinColor: "#3a3a3a",
+			notablePinColor: "#c0202a", observerPinColor: "#0f766e", radarSweep: false, trailMultiplier: 1,
+		};
+
+		it("track mode locks the camera and jumps it top-down onto the flight", () => {
+			const getRaf = withRaf();
+			const { rerender } = render(
+				<FlightMap {...common} positions={[pos({ id: 1, flight: "AA11", lon: -74, lat: 40 })]}
+					followFlight={null} cameraMode="track" />,
+			);
+			const map = FakeMap.last!;
+			map.fire("load");
+			expect(map.dragPanDisabled).toBe(false); // free camera until follow arms
+
+			rerender(
+				<FlightMap {...common} positions={[pos({ id: 1, flight: "AA11", lon: -74, lat: 40 })]}
+					followFlight="AA11" cameraMode="track" />,
+			);
+			// Arming the lock disables user pan.
+			expect(map.dragPanDisabled).toBe(true);
+			getRaf()!(100);
+			const jt = map.jumpToCalls.at(-1)!;
+			expect(jt.center).toEqual([-74, 40]); // centered on the flight
+			expect(jt.pitch).toBe(0); // top-down
+			expect(jt.bearing).toBe(0); // north-up
+			expect(jt.zoom).toBe(map.getZoom()); // track keeps the current zoom
+
+			// Releasing re-enables pan.
+			rerender(
+				<FlightMap {...common} positions={[pos({ id: 1, flight: "AA11", lon: -74, lat: 40 })]}
+					followFlight={null} cameraMode="track" />,
+			);
+			expect(map.dragPanDisabled).toBe(false);
+		});
+
+		it("cockpit mode opens the pitch band and drives a steep heading-aligned view", () => {
+			const getRaf = withRaf();
+			// Two samples give AA11 an eastbound heading (≈90°).
+			const p1 = pos({ id: 1, flight: "AA11", lon: -74, lat: 40, start_date: "2001-09-11T13:00:00.000Z" });
+			const p2 = pos({ id: 2, flight: "AA11", lon: -73, lat: 40, start_date: "2001-09-11T13:01:00.000Z" });
+			const t1 = Date.parse("2001-09-11T13:01:00.000Z");
+			const { rerender } = render(
+				<FlightMap {...common} positions={[p1]} nowMs={Date.parse("2001-09-11T13:00:00.000Z")}
+					followFlight="AA11" cameraMode="cockpit" />,
+			);
+			const map = FakeMap.last!;
+			map.fire("load");
+			// The follow lock relaxes the pitch cap so cockpit's steep pitch survives.
+			expect(map.maxPitchCalls.at(-1)).toBe(85);
+			rerender(
+				<FlightMap {...common} positions={[p2]} nowMs={t1}
+					followFlight="AA11" cameraMode="cockpit" />,
+			);
+			getRaf()!(100);
+			const jt = map.jumpToCalls.at(-1)!;
+			expect(jt.pitch as number).toBeGreaterThan(60); // steeper than the 3D cap
+			expect(jt.bearing as number).toBeCloseTo(90, 0); // aligned with the eastbound heading
+			expect((jt.center as [number, number])[0]).toBeGreaterThan(-73); // look-point ahead (east)
+		});
+
+		it("does not report follow-driven pitch as a manual 3D change", () => {
+			const getRaf = withRaf();
+			const onPitchedChange = vi.fn();
+			render(
+				<FlightMap {...common} positions={[pos({ id: 1, flight: "AA11", lon: -74, lat: 40 })]}
+					followFlight="AA11" cameraMode="highlight" onPitchedChange={onPitchedChange} />,
+			);
+			const map = FakeMap.last!;
+			map.fire("load");
+			getRaf()!(100); // jumpTo sets a pitched camera and fires "pitch"
+			expect(map.getPitch()).toBeGreaterThan(5); // camera really did pitch
+			expect(onPitchedChange).not.toHaveBeenCalled(); // but the 3D toggle isn't touched
+		});
+	});
+
 	it("compass tracks map rotation and resets bearing on click", () => {
 		render(
 			<FlightMap positions={[]} basemapUrls={TEST_URLS} trackGeoJSON={null}

--- a/packages/frontend/src/Applications/FlightTracker/FlightMap.tsx
+++ b/packages/frontend/src/Applications/FlightTracker/FlightMap.tsx
@@ -78,6 +78,11 @@ import {
 	replayPointsAt,
 } from "./flightReplay";
 import { type LoopClock, playheadAt } from "./loopClock";
+import {
+	type CameraMode,
+	cameraPose,
+	MAX_FOLLOW_PITCH,
+} from "./flightCamera";
 
 // Register the pmtiles:// protocol once per page (adding it twice throws).
 let protocolRegistered = false;
@@ -265,8 +270,41 @@ interface FlightMapProps {
 	// Airframe family for a flight (aircraftModels.familyForAircraftType via
 	// the route index) — picks which 3D model its instances render with.
 	aircraftFamilyOf?: (flight: string, startDate: string) => string;
+	// Camera follow (tracked flights): while `followFlight` is a callsign the
+	// camera locks onto that flight every frame in `cameraMode`'s framing, and
+	// user pan/zoom/rotate are disabled. null/omitted = free camera.
+	followFlight?: string | null;
+	cameraMode?: CameraMode;
 	onSelectFlight: (flight: string) => void;
 	onClearSelection: () => void;
+}
+
+// Enable/disable every user camera handler in one place (the follow lock owns
+// the camera while active). Defensive against handlers a given build/mock may
+// not expose — only dragPan is guaranteed in the test harness.
+type MapHandler = { enable?: () => void; disable?: () => void };
+function setCameraInteractive(map: maplibregl.Map, on: boolean) {
+	const m = map as unknown as Record<string, MapHandler | undefined>;
+	for (const key of [
+		"dragPan", "dragRotate", "scrollZoom", "boxZoom",
+		"doubleClickZoom", "keyboard", "touchZoomRotate", "touchPitch",
+	]) {
+		const h = m[key];
+		if (on) h?.enable?.();
+		else h?.disable?.();
+	}
+}
+
+// Restore the pitch band to the 2D/3D toggle's constraints (mirrors the threeD
+// effect's ordering — maplibre rejects min > max).
+function restorePitchConstraints(map: maplibregl.Map, threeD: boolean) {
+	if (threeD) {
+		map.setMaxPitch(THREE_D_PITCH);
+		map.setMinPitch(THREE_D_MIN_PITCH);
+	} else {
+		map.setMinPitch(0);
+		map.setMaxPitch(0);
+	}
 }
 
 /** Non-highlighted features only — notables and observers never cluster (issue #222). */
@@ -424,6 +462,7 @@ export const FlightMap: FC<FlightMapProps> = ({
 	visibleFlights = null, landingClock,
 	globe = false, threeD = false, terrain = false, cluster = false,
 	selectMode = "off", onAreaSelect, onPitchedChange, aircraftFamilyOf,
+	followFlight = null, cameraMode = "track",
 	onSelectFlight, onClearSelection,
 }) => {
 	const containerRef = useRef<HTMLDivElement>(null);
@@ -474,6 +513,11 @@ export const FlightMap: FC<FlightMapProps> = ({
 		enabled: loopEnabled, windowMs: loopWindowMs, clock: loopClock, buffer: replayBuffer,
 		visible: visibleFlights,
 	};
+	// Camera follow: the rAF loop reads the current target/mode; followActiveRef
+	// is the lock flag other effects check so they don't fight the driven camera.
+	const followRef = useRef({ flight: followFlight, mode: cameraMode });
+	followRef.current = { flight: followFlight, mode: cameraMode };
+	const followActiveRef = useRef(false);
 
 	useImperativeHandle(handleRef, () => ({
 		zoomIn: () => {
@@ -923,7 +967,9 @@ export const FlightMap: FC<FlightMapProps> = ({
 			pitchedRef.current = on;
 			if (loadedRef.current) syncPlaneVisibility(map);
 			dirtyRef.current = true;
-			cbRef.current.onPitchedChange?.(on);
+			// While following, pitch is camera-driven (not a manual right-drag), so
+			// it must not flip the persisted 3D toggle — only report real user tilts.
+			if (!followActiveRef.current) cbRef.current.onPitchedChange?.(on);
 		});
 		// Plane-slab size tracks the zoom (constant on-screen size); wake a
 		// paused map so a zoom while paused re-sizes the 3D planes.
@@ -1002,6 +1048,9 @@ export const FlightMap: FC<FlightMapProps> = ({
 	useEffect(() => {
 		const map = mapRef.current;
 		if (!map) return;
+		// The follow lock owns pan while active; it re-applies the select-tool
+		// state on release, so don't let a selectMode change re-enable pan here.
+		if (followActiveRef.current) return;
 		if (selectMode !== "off") {
 			map.dragPan.disable();
 			map.getCanvas().style.cursor = "crosshair";
@@ -1043,6 +1092,10 @@ export const FlightMap: FC<FlightMapProps> = ({
 	useEffect(() => {
 		const map = mapRef.current;
 		if (!map || !loadedRef.current) return;
+		// The follow lock owns the pitch band while active (cockpit needs more
+		// than THREE_D_PITCH); it re-applies these constraints from threeDRef on
+		// release, so skip here to avoid clamping the driven pitch.
+		if (followActiveRef.current) return;
 		if (threeD) {
 			map.setMaxPitch(THREE_D_PITCH);
 			map.setMinPitch(THREE_D_MIN_PITCH);
@@ -1065,6 +1118,35 @@ export const FlightMap: FC<FlightMapProps> = ({
 		map.setTerrain(terrain ? { source: TERRAIN_SOURCE, exaggeration: ALT_EXAGGERATION } : null);
 		dirtyRef.current = true;
 	}, [terrain]);
+
+	// Camera follow lock (tracked flights): entering disables user camera control
+	// and opens the pitch band so the rAF loop can drive any framing; leaving
+	// re-enables control (honoring an armed select tool) and restores the 2D/3D
+	// pitch constraints. The per-frame camera drive lives in the rAF loop below.
+	useEffect(() => {
+		// dragPan / pitch APIs exist from construction (no layers needed), so this
+		// runs pre-load safely — a follow set before "load" still locks the camera.
+		const map = mapRef.current;
+		if (!map) return;
+		const active = followFlight != null;
+		if (active === followActiveRef.current) return;
+		followActiveRef.current = active;
+		if (active) {
+			setCameraInteractive(map, false);
+			map.setMinPitch(0);
+			map.setMaxPitch(MAX_FOLLOW_PITCH);
+		} else {
+			setCameraInteractive(map, true);
+			// A select tool armed during follow (shouldn't happen — it's disabled in
+			// the toolbar — but be safe) keeps pan off and the crosshair cursor.
+			if (selectModeRef.current !== "off") {
+				map.dragPan.disable();
+				map.getCanvas().style.cursor = "crosshair";
+			}
+			restorePitchConstraints(map, threeDRef.current);
+		}
+		dirtyRef.current = true;
+	}, [followFlight]);
 
 	// Show/hide the radar sweep. On re-enable, re-resolve the theme color so an
 	// Appearance-theme switch that happened while hidden is picked up. dirtyRef
@@ -1126,6 +1208,24 @@ export const FlightMap: FC<FlightMapProps> = ({
 			const now = playingRef.current ? a.virtual + (wall - a.wall) : a.virtual;
 			const buf = motionBufferRef.current;
 			const landing = landingRef.current;
+			// Camera follow: lock onto the followed flight's live (glided) position,
+			// heading-driven framing per mode. jumpTo (not easeTo) so it tracks the
+			// dot frame-for-frame instead of chasing an animation. Its pitch change
+			// flows through the "pitch" handler → 3D geometry arms for cockpit/highlight.
+			const follow = followRef.current;
+			if (follow.flight) {
+				const fm = buf.get(follow.flight);
+				if (fm) {
+					const head = extrapolate(fm, motionNow(fm, now, landing));
+					map.jumpTo(
+						cameraPose(
+							follow.mode,
+							{ lon: head.lon, lat: head.lat, headingDeg: fm.headingDeg },
+							map.getZoom(),
+						),
+					);
+				}
+			}
 			const pointsFc = motionPointsToGeoJSON(
 				buf, now, landing,
 				(m: FlightMotion) => cbRef.current.aircraftFamilyOf?.(m.item.flight, m.item.start_date) ?? "generic",

--- a/packages/frontend/src/Applications/FlightTracker/FlightTracker.test.tsx
+++ b/packages/frontend/src/Applications/FlightTracker/FlightTracker.test.tsx
@@ -881,4 +881,54 @@ describe("FlightTracker", () => {
 			expect(select.value).toBe("UA");
 		});
 	});
+
+	describe("camera follow (tracked flights)", () => {
+		const aa11 = {
+			id: 1, flight: "AA11", carrier: "AA",
+			start_date: "2001-09-11T13:00:00Z", lat: 40, lon: -74, alt_ft: 30000,
+		};
+		const dl404 = {
+			id: 2, flight: "DL404", carrier: "DL",
+			start_date: "2001-09-11T13:00:00Z", lat: 41, lon: -73, alt_ft: 31000,
+		};
+		const stubFetch = () =>
+			vi.stubGlobal(
+				"fetch",
+				vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data: [] }) }),
+			);
+
+		it("arms the follow lock onto a selected tracked flight", () => {
+			stubFetch();
+			renderWithContext({ flightPositions: [aa11], connected: true });
+			expect(mapProps.at(-1)!.followFlight).toBeNull(); // idle until armed
+			act(() => (mapProps.at(-1)!.onSelectFlight as (f: string) => void)("AA11"));
+			fireEvent.click(screen.getByText("Follow"));
+			expect(mapProps.at(-1)!.followFlight).toBe("AA11");
+			expect(screen.getByText("Following")).toBeTruthy();
+			vi.unstubAllGlobals();
+		});
+
+		it("passes the persisted camera mode and dispatches a dropdown change", () => {
+			mockAppData.current = { mapSettings: { cameraMode: "highlight" } };
+			renderWithContext({ connected: true });
+			expect(mapProps.at(-1)!.cameraMode).toBe("highlight");
+			fireEvent.change(screen.getByTestId("flight_camera_mode"), {
+				target: { value: "cockpit" },
+			});
+			expect(dispatchMock).toHaveBeenCalledWith({
+				type: "ClassicyAppFlightTrackerSetMapSettings",
+				mapSettings: { ...DEFAULT_FLIGHT_MAP_SETTINGS, cameraMode: "cockpit" },
+			});
+		});
+
+		it("never follows an untracked flight even if the toggle is forced", () => {
+			stubFetch();
+			renderWithContext({ flightPositions: [dl404], connected: true });
+			act(() => (mapProps.at(-1)!.onSelectFlight as (f: string) => void)("DL404"));
+			// A regular flight isn't one of the five tracked flights: arming stays inert.
+			act(() => fireEvent.click(screen.getByText("Follow")));
+			expect(mapProps.at(-1)!.followFlight).toBeNull();
+			vi.unstubAllGlobals();
+		});
+	});
 });

--- a/packages/frontend/src/Applications/FlightTracker/FlightTracker.tsx
+++ b/packages/frontend/src/Applications/FlightTracker/FlightTracker.tsx
@@ -64,6 +64,8 @@ import {
 	flightTrackerSetFocusedFlight,
 } from "./flightTrackerCommands";
 import { useNotableCrashSites } from "./useNotableCrashSites";
+import { isNotable, isObserver } from "./notableFlights";
+import type { CameraMode } from "./flightCamera";
 import { useRouteIndex } from "./useRouteIndex";
 import { groundStopStatus } from "./groundStop";
 import { insertReplaySamples, pruneReplay, type ReplayBuffer } from "./flightReplay";
@@ -187,6 +189,21 @@ export const FlightTracker: FC = () => {
 	// View-menu items above; one-shot camera moves go through the map handle.
 	const mapApi = useRef<FlightMapHandle>(null);
 	const [selectMode, setSelectMode] = useState<SelectMode>("off");
+	// Camera follow (tracked flights): the on/off toggle is ephemeral (it needs a
+	// live selection, so it isn't persisted like the mode below); arming it clears
+	// any select tool, since the two fight over the pointer/camera.
+	const [cameraFollow, setCameraFollow] = useState(false);
+	const setCameraMode = useCallback(
+		(cameraMode: CameraMode) =>
+			desktopEventDispatch(flightTrackerSetMapSettings({ ...settings, cameraMode })),
+		[settings, desktopEventDispatch],
+	);
+	const toggleCameraFollow = useCallback(() => {
+		setCameraFollow((on) => {
+			if (!on) setSelectMode("off");
+			return !on;
+		});
+	}, []);
 	const toggleGlobe = useCallback(() => {
 		desktopEventDispatch(
 			flightTrackerSetMapSettings({ ...settings, globe: !settings.globe }),
@@ -334,6 +351,17 @@ export const FlightTracker: FC = () => {
 	const [multiSelected, setMultiSelected] = useState<FlightPosition[]>([]);
 	const [activeFlightIdx, setActiveFlightIdx] = useState(0);
 	const selected = multiSelected[Math.min(activeFlightIdx, multiSelected.length - 1)] ?? null;
+
+	// Camera follow targets the five tracked flights (the notables + observer).
+	// canFollow gates the toggle; followFlight (null unless armed AND a tracked
+	// flight is selected) is what FlightMap locks onto. Keeping cameraFollow in
+	// lockstep with canFollow means "following" never lingers with nothing to
+	// follow — so cameraFollow alone drives the toolbar's locked-out controls.
+	const canFollow = !!selected && (isNotable(selected.flight) || isObserver(selected.flight));
+	useEffect(() => {
+		if (cameraFollow && !canFollow) setCameraFollow(false);
+	}, [cameraFollow, canFollow]);
+	const followFlight = cameraFollow && canFollow ? selected!.flight : null;
 
 	const onAreaSelect = useCallback(
 		(flights: string[]) => {
@@ -984,6 +1012,11 @@ export const FlightTracker: FC = () => {
 						onToggleDarkMap={toggleDarkMap}
 						filterOn={!!visibleFlights}
 						onOpenFilter={openFilter}
+						cameraMode={settings.cameraMode}
+						cameraFollow={cameraFollow}
+						canFollow={canFollow}
+						onSetCameraMode={setCameraMode}
+						onToggleCameraFollow={toggleCameraFollow}
 					/>
 					<div className={styles.body}>
 						<div className={styles.map}>
@@ -1028,6 +1061,8 @@ export const FlightTracker: FC = () => {
 								onAreaSelect={onAreaSelect}
 								onPitchedChange={onPitchedChange}
 								aircraftFamilyOf={aircraftFamilyOf}
+								followFlight={followFlight}
+								cameraMode={settings.cameraMode}
 								onClearSelection={() => setMultiSelected([])}
 							/>
 						</div>

--- a/packages/frontend/src/Applications/FlightTracker/MapControls.test.tsx
+++ b/packages/frontend/src/Applications/FlightTracker/MapControls.test.tsx
@@ -14,6 +14,9 @@ const baseProps = (): MapControlsProps => ({
 	mapStyle: "classic",
 	darkMap: false,
 	filterOn: false,
+	cameraMode: "track",
+	cameraFollow: false,
+	canFollow: false,
 	onZoomIn: vi.fn(),
 	onZoomOut: vi.fn(),
 	onToggleGlobe: vi.fn(),
@@ -25,6 +28,8 @@ const baseProps = (): MapControlsProps => ({
 	onSetMapStyle: vi.fn(),
 	onToggleDarkMap: vi.fn(),
 	onOpenFilter: vi.fn(),
+	onSetCameraMode: vi.fn(),
+	onToggleCameraFollow: vi.fn(),
 });
 
 // ClassicyPopUpMenu's label isn't wired to the select for a11y-name queries,
@@ -131,6 +136,45 @@ describe("MapControls", () => {
 		rerender(<MapControls {...p} filterOn={true} />);
 		expect(filter.textContent).toBe("Filter (on)…");
 		expect(filter.getAttribute("aria-pressed")).toBe("true");
+	});
+
+	it("follow toggle is disabled until a tracked flight is selectable, then arms", () => {
+		const p = baseProps();
+		const { rerender } = render(<MapControls {...p} canFollow={false} />);
+		const follow = screen.getByRole("button", { name: "Follow flight" }) as HTMLButtonElement;
+		expect(follow.disabled).toBe(true);
+		expect(follow.textContent).toBe("Follow");
+		fireEvent.click(follow);
+		expect(p.onToggleCameraFollow).not.toHaveBeenCalled();
+		// A tracked flight is selected: the toggle arms.
+		rerender(<MapControls {...p} canFollow={true} />);
+		expect(follow.disabled).toBe(false);
+		fireEvent.click(follow);
+		expect(p.onToggleCameraFollow).toHaveBeenCalledOnce();
+	});
+
+	it("camera mode dropdown shows the current mode and fires onSetCameraMode", () => {
+		const p = baseProps();
+		render(<MapControls {...p} cameraMode="cockpit" />);
+		const dd = selectById("flight_camera_mode");
+		expect(dd.value).toBe("cockpit");
+		expect(dd.disabled).toBe(false); // the framing preference stays editable
+		fireEvent.change(dd, { target: { value: "highlight" } });
+		expect(p.onSetCameraMode).toHaveBeenCalledWith("highlight");
+	});
+
+	it("locks out zoom, marquee, and pinpoints while following (depressed toggle)", () => {
+		const p = baseProps();
+		render(<MapControls {...p} canFollow={true} cameraFollow={true} />);
+		const follow = screen.getByRole("button", { name: "Follow flight" });
+		expect(follow.getAttribute("aria-pressed")).toBe("true");
+		expect(follow.textContent).toBe("Following");
+		for (const name of ["Zoom in", "Zoom out", "Select rectangle", "Select circle"]) {
+			expect((screen.getByRole("button", { name }) as HTMLButtonElement).disabled).toBe(true);
+		}
+		expect(selectById("flight_map_pinpoints").disabled).toBe(true);
+		// The follow toggle itself stays live so you can turn it off.
+		expect((follow as HTMLButtonElement).disabled).toBe(false);
 	});
 
 	it("radar scope disables the dark toggle and shows it unpressed, keeping darkMap", () => {

--- a/packages/frontend/src/Applications/FlightTracker/MapControls.test.tsx
+++ b/packages/frontend/src/Applications/FlightTracker/MapControls.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { pinpointById } from "./mapPinpoints";
 import { MapControls, type MapControlsProps } from "./MapControls";
@@ -32,12 +32,20 @@ const baseProps = (): MapControlsProps => ({
 	onToggleCameraFollow: vi.fn(),
 });
 
-// ClassicyPopUpMenu's label isn't wired to the select for a11y-name queries,
-// so the two menus (pinpoints, style) are told apart by their element ids.
-const selectById = (id: string): HTMLSelectElement => {
+// classicy's ClassicyPopUpMenu renders as a <button id=…> whose label isn't
+// htmlFor-associated, plus a listbox that only mounts while open. Menus are
+// told apart by their element ids: read the shown value from the button's
+// label span; pick an option by opening the button and clicking its label.
+const popupButton = (id: string): HTMLButtonElement => {
 	const el = document.getElementById(id);
-	if (!(el instanceof HTMLSelectElement)) throw new Error(`no select #${id}`);
+	if (!(el instanceof HTMLButtonElement)) throw new Error(`no popup #${id}`);
 	return el;
+};
+const popupValue = (id: string): string =>
+	popupButton(id).querySelector(".classicyPopUpMenuValue")?.textContent ?? "";
+const pickOption = (id: string, label: string) => {
+	fireEvent.click(popupButton(id));
+	fireEvent.click(within(screen.getByRole("listbox")).getByText(label));
 };
 
 describe("MapControls", () => {
@@ -78,17 +86,15 @@ describe("MapControls", () => {
 	it("pinpoints dropdown flies to the chosen place then snaps back to Choose…", () => {
 		const p = baseProps();
 		render(<MapControls {...p} />);
-		const dd = selectById("flight_map_pinpoints");
-		const placeholder = screen.getByText("Choose…") as HTMLOptionElement;
-		expect(placeholder.disabled).toBe(true);
-		expect(dd.value).toBe(placeholder.value);
-		fireEvent.change(dd, { target: { value: "pentagon" } });
+		// The button shows the placeholder until (and after) a pick — no value sticks.
+		expect(popupValue("flight_map_pinpoints")).toBe("Choose…");
 		const pentagon = pinpointById("pentagon")!;
+		pickOption("flight_map_pinpoints", pentagon.label);
 		// Assert against the data table, not a hardcoded copy — zoom tuning is a
 		// product decision this test must follow, not police.
 		expect(p.onPinpoint).toHaveBeenCalledWith(pentagon.center, pentagon.zoom);
 		// Remounted onto the placeholder — the picked value never sticks.
-		expect(selectById("flight_map_pinpoints").value).toBe(placeholder.value);
+		expect(popupValue("flight_map_pinpoints")).toBe("Choose…");
 	});
 
 	it("select tools are mutually exclusive toggles: active tool re-click turns off", () => {
@@ -109,9 +115,8 @@ describe("MapControls", () => {
 	it("style dropdown shows the current style and fires onSetMapStyle", () => {
 		const p = baseProps();
 		render(<MapControls {...p} mapStyle="satellite" />);
-		const dd = selectById("flight_map_style");
-		expect(dd.value).toBe("satellite");
-		fireEvent.change(dd, { target: { value: "radar" } });
+		expect(popupValue("flight_map_style")).toBe("Satellite");
+		pickOption("flight_map_style", "Radar");
 		expect(p.onSetMapStyle).toHaveBeenCalledWith("radar");
 	});
 
@@ -156,10 +161,9 @@ describe("MapControls", () => {
 	it("camera mode dropdown shows the current mode and fires onSetCameraMode", () => {
 		const p = baseProps();
 		render(<MapControls {...p} cameraMode="cockpit" />);
-		const dd = selectById("flight_camera_mode");
-		expect(dd.value).toBe("cockpit");
-		expect(dd.disabled).toBe(false); // the framing preference stays editable
-		fireEvent.change(dd, { target: { value: "highlight" } });
+		expect(popupValue("flight_camera_mode")).toBe("Cockpit");
+		expect(popupButton("flight_camera_mode").disabled).toBe(false); // preference stays editable
+		pickOption("flight_camera_mode", "Highlight");
 		expect(p.onSetCameraMode).toHaveBeenCalledWith("highlight");
 	});
 
@@ -172,7 +176,7 @@ describe("MapControls", () => {
 		for (const name of ["Zoom in", "Zoom out", "Select rectangle", "Select circle"]) {
 			expect((screen.getByRole("button", { name }) as HTMLButtonElement).disabled).toBe(true);
 		}
-		expect(selectById("flight_map_pinpoints").disabled).toBe(true);
+		expect(popupButton("flight_map_pinpoints").disabled).toBe(true);
 		// The follow toggle itself stays live so you can turn it off.
 		expect((follow as HTMLButtonElement).disabled).toBe(false);
 	});

--- a/packages/frontend/src/Applications/FlightTracker/MapControls.tsx
+++ b/packages/frontend/src/Applications/FlightTracker/MapControls.tsx
@@ -6,6 +6,12 @@ import {
 	type BasemapStyleId,
 	normalizeBasemapStyle,
 } from "../../lib/basemap/basemapStyles";
+import {
+	type CameraMode,
+	CAMERA_MODE_LABELS,
+	CAMERA_MODES,
+	normalizeCameraMode,
+} from "./flightCamera";
 
 import type { SelectMode } from "./selectTool";
 
@@ -32,6 +38,12 @@ export interface MapControlsProps {
 	mapStyle: BasemapStyleId;
 	darkMap: boolean;
 	filterOn: boolean;
+	// Camera-follow (tracked flights): `cameraMode` is the dropdown framing;
+	// `cameraFollow` is true while the camera is locked onto a flight; `canFollow`
+	// is true when a tracked flight is selected (so the toggle can arm).
+	cameraMode: CameraMode;
+	cameraFollow: boolean;
+	canFollow: boolean;
 	onZoomIn(): void;
 	onZoomOut(): void;
 	onToggleGlobe(): void;
@@ -43,6 +55,8 @@ export interface MapControlsProps {
 	onSetMapStyle(style: BasemapStyleId): void;
 	onToggleDarkMap(): void;
 	onOpenFilter(): void;
+	onSetCameraMode(mode: CameraMode): void;
+	onToggleCameraFollow(): void;
 }
 
 export const MapControls: FC<MapControlsProps> = (p) => {
@@ -53,10 +67,21 @@ export const MapControls: FC<MapControlsProps> = (p) => {
 	return (
 	<div className={styles.mapControls}>
 		<div className={styles.mapControlsContainer}>
-		<ClassicyButton buttonSize="small" aria-label="Zoom out" onClickFunc={p.onZoomOut}>
+		{/* Zoom is the camera's domain while a follow lock is active. */}
+		<ClassicyButton
+			buttonSize="small"
+			aria-label="Zoom out"
+			disabled={p.cameraFollow}
+			onClickFunc={p.onZoomOut}
+		>
 			−
 		</ClassicyButton>
-		<ClassicyButton buttonSize="small" aria-label="Zoom in" onClickFunc={p.onZoomIn}>
+		<ClassicyButton
+			buttonSize="small"
+			aria-label="Zoom in"
+			disabled={p.cameraFollow}
+			onClickFunc={p.onZoomIn}
+		>
 			+
 		</ClassicyButton>
 		</div>
@@ -97,10 +122,12 @@ export const MapControls: FC<MapControlsProps> = (p) => {
 		</div>
 		<span className={styles.mapControlsDivider} />
 		<div className={styles.mapControlsContainer}>
+		{/* The marquee selectors move/read the map, so they lock out while following. */}
 		<ClassicyButton
 			buttonSize="small"
 			aria-label="Select rectangle"
 			depressed={p.selectMode === "rect"}
+			disabled={p.cameraFollow}
 			onClickFunc={() => p.onSetSelectMode(p.selectMode === "rect" ? "off" : "rect")}
 		>
 			▭
@@ -109,10 +136,35 @@ export const MapControls: FC<MapControlsProps> = (p) => {
 			buttonSize="small"
 			aria-label="Select circle"
 			depressed={p.selectMode === "circle"}
+			disabled={p.cameraFollow}
 			onClickFunc={() => p.onSetSelectMode(p.selectMode === "circle" ? "off" : "circle")}
 		>
 			◯
 		</ClassicyButton>
+		</div>
+		<span className={styles.mapControlsDivider} />
+		{/* Camera follow (tracked flights): a toggle that locks the camera onto
+		    the selected flight, and a dropdown picking the framing. */}
+		<div className={styles.mapControlsContainer}>
+		<ClassicyButton
+			buttonSize="small"
+			aria-label="Follow flight"
+			depressed={p.cameraFollow}
+			disabled={!p.canFollow}
+			onClickFunc={p.onToggleCameraFollow}
+		>
+			{p.cameraFollow ? "Following" : "Follow"}
+		</ClassicyButton>
+		<ClassicyPopUpMenu
+			id="flight_camera_mode"
+			label="Camera"
+			labelPosition="left"
+			labelSize="small"
+			size="small"
+			selected={p.cameraMode}
+			options={CAMERA_MODES.map((m) => ({ value: m, label: CAMERA_MODE_LABELS[m] }))}
+			onChangeFunc={(e) => p.onSetCameraMode(normalizeCameraMode(e.target.value))}
+		/>
 		</div>
 		<span className={styles.mapControlsDivider} />
 		<div className={styles.mapControlsContainer}>
@@ -123,6 +175,8 @@ export const MapControls: FC<MapControlsProps> = (p) => {
 			labelPosition="left"
 			labelSize="small"
 			size="small"
+			// A pinpoint fly-to would fight the follow lock, so it's disabled then.
+			disabled={p.cameraFollow}
 			placeholder="Choose…"
 			options={PINPOINTS.map((pin) => ({ value: pin.id, label: pin.label }))}
 			onChangeFunc={(e) => {

--- a/packages/frontend/src/Applications/FlightTracker/flightCamera.test.ts
+++ b/packages/frontend/src/Applications/FlightTracker/flightCamera.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+	CAMERA_MODES,
+	cameraPose,
+	DEFAULT_CAMERA_MODE,
+	MAX_FOLLOW_PITCH,
+	normalizeCameraMode,
+	offsetLngLat,
+} from "./flightCamera";
+
+describe("normalizeCameraMode", () => {
+	it("keeps the three known modes", () => {
+		expect(normalizeCameraMode("track")).toBe("track");
+		expect(normalizeCameraMode("cockpit")).toBe("cockpit");
+		expect(normalizeCameraMode("highlight")).toBe("highlight");
+	});
+	it("falls back to the default for unknown/legacy values", () => {
+		expect(normalizeCameraMode("orbit")).toBe(DEFAULT_CAMERA_MODE);
+		expect(normalizeCameraMode(undefined)).toBe(DEFAULT_CAMERA_MODE);
+		expect(normalizeCameraMode(null)).toBe("track");
+	});
+	it("exposes exactly the three modes", () => {
+		expect(CAMERA_MODES).toEqual(["track", "cockpit", "highlight"]);
+	});
+});
+
+describe("offsetLngLat", () => {
+	it("moves north for heading 0", () => {
+		const [lon, lat] = offsetLngLat(-74, 40, 0, 11.0574);
+		expect(lon).toBeCloseTo(-74, 6);
+		expect(lat).toBeCloseTo(40.1, 4); // 11.0574 km ≈ 0.1° lat
+	});
+	it("moves east for heading 90, expanding longitude by 1/cos(lat)", () => {
+		const [lon, lat] = offsetLngLat(-74, 60, 90, 11.132);
+		expect(lat).toBeCloseTo(60, 6);
+		// 11.132 km east at 60°N ≈ 0.1° / cos(60°) = 0.2° of longitude.
+		expect(lon).toBeCloseTo(-73.8, 3);
+	});
+});
+
+describe("cameraPose", () => {
+	const target = { lon: -74, lat: 40, headingDeg: 90 };
+
+	it("track recenters top-down, north-up, keeping the current zoom", () => {
+		const pose = cameraPose("track", target, 7.3);
+		expect(pose.center).toEqual([-74, 40]);
+		expect(pose.zoom).toBe(7.3);
+		expect(pose.pitch).toBe(0);
+		expect(pose.bearing).toBe(0);
+	});
+
+	it("highlight tilts, faces the heading, and frames ahead of the plane", () => {
+		const pose = cameraPose("highlight", target, 7.3);
+		expect(pose.bearing).toBe(90);
+		expect(pose.pitch).toBeGreaterThan(0);
+		expect(pose.pitch).toBeLessThan(MAX_FOLLOW_PITCH);
+		expect(pose.zoom).toBeGreaterThan(7.3); // fixed closer framing, not the current zoom
+		// heading east → look-point shifted east of the plane.
+		expect(pose.center[0]).toBeGreaterThan(-74);
+		expect(pose.center[1]).toBeCloseTo(40, 4);
+	});
+
+	it("cockpit is steeper and closer than highlight", () => {
+		const highlight = cameraPose("highlight", target, 7.3);
+		const cockpit = cameraPose("cockpit", target, 7.3);
+		expect(cockpit.bearing).toBe(90);
+		expect(cockpit.pitch).toBeGreaterThan(highlight.pitch);
+		expect(cockpit.pitch).toBeLessThanOrEqual(MAX_FOLLOW_PITCH);
+		expect(cockpit.zoom).toBeGreaterThan(highlight.zoom);
+		// Look-point pushed further ahead than highlight (camera sits ~at the plane).
+		expect(cockpit.center[0]).toBeGreaterThan(highlight.center[0]);
+	});
+});

--- a/packages/frontend/src/Applications/FlightTracker/flightCamera.ts
+++ b/packages/frontend/src/Applications/FlightTracker/flightCamera.ts
@@ -1,0 +1,114 @@
+// Camera-follow modes for the tracked flights (issue: flight camera modes).
+// A "follow" toggle locks the map camera onto the selected flight and drives it
+// every frame from the flight's live extrapolated position/heading; the mode
+// picks the framing. Pure geometry only — FlightMap owns the map instance and
+// feeds the pose from cameraPose() into map.jumpTo() while following.
+//
+//  - track:     top-down, north-up, centered on the flight. The default; keeps
+//               the caller's current zoom so it only recenters (works whether
+//               the map is in 2D or 3D — it just flattens the pitch).
+//  - highlight: an elevated forward-looking "hero" shot — bearing along the
+//               flight's heading, a slight downward tilt, framed just ahead of
+//               the plane so its path fills the view.
+//  - cockpit:   a near first-person forward view from the plane — bearing along
+//               the heading, a steep tilt toward the horizon, zoomed in close.
+
+export type CameraMode = "track" | "cockpit" | "highlight";
+
+export const CAMERA_MODES: readonly CameraMode[] = ["track", "cockpit", "highlight"] as const;
+
+export const CAMERA_MODE_LABELS: Record<CameraMode, string> = {
+	track: "Track",
+	cockpit: "Cockpit",
+	highlight: "Highlight",
+};
+
+export const DEFAULT_CAMERA_MODE: CameraMode = "track";
+
+// Unknown/legacy stored values fall back to the default (no migration needed).
+export function normalizeCameraMode(value: unknown): CameraMode {
+	return value === "cockpit" || value === "highlight" || value === "track"
+		? value
+		: DEFAULT_CAMERA_MODE;
+}
+
+// The follow camera drives pitch directly, so while it is active the map's
+// pitch band is opened all the way up (cockpit needs more than the 3D toggle's
+// 60° cap). Restored to the 2D/3D constraints on release.
+export const MAX_FOLLOW_PITCH = 85;
+
+export interface CameraTarget {
+	lon: number;
+	lat: number;
+	// Direction of travel, degrees clockwise from north (FlightMotion.headingDeg).
+	headingDeg: number;
+}
+
+export interface CameraPose {
+	center: [number, number];
+	zoom: number;
+	pitch: number;
+	bearing: number;
+}
+
+// Per-mode framing. Zoom/pitch are tuning knobs; aheadKm shifts the look-point
+// forward along the heading so the plane sits lower in a pitched frame.
+const HIGHLIGHT_ZOOM = 9.5;
+const HIGHLIGHT_PITCH = 52;
+const HIGHLIGHT_AHEAD_KM = 6;
+const COCKPIT_ZOOM = 12.5;
+const COCKPIT_PITCH = 78;
+const COCKPIT_AHEAD_KM = 14;
+
+const KM_PER_DEG_LAT = 110.574;
+const KM_PER_DEG_LON_EQ = 111.320;
+const DEG = Math.PI / 180;
+
+/**
+ * Move a lon/lat by `km` along a compass heading (degrees clockwise from north).
+ * Longitude is expanded by 1/cos(lat) so the step is a true ground distance.
+ */
+export function offsetLngLat(
+	lon: number,
+	lat: number,
+	headingDeg: number,
+	km: number,
+): [number, number] {
+	const h = headingDeg * DEG;
+	const dLat = (km * Math.cos(h)) / KM_PER_DEG_LAT;
+	const cosLat = Math.max(Math.cos(lat * DEG), 0.01);
+	const dLon = (km * Math.sin(h)) / (KM_PER_DEG_LON_EQ * cosLat);
+	return [lon + dLon, lat + dLat];
+}
+
+/**
+ * Camera pose for a followed flight. `currentZoom` is the map's live zoom, used
+ * by track mode so enabling follow only recenters (doesn't jump the zoom).
+ */
+export function cameraPose(
+	mode: CameraMode,
+	target: CameraTarget,
+	currentZoom: number,
+): CameraPose {
+	const { lon, lat, headingDeg } = target;
+	switch (mode) {
+		case "cockpit":
+			return {
+				center: offsetLngLat(lon, lat, headingDeg, COCKPIT_AHEAD_KM),
+				zoom: COCKPIT_ZOOM,
+				pitch: COCKPIT_PITCH,
+				bearing: headingDeg,
+			};
+		case "highlight":
+			return {
+				center: offsetLngLat(lon, lat, headingDeg, HIGHLIGHT_AHEAD_KM),
+				zoom: HIGHLIGHT_ZOOM,
+				pitch: HIGHLIGHT_PITCH,
+				bearing: headingDeg,
+			};
+		case "track":
+		default:
+			// Top-down, north-up, centered: just recenter at the current zoom.
+			return { center: [lon, lat], zoom: currentZoom, pitch: 0, bearing: 0 };
+	}
+}

--- a/packages/frontend/src/Applications/FlightTracker/flightMapSettings.test.ts
+++ b/packages/frontend/src/Applications/FlightTracker/flightMapSettings.test.ts
@@ -26,7 +26,7 @@ function storeWithApp(data: Record<string, unknown> = {}): ClassicyStore {
 
 describe("classicyFlightTrackerEventHandler", () => {
 	it("persists mapSettings from a SetMapSettings action", () => {
-		const settings = { mapStyle: "radar" as const, darkMap: true, pinColorLight: 0x112233, pinColorDark: 0x778899, notablePinColorLight: 0x445566, notablePinColorDark: 0xaabbcc, observerPinColorLight: 0x0f766e, observerPinColorDark: 0x2dd4bf, radarSweep: false, trailMultiplier: 2, globe: true, cluster: false, threeD: true, terrain: true };
+		const settings = { mapStyle: "radar" as const, darkMap: true, pinColorLight: 0x112233, pinColorDark: 0x778899, notablePinColorLight: 0x445566, notablePinColorDark: 0xaabbcc, observerPinColorLight: 0x0f766e, observerPinColorDark: 0x2dd4bf, radarSweep: false, trailMultiplier: 2, globe: true, cluster: false, threeD: true, terrain: true, cameraMode: "cockpit" as const };
 		const out = classicyFlightTrackerEventHandler(
 			storeWithApp(),
 			flightTrackerSetMapSettings(settings),
@@ -135,6 +135,18 @@ describe("readFlightMapSettings", () => {
 		expect(readFlightMapSettings({ mapSettings: { terrain: false } }).terrain).toBe(false);
 		// Pre-terrain stored state (no key at all) upgrades to the default.
 		expect(readFlightMapSettings({ mapSettings: { globe: true } }).terrain).toBe(true);
+	});
+
+	it("defaults cameraMode to track, honors a stored mode, and normalizes junk", () => {
+		expect(readFlightMapSettings(undefined).cameraMode).toBe("track");
+		// Pre-camera-mode stored state (no key at all) upgrades to the default.
+		expect(readFlightMapSettings({ mapSettings: { globe: true } }).cameraMode).toBe("track");
+		expect(
+			readFlightMapSettings({ mapSettings: { cameraMode: "highlight" } }).cameraMode,
+		).toBe("highlight");
+		expect(
+			readFlightMapSettings({ mapSettings: { cameraMode: "orbit" } }).cameraMode,
+		).toBe("track");
 	});
 });
 

--- a/packages/frontend/src/Applications/FlightTracker/flightMapSettings.ts
+++ b/packages/frontend/src/Applications/FlightTracker/flightMapSettings.ts
@@ -1,6 +1,7 @@
 import type { ActionMessage, ClassicyStore } from "classicy";
 import { registerAppEventHandler } from "classicy";
 import type { LoopSpeed, LoopWindowMinutes } from "./loopClock";
+import { type CameraMode, DEFAULT_CAMERA_MODE, normalizeCameraMode } from "./flightCamera";
 import { EMPTY_FLIGHT_FILTER, type FlightFilter } from "./flightFilter";
 import {
 	type BasemapStyleId,
@@ -36,6 +37,10 @@ export interface FlightMapSettings {
 	threeD: boolean;
 	// Topographic relief (hillshade + 3D ground mesh) — one switch for both.
 	terrain: boolean;
+	// Camera-follow framing for the tracked flights (track/cockpit/highlight).
+	// Persisted as a preference; the follow on/off toggle itself is ephemeral
+	// (it needs a live selection), so it lives in FlightTracker, not here.
+	cameraMode: CameraMode;
 }
 
 export const DEFAULT_FLIGHT_MAP_SETTINGS: FlightMapSettings = {
@@ -53,6 +58,7 @@ export const DEFAULT_FLIGHT_MAP_SETTINGS: FlightMapSettings = {
 	cluster: false,
 	threeD: false,
 	terrain: true,
+	cameraMode: DEFAULT_CAMERA_MODE,
 };
 
 /** Persist the whole map-settings object in one dispatch. */
@@ -70,7 +76,11 @@ export const readFlightMapSettings = (
 	const stored =
 		(data?.mapSettings as Partial<FlightMapSettings> | undefined) ?? {};
 	const merged = { ...DEFAULT_FLIGHT_MAP_SETTINGS, ...stored };
-	return { ...merged, mapStyle: normalizeBasemapStyle(merged.mapStyle) };
+	return {
+		...merged,
+		mapStyle: normalizeBasemapStyle(merged.mapStyle),
+		cameraMode: normalizeCameraMode(merged.cameraMode),
+	};
 };
 
 // Loop playback preferences. Kept separate from mapSettings so the Settings

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 18.1.0
       classicy:
         specifier: latest
-        version: 0.41.4(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30)
+        version: 0.41.6(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30)
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -1847,8 +1847,8 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
-  classicy@0.41.4:
-    resolution: {integrity: sha512-i7xazx+gnZGDHTUS6C/weEfam//ISIFkhGstTGU++aPpP4o2gVTBhQ4AAQJcPDU2DgxRtqbVZguCGd4FWHViNg==}
+  classicy@0.41.6:
+    resolution: {integrity: sha512-ZK1vWoT1tyDUm7cUMN1DEbX04L3DIyf0mDrk0zIJe963mYk0SQjbjkarBe+FZyAiX5z8WxFIjw98OzbyPXTceA==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -5846,7 +5846,7 @@ snapshots:
       readdirp: 5.0.0
     optional: true
 
-  classicy@0.41.4(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30):
+  classicy@0.41.6(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30):
     dependencies:
       '@analytics/google-tag-manager': 0.6.0
       '@mdxeditor/editor': 3.55.0(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30)


### PR DESCRIPTION
## Summary

Adds a **Follow** toggle and a **Camera** mode dropdown to the Flight Tracker toolbar that lock the map camera onto the selected tracked flight (the four notables AA11/UA175/AA77/UA93 + observer GOFER06). The dropdown picks one of three framings:

- **track** (default): top-down, north-up, centered on the flight — keeps the current zoom and works whether the map is in 2D or 3D.
- **highlight**: an elevated, heading-aligned "hero" shot framed just ahead of the plane, at a slight downward tilt.
- **cockpit**: a near first-person forward view — steep pitch toward the horizon, zoomed in close.

While follow is active the camera is driven every animation frame from the flight's live extrapolated position/heading (via `jumpTo`, so it tracks the dot frame-for-frame and stays locked). User pan/zoom/rotate are disabled, and the toolbar's **zoom buttons, marquee (rectangle/circle) selectors, and pinpoints dropdown lock out**. The Follow toggle only arms when one of the five tracked flights is selected.

## How it's structured

- **`flightCamera.ts`** (new, pure): computes the per-mode camera pose (center/zoom/pitch/bearing) plus the mode enum/labels/normalizer.
- **`FlightMap.tsx`**: owns the lock — disables camera interaction, opens the pitch band so cockpit's steep angle survives, suppresses the follow-driven pitch from flipping the persisted 3D toggle, and restores the 2D/3D pitch constraints on release. The per-frame camera drive lives in the existing rAF loop.
- **`MapControls.tsx` / `FlightTracker.tsx`**: the toolbar UI and state wiring. The camera **mode** persists as a preference in `FlightMapSettings`; the on/off **toggle** is ephemeral (it needs a live selection), and it never lingers with nothing to follow.

## Testing

- `tsc -b`: clean
- `eslint .`: 0 errors (pre-existing warnings only)
- Frontend suite: **1213 tests pass**, including new coverage for the pose math (`flightCamera.test.ts`), `cameraMode` persistence, toolbar lockout, the FlightMap follow lock (jumpTo poses, pitch-band relaxation, pitch-suppression), and FlightTracker gating (only tracked flights follow).

Behavior was verified via the unit tests, which drive the real logic against the repo's maplibre mock (it mirrors `jumpTo`/pitch-clamp semantics) rather than a headless-WebGL browser run, since the map requires WebGL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xsg4eLQoWkkgYFd5bVHmrJ)_