### PR TITLE
HyperCard extensions: news, pager, weather, flight embeds + setDateTime action

### DIFF
--- a/packages/frontend/src/Applications/HyperCard/README.md
+++ b/packages/frontend/src/Applications/HyperCard/README.md
@@ -28,6 +28,16 @@ result into its authored `rect`.
   Exports the reusable `DirectusVideo` body.
 - `extensions/DirectusMultiviewPart.tsx` — the `directusMultiview` part: a grid
   ("video wall") of `DirectusVideo` tiles with solo/mute/all audio modes.
+- `extensions/DirectusNewsPart.tsx` — the `directusNews` part: one article from
+  `news_items` (headline, dateline, image, HTML body).
+- `extensions/DirectusPagerPart.tsx` — the `directusPager` part: one instant
+  message from `pager_items`, styled as a pager readout.
+- `extensions/useDirectusItem.ts` — shared id-resolution + fetch/load-state hook
+  used by the news/pager parts.
+- `extensions/HyperCardClockBridge.tsx` + `extensions/dateRange.ts` — the
+  `setDateTime` *action*: a command queues an effect, the mounted bridge applies
+  it through the sanctioned `setDateTimeFromUtc` seam, clamped to the canonical
+  date range (`dateRange.ts`).
 - `extensions/videoOptions.ts` / `extensions/videoSegment.ts` — the video option
   shape, and the pure start/end bound resolver (offset seconds, `M:SS`, or a
   date-bearing wall-clock mapped via the channel `start_date`).
@@ -99,6 +109,34 @@ the part's own `script` (e.g. `go next`), so clips can chain.
 ```
 
 Each tile takes the full `directusVideo` option set.
+
+## Authoring news / pager embeds
+
+```jsonc
+{ "id": "story", "type": "directusNews",  "rect": [12, 12, 396, 232], "options": { "itemId": 42 } }
+{ "id": "page",  "type": "directusPager", "rect": [12, 40, 396, 150], "options": { "itemId": 128 } }
+```
+
+Both take an `itemId` (a `news_items` / `pager_items` row, resolved through the
+stack expression engine). News accepts `showImage`/`showDate`; pager accepts
+`showMeta`.
+
+## The `setDateTime` action
+
+Seeks the desktop's virtual clock — every app follows.
+
+```jsonc
+{ "do": "setDateTime", "to": "2001-09-11T12:46:00" }   // a UTC datetime literal
+{ "do": "setDateTime", "toVar": "moment" }              // read it from a variable
+```
+
+The requested instant is clamped into the canonical range (`dateRange.ts`,
+`2001-09-09`…`2001-09-12` today) and applied through the sanctioned
+`setDateTimeFromUtc` seam; a stack cannot fight the streamer's forced clock
+(`dateTimeLocked`). The action is a *command* that queues an effect; the effect
+is applied by `HyperCardClockBridge`, mounted once in `Desktop.tsx`. Because the
+`do` name isn't in classicy's typed `HCAction` union (plugin commands are
+untyped-JSON by design), a typed stack literal casts it — see `newsPagerStack.ts`.
 
 ## Adding another collection (images, PDFs, …)
 

--- a/packages/frontend/src/Applications/HyperCard/README.md
+++ b/packages/frontend/src/Applications/HyperCard/README.md
@@ -34,6 +34,11 @@ result into its authored `rect`.
   message from `pager_items`, styled as a pager readout.
 - `extensions/useDirectusItem.ts` — shared id-resolution + fetch/load-state hook
   used by the news/pager parts.
+- `extensions/DirectusWeatherPart.tsx` — the `directusWeatherStation` part: one
+  station's live conditions/forecast/almanac, reusing the Weather app's
+  `WeatherStationPanel` (extracted from `Weather.tsx`).
+- `extensions/DirectusFlightMapPart.tsx` — the `directusFlightMap` part: a live
+  plane map reusing the Flight Tracker's `FlightMap` (maplibre/WebGL).
 - `extensions/HyperCardClockBridge.tsx` + `extensions/dateRange.ts` — the
   `setDateTime` *action*: a command queues an effect, the mounted bridge applies
   it through the sanctioned `setDateTimeFromUtc` seam, clamped to the canonical
@@ -120,6 +125,21 @@ Each tile takes the full `directusVideo` option set.
 Both take an `itemId` (a `news_items` / `pager_items` row, resolved through the
 stack expression engine). News accepts `showImage`/`showDate`; pager accepts
 `showMeta`.
+
+## Authoring weather / flight embeds
+
+```jsonc
+{ "id": "wx",  "type": "directusWeatherStation", "rect": [12, 40, 396, 210], "options": { "station": "KJFK" } }
+{ "id": "map", "type": "directusFlightMap",      "rect": [12, 44, 396, 206], "options": { "notablesOnly": true, "flight": "AA11", "mapStyle": "radar" } }
+```
+
+Both read the shared virtual clock and the streamed flight/weather channels via
+`MediaStreamContext` (ref-counted `subscribe*`), so they stay in lockstep with
+the desktop. The weather station reuses `Weather/WeatherStationPanel`; the flight
+map reuses `FlightTracker/FlightMap` and **requires WebGL + a sized card**.
+`station`/`flight` resolve through the stack expression engine (variable-driven
+selection). Flight options: `notablesOnly`, `flight` (focus a callsign),
+`mapStyle`/`darkMap`/`radarSweep`/`trailMultiplier`, pin-color overrides.
 
 ## The `setDateTime` action
 

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusFlightMapPart.css
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusFlightMapPart.css
@@ -1,0 +1,15 @@
+/* Flight-map embed for HyperCard cards. maplibre needs a sized container, so
+   the wrapper fills the authored rect and the map fills the wrapper. */
+.classicyHyperCardFlightMap {
+	position: relative;
+	width: 100%;
+	height: 100%;
+	min-height: 0;
+	background: #0a1622;
+	overflow: hidden;
+}
+
+.classicyHyperCardFlightMap > * {
+	width: 100%;
+	height: 100%;
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusFlightMapPart.test.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusFlightMapPart.test.tsx
@@ -1,0 +1,100 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { HyperCardPartProps } from "classicy";
+import {
+	MediaStreamContext,
+	type MediaStreamContextValue,
+} from "../../../Providers/MediaStream/MediaStreamContext";
+
+// Mock the clock hook and the heavy WebGL FlightMap; capture what the part
+// passes to the map.
+vi.mock("classicy", () => ({
+	useClassicyDateTime: () => ({
+		localDate: new Date("2001-09-11T12:46:00.000Z"),
+		tzOffset: 0,
+		paused: false,
+	}),
+}));
+const mapProps = vi.hoisted(() => [] as Array<Record<string, unknown>>);
+vi.mock("../../FlightTracker/FlightMap", () => ({
+	FlightMap: (props: Record<string, unknown>) => {
+		mapProps.push(props);
+		return <div data-testid="flightmap" />;
+	},
+}));
+
+import { DirectusFlightMapPart } from "./DirectusFlightMapPart";
+
+afterEach(() => {
+	cleanup();
+	mapProps.length = 0;
+});
+
+const POS = [
+	{ id: 1, flight: "AA11", start_date: "x", lat: 42, lon: -71, alt_ft: 30000 },
+	{ id: 2, flight: "DAL123", start_date: "x", lat: 40, lon: -75, alt_ft: 35000 },
+];
+
+function renderPart(options: Record<string, unknown>, flightPositions = POS) {
+	const ctx = {
+		flightPositions,
+		subscribeFlights: vi.fn(),
+		unsubscribeFlights: vi.fn(),
+	} as unknown as MediaStreamContextValue;
+	return render(
+		<MediaStreamContext.Provider value={ctx}>
+			<DirectusFlightMapPart {...partProps(options)} />
+		</MediaStreamContext.Provider>,
+	);
+}
+
+const last = () => mapProps[mapProps.length - 1];
+
+describe("DirectusFlightMapPart", () => {
+	it("passes every position through by default", () => {
+		renderPart({});
+		expect((last().positions as unknown[]).length).toBe(2);
+		expect(last().playing).toBe(true);
+	});
+
+	it("filters to the notable flights when notablesOnly is set", () => {
+		renderPart({ notablesOnly: true });
+		const positions = last().positions as Array<{ flight: string }>;
+		expect(positions.map((p) => p.flight)).toEqual(["AA11"]);
+	});
+
+	it("defaults the map style and pin colors, overridable via options", () => {
+		renderPart({ mapStyle: "radar", pinColor: "#123456" });
+		expect(last().mapStyle).toBe("radar");
+		expect(last().pinColor).toBe("#123456");
+	});
+
+	it("subscribes to the flight channel on mount", () => {
+		const ctx = {
+			flightPositions: [],
+			subscribeFlights: vi.fn(),
+			unsubscribeFlights: vi.fn(),
+		} as unknown as MediaStreamContextValue;
+		render(
+			<MediaStreamContext.Provider value={ctx}>
+				<DirectusFlightMapPart {...partProps({})} />
+			</MediaStreamContext.Provider>,
+		);
+		expect(ctx.subscribeFlights).toHaveBeenCalledTimes(1);
+	});
+});
+
+function partProps(options: Record<string, unknown>): HyperCardPartProps {
+	return {
+		part: { id: "p", type: "directusFlightMap" },
+		partId: "p",
+		stackId: "s",
+		options,
+		locked: false,
+		value: "",
+		setValue: vi.fn(),
+		fire: vi.fn(),
+		getVariable: vi.fn(),
+		resolve: (e: string) => e,
+	} as unknown as HyperCardPartProps;
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusFlightMapPart.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusFlightMapPart.tsx
@@ -1,0 +1,107 @@
+import type { HyperCardPartProps } from "classicy";
+import { useClassicyDateTime } from "classicy";
+import { useCallback, useContext, useEffect, useMemo, useRef } from "react";
+import { MediaStreamContext } from "../../../Providers/MediaStream/MediaStreamContext";
+import { virtualUtcMs } from "../../../Providers/MediaStream/virtualClock";
+import { BASEMAP_URLS, type BasemapStyleId } from "../../../lib/basemap/basemapStyles";
+import { FlightMap, type FlightMapHandle } from "../../FlightTracker/FlightMap";
+import { isNotable } from "../../FlightTracker/notableFlights";
+import "./DirectusFlightMapPart.css";
+
+/**
+ * `directusFlightMap` HyperCard part — a live plane map for the current virtual
+ * instant, reusing the Flight Tracker's `FlightMap` (maplibre/WebGL). It shares
+ * the desktop's single flight WebSocket channel (`MediaStreamContext`) and the
+ * virtual clock, so planes move in lockstep with the rest of the desktop.
+ *
+ *   { "id": "map", "type": "directusFlightMap", "rect": [8, 32, 404, 240],
+ *     "options": { "notablesOnly": true, "flight": "AA11", "mapStyle": "radar" } }
+ *
+ * Options: `notablesOnly` curates to the four hijacked flights; `flight` focuses
+ * the camera on a callsign; `mapStyle`/`darkMap`/`radarSweep`/`trailMultiplier`
+ * mirror the app's map settings; `pinColor`/`notablePinColor`/`observerPinColor`
+ * override the pin colors. Requires WebGL and a sized card.
+ */
+
+const DEFAULT_PIN = "#f5a623";
+const DEFAULT_NOTABLE_PIN = "#ff3b30";
+const DEFAULT_OBSERVER_PIN = "#4a90d9";
+
+function readMapStyle(v: unknown): BasemapStyleId {
+	return v === "radar" || v === "satellite" ? v : "classic";
+}
+
+export const DirectusFlightMapPart = ({ options, resolve, value, partId, stackId }: HyperCardPartProps) => {
+	const focusFlight = useMemo(() => {
+		const raw = typeof options.flight === "string" ? options.flight : value;
+		const r = raw ? resolve(String(raw)).trim().toUpperCase() : "";
+		return r || undefined;
+	}, [options.flight, value, resolve]);
+	const notablesOnly = options.notablesOnly === true;
+	const mapStyle = readMapStyle(options.mapStyle);
+	const darkMap = options.darkMap === true;
+	const radarSweep = options.radarSweep === true;
+	const trailMultiplier = typeof options.trailMultiplier === "number" ? options.trailMultiplier : 1;
+	const pinColor = typeof options.pinColor === "string" ? options.pinColor : DEFAULT_PIN;
+	const notablePinColor =
+		typeof options.notablePinColor === "string" ? options.notablePinColor : DEFAULT_NOTABLE_PIN;
+	const observerPinColor =
+		typeof options.observerPinColor === "string" ? options.observerPinColor : DEFAULT_OBSERVER_PIN;
+
+	const { flightPositions, subscribeFlights, unsubscribeFlights } = useContext(MediaStreamContext);
+
+	const appId = `hc-flight-${stackId}-${partId}`;
+	useEffect(() => {
+		subscribeFlights(appId);
+		return () => unsubscribeFlights(appId);
+	}, [subscribeFlights, unsubscribeFlights, appId]);
+
+	// Read-only clock → true-UTC instant + play state (same as FlightTracker).
+	const { localDate, tzOffset, paused } = useClassicyDateTime({ tick: true });
+	const nowMs = virtualUtcMs(localDate, tzOffset);
+
+	const positions = useMemo(
+		() => (notablesOnly ? flightPositions.filter((p) => isNotable(p.flight)) : flightPositions),
+		[flightPositions, notablesOnly],
+	);
+
+	// Fly the camera to a focused callsign once it first appears on the map.
+	const mapApi = useRef<FlightMapHandle>(null);
+	const flownFor = useRef<string | undefined>(undefined);
+	useEffect(() => {
+		if (!focusFlight) {
+			flownFor.current = undefined;
+			return;
+		}
+		if (flownFor.current === focusFlight) return;
+		const pos = flightPositions.find((p) => p.flight === focusFlight);
+		if (pos) {
+			mapApi.current?.flyTo([pos.lon, pos.lat], 7);
+			flownFor.current = focusFlight;
+		}
+	}, [focusFlight, flightPositions]);
+
+	const noop = useCallback(() => {}, []);
+
+	return (
+		<div className="classicyHyperCardFlightMap">
+			<FlightMap
+				ref={mapApi}
+				positions={positions}
+				basemapUrls={BASEMAP_URLS}
+				trackGeoJSON={null}
+				nowMs={nowMs}
+				playing={!paused}
+				mapStyle={mapStyle}
+				darkMap={darkMap}
+				pinColor={pinColor}
+				notablePinColor={notablePinColor}
+				observerPinColor={observerPinColor}
+				radarSweep={radarSweep}
+				trailMultiplier={trailMultiplier}
+				onSelectFlight={noop}
+				onClearSelection={noop}
+			/>
+		</div>
+	);
+};

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusNewsPart.css
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusNewsPart.css
@@ -1,0 +1,59 @@
+/* News article embed for HyperCard cards. Scrolls within the authored rect. */
+.classicyHyperCardNews {
+	width: 100%;
+	height: 100%;
+	overflow-y: auto;
+	padding: 8px 10px;
+	background: #fff;
+	box-sizing: border-box;
+	font-size: 12px;
+	line-height: 1.4;
+}
+
+.classicyHyperCardNewsHeadline {
+	margin: 0 0 4px;
+	font-size: 16px;
+	font-weight: bold;
+	line-height: 1.2;
+}
+
+.classicyHyperCardNewsDate {
+	margin: 0 0 8px;
+	font-size: 10px;
+	color: #666;
+}
+
+.classicyHyperCardNewsFigure {
+	margin: 0 0 8px;
+}
+
+.classicyHyperCardNewsFigure img {
+	max-width: 100%;
+	height: auto;
+	display: block;
+}
+
+.classicyHyperCardNewsFigure figcaption {
+	font-size: 10px;
+	font-style: italic;
+	color: #666;
+	margin-top: 2px;
+}
+
+.classicyHyperCardNewsBody :is(p, ul, ol) {
+	margin: 0 0 8px;
+}
+
+.classicyHyperCardNewsBody img {
+	max-width: 100%;
+	height: auto;
+}
+
+.classicyHyperCardNewsMessage {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-style: italic;
+	color: #555;
+	text-align: center;
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusNewsPart.test.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusNewsPart.test.tsx
@@ -1,0 +1,74 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { HyperCardPartProps } from "classicy";
+import { DirectusNewsPart } from "./DirectusNewsPart";
+
+afterEach(() => {
+	cleanup();
+	vi.restoreAllMocks();
+});
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+	return { ok, status, json: async () => body } as unknown as Response;
+}
+
+function partProps(options: Record<string, unknown>): HyperCardPartProps {
+	return {
+		part: { id: "p", type: "directusNews" },
+		partId: "p",
+		stackId: "s",
+		options,
+		locked: false,
+		value: "",
+		setValue: vi.fn(),
+		fire: vi.fn(),
+		getVariable: vi.fn(),
+		resolve: (e: string) => e,
+	} as unknown as HyperCardPartProps;
+}
+
+describe("DirectusNewsPart", () => {
+	it("shows a placeholder with no id", () => {
+		render(<DirectusNewsPart {...partProps({})} />);
+		expect(screen.getByText("No article selected")).toBeTruthy();
+	});
+
+	it("renders the headline, dateline, image and HTML body", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			jsonResponse({
+				data: {
+					id: 9,
+					title: "Short",
+					full_title: "A Fuller Headline",
+					start_date: "2001-09-11T12:46:00",
+					image: "https://x/hero.jpg",
+					image_caption: "the caption",
+					content: "<p>Body <strong>text</strong>.</p>",
+				},
+			}),
+		);
+		render(<DirectusNewsPart {...partProps({ itemId: 9 })} />);
+		expect(await screen.findByText("A Fuller Headline")).toBeTruthy();
+		expect(screen.getByText(/Body/)).toBeTruthy();
+		expect((screen.getByAltText("the caption") as HTMLImageElement).getAttribute("src")).toBe(
+			"https://x/hero.jpg",
+		);
+		expect(screen.getByText(/September/)).toBeTruthy();
+	});
+
+	it("hides the image when showImage is false", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			jsonResponse({ data: { id: 9, title: "T", image: "https://x/hero.jpg", content: "<p>b</p>" } }),
+		);
+		render(<DirectusNewsPart {...partProps({ itemId: 9, showImage: false })} />);
+		await screen.findByText("T");
+		expect(screen.queryByRole("img")).toBeNull();
+	});
+
+	it("shows an error note when the fetch fails", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({}, false, 404));
+		render(<DirectusNewsPart {...partProps({ itemId: 9 })} />);
+		expect(await screen.findByRole("alert")).toBeTruthy();
+		expect(screen.getByText(/Could not load article/)).toBeTruthy();
+	});
+});

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusNewsPart.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusNewsPart.tsx
@@ -1,0 +1,93 @@
+import type { HyperCardPartProps } from "classicy";
+import { useMemo } from "react";
+import { fetchDirectusNewsItem } from "./directusCollections";
+import { resolveItemId, useDirectusItem } from "./useDirectusItem";
+import "./DirectusNewsPart.css";
+
+/**
+ * `directusNews` HyperCard part — embeds one article from the `news_items`
+ * Directus collection (History Commons news entries).
+ *
+ *   { "id": "story", "type": "directusNews", "rect": [16, 40, 388, 220],
+ *     "options": { "itemId": 42, "showImage": true } }
+ *
+ * `itemId` resolves through the stack expression engine (so it may reference a
+ * variable/field). The article's `content` is first-party HTML authored in
+ * Directus — rendered the same way the News app renders it.
+ */
+
+interface DirectusNewsOptions {
+	itemId?: string | number;
+	showImage: boolean;
+	showDate: boolean;
+}
+
+function readOptions(options: Record<string, unknown>): DirectusNewsOptions {
+	const o = options;
+	return {
+		itemId:
+			typeof o.itemId === "string" || typeof o.itemId === "number" ? o.itemId : undefined,
+		showImage: o.showImage !== false,
+		showDate: o.showDate !== false,
+	};
+}
+
+/** Format an ISO/naive-UTC date as a readable dateline; passthrough on junk. */
+function formatDate(iso: string | null | undefined): string {
+	if (!iso) return "";
+	const hasZone = /[zZ]$|[+-]\d\d:?\d\d$/.test(iso.trim());
+	const d = new Date(hasZone ? iso : `${iso}Z`);
+	if (Number.isNaN(d.getTime())) return iso;
+	return d.toLocaleString("en-US", {
+		timeZone: "UTC",
+		month: "long",
+		day: "numeric",
+		year: "numeric",
+		hour: "numeric",
+		minute: "2-digit",
+	});
+}
+
+export const DirectusNewsPart = ({ options, value, resolve }: HyperCardPartProps) => {
+	const opts = useMemo(() => readOptions(options), [options]);
+	const id = resolveItemId(opts.itemId, value, resolve);
+	const state = useDirectusItem(id, fetchDirectusNewsItem);
+
+	if (state.status === "error") {
+		return (
+			<div className="classicyHyperCardNews classicyHyperCardNewsMessage" role="alert">
+				Could not load article — {state.message}
+			</div>
+		);
+	}
+	if (state.status === "loading") {
+		return <div className="classicyHyperCardNews classicyHyperCardNewsMessage">Loading article…</div>;
+	}
+	if (state.status !== "ready") {
+		return <div className="classicyHyperCardNews classicyHyperCardNewsMessage">No article selected</div>;
+	}
+
+	const { item } = state;
+	return (
+		<article className="classicyHyperCardNews">
+			<h1 className="classicyHyperCardNewsHeadline">{item.full_title || item.title}</h1>
+			{opts.showDate && item.start_date && (
+				<p className="classicyHyperCardNewsDate">{formatDate(item.start_date)}</p>
+			)}
+			{opts.showImage && item.image && (
+				<figure className="classicyHyperCardNewsFigure">
+					<img src={item.image} alt={item.image_caption || item.title} />
+					{item.image_caption && <figcaption>{item.image_caption}</figcaption>}
+				</figure>
+			)}
+			{item.content && (
+				// First-party HTML authored in Directus — rendered raw, exactly as
+				// the News app renders news_items.content.
+				<div
+					className="classicyHyperCardNewsBody"
+					dangerouslySetInnerHTML={{ __html: item.content }}
+				/>
+			)}
+		</article>
+	);
+};

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusPagerPart.css
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusPagerPart.css
@@ -1,0 +1,57 @@
+/* Pager message embed for HyperCard cards — a small LCD-style readout. */
+.classicyHyperCardPager {
+	width: 100%;
+	height: 100%;
+	display: flex;
+	padding: 6px;
+	box-sizing: border-box;
+	background: #b6b6a8;
+}
+
+.classicyHyperCardPagerScreen {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	padding: 8px 10px;
+	background: #c7d0a8;
+	border: 2px inset #8a927a;
+	color: #1a1f14;
+	font-family: "Courier New", monospace;
+	overflow-y: auto;
+}
+
+.classicyHyperCardPagerHeader {
+	display: flex;
+	justify-content: space-between;
+	font-size: 10px;
+	opacity: 0.75;
+	border-bottom: 1px solid rgba(26, 31, 20, 0.3);
+	padding-bottom: 2px;
+}
+
+.classicyHyperCardPagerBody {
+	margin: 0;
+	font-size: 13px;
+	line-height: 1.35;
+	white-space: pre-wrap;
+	word-break: break-word;
+	flex: 1;
+}
+
+.classicyHyperCardPagerMeta {
+	font-size: 10px;
+	opacity: 0.75;
+	border-top: 1px solid rgba(26, 31, 20, 0.3);
+	padding-top: 2px;
+}
+
+.classicyHyperCardPagerMessage {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-style: italic;
+	color: #333;
+	text-align: center;
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusPagerPart.test.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusPagerPart.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { HyperCardPartProps } from "classicy";
+import { DirectusPagerPart } from "./DirectusPagerPart";
+
+afterEach(() => {
+	cleanup();
+	vi.restoreAllMocks();
+});
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+	return { ok, status, json: async () => body } as unknown as Response;
+}
+
+function partProps(options: Record<string, unknown>): HyperCardPartProps {
+	return {
+		part: { id: "p", type: "directusPager" },
+		partId: "p",
+		stackId: "s",
+		options,
+		locked: false,
+		value: "",
+		setValue: vi.fn(),
+		fire: vi.fn(),
+		getVariable: vi.fn(),
+		resolve: (e: string) => e,
+	} as unknown as HyperCardPartProps;
+}
+
+describe("DirectusPagerPart", () => {
+	it("shows a placeholder with no id", () => {
+		render(<DirectusPagerPart {...partProps({})} />);
+		expect(screen.getByText("No page selected")).toBeTruthy();
+	});
+
+	it("renders the message and metadata row", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			jsonResponse({
+				data: {
+					id: 5,
+					start_date: "2001-09-11T13:00:00",
+					provider: "SkyTel",
+					recipient_id: "123456",
+					mode: "ALPHA",
+					message: "CALL OPS CENTER",
+				},
+			}),
+		);
+		render(<DirectusPagerPart {...partProps({ itemId: 5 })} />);
+		expect(await screen.findByText("CALL OPS CENTER")).toBeTruthy();
+		expect(screen.getByText(/SkyTel/)).toBeTruthy();
+		expect(screen.getByText(/123456/)).toBeTruthy();
+	});
+
+	it("hides metadata when showMeta is false", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			jsonResponse({ data: { id: 5, message: "PAGE", provider: "SkyTel" } }),
+		);
+		render(<DirectusPagerPart {...partProps({ itemId: 5, showMeta: false })} />);
+		await screen.findByText("PAGE");
+		expect(screen.queryByText(/SkyTel/)).toBeNull();
+	});
+
+	it("shows an error note when the fetch fails", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({}, false, 500));
+		render(<DirectusPagerPart {...partProps({ itemId: 5 })} />);
+		expect(await screen.findByRole("alert")).toBeTruthy();
+		expect(screen.getByText(/Could not load page/)).toBeTruthy();
+	});
+});

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusPagerPart.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusPagerPart.tsx
@@ -1,0 +1,83 @@
+import type { HyperCardPartProps } from "classicy";
+import { useMemo } from "react";
+import { fetchDirectusPagerItem } from "./directusCollections";
+import { resolveItemId, useDirectusItem } from "./useDirectusItem";
+import "./DirectusPagerPart.css";
+
+/**
+ * `directusPager` HyperCard part — embeds one instant pager message from the
+ * `pager_items` Directus collection, styled as a pager readout.
+ *
+ *   { "id": "page", "type": "directusPager", "rect": [16, 40, 388, 140],
+ *     "options": { "itemId": 128 } }
+ *
+ * `itemId` resolves through the stack expression engine (so it may reference a
+ * variable/field).
+ */
+
+interface DirectusPagerOptions {
+	itemId?: string | number;
+	/** Show the provider/recipient/mode metadata row (default true). */
+	showMeta: boolean;
+}
+
+function readOptions(options: Record<string, unknown>): DirectusPagerOptions {
+	const o = options;
+	return {
+		itemId:
+			typeof o.itemId === "string" || typeof o.itemId === "number" ? o.itemId : undefined,
+		showMeta: o.showMeta !== false,
+	};
+}
+
+function formatTimestamp(iso: string | null | undefined): string {
+	if (!iso) return "";
+	const hasZone = /[zZ]$|[+-]\d\d:?\d\d$/.test(iso.trim());
+	const d = new Date(hasZone ? iso : `${iso}Z`);
+	if (Number.isNaN(d.getTime())) return iso;
+	return d.toLocaleString("en-US", {
+		timeZone: "UTC",
+		month: "short",
+		day: "numeric",
+		hour: "2-digit",
+		minute: "2-digit",
+		second: "2-digit",
+	});
+}
+
+export const DirectusPagerPart = ({ options, value, resolve }: HyperCardPartProps) => {
+	const opts = useMemo(() => readOptions(options), [options]);
+	const id = resolveItemId(opts.itemId, value, resolve);
+	const state = useDirectusItem(id, fetchDirectusPagerItem);
+
+	if (state.status === "error") {
+		return (
+			<div className="classicyHyperCardPager classicyHyperCardPagerMessage" role="alert">
+				Could not load page — {state.message}
+			</div>
+		);
+	}
+	if (state.status === "loading") {
+		return <div className="classicyHyperCardPager classicyHyperCardPagerMessage">Loading page…</div>;
+	}
+	if (state.status !== "ready") {
+		return <div className="classicyHyperCardPager classicyHyperCardPagerMessage">No page selected</div>;
+	}
+
+	const { item } = state;
+	const meta = [item.provider, item.recipient_id && `→ ${item.recipient_id}`, item.mode]
+		.filter(Boolean)
+		.join("  ·  ");
+
+	return (
+		<div className="classicyHyperCardPager">
+			<div className="classicyHyperCardPagerScreen">
+				<div className="classicyHyperCardPagerHeader">
+					<span className="classicyHyperCardPagerTime">{formatTimestamp(item.start_date)}</span>
+				</div>
+				<p className="classicyHyperCardPagerBody">{item.message}</p>
+				{opts.showMeta && meta && <div className="classicyHyperCardPagerMeta">{meta}</div>}
+			</div>
+		</div>
+	);
+};

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusWeatherPart.css
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusWeatherPart.css
@@ -1,0 +1,14 @@
+/* Weather-station readout embed for HyperCard cards. Scrolls within the rect;
+   the panel markup and styling come from the Weather app (WeatherStationPanel). */
+.classicyHyperCardWeather {
+	width: 100%;
+	height: 100%;
+	overflow-y: auto;
+	padding: 8px;
+	box-sizing: border-box;
+	background: #dcdcdc;
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	font-size: 12px;
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusWeatherPart.test.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusWeatherPart.test.tsx
@@ -1,0 +1,83 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import type { HyperCardPartProps } from "classicy";
+import {
+	MediaStreamContext,
+	type MediaStreamContextValue,
+} from "../../../Providers/MediaStream/MediaStreamContext";
+
+vi.mock("classicy", () => ({
+	useClassicyDateTime: () => ({ dateTime: "2001-09-11T12:46:00.000Z" }),
+	ClassicyControlGroup: ({ label, children }: { label?: string; children?: ReactNode }) => (
+		<div>
+			<span>{label}</span>
+			{children}
+		</div>
+	),
+}));
+
+import { DirectusWeatherPart } from "./DirectusWeatherPart";
+
+afterEach(() => {
+	cleanup();
+	vi.restoreAllMocks();
+});
+
+function renderPart(options: Record<string, unknown>, obs?: Record<string, unknown>) {
+	// Almanac is fetched from the network; keep it absent in tests.
+	vi.spyOn(globalThis, "fetch").mockResolvedValue({ ok: false, status: 404 } as Response);
+	const ctx = {
+		weatherObservations: obs ? { KJFK: obs } : {},
+		weatherForecastByZone: {},
+		subscribeWeather: vi.fn(),
+		unsubscribeWeather: vi.fn(),
+		requestWeatherForecast: vi.fn(),
+	} as unknown as MediaStreamContextValue;
+	render(
+		<MediaStreamContext.Provider value={ctx}>
+			<DirectusWeatherPart {...partProps(options)} />
+		</MediaStreamContext.Provider>,
+	);
+	return ctx;
+}
+
+describe("DirectusWeatherPart", () => {
+	it("renders the requested station's conditions", () => {
+		renderPart(
+			{ station: "KJFK" },
+			{ id: 1, station_id: "KJFK", start_date: "2001-09-11T12:46:00Z", temp_c: 20 },
+		);
+		// 20°C → 68°F via cToF, rendered in the Conditions group.
+		expect(screen.getByText("68°F")).toBeTruthy();
+		expect(screen.getByText("Conditions")).toBeTruthy();
+	});
+
+	it("defaults to KJFK when no station option is given", () => {
+		renderPart(
+			{},
+			{ id: 1, station_id: "KJFK", start_date: "2001-09-11T12:46:00Z", temp_c: 0 },
+		);
+		expect(screen.getByText("32°F")).toBeTruthy();
+	});
+
+	it("subscribes to the weather channel on mount", () => {
+		const ctx = renderPart({ station: "KJFK" });
+		expect(ctx.subscribeWeather).toHaveBeenCalledTimes(1);
+	});
+});
+
+function partProps(options: Record<string, unknown>): HyperCardPartProps {
+	return {
+		part: { id: "p", type: "directusWeatherStation" },
+		partId: "p",
+		stackId: "s",
+		options,
+		locked: false,
+		value: "",
+		setValue: vi.fn(),
+		fire: vi.fn(),
+		getVariable: vi.fn(),
+		resolve: (e: string) => e,
+	} as unknown as HyperCardPartProps;
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusWeatherPart.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusWeatherPart.tsx
@@ -1,0 +1,82 @@
+import type { HyperCardPartProps } from "classicy";
+import { useClassicyDateTime } from "classicy";
+import { useContext, useEffect, useMemo } from "react";
+import { MediaStreamContext } from "../../../Providers/MediaStream/MediaStreamContext";
+import stationsRaw from "../../Weather/stations.json";
+import { ALMANAC_DAYS, useAlmanac } from "../../Weather/useAlmanac";
+import type { WeatherStation } from "../../Weather/WeatherMap";
+import { WeatherStationPanel } from "../../Weather/WeatherStationPanel";
+import "./DirectusWeatherPart.css";
+
+/**
+ * `directusWeatherStation` HyperCard part — embeds one weather station's live
+ * readout (conditions, forecast, almanac) using the same `WeatherStationPanel`
+ * the Weather app renders. Reads the shared virtual clock and the streamed
+ * weather channel (via `MediaStreamContext`), so it stays in lockstep with the
+ * desktop like every other app.
+ *
+ *   { "id": "wx", "type": "directusWeatherStation", "rect": [12, 12, 260, 300],
+ *     "options": { "station": "KJFK" } }
+ *
+ * `station` is an ICAO station id from the app's static station list; it
+ * resolves through the stack expression engine (so it may track a variable).
+ */
+
+const STATIONS = stationsRaw as WeatherStation[];
+const DEFAULT_STATION_ID = "KJFK";
+
+export const DirectusWeatherPart = ({ options, value, resolve, partId, stackId }: HyperCardPartProps) => {
+	const stationId = useMemo(() => {
+		const raw = (typeof options.station === "string" || typeof options.station === "number"
+			? options.station
+			: undefined) ?? value;
+		const resolved = raw ? resolve(String(raw)).trim() : "";
+		return resolved || DEFAULT_STATION_ID;
+	}, [options.station, value, resolve]);
+
+	const station = useMemo(
+		() => STATIONS.find((s) => s.station_id === stationId) ?? null,
+		[stationId],
+	);
+
+	const {
+		weatherObservations,
+		weatherForecastByZone,
+		subscribeWeather,
+		unsubscribeWeather,
+		requestWeatherForecast,
+	} = useContext(MediaStreamContext);
+
+	// Ref-counted subscription to the shared weather channel (one appId per
+	// embed), released on unmount — the same pattern the Weather app uses.
+	const appId = `hc-weather-${stackId}-${partId}`;
+	useEffect(() => {
+		subscribeWeather(appId);
+		return () => unsubscribeWeather(appId);
+	}, [subscribeWeather, unsubscribeWeather, appId]);
+
+	useEffect(() => {
+		if (station?.nws_zone) requestWeatherForecast(station.nws_zone);
+	}, [station?.nws_zone, requestWeatherForecast]);
+
+	// Read-only clock; `dateTime` is already true UTC, so the almanac day key is
+	// just its MM-DD slice (same as Weather.tsx).
+	const { dateTime } = useClassicyDateTime({ tick: true });
+	const currentMMDD = dateTime.slice(5, 10);
+
+	const { almanac } = useAlmanac(station?.station_id ?? null);
+	const obs = station ? weatherObservations[station.station_id] : undefined;
+	const forecastEntry = station?.nws_zone ? weatherForecastByZone[station.nws_zone] : undefined;
+
+	return (
+		<div className="classicyHyperCardWeather">
+			<WeatherStationPanel
+				station={station}
+				obs={obs}
+				forecastEntry={forecastEntry}
+				almanacDay={almanac?.days[currentMMDD] ?? null}
+				showAlmanac={ALMANAC_DAYS.has(currentMMDD)}
+			/>
+		</div>
+	);
+};

--- a/packages/frontend/src/Applications/HyperCard/extensions/HyperCardClockBridge.test.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/HyperCardClockBridge.test.tsx
@@ -1,0 +1,69 @@
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Capture the registered effect handler and control the mocked clock hooks.
+const hooks = vi.hoisted(() => ({
+	setDateTime: undefined as unknown as ReturnType<typeof vi.fn>,
+	locked: false,
+	handler: undefined as unknown as (args: Record<string, unknown>, api: unknown) => void,
+}));
+
+vi.mock("classicy", () => ({
+	useClassicyDateTime: () => ({ setDateTime: hooks.setDateTime }),
+	useAppManager: (sel: (s: unknown) => unknown) =>
+		sel({ System: { Manager: { DateAndTime: { dateTimeLocked: hooks.locked } } } }),
+	registerHyperCardEffectHandler: (_name: string, h: typeof hooks.handler) => {
+		hooks.handler = h;
+	},
+}));
+
+import { HyperCardClockBridge } from "./HyperCardClockBridge";
+import { CLOCK_RANGE_END_ISO } from "./dateRange";
+
+afterEach(() => {
+	cleanup();
+	vi.restoreAllMocks();
+});
+
+function mount(locked = false) {
+	hooks.setDateTime = vi.fn();
+	hooks.locked = locked;
+	hooks.handler = undefined as never;
+	render(<HyperCardClockBridge />);
+	expect(hooks.handler).toBeTruthy();
+}
+
+const appliedIso = () => (hooks.setDateTime.mock.calls[0][0] as Date).toISOString();
+
+describe("HyperCardClockBridge", () => {
+	it("applies an in-range instant through the clock seam", () => {
+		mount();
+		act(() => hooks.handler({ to: "2001-09-11T12:46:00" }, {}));
+		expect(hooks.setDateTime).toHaveBeenCalledTimes(1);
+		expect(appliedIso()).toBe("2001-09-11T12:46:00.000Z");
+	});
+
+	it("clamps an out-of-range instant into the window", () => {
+		mount();
+		act(() => hooks.handler({ to: "2001-09-20T00:00:00" }, {}));
+		expect(appliedIso()).toBe(new Date(CLOCK_RANGE_END_ISO).toISOString());
+	});
+
+	it("does nothing while the clock is locked (forced-clock mode)", () => {
+		mount(true);
+		act(() => hooks.handler({ to: "2001-09-11T12:46:00" }, {}));
+		expect(hooks.setDateTime).not.toHaveBeenCalled();
+	});
+
+	it("ignores an unparseable date", () => {
+		mount();
+		act(() => hooks.handler({ to: "not a date" }, {}));
+		expect(hooks.setDateTime).not.toHaveBeenCalled();
+	});
+
+	it("ignores a missing `to`", () => {
+		mount();
+		act(() => hooks.handler({}, {}));
+		expect(hooks.setDateTime).not.toHaveBeenCalled();
+	});
+});

--- a/packages/frontend/src/Applications/HyperCard/extensions/HyperCardClockBridge.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/HyperCardClockBridge.tsx
@@ -1,0 +1,48 @@
+import { registerHyperCardEffectHandler, useAppManager, useClassicyDateTime } from "classicy";
+import { useEffect, useRef } from "react";
+import { setDateTimeFromUtc } from "../../TimeMachine/setVirtualClock";
+import { clampClockIso } from "./dateRange";
+
+/**
+ * Bridges the HyperCard `setDateTime` action to the virtual clock.
+ *
+ * A HyperCard command runs inside classicy's pure reducer and can't touch the
+ * app-manager clock directly, so the `setDateTime` command (registered in
+ * registerHyperCardExtensions) only *queues* a custom effect. This mounted
+ * component registers the matching effect handler — the one place with live
+ * access to the clock — and applies the seek through the sanctioned
+ * `setDateTimeFromUtc` seam (frontend CLAUDE.md hard-rule #2), clamped to the
+ * canonical date range.
+ *
+ * Mounted once above the desktop (see Desktop.tsx). Renders nothing.
+ */
+export function HyperCardClockBridge() {
+	const { setDateTime } = useClassicyDateTime();
+	// Forced-clock mode locks the date/time editors; honour it the same way the
+	// other user-driven seek writers (TimeMachine, mobile Time Travel) do.
+	const dateTimeLocked = useAppManager(
+		(s) => s.System.Manager.DateAndTime.dateTimeLocked,
+	);
+
+	// The effect handler is registered once but must always see the latest
+	// setDateTime/lock — hold them in a ref rather than re-registering.
+	const latest = useRef({ setDateTime, dateTimeLocked });
+	latest.current = { setDateTime, dateTimeLocked };
+
+	useEffect(() => {
+		registerHyperCardEffectHandler("setDateTime", (args) => {
+			const { setDateTime, dateTimeLocked } = latest.current;
+			if (dateTimeLocked) return; // the streamer's forced clock wins
+			const to = typeof args.to === "string" ? args.to : undefined;
+			if (!to) return;
+			const clamped = clampClockIso(to);
+			if (!clamped) {
+				console.warn(`HyperCard setDateTime: unparseable date "${to}"`);
+				return;
+			}
+			setDateTimeFromUtc(setDateTime, clamped.iso);
+		});
+	}, []);
+
+	return null;
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/dateRange.test.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/dateRange.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+	CLOCK_RANGE_END_ISO,
+	CLOCK_RANGE_START_ISO,
+	clampClockIso,
+	parseClockMs,
+} from "./dateRange";
+
+describe("parseClockMs", () => {
+	it("treats a naive datetime as UTC", () => {
+		expect(parseClockMs("2001-09-11T12:46:00")).toBe(Date.UTC(2001, 8, 11, 12, 46, 0));
+	});
+	it("honours an explicit zone", () => {
+		expect(parseClockMs("2001-09-11T08:46:00-04:00")).toBe(Date.UTC(2001, 8, 11, 12, 46, 0));
+	});
+	it("returns null on junk", () => {
+		expect(parseClockMs("nope")).toBeNull();
+	});
+});
+
+describe("clampClockIso", () => {
+	it("passes an in-range instant through unchanged", () => {
+		const r = clampClockIso("2001-09-11T12:46:00");
+		expect(r?.iso).toBe("2001-09-11T12:46:00.000Z");
+		expect(r?.clamped).toBe(false);
+	});
+	it("clamps below the start up to the range start", () => {
+		const r = clampClockIso("2001-09-08T00:00:00");
+		expect(r?.iso).toBe(new Date(CLOCK_RANGE_START_ISO).toISOString());
+		expect(r?.clamped).toBe(true);
+	});
+	it("clamps above the end down to the range end", () => {
+		const r = clampClockIso("2001-09-20T00:00:00");
+		expect(r?.iso).toBe(new Date(CLOCK_RANGE_END_ISO).toISOString());
+		expect(r?.clamped).toBe(true);
+	});
+	it("returns null for an unparseable request", () => {
+		expect(clampClockIso("not a date")).toBeNull();
+	});
+	it("honours custom bounds", () => {
+		const r = clampClockIso("2001-09-11T00:00:00", "2001-09-11T06:00:00Z", "2001-09-11T18:00:00Z");
+		expect(r?.iso).toBe("2001-09-11T06:00:00.000Z");
+		expect(r?.clamped).toBe(true);
+	});
+});

--- a/packages/frontend/src/Applications/HyperCard/extensions/dateRange.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/dateRange.ts
@@ -1,0 +1,52 @@
+// The canonical virtual-clock range for 911realtime. The replay data window
+// begins 2001-09-09T00:00:00Z (video-grabber/config.py) and the Weather
+// almanac only carries 09-09…09-12, so the standard authored range is those
+// four days. The `setDateTime` HyperCard action clamps into this window so a
+// stack can't seek the desktop to an instant with no data.
+//
+// Widen CLOCK_RANGE_END_ISO here (e.g. to 2001-09-18) if the product range
+// grows — it's the single source of truth for the clamp.
+export const CLOCK_RANGE_START_ISO = "2001-09-09T00:00:00Z";
+/** Exclusive-feeling upper bound: the end of 2001-09-12 (start of 09-13). */
+export const CLOCK_RANGE_END_ISO = "2001-09-13T00:00:00Z";
+
+const HAS_ZONE = /[zZ]$|[+-]\d\d:?\d\d$/;
+
+/** Parse an ISO/naive datetime as UTC ms (naive → treated as UTC). */
+export function parseClockMs(iso: string): number | null {
+	const t = iso.trim();
+	if (t === "") return null;
+	const ms = Date.parse(HAS_ZONE.test(t) ? t : `${t}Z`);
+	return Number.isNaN(ms) ? null : ms;
+}
+
+export interface ClampResult {
+	/** The clamped instant as a UTC ISO string (…Z), ready for the clock seam. */
+	iso: string;
+	/** Epoch ms of the clamped instant. */
+	ms: number;
+	/** True when the requested instant fell outside the range and was moved. */
+	clamped: boolean;
+}
+
+/**
+ * Clamp a requested datetime into [start, end]. Returns null only when the
+ * input is unparseable (an author typo) — callers should ignore that rather
+ * than seeking to Invalid Date.
+ */
+export function clampClockIso(
+	requested: string,
+	startIso: string = CLOCK_RANGE_START_ISO,
+	endIso: string = CLOCK_RANGE_END_ISO,
+): ClampResult | null {
+	const ms = parseClockMs(requested);
+	if (ms === null) return null;
+	const startMs = parseClockMs(startIso)!;
+	const endMs = parseClockMs(endIso)!;
+	const clampedMs = Math.min(Math.max(ms, startMs), endMs);
+	return {
+		iso: new Date(clampedMs).toISOString(),
+		ms: clampedMs,
+		clamped: clampedMs !== ms,
+	};
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/directusCollections.test.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/directusCollections.test.ts
@@ -4,6 +4,8 @@ import {
 	DIRECTUS_URL,
 	fetchDirectusAudioItem,
 	fetchDirectusItem,
+	fetchDirectusNewsItem,
+	fetchDirectusPagerItem,
 	fetchDirectusVideoItem,
 } from "./directusCollections";
 
@@ -80,6 +82,36 @@ describe("fetchDirectusVideoItem", () => {
 		const url = fetchFn.mock.calls[0][0] as string;
 		expect(url).toContain("/items/tv_channels/3?fields=");
 		for (const field of DIRECTUS_COLLECTIONS.video.fields) {
+			expect(url).toContain(field);
+		}
+	});
+});
+
+describe("fetchDirectusNewsItem", () => {
+	it("targets the news_items collection with the news field set", async () => {
+		const fetchFn = vi.fn().mockResolvedValue(
+			jsonResponse({ data: { id: 9, title: "Headline", content: "<p>hi</p>" } }),
+		);
+		const item = await fetchDirectusNewsItem(9, fetchFn);
+		expect(item.content).toBe("<p>hi</p>");
+		const url = fetchFn.mock.calls[0][0] as string;
+		expect(url).toContain("/items/news_items/9?fields=");
+		for (const field of DIRECTUS_COLLECTIONS.news.fields) {
+			expect(url).toContain(field);
+		}
+	});
+});
+
+describe("fetchDirectusPagerItem", () => {
+	it("targets the pager_items collection with the pager field set", async () => {
+		const fetchFn = vi.fn().mockResolvedValue(
+			jsonResponse({ data: { id: 5, message: "CALL OPS", provider: "SkyTel" } }),
+		);
+		const item = await fetchDirectusPagerItem(5, fetchFn);
+		expect(item.message).toBe("CALL OPS");
+		const url = fetchFn.mock.calls[0][0] as string;
+		expect(url).toContain("/items/pager_items/5?fields=");
+		for (const field of DIRECTUS_COLLECTIONS.pager.fields) {
 			expect(url).toContain(field);
 		}
 	});

--- a/packages/frontend/src/Applications/HyperCard/extensions/directusCollections.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/directusCollections.ts
@@ -54,6 +54,35 @@ export const DIRECTUS_COLLECTIONS = {
 			"subtitles",
 		],
 	},
+	/** History-Commons news entries (media-shaped; `content` holds HTML body). */
+	news: {
+		collection: "news_items",
+		fields: [
+			"id",
+			"title",
+			"full_title",
+			"content",
+			"start_date",
+			"image",
+			"image_caption",
+			"url",
+			"format",
+		],
+	},
+	/** Instant pager messages (bespoke shape — a message with routing metadata). */
+	pager: {
+		collection: "pager_items",
+		fields: [
+			"id",
+			"start_date",
+			"provider",
+			"recipient_id",
+			"id_type",
+			"channel",
+			"mode",
+			"message",
+		],
+	},
 } as const;
 
 export type DirectusCollectionKey = keyof typeof DIRECTUS_COLLECTIONS;
@@ -133,4 +162,50 @@ export function fetchDirectusVideoItem(
 ): Promise<DirectusVideoItem> {
 	const { collection, fields } = DIRECTUS_COLLECTIONS.video;
 	return fetchDirectusItem<DirectusVideoItem>(collection, id, fields, fetchFn, signal);
+}
+
+/** One row of the `news_items` collection — the subset a news embed reads. */
+export interface DirectusNewsItem {
+	id: number;
+	title: string;
+	full_title?: string | null;
+	/** HTML article body. */
+	content?: string | null;
+	start_date?: string | null;
+	image?: string | null;
+	image_caption?: string | null;
+	url?: string | null;
+	format?: string | null;
+}
+
+/** Fetch one `news_items` row by id, projecting the news-embed field set. */
+export function fetchDirectusNewsItem(
+	id: string | number,
+	fetchFn: typeof fetch = fetch,
+	signal?: AbortSignal,
+): Promise<DirectusNewsItem> {
+	const { collection, fields } = DIRECTUS_COLLECTIONS.news;
+	return fetchDirectusItem<DirectusNewsItem>(collection, id, fields, fetchFn, signal);
+}
+
+/** One row of the `pager_items` collection — an instant pager message. */
+export interface DirectusPagerItem {
+	id: number;
+	start_date?: string | null;
+	provider?: string | null;
+	recipient_id?: string | null;
+	id_type?: string | null;
+	channel?: string | null;
+	mode?: string | null;
+	message: string;
+}
+
+/** Fetch one `pager_items` row by id, projecting the pager-embed field set. */
+export function fetchDirectusPagerItem(
+	id: string | number,
+	fetchFn: typeof fetch = fetch,
+	signal?: AbortSignal,
+): Promise<DirectusPagerItem> {
+	const { collection, fields } = DIRECTUS_COLLECTIONS.pager;
+	return fetchDirectusItem<DirectusPagerItem>(collection, id, fields, fetchFn, signal);
 }

--- a/packages/frontend/src/Applications/HyperCard/extensions/newsPagerStack.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/newsPagerStack.ts
@@ -1,5 +1,13 @@
 import type { HCAction, HCStack } from "classicy";
 
+/**
+ * A built-in HyperCard stack demonstrating the news/pager embeds and the
+ * `setDateTime` action. The intro card's buttons seek the desktop's virtual
+ * clock to key moments (the action clamps into the 09-09…09-12 range); the
+ * news and pager cards step through real `news_items` (5–13) and `pager_items`
+ * (323–328) rows via a stack variable.
+ */
+
 // Plugin-command actions (a registered `do` name like our `setDateTime`) are
 // deliberately outside the typed HCAction union — stacks are normally untyped
 // JSON and the engine handles unknown `do`s in its default case. Authoring the
@@ -7,22 +15,18 @@ import type { HCAction, HCStack } from "classicy";
 const setDateTime = (to: string): HCAction =>
 	({ do: "setDateTime", to }) as unknown as HCAction;
 
-/**
- * A built-in HyperCard stack demonstrating the news/pager embeds and the
- * `setDateTime` action. The intro card's buttons seek the desktop's virtual
- * clock to key moments (the action clamps into the 09-09…09-12 range); the
- * later cards embed a news article and a pager message.
- *
- * The `itemId`s below are PLACEHOLDERS (1) pending real `news_items` /
- * `pager_items` ids; the parts fetch on render and degrade gracefully.
- */
-
 export const NEWS_PAGER_STACK_ID = "directus-news-pager";
+
+const NEWS_MIN = 5;
+const NEWS_MAX = 13;
+const PAGER_MIN = 323;
+const PAGER_MAX = 328;
 
 export const newsPagerStack: HCStack = {
 	name: "News & Pager",
 	version: "2",
 	size: [420, 320],
+	variables: { newsId: String(NEWS_MIN), pagerId: String(PAGER_MIN) },
 	backgrounds: [
 		{
 			id: "main",
@@ -55,7 +59,7 @@ export const newsPagerStack: HCStack = {
 					rect: [12, 48, 396, 52],
 					locked: true,
 					content:
-						"These buttons run the setDateTime action, seeking every app on the desktop to that moment. Then page through a news story and a pager message.",
+						"These buttons run the setDateTime action, seeking every app on the desktop to that moment. Then page through news stories and pager messages.",
 				},
 				{
 					id: "jump846",
@@ -74,7 +78,7 @@ export const newsPagerStack: HCStack = {
 				{
 					id: "introNext",
 					type: "button",
-					name: "Next →",
+					name: "News →",
 					rect: [304, 154, 104, 28],
 					script: {
 						onMouseUp: [
@@ -91,28 +95,52 @@ export const newsPagerStack: HCStack = {
 			background: "main",
 			parts: [
 				{
+					id: "newsTitle",
+					type: "label",
+					rect: [12, 12, 396, 20],
+					content: "News items 5–13",
+				},
+				{
 					id: "newsArticle",
 					type: "directusNews",
-					rect: [12, 12, 396, 232],
-					options: { itemId: 1 },
+					rect: [12, 36, 396, 200],
+					options: { itemId: "newsId" },
 				},
 				{
 					id: "newsPrev",
 					type: "button",
-					name: "← Prev",
-					rect: [12, 252, 104, 28],
+					name: "◀",
+					rect: [12, 244, 60, 26],
 					script: {
 						onMouseUp: [
-							{ do: "visual", effect: "wipeRight" },
-							{ do: "go", to: "prev" },
+							{
+								do: "if",
+								condition: `newsId > ${NEWS_MIN}`,
+								then: [{ do: "subtract", value: "1", var: "newsId" }],
+							},
 						],
 					},
 				},
 				{
 					id: "newsNext",
 					type: "button",
-					name: "Next →",
-					rect: [304, 252, 104, 28],
+					name: "▶",
+					rect: [80, 244, 60, 26],
+					script: {
+						onMouseUp: [
+							{
+								do: "if",
+								condition: `newsId < ${NEWS_MAX}`,
+								then: [{ do: "add", value: "1", var: "newsId" }],
+							},
+						],
+					},
+				},
+				{
+					id: "newsToPager",
+					type: "button",
+					name: "Pager →",
+					rect: [304, 244, 104, 26],
 					script: {
 						onMouseUp: [
 							{ do: "visual", effect: "wipeLeft" },
@@ -130,20 +158,50 @@ export const newsPagerStack: HCStack = {
 				{
 					id: "pagerTitle",
 					type: "label",
-					rect: [12, 14, 396, 22],
-					content: "A pager message",
+					rect: [12, 12, 396, 20],
+					content: "Pager messages 323–328",
 				},
 				{
 					id: "pagerMsg",
 					type: "directusPager",
-					rect: [12, 40, 396, 150],
-					options: { itemId: 1 },
+					rect: [12, 36, 396, 200],
+					options: { itemId: "pagerId" },
 				},
 				{
 					id: "pagerPrev",
 					type: "button",
-					name: "← Prev",
-					rect: [12, 252, 104, 28],
+					name: "◀",
+					rect: [12, 244, 60, 26],
+					script: {
+						onMouseUp: [
+							{
+								do: "if",
+								condition: `pagerId > ${PAGER_MIN}`,
+								then: [{ do: "subtract", value: "1", var: "pagerId" }],
+							},
+						],
+					},
+				},
+				{
+					id: "pagerNext",
+					type: "button",
+					name: "▶",
+					rect: [80, 244, 60, 26],
+					script: {
+						onMouseUp: [
+							{
+								do: "if",
+								condition: `pagerId < ${PAGER_MAX}`,
+								then: [{ do: "add", value: "1", var: "pagerId" }],
+							},
+						],
+					},
+				},
+				{
+					id: "pagerToNews",
+					type: "button",
+					name: "← News",
+					rect: [304, 244, 104, 26],
 					script: {
 						onMouseUp: [
 							{ do: "visual", effect: "wipeRight" },

--- a/packages/frontend/src/Applications/HyperCard/extensions/newsPagerStack.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/newsPagerStack.ts
@@ -1,0 +1,157 @@
+import type { HCAction, HCStack } from "classicy";
+
+// Plugin-command actions (a registered `do` name like our `setDateTime`) are
+// deliberately outside the typed HCAction union — stacks are normally untyped
+// JSON and the engine handles unknown `do`s in its default case. Authoring the
+// stack as a typed literal, we cast the command action back to HCAction.
+const setDateTime = (to: string): HCAction =>
+	({ do: "setDateTime", to }) as unknown as HCAction;
+
+/**
+ * A built-in HyperCard stack demonstrating the news/pager embeds and the
+ * `setDateTime` action. The intro card's buttons seek the desktop's virtual
+ * clock to key moments (the action clamps into the 09-09…09-12 range); the
+ * later cards embed a news article and a pager message.
+ *
+ * The `itemId`s below are PLACEHOLDERS (1) pending real `news_items` /
+ * `pager_items` ids; the parts fetch on render and degrade gracefully.
+ */
+
+export const NEWS_PAGER_STACK_ID = "directus-news-pager";
+
+export const newsPagerStack: HCStack = {
+	name: "News & Pager",
+	version: "2",
+	size: [420, 320],
+	backgrounds: [
+		{
+			id: "main",
+			parts: [
+				{
+					id: "footer",
+					type: "label",
+					shared: true,
+					rect: [12, 292, 396, 20],
+					content: "news_items + pager_items + the setDateTime action — Directus HyperCard extensions",
+				},
+			],
+		},
+	],
+	cards: [
+		{
+			id: "intro",
+			name: "Set the Clock",
+			background: "main",
+			parts: [
+				{
+					id: "introTitle",
+					type: "label",
+					rect: [12, 16, 396, 24],
+					content: "Jump the desktop clock",
+				},
+				{
+					id: "introText",
+					type: "field",
+					rect: [12, 48, 396, 52],
+					locked: true,
+					content:
+						"These buttons run the setDateTime action, seeking every app on the desktop to that moment. Then page through a news story and a pager message.",
+				},
+				{
+					id: "jump846",
+					type: "button",
+					name: "8:46 AM — Flight 11",
+					rect: [12, 112, 190, 28],
+					script: { onMouseUp: [setDateTime("2001-09-11T12:46:00")] },
+				},
+				{
+					id: "jump903",
+					type: "button",
+					name: "9:03 AM — Flight 175",
+					rect: [214, 112, 190, 28],
+					script: { onMouseUp: [setDateTime("2001-09-11T13:03:00")] },
+				},
+				{
+					id: "introNext",
+					type: "button",
+					name: "Next →",
+					rect: [304, 154, 104, 28],
+					script: {
+						onMouseUp: [
+							{ do: "visual", effect: "dissolve" },
+							{ do: "go", to: "next" },
+						],
+					},
+				},
+			],
+		},
+		{
+			id: "news",
+			name: "News",
+			background: "main",
+			parts: [
+				{
+					id: "newsArticle",
+					type: "directusNews",
+					rect: [12, 12, 396, 232],
+					options: { itemId: 1 },
+				},
+				{
+					id: "newsPrev",
+					type: "button",
+					name: "← Prev",
+					rect: [12, 252, 104, 28],
+					script: {
+						onMouseUp: [
+							{ do: "visual", effect: "wipeRight" },
+							{ do: "go", to: "prev" },
+						],
+					},
+				},
+				{
+					id: "newsNext",
+					type: "button",
+					name: "Next →",
+					rect: [304, 252, 104, 28],
+					script: {
+						onMouseUp: [
+							{ do: "visual", effect: "wipeLeft" },
+							{ do: "go", to: "next" },
+						],
+					},
+				},
+			],
+		},
+		{
+			id: "pager",
+			name: "Pager",
+			background: "main",
+			parts: [
+				{
+					id: "pagerTitle",
+					type: "label",
+					rect: [12, 14, 396, 22],
+					content: "A pager message",
+				},
+				{
+					id: "pagerMsg",
+					type: "directusPager",
+					rect: [12, 40, 396, 150],
+					options: { itemId: 1 },
+				},
+				{
+					id: "pagerPrev",
+					type: "button",
+					name: "← Prev",
+					rect: [12, 252, 104, 28],
+					script: {
+						onMouseUp: [
+							{ do: "visual", effect: "wipeRight" },
+							{ do: "go", to: "prev" },
+						],
+					},
+				},
+			],
+		},
+	],
+};

--- a/packages/frontend/src/Applications/HyperCard/extensions/registerHyperCardExtensions.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/registerHyperCardExtensions.ts
@@ -5,13 +5,16 @@ import {
 	registerHyperCardStack,
 } from "classicy";
 import { DirectusAudioPart } from "./DirectusAudioPart";
+import { DirectusFlightMapPart } from "./DirectusFlightMapPart";
 import { DirectusMultiviewPart } from "./DirectusMultiviewPart";
 import { DirectusNewsPart } from "./DirectusNewsPart";
 import { DirectusPagerPart } from "./DirectusPagerPart";
 import { DirectusVideoPart } from "./DirectusVideoPart";
+import { DirectusWeatherPart } from "./DirectusWeatherPart";
 import { MP3_AUDIO_STACK_ID, mp3AudioStack } from "./mp3AudioStack";
 import { NEWS_PAGER_STACK_ID, newsPagerStack } from "./newsPagerStack";
 import { TV_CHANNEL_STACK_ID, tvChannelStack } from "./tvChannelStack";
+import { WEATHER_FLIGHT_STACK_ID, weatherFlightStack } from "./weatherFlightStack";
 
 // Registration must run once, before the HyperCard app opens a stack that uses
 // a Directus part. Classicy's registries are last-write-wins Maps, so repeat
@@ -34,6 +37,8 @@ export function registerHyperCardExtensions(): void {
 	registerHyperCardPart("directusMultiview", DirectusMultiviewPart);
 	registerHyperCardPart("directusNews", DirectusNewsPart);
 	registerHyperCardPart("directusPager", DirectusPagerPart);
+	registerHyperCardPart("directusWeatherStation", DirectusWeatherPart);
+	registerHyperCardPart("directusFlightMap", DirectusFlightMapPart);
 
 	// Actions (stack commands). `setDateTime` seeks the desktop's virtual clock;
 	// the pure reducer can't touch the clock, so it queues an effect that
@@ -56,4 +61,5 @@ export function registerHyperCardExtensions(): void {
 	registerHyperCardStack(MP3_AUDIO_STACK_ID, mp3AudioStack.name, mp3AudioStack);
 	registerHyperCardStack(TV_CHANNEL_STACK_ID, tvChannelStack.name, tvChannelStack);
 	registerHyperCardStack(NEWS_PAGER_STACK_ID, newsPagerStack.name, newsPagerStack);
+	registerHyperCardStack(WEATHER_FLIGHT_STACK_ID, weatherFlightStack.name, weatherFlightStack);
 }

--- a/packages/frontend/src/Applications/HyperCard/extensions/registerHyperCardExtensions.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/registerHyperCardExtensions.ts
@@ -1,8 +1,16 @@
-import { registerHyperCardPart, registerHyperCardStack } from "classicy";
+import {
+	type HCCommandContext,
+	registerHyperCardCommand,
+	registerHyperCardPart,
+	registerHyperCardStack,
+} from "classicy";
 import { DirectusAudioPart } from "./DirectusAudioPart";
 import { DirectusMultiviewPart } from "./DirectusMultiviewPart";
+import { DirectusNewsPart } from "./DirectusNewsPart";
+import { DirectusPagerPart } from "./DirectusPagerPart";
 import { DirectusVideoPart } from "./DirectusVideoPart";
 import { MP3_AUDIO_STACK_ID, mp3AudioStack } from "./mp3AudioStack";
+import { NEWS_PAGER_STACK_ID, newsPagerStack } from "./newsPagerStack";
 import { TV_CHANNEL_STACK_ID, tvChannelStack } from "./tvChannelStack";
 
 // Registration must run once, before the HyperCard app opens a stack that uses
@@ -24,8 +32,28 @@ export function registerHyperCardExtensions(): void {
 	registerHyperCardPart("directusAudio", DirectusAudioPart);
 	registerHyperCardPart("directusVideo", DirectusVideoPart);
 	registerHyperCardPart("directusMultiview", DirectusMultiviewPart);
+	registerHyperCardPart("directusNews", DirectusNewsPart);
+	registerHyperCardPart("directusPager", DirectusPagerPart);
+
+	// Actions (stack commands). `setDateTime` seeks the desktop's virtual clock;
+	// the pure reducer can't touch the clock, so it queues an effect that
+	// HyperCardClockBridge (mounted in Desktop) applies through the sanctioned
+	// setDateTimeFromUtc seam. `to` is a UTC datetime literal; `toVar` reads it
+	// from a stack variable instead.
+	registerHyperCardCommand("setDateTime", {
+		run: (ctx: HCCommandContext, action) => {
+			const to =
+				typeof action.toVar === "string"
+					? String(ctx.getVar(action.toVar) ?? "")
+					: typeof action.to === "string"
+						? action.to
+						: "";
+			if (to) ctx.queueEffect("setDateTime", { to });
+		},
+	});
 
 	// Built-in stacks that demonstrate the parts (File → Open in HyperCard).
 	registerHyperCardStack(MP3_AUDIO_STACK_ID, mp3AudioStack.name, mp3AudioStack);
 	registerHyperCardStack(TV_CHANNEL_STACK_ID, tvChannelStack.name, tvChannelStack);
+	registerHyperCardStack(NEWS_PAGER_STACK_ID, newsPagerStack.name, newsPagerStack);
 }

--- a/packages/frontend/src/Applications/HyperCard/extensions/useDirectusItem.test.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/useDirectusItem.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { resolveItemId } from "./useDirectusItem";
+
+const identity = (e: string) => e;
+
+describe("resolveItemId", () => {
+	it("uses the option id when set", () => {
+		expect(resolveItemId(42, "", identity)).toBe("42");
+	});
+	it("falls back to the field value", () => {
+		expect(resolveItemId(undefined, "7", identity)).toBe("7");
+	});
+	it("prefers the option id over the field value", () => {
+		expect(resolveItemId(3, "9", identity)).toBe("3");
+	});
+	it("resolves through the expression engine", () => {
+		expect(resolveItemId("clip", "", (e) => (e === "clip" ? "5" : e))).toBe("5");
+	});
+	it("is undefined when nothing usable is set", () => {
+		expect(resolveItemId(undefined, "", identity)).toBeUndefined();
+		expect(resolveItemId("", "", identity)).toBeUndefined();
+	});
+});

--- a/packages/frontend/src/Applications/HyperCard/extensions/useDirectusItem.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/useDirectusItem.ts
@@ -1,0 +1,60 @@
+import { useEffect, useState } from "react";
+
+// Shared load plumbing for id-keyed collection embeds (news, pager, …). The
+// audio/video parts predate this and inline their own copy; new single-item
+// parts use these helpers instead of duplicating the fetch/abort/load-state
+// dance.
+
+/**
+ * Resolve an embed's item id from its authored option (passed through the stack
+ * expression engine, so it can reference a variable/field) with a fallback to
+ * the part's own field `value`. Returns undefined when nothing usable is set.
+ */
+export function resolveItemId(
+	optionId: string | number | undefined,
+	value: string,
+	resolve: (expr: string) => string,
+): string | undefined {
+	const raw = optionId ?? value;
+	if (raw === undefined || raw === "") return undefined;
+	const resolved = resolve(String(raw)).trim();
+	return resolved === "" ? undefined : resolved;
+}
+
+export type ItemLoadState<T> =
+	| { status: "idle" }
+	| { status: "loading" }
+	| { status: "ready"; item: T }
+	| { status: "error"; message: string };
+
+/**
+ * Fetch a single Directus item by resolved id, exposing an idle/loading/ready/
+ * error state. One in-flight request per id; aborts on id change / unmount.
+ */
+export function useDirectusItem<T>(
+	id: string | undefined,
+	fetcher: (id: string, fetchFn: typeof fetch, signal: AbortSignal) => Promise<T>,
+): ItemLoadState<T> {
+	const [state, setState] = useState<ItemLoadState<T>>({ status: "idle" });
+
+	useEffect(() => {
+		if (id === undefined) {
+			setState({ status: "idle" });
+			return;
+		}
+		const controller = new AbortController();
+		setState({ status: "loading" });
+		fetcher(id, fetch, controller.signal)
+			.then((item) => setState({ status: "ready", item }))
+			.catch((err: unknown) => {
+				if (controller.signal.aborted) return;
+				setState({
+					status: "error",
+					message: err instanceof Error ? err.message : String(err),
+				});
+			});
+		return () => controller.abort();
+	}, [id, fetcher]);
+
+	return state;
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/weatherFlightStack.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/weatherFlightStack.ts
@@ -1,0 +1,129 @@
+import type { HCAction, HCStack } from "classicy";
+
+/**
+ * A built-in HyperCard stack demonstrating the weather-station and flight-map
+ * embeds. The flight map only shows planes when the clock sits in the 9/11
+ * morning window, so the second card includes a setDateTime button.
+ */
+
+// Plugin-command actions are outside the typed HCAction union (see
+// newsPagerStack.ts) — cast the setDateTime command back to HCAction.
+const setDateTime = (to: string): HCAction =>
+	({ do: "setDateTime", to }) as unknown as HCAction;
+
+export const WEATHER_FLIGHT_STACK_ID = "directus-weather-flight";
+
+export const weatherFlightStack: HCStack = {
+	name: "Weather & Flights",
+	version: "2",
+	size: [420, 340],
+	variables: { wxStation: "KJFK" },
+	backgrounds: [
+		{
+			id: "main",
+			parts: [
+				{
+					id: "footer",
+					type: "label",
+					shared: true,
+					rect: [12, 312, 396, 20],
+					content: "tv_channels weather stations + the flight map — Directus HyperCard extensions",
+				},
+			],
+		},
+	],
+	cards: [
+		{
+			id: "weather",
+			name: "Weather",
+			background: "main",
+			parts: [
+				{
+					id: "wxTitle",
+					type: "label",
+					rect: [12, 14, 396, 22],
+					content: "Weather station",
+				},
+				{
+					id: "wxPanel",
+					// station resolves through the expression engine, so the buttons
+					// below can switch it via the wxStation variable.
+					type: "directusWeatherStation",
+					rect: [12, 40, 396, 210],
+					options: { station: "wxStation" },
+				},
+				{
+					id: "wxJFK",
+					type: "button",
+					name: "JFK",
+					rect: [12, 258, 74, 26],
+					script: { onMouseUp: [{ do: "put", value: "KJFK", var: "wxStation" }] },
+				},
+				{
+					id: "wxBOS",
+					type: "button",
+					name: "Boston",
+					rect: [94, 258, 74, 26],
+					script: { onMouseUp: [{ do: "put", value: "KBOS", var: "wxStation" }] },
+				},
+				{
+					id: "wxIAD",
+					type: "button",
+					name: "Dulles",
+					rect: [176, 258, 74, 26],
+					script: { onMouseUp: [{ do: "put", value: "KIAD", var: "wxStation" }] },
+				},
+				{
+					id: "wxNext",
+					type: "button",
+					name: "Flights →",
+					rect: [304, 258, 104, 26],
+					script: {
+						onMouseUp: [
+							{ do: "visual", effect: "dissolve" },
+							{ do: "go", to: "next" },
+						],
+					},
+				},
+			],
+		},
+		{
+			id: "flights",
+			name: "Flights",
+			background: "main",
+			parts: [
+				{
+					id: "flTitle",
+					type: "label",
+					rect: [12, 14, 260, 22],
+					content: "Notable flights, live",
+				},
+				{
+					id: "flJump",
+					type: "button",
+					name: "Jump to 8:46 AM",
+					rect: [276, 12, 132, 26],
+					script: { onMouseUp: [setDateTime("2001-09-11T12:46:00")] },
+				},
+				{
+					id: "flMap",
+					type: "directusFlightMap",
+					rect: [12, 44, 396, 206],
+					options: { notablesOnly: true, mapStyle: "radar" },
+				},
+				{
+					id: "flPrev",
+					type: "button",
+					name: "← Weather",
+					rect: [12, 258, 104, 26],
+					script: {
+						onMouseUp: [
+							{ do: "visual", effect: "wipeRight" },
+							{ do: "go", to: "prev" },
+						],
+					},
+				},
+			],
+		},
+	],
+};

--- a/packages/frontend/src/Applications/HyperCard/index.ts
+++ b/packages/frontend/src/Applications/HyperCard/index.ts
@@ -19,6 +19,8 @@ export { DirectusVideo, DirectusVideoPart } from "./extensions/DirectusVideoPart
 export { DirectusMultiviewPart } from "./extensions/DirectusMultiviewPart";
 export { DirectusNewsPart } from "./extensions/DirectusNewsPart";
 export { DirectusPagerPart } from "./extensions/DirectusPagerPart";
+export { DirectusWeatherPart } from "./extensions/DirectusWeatherPart";
+export { DirectusFlightMapPart } from "./extensions/DirectusFlightMapPart";
 export { HyperCardClockBridge } from "./extensions/HyperCardClockBridge";
 export {
 	CLOCK_RANGE_START_ISO,

--- a/packages/frontend/src/Applications/HyperCard/index.ts
+++ b/packages/frontend/src/Applications/HyperCard/index.ts
@@ -17,11 +17,23 @@ export { tvChannelStack, TV_CHANNEL_STACK_ID } from "./extensions/tvChannelStack
 export { DirectusAudioPart } from "./extensions/DirectusAudioPart";
 export { DirectusVideo, DirectusVideoPart } from "./extensions/DirectusVideoPart";
 export { DirectusMultiviewPart } from "./extensions/DirectusMultiviewPart";
+export { DirectusNewsPart } from "./extensions/DirectusNewsPart";
+export { DirectusPagerPart } from "./extensions/DirectusPagerPart";
+export { HyperCardClockBridge } from "./extensions/HyperCardClockBridge";
+export {
+	CLOCK_RANGE_START_ISO,
+	CLOCK_RANGE_END_ISO,
+	clampClockIso,
+} from "./extensions/dateRange";
 export {
 	DIRECTUS_COLLECTIONS,
 	fetchDirectusAudioItem,
 	fetchDirectusItem,
 	fetchDirectusVideoItem,
+	fetchDirectusNewsItem,
+	fetchDirectusPagerItem,
 	type DirectusAudioItem,
 	type DirectusVideoItem,
+	type DirectusNewsItem,
+	type DirectusPagerItem,
 } from "./extensions/directusCollections";

--- a/packages/frontend/src/Applications/Weather/Weather.tsx
+++ b/packages/frontend/src/Applications/Weather/Weather.tsx
@@ -1,7 +1,6 @@
 import {
 	ClassicyApp,
 	ClassicyButton,
-	ClassicyControlGroup,
 	ClassicyIcons,
 	ClassicyPopUpMenu,
 	ClassicySlider,
@@ -16,10 +15,10 @@ import { type FC, useCallback, useContext, useEffect, useMemo, useState } from "
 import appIconPng from "./app.png";
 import { MediaStreamContext } from "../../Providers/MediaStream/MediaStreamContext";
 import { BASEMAP_URLS, type BasemapStyleId } from "../../lib/basemap/basemapStyles";
-import { useAlmanac } from "./useAlmanac";
+import { ALMANAC_DAYS, useAlmanac } from "./useAlmanac";
 import type { RadarIndex } from "./weatherRadar";
-import { cToF, degToCompass, hpaToInHg, kmToMiles, ktToMph } from "./weatherUnits";
 import { WeatherMap, type WeatherStation } from "./WeatherMap";
+import { WeatherStationPanel } from "./WeatherStationPanel";
 import stationsRaw from "./stations.json";
 import styles from "./Weather.module.scss";
 import { formatPlayhead, type LoopClock, playheadAt } from "../../lib/loopClock";
@@ -41,43 +40,6 @@ const RADAR_INDEX_URL = "https://files.911realtime.org/weather/radar/index.json"
 const STATIONS = stationsRaw as WeatherStation[];
 
 const DEFAULT_STATION_ID = "KJFK";
-
-// Almanac data exists only for these four calendar days (the weather-recon
-// almanac flow's anachronism-cutoff window) — outside this range the block
-// is hidden entirely rather than showing an empty/misleading section.
-const ALMANAC_DAYS = new Set(["09-09", "09-10", "09-11", "09-12"]);
-
-// "8:55 AM"-style local time for a UTC instant, rendered in the *station's*
-// own timezone (its `tz` field) — this is "what does the station's local
-// clock read", not the app's display-timezone menu-bar clock.
-function formatStationTime(iso: string, tz: string): string {
-	return new Intl.DateTimeFormat("en-US", {
-		timeZone: tz,
-		hour: "numeric",
-		minute: "2-digit",
-		hour12: true,
-	}).format(new Date(iso));
-}
-
-// METAR visibility reports cap at 10sm; kmToMiles itself is uncapped, so the
-// display cap is applied here, at render time, not in the unit conversion.
-function formatVisibility(km: number): string {
-	const mi = kmToMiles(km);
-	return mi >= 10 ? "10 mi" : `${mi} mi`;
-}
-
-// Absent wind speed means no reading at all ("—"); direction and gusts are
-// each optional add-ons layered onto a present speed.
-function formatWind(
-	dirDeg: number | undefined,
-	speedKt: number | undefined,
-	gustKt: number | undefined,
-): string {
-	if (speedKt === undefined) return "—";
-	const dir = dirDeg !== undefined ? `${degToCompass(dirDeg)} ` : "";
-	const gust = gustKt !== undefined ? ` (gusts ${ktToMph(gustKt)} mph)` : "";
-	return `${dir}${ktToMph(speedKt)} mph${gust}`;
-}
 
 // This app's own icon, registered into the shared registry at
 // ClassicyIcons.applications.weather.app. registerClassicyIcons assigns
@@ -346,100 +308,13 @@ export const Weather: FC = () => {
 							/>
 						</div>
 						<div className={styles.panel}>
-							{!station ? (
-								<p className={styles.panelEmpty}>Select a station.</p>
-							) : (
-								<>
-									<div className={styles.stationHeader}>
-										<span className={styles.stationName}>{station.name}</span>
-										<span className={styles.stationAsOf}>
-											{obs
-												? `as of ${formatStationTime(obs.start_date, station.tz)}`
-												: "no recent observation"}
-										</span>
-									</div>
-
-									<ClassicyControlGroup label="Conditions">
-										<span className={styles.tempBig}>
-											{obs?.temp_c !== undefined ? `${cToF(obs.temp_c)}°F` : "—"}
-										</span>
-										<div className={styles.skyLine}>
-											{[obs?.sky_condition, obs?.present_weather]
-												.filter(Boolean)
-												.join(" ") || "—"}
-										</div>
-										<dl className={styles.fields}>
-											<dt>Wind</dt>
-											<dd>
-												{formatWind(obs?.wind_dir_deg, obs?.wind_speed_kt, obs?.gust_kt)}
-											</dd>
-											<dt>Visibility</dt>
-											<dd>
-												{obs?.visibility_km !== undefined
-													? formatVisibility(obs.visibility_km)
-													: "—"}
-											</dd>
-											<dt>Pressure</dt>
-											<dd>
-												{obs?.pressure_hpa !== undefined
-													? `${hpaToInHg(obs.pressure_hpa)} inHg`
-													: "—"}
-											</dd>
-											<dt>Dewpoint</dt>
-											<dd>
-												{obs?.dewpoint_c !== undefined ? `${cToF(obs.dewpoint_c)}°F` : "—"}
-											</dd>
-										</dl>
-									</ClassicyControlGroup>
-
-									<ClassicyControlGroup label="Forecast">
-										{!station.nws_zone ? (
-											<p className={styles.note}>
-												No archived forecast for this station.
-											</p>
-										) : forecastEntry === undefined ? (
-											<p className={styles.note}>retrieving…</p>
-										) : forecastEntry === null ? (
-											<p className={styles.note}>No forecast product at this hour.</p>
-										) : (
-											<pre className={styles.forecastText}>{forecastEntry.raw_text}</pre>
-										)}
-									</ClassicyControlGroup>
-
-									{showAlmanac && (
-									<ClassicyControlGroup label="Almanac">
-											{almanacDay ? (
-												<div className={styles.almanacDay}>
-													<span>
-														Normal high/low:{" "}
-														{almanacDay.normal_high_c !== null
-															? `${cToF(almanacDay.normal_high_c)}°F`
-															: "—"}
-														{" / "}
-														{almanacDay.normal_low_c !== null
-															? `${cToF(almanacDay.normal_low_c)}°F`
-															: "—"}
-													</span>
-													<span>
-														Record high:{" "}
-														{almanacDay.record_high_c !== null
-															? `${cToF(almanacDay.record_high_c)}°F (${almanacDay.record_high_year})`
-															: "—"}
-													</span>
-													<span>
-														Record low:{" "}
-														{almanacDay.record_low_c !== null
-															? `${cToF(almanacDay.record_low_c)}°F (${almanacDay.record_low_year})`
-															: "—"}
-													</span>
-												</div>
-											) : (
-												<p className={styles.note}>No almanac data.</p>
-											)}
-										</ClassicyControlGroup>
-									)}
-								</>
-							)}
+							<WeatherStationPanel
+								station={station}
+								obs={obs}
+								forecastEntry={forecastEntry}
+								almanacDay={almanacDay}
+								showAlmanac={showAlmanac}
+							/>
 						</div>
 					</div>
 					{loopEnabled && (

--- a/packages/frontend/src/Applications/Weather/WeatherStationPanel.tsx
+++ b/packages/frontend/src/Applications/Weather/WeatherStationPanel.tsx
@@ -1,0 +1,145 @@
+import { ClassicyControlGroup } from "classicy";
+import type { FC } from "react";
+import type {
+	WeatherForecast,
+	WeatherObservation,
+} from "../../Providers/MediaStream/MediaStreamContext";
+import type { AlmanacDay } from "./useAlmanac";
+import { cToF, degToCompass, hpaToInHg, kmToMiles, ktToMph } from "./weatherUnits";
+import type { WeatherStation } from "./WeatherMap";
+import styles from "./Weather.module.scss";
+
+// "8:55 AM"-style local time for a UTC instant, rendered in the *station's* own
+// timezone (its `tz` field) — "what the station's local clock reads", not the
+// app's display-timezone menu-bar clock.
+function formatStationTime(iso: string, tz: string): string {
+	return new Intl.DateTimeFormat("en-US", {
+		timeZone: tz,
+		hour: "numeric",
+		minute: "2-digit",
+		hour12: true,
+	}).format(new Date(iso));
+}
+
+// METAR visibility reports cap at 10sm; kmToMiles is uncapped, so the display
+// cap is applied here at render time, not in the unit conversion.
+function formatVisibility(km: number): string {
+	const mi = kmToMiles(km);
+	return mi >= 10 ? "10 mi" : `${mi} mi`;
+}
+
+// Absent wind speed means no reading at all ("—"); direction and gusts are each
+// optional add-ons layered onto a present speed.
+function formatWind(
+	dirDeg: number | undefined,
+	speedKt: number | undefined,
+	gustKt: number | undefined,
+): string {
+	if (speedKt === undefined) return "—";
+	const dir = dirDeg !== undefined ? `${degToCompass(dirDeg)} ` : "";
+	const gust = gustKt !== undefined ? ` (gusts ${ktToMph(gustKt)} mph)` : "";
+	return `${dir}${ktToMph(speedKt)} mph${gust}`;
+}
+
+export interface WeatherStationPanelProps {
+	station: WeatherStation | null;
+	obs: WeatherObservation | undefined;
+	/** undefined = pending, null = confirmed no product, else the forecast. */
+	forecastEntry: WeatherForecast | null | undefined;
+	almanacDay: AlmanacDay | null;
+	/** Whether the current virtual day falls inside the almanac window. */
+	showAlmanac: boolean;
+}
+
+/**
+ * The station readout — conditions, forecast, almanac — for one weather
+ * station. Extracted from Weather.tsx so both the Weather app and the
+ * `directusWeatherStation` HyperCard embed render the identical panel.
+ */
+export const WeatherStationPanel: FC<WeatherStationPanelProps> = ({
+	station,
+	obs,
+	forecastEntry,
+	almanacDay,
+	showAlmanac,
+}) => {
+	if (!station) {
+		return <p className={styles.panelEmpty}>Select a station.</p>;
+	}
+	return (
+		<>
+			<div className={styles.stationHeader}>
+				<span className={styles.stationName}>{station.name}</span>
+				<span className={styles.stationAsOf}>
+					{obs
+						? `as of ${formatStationTime(obs.start_date, station.tz)}`
+						: "no recent observation"}
+				</span>
+			</div>
+
+			<ClassicyControlGroup label="Conditions">
+				<span className={styles.tempBig}>
+					{obs?.temp_c !== undefined ? `${cToF(obs.temp_c)}°F` : "—"}
+				</span>
+				<div className={styles.skyLine}>
+					{[obs?.sky_condition, obs?.present_weather].filter(Boolean).join(" ") || "—"}
+				</div>
+				<dl className={styles.fields}>
+					<dt>Wind</dt>
+					<dd>{formatWind(obs?.wind_dir_deg, obs?.wind_speed_kt, obs?.gust_kt)}</dd>
+					<dt>Visibility</dt>
+					<dd>
+						{obs?.visibility_km !== undefined ? formatVisibility(obs.visibility_km) : "—"}
+					</dd>
+					<dt>Pressure</dt>
+					<dd>
+						{obs?.pressure_hpa !== undefined ? `${hpaToInHg(obs.pressure_hpa)} inHg` : "—"}
+					</dd>
+					<dt>Dewpoint</dt>
+					<dd>{obs?.dewpoint_c !== undefined ? `${cToF(obs.dewpoint_c)}°F` : "—"}</dd>
+				</dl>
+			</ClassicyControlGroup>
+
+			<ClassicyControlGroup label="Forecast">
+				{!station.nws_zone ? (
+					<p className={styles.note}>No archived forecast for this station.</p>
+				) : forecastEntry === undefined ? (
+					<p className={styles.note}>retrieving…</p>
+				) : forecastEntry === null ? (
+					<p className={styles.note}>No forecast product at this hour.</p>
+				) : (
+					<pre className={styles.forecastText}>{forecastEntry.raw_text}</pre>
+				)}
+			</ClassicyControlGroup>
+
+			{showAlmanac && (
+				<ClassicyControlGroup label="Almanac">
+					{almanacDay ? (
+						<div className={styles.almanacDay}>
+							<span>
+								Normal high/low:{" "}
+								{almanacDay.normal_high_c !== null ? `${cToF(almanacDay.normal_high_c)}°F` : "—"}
+								{" / "}
+								{almanacDay.normal_low_c !== null ? `${cToF(almanacDay.normal_low_c)}°F` : "—"}
+							</span>
+							<span>
+								Record high:{" "}
+								{almanacDay.record_high_c !== null
+									? `${cToF(almanacDay.record_high_c)}°F (${almanacDay.record_high_year})`
+									: "—"}
+							</span>
+							<span>
+								Record low:{" "}
+								{almanacDay.record_low_c !== null
+									? `${cToF(almanacDay.record_low_c)}°F (${almanacDay.record_low_year})`
+									: "—"}
+							</span>
+						</div>
+					) : (
+						<p className={styles.note}>No almanac data.</p>
+					)}
+				</ClassicyControlGroup>
+			)}
+		</>
+	);
+};

--- a/packages/frontend/src/Applications/Weather/useAlmanac.ts
+++ b/packages/frontend/src/Applications/Weather/useAlmanac.ts
@@ -35,6 +35,21 @@ export function almanacUrl(stationId: string): string {
 	return `${ALMANAC_BASE}${stationId}.json`;
 }
 
+// Almanac data exists only for these four calendar days (the weather-recon
+// almanac flow's anachronism-cutoff window). Outside this range the almanac
+// block is hidden rather than showing an empty/misleading section.
+export const ALMANAC_DAYS: ReadonlySet<string> = new Set([
+	"09-09",
+	"09-10",
+	"09-11",
+	"09-12",
+]);
+
+/** True when an "MM-DD" day key falls inside the almanac window. */
+export function isAlmanacDay(mmdd: string): boolean {
+	return ALMANAC_DAYS.has(mmdd);
+}
+
 // Fetch a station's almanac file, cached by station_id (the file is
 // immutable/static). Aborts an in-flight request when the station changes
 // or the component unmounts. A miss or error surfaces as `error` with a

--- a/packages/frontend/src/Desktop.tsx
+++ b/packages/frontend/src/Desktop.tsx
@@ -4,6 +4,7 @@ import { ClassicyDesktop } from "classicy";
 // stacks with classicy's HyperCard plugin registries. The HyperCard app itself
 // is bundled in classicy and auto-mounted by ClassicyDesktop.
 import "./Applications/HyperCard";
+import { HyperCardClockBridge } from "./Applications/HyperCard/extensions/HyperCardClockBridge";
 import { Account } from "./Applications/Account/Account";
 import { Browser } from "./Applications/Browser/Browser";
 import { Feedback } from "./Applications/Feedback/Feedback";
@@ -22,6 +23,7 @@ import { Weather } from "./Applications/Weather/Weather";
 export default function Desktop() {
 	return (
 		<ClassicyDesktop>
+			<HyperCardClockBridge />
 			<Browser />
 			<TimeMachine />
 			<Feedback />


### PR DESCRIPTION
## What & why

Continues the Directus-collection HyperCard extensions (after the merged audio #275 and video #276) with four more embeds and a clock-seeking action. HyperCard stacks are portable JSON and can't fetch, so each part fetches/reads live data at render time and paints it into the card's `rect`. This repo only supplies content for the bundled HyperCard app.

## New parts

- **`directusNews`** — one `news_items` article: headline, dateline, image, first-party HTML body (rendered like the News app). `showImage`/`showDate` options.
- **`directusPager`** — one `pager_items` message as an LCD-style readout with provider/recipient/mode metadata.
- **`directusWeatherStation`** — one station's live conditions/forecast/almanac. Reuses the Weather app's station panel, which this PR **extracts** from `Weather.tsx` into a shared `WeatherStationPanel` (behavior preserved). Reads the shared clock + streamed weather channel (ref-counted subscribe).
- **`directusFlightMap`** — a live plane map at the current virtual instant, reusing the Flight Tracker's `FlightMap` (maplibre/WebGL). Options: `notablesOnly`, focus a callsign (`flyTo`), `mapStyle`/`darkMap`/`radarSweep`/`trailMultiplier`, pin-color overrides. **Requires WebGL + a sized card.**

## New action

- **`setDateTime`** — seeks the desktop's virtual clock (every app follows). A registered command queues an effect; `HyperCardClockBridge` (mounted in `Desktop.tsx`) applies it through the sanctioned `setDateTimeFromUtc` seam, **clamped to 2001-09-09…09-12** (the almanac-data window, `dateRange.ts`) and skipped while the streamer's forced clock is locked. Supports `to` (UTC literal) and `toVar` (from a stack variable).

## Supporting changes

- `useDirectusItem.ts` — shared id-resolution + fetch/load-state hook for id-keyed parts.
- `directusCollections.ts` — `news`/`pager` collections + row types/fetchers.
- `Weather/WeatherStationPanel.tsx` (extracted) and `Weather/useAlmanac.ts` (`ALMANAC_DAYS`/`isAlmanacDay` moved to their domain module).
- Demo stacks: **News & Pager** (steps real `news_items` 5–13 / `pager_items` 323–328 with guarded prev/next; clock-jump buttons) and **Weather & Flights** (station picker KJFK/KBOS/KIAD + a notables-only flight map).
- Co-located tests; README documents authoring each.

## Verification

Rebased onto latest `main` (which includes the classicy 0.41.6 pop-up-menu test migration). Full frontend suite green on 0.41.6 — **1248 tests, 0 failures**, including 40+ new tests. Parts/commands/stacks validated against classicy's runtime (`validateStack`, `getHyperCardPart`, `getHyperCardCommand`). Live Directus/HLS/WebSocket/WebGL paths run in the browser; the sandbox blocks `api-beta` and has no GL, so those aren't exercised here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C449E6WHyMkjFVHKELYcmB