### PR TITLE
Declutter Account app: tinted body, tabbed fields, bevel-button avatar

### DIFF
--- a/packages/frontend/src/Applications/Account/Account.module.scss
+++ b/packages/frontend/src/Applications/Account/Account.module.scss
@@ -1,0 +1,92 @@
+// Account app — declutter pass. The window body is filled with the Platinum
+// "system-03" surface (the same fill the Appearance Manager control panel
+// uses) and the profile fields are grouped under Classicy tabs; the profile
+// image is a bevel button that opens the avatar picker.
+
+.accountContent {
+	background-color: var(--color-system-03);
+	width: 100%;
+	box-sizing: border-box;
+	padding: var(--window-padding-size);
+	min-width: 360px;
+}
+
+// Identity header: profile-image bevel button beside the name + sign-out.
+.identity {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: var(--window-padding-size);
+	margin-bottom: var(--window-padding-size);
+}
+
+.identityInfo {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: calc(var(--window-padding-size) / 2);
+}
+
+.identityName {
+	font-weight: bold;
+}
+
+.playlists {
+	color: var(--color-system-06);
+}
+
+// The bevel button sizes to this image; keep it a tidy square avatar.
+.avatarImage {
+	display: block;
+	width: 74px;
+	height: 74px;
+	object-fit: cover;
+}
+
+// Shown inside the bevel button when the user has no avatar yet.
+.avatarPlaceholder {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 74px;
+	height: 74px;
+	text-align: center;
+}
+
+// The Classicy file input carries its own "Choose File…" chrome; the bevel
+// button is the trigger here, so the input (its visually-hidden native
+// element still reachable by id) is tucked away.
+.hiddenFileInput {
+	display: none;
+}
+
+.banner {
+	margin-bottom: calc(var(--window-padding-size) / 2);
+}
+
+.error {
+	color: #c00;
+	margin-bottom: calc(var(--window-padding-size) / 2);
+}
+
+// One tab panel's worth of stacked fields.
+.tabPanel {
+	display: flex;
+	flex-direction: column;
+	gap: calc(var(--window-padding-size) / 2);
+	align-items: flex-start;
+	padding-top: calc(var(--window-padding-size) / 2);
+}
+
+// The toggle-button multi-selects (grade levels, subjects) wrap into rows.
+.toggleGroup {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	gap: calc(var(--window-padding-size) / 4);
+}
+
+.fieldNote {
+	color: var(--color-system-06);
+}
+

--- a/packages/frontend/src/Applications/Account/Account.tsx
+++ b/packages/frontend/src/Applications/Account/Account.tsx
@@ -1,5 +1,6 @@
 import {
 	ClassicyApp,
+	ClassicyBevelButton,
 	ClassicyButton,
 	ClassicyFileInput,
 	ClassicyIcons,
@@ -13,6 +14,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAuth } from "../../Providers/Auth/AuthContext";
 import { avatarUrl, uploadAvatar, verifyRegistration } from "../../Providers/Auth/authApi";
 import { confirmEmailChange } from "../../Providers/Auth/profileApi";
+import styles from "./Account.module.scss";
 import { ProfileEditor } from "./ProfileEditor";
 import { SignInForm } from "./SignInForm";
 
@@ -166,31 +168,55 @@ export const Account: React.FC<AccountProps> = ({ hostnameForTest }) => {
 				modal={false}
 				appMenu={appMenu}
 			>
-				{regResult && <div>{regResult}</div>}
-				{confirmBanner && <div>{confirmBanner}</div>}
+				{regResult && <div className={styles.banner}>{regResult}</div>}
+				{confirmBanner && <div className={styles.banner}>{confirmBanner}</div>}
 				{status === "loading" ? (
 					<div />
 				) : status === "signedIn" ? (
-					<div>
-						<div>{`Signed in as ${user?.first_name ?? user?.email}`}</div>
-						<ClassicyButton onClickFunc={() => void signOut()}>Sign Out</ClassicyButton>
-						<div>My Playlists — coming soon</div>
-						{user?.avatar && (
-							<img src={avatarUrl(user.avatar)} alt="Your avatar" width={74} height={74} />
-						)}
-						<ClassicyFileInput
-							id="account-avatar-file"
-							accept="image/*"
-							disabled={avatarUploading}
-							onChangeFunc={handleAvatarFiles}
-						/>
-						<ClassicyButton
-							disabled={avatarUploading}
-							onClickFunc={() => document.getElementById("account-avatar-file")?.click()}
-						>
-							{user?.avatar ? "Change Avatar" : "Upload Avatar"}
-						</ClassicyButton>
-						{avatarError && <div>{avatarError}</div>}
+					<div className={styles.accountContent}>
+						<div className={styles.identity}>
+							{/* Profile image doubles as the avatar picker: a bevel
+							    button showing the current avatar (or an "Add Photo"
+							    prompt) that clicks through to the hidden file input. */}
+							<ClassicyBevelButton
+								bevelWidth="large"
+								disabled={avatarUploading}
+								aria-label={user?.avatar ? "Change Avatar" : "Upload Avatar"}
+								onClickFunc={() =>
+									document.getElementById("account-avatar-file")?.click()
+								}
+							>
+								{user?.avatar ? (
+									<img
+										className={styles.avatarImage}
+										src={avatarUrl(user.avatar)}
+										alt="Your avatar"
+										width={74}
+										height={74}
+									/>
+								) : (
+									<span className={styles.avatarPlaceholder}>Add Photo</span>
+								)}
+							</ClassicyBevelButton>
+							<div className={styles.identityInfo}>
+								<div className={styles.identityName}>
+									{`Signed in as ${user?.first_name ?? user?.email}`}
+								</div>
+								<div className={styles.playlists}>My Playlists — coming soon</div>
+								<ClassicyButton onClickFunc={() => void signOut()}>
+									Sign Out
+								</ClassicyButton>
+							</div>
+						</div>
+						<div className={styles.hiddenFileInput}>
+							<ClassicyFileInput
+								id="account-avatar-file"
+								accept="image/*"
+								disabled={avatarUploading}
+								onChangeFunc={handleAvatarFiles}
+							/>
+						</div>
+						{avatarError && <div className={styles.error}>{avatarError}</div>}
 						<ProfileEditor />
 					</div>
 				) : (

--- a/packages/frontend/src/Applications/Account/ProfileEditor.test.tsx
+++ b/packages/frontend/src/Applications/Account/ProfileEditor.test.tsx
@@ -24,6 +24,11 @@ vi.mock("../../Providers/Auth/AuthContext", () => ({
 
 import { ProfileEditor } from "./ProfileEditor";
 
+// Fields are grouped under Classicy tabs; inactive panels render `hidden`, so
+// their controls are out of the accessibility tree until the tab is selected.
+// ClassicyTabs commits the active tab on mouseUp (not click).
+const selectTab = (name: string) => fireEvent.mouseUp(screen.getByRole("tab", { name }));
+
 const makeUser = (over: Partial<AuthUser>): AuthUser => ({
 	id: "1", email: "t@x.org", first_name: null, last_name: null, avatar: null,
 	provider: "google", city: null, state: null, country: null,
@@ -67,6 +72,7 @@ describe("ProfileEditor — names", () => {
 describe("ProfileEditor — about you (all optional)", () => {
 	it("saves with everything empty (never blocks)", async () => {
 		render(<ProfileEditor />);
+		selectTab("About You");
 		fireEvent.click(screen.getByRole("button", { name: "Save Profile" }));
 		await waitFor(() => expect(mockUpdateProfile).toHaveBeenCalled());
 		const patch = mockUpdateProfile.mock.calls[0][0];
@@ -76,6 +82,7 @@ describe("ProfileEditor — about you (all optional)", () => {
 	});
 	it("round-trips educator role and toggled grade levels", async () => {
 		render(<ProfileEditor />);
+		selectTab("About You");
 		// ClassicyPopUpMenu renders as a <button id=…> + a listbox that mounts on
 		// open (classicy quirk: the label isn't htmlFor-associated) — open it by id
 		// and click the option's visible label.
@@ -97,6 +104,7 @@ describe("ProfileEditor — about you (all optional)", () => {
 describe("ProfileEditor — email", () => {
 	it("blocks mismatched addresses locally", async () => {
 		render(<ProfileEditor />);
+		selectTab("Email");
 		fireEvent.change(screen.getByLabelText("New Email"), { target: { value: "a@b.co" } });
 		fireEvent.change(screen.getByLabelText("Confirm New Email"), { target: { value: "b@b.co" } });
 		fireEvent.click(screen.getByRole("button", { name: "Send Confirmation Link" }));
@@ -105,6 +113,7 @@ describe("ProfileEditor — email", () => {
 	});
 	it("sends the link and shows the sent state", async () => {
 		render(<ProfileEditor />);
+		selectTab("Email");
 		fireEvent.change(screen.getByLabelText("New Email"), { target: { value: "new@x.org" } });
 		fireEvent.change(screen.getByLabelText("Confirm New Email"), { target: { value: "new@x.org" } });
 		fireEvent.click(screen.getByRole("button", { name: "Send Confirmation Link" }));
@@ -122,6 +131,7 @@ describe("ProfileEditor — password", () => {
 	it("validates locally then saves for default-provider accounts", async () => {
 		mockAuth.user = makeUser({ provider: "default" });
 		render(<ProfileEditor />);
+		selectTab("Password");
 		fireEvent.change(screen.getByLabelText("New Password"), { target: { value: "short" } });
 		fireEvent.change(screen.getByLabelText("Confirm Password"), { target: { value: "short" } });
 		fireEvent.click(screen.getByRole("button", { name: "Set Password" }));
@@ -143,6 +153,7 @@ describe("ProfileEditor — password", () => {
 	it("masks both password inputs", () => {
 		mockAuth.user = makeUser({ provider: "default" });
 		render(<ProfileEditor />);
+		selectTab("Password");
 		expect(screen.getByLabelText("New Password").getAttribute("type")).toBe("password");
 		expect(screen.getByLabelText("Confirm Password").getAttribute("type")).toBe("password");
 	});

--- a/packages/frontend/src/Applications/Account/ProfileEditor.tsx
+++ b/packages/frontend/src/Applications/Account/ProfileEditor.tsx
@@ -1,12 +1,13 @@
 // Signed-in profile editor: per-section saves so a failure in one section
 // never blocks another. Demographics are ALL optional — empty saves as null.
 // Email is absent from updateProfile by design (verified round-trip only).
-import { ClassicyButton, ClassicyInput, ClassicyPopUpMenu } from "classicy";
-import type { ChangeEvent } from "react";
+import { ClassicyButton, ClassicyInput, ClassicyPopUpMenu, ClassicyTabs } from "classicy";
+import type { ChangeEvent, ReactNode } from "react";
 import { useState } from "react";
 import type React from "react";
 import { useAuth } from "../../Providers/Auth/AuthContext";
 import { requestEmailChange, updateProfile } from "../../Providers/Auth/profileApi";
+import styles from "./Account.module.scss";
 
 const EDUCATOR_ROLES = [
 	{ value: "", label: "—" },
@@ -46,7 +47,7 @@ const ToggleGroup: React.FC<{
 	onToggle: (value: string) => void;
 	disabled: boolean;
 }> = ({ options, selected, onToggle, disabled }) => (
-	<div>
+	<div className={styles.toggleGroup}>
 		{options.map(([value, label]) => (
 			<ClassicyButton
 				key={value}
@@ -166,110 +167,129 @@ export const ProfileEditor: React.FC = () => {
 			.finally(() => setPasswordBusy(false));
 	};
 
-	return (
-		<div>
-			<div>
-				<ClassicyInput
-					id="profile-first-name"
-					labelTitle="First Name"
-					prefillValue={firstName}
-					disabled={namesBusy}
-					onChangeFunc={(e) => setFirstName(e.target.value)}
-				/>
-				<ClassicyInput
-					id="profile-last-name"
-					labelTitle="Last Name"
-					prefillValue={lastName}
-					disabled={namesBusy}
-					onChangeFunc={(e) => setLastName(e.target.value)}
-				/>
-				<ClassicyButton disabled={namesBusy} onClickFunc={saveNames}>
-					Save Names
-				</ClassicyButton>
-				{namesMsg && <div>{namesMsg}</div>}
-			</div>
+	// Grouped into Classicy tabs so each concern (name, demographics, email,
+	// password) is one uncluttered panel. Password is default-provider only,
+	// so it's appended conditionally rather than rendered-then-hidden.
+	const tabs: { title: string; children: ReactNode }[] = [
+		{
+			title: "Profile",
+			children: (
+				<div className={styles.tabPanel}>
+					<ClassicyInput
+						id="profile-first-name"
+						labelTitle="First Name"
+						prefillValue={firstName}
+						disabled={namesBusy}
+						onChangeFunc={(e) => setFirstName(e.target.value)}
+					/>
+					<ClassicyInput
+						id="profile-last-name"
+						labelTitle="Last Name"
+						prefillValue={lastName}
+						disabled={namesBusy}
+						onChangeFunc={(e) => setLastName(e.target.value)}
+					/>
+					<ClassicyButton disabled={namesBusy} onClickFunc={saveNames}>
+						Save Names
+					</ClassicyButton>
+					{namesMsg && <div>{namesMsg}</div>}
+				</div>
+			),
+		},
+		{
+			title: "About You",
+			children: (
+				<div className={styles.tabPanel}>
+					<ClassicyInput
+						id="profile-city"
+						labelTitle="City"
+						prefillValue={city}
+						disabled={aboutBusy}
+						onChangeFunc={(e) => setCity(e.target.value)}
+					/>
+					<ClassicyInput
+						id="profile-state"
+						labelTitle="State"
+						prefillValue={stateRegion}
+						disabled={aboutBusy}
+						onChangeFunc={(e) => setStateRegion(e.target.value)}
+					/>
+					<ClassicyInput
+						id="profile-country"
+						labelTitle="Country"
+						prefillValue={country}
+						disabled={aboutBusy}
+						onChangeFunc={(e) => setCountry(e.target.value)}
+					/>
+					<ClassicyInput
+						id="profile-school"
+						labelTitle="School"
+						prefillValue={school}
+						disabled={aboutBusy}
+						onChangeFunc={(e) => setSchool(e.target.value)}
+					/>
+					<ClassicyPopUpMenu
+						id="profile-educator-role"
+						label="Educator Role"
+						labelPosition="left"
+						options={EDUCATOR_ROLES}
+						selected={educatorRole}
+						onChangeFunc={(e: ChangeEvent<HTMLSelectElement>) =>
+							setEducatorRole(e.target.value)
+						}
+					/>
+					<ToggleGroup
+						options={GRADE_LEVELS}
+						selected={gradeLevels}
+						onToggle={toggle(gradeLevels, setGradeLevels)}
+						disabled={aboutBusy}
+					/>
+					<ToggleGroup
+						options={SUBJECTS}
+						selected={subjects}
+						onToggle={toggle(subjects, setSubjects)}
+						disabled={aboutBusy}
+					/>
+					<ClassicyButton disabled={aboutBusy} onClickFunc={saveAbout}>
+						Save Profile
+					</ClassicyButton>
+					{aboutMsg && <div>{aboutMsg}</div>}
+				</div>
+			),
+		},
+		{
+			title: "Email",
+			children: (
+				<div className={styles.tabPanel}>
+					<div className={styles.fieldNote}>{`Email: ${user?.email ?? ""}`}</div>
+					<ClassicyInput
+						id="profile-new-email"
+						labelTitle="New Email"
+						prefillValue={newEmail}
+						disabled={emailBusy}
+						onChangeFunc={(e) => setNewEmail(e.target.value)}
+					/>
+					<ClassicyInput
+						id="profile-confirm-email"
+						labelTitle="Confirm New Email"
+						prefillValue={confirmEmail}
+						disabled={emailBusy}
+						onChangeFunc={(e) => setConfirmEmail(e.target.value)}
+					/>
+					<ClassicyButton disabled={emailBusy} onClickFunc={sendEmailLink}>
+						Send Confirmation Link
+					</ClassicyButton>
+					{emailMsg && <div>{emailMsg}</div>}
+				</div>
+			),
+		},
+	];
 
-			<div>
-				<ClassicyInput
-					id="profile-city"
-					labelTitle="City"
-					prefillValue={city}
-					disabled={aboutBusy}
-					onChangeFunc={(e) => setCity(e.target.value)}
-				/>
-				<ClassicyInput
-					id="profile-state"
-					labelTitle="State"
-					prefillValue={stateRegion}
-					disabled={aboutBusy}
-					onChangeFunc={(e) => setStateRegion(e.target.value)}
-				/>
-				<ClassicyInput
-					id="profile-country"
-					labelTitle="Country"
-					prefillValue={country}
-					disabled={aboutBusy}
-					onChangeFunc={(e) => setCountry(e.target.value)}
-				/>
-				<ClassicyInput
-					id="profile-school"
-					labelTitle="School"
-					prefillValue={school}
-					disabled={aboutBusy}
-					onChangeFunc={(e) => setSchool(e.target.value)}
-				/>
-				<ClassicyPopUpMenu
-					id="profile-educator-role"
-					label="Educator Role"
-					labelPosition="left"
-					options={EDUCATOR_ROLES}
-					selected={educatorRole}
-					onChangeFunc={(e: ChangeEvent<HTMLSelectElement>) =>
-						setEducatorRole(e.target.value)
-					}
-				/>
-				<ToggleGroup
-					options={GRADE_LEVELS}
-					selected={gradeLevels}
-					onToggle={toggle(gradeLevels, setGradeLevels)}
-					disabled={aboutBusy}
-				/>
-				<ToggleGroup
-					options={SUBJECTS}
-					selected={subjects}
-					onToggle={toggle(subjects, setSubjects)}
-					disabled={aboutBusy}
-				/>
-				<ClassicyButton disabled={aboutBusy} onClickFunc={saveAbout}>
-					Save Profile
-				</ClassicyButton>
-				{aboutMsg && <div>{aboutMsg}</div>}
-			</div>
-
-			<div>
-				<div>{`Email: ${user?.email ?? ""}`}</div>
-				<ClassicyInput
-					id="profile-new-email"
-					labelTitle="New Email"
-					prefillValue={newEmail}
-					disabled={emailBusy}
-					onChangeFunc={(e) => setNewEmail(e.target.value)}
-				/>
-				<ClassicyInput
-					id="profile-confirm-email"
-					labelTitle="Confirm New Email"
-					prefillValue={confirmEmail}
-					disabled={emailBusy}
-					onChangeFunc={(e) => setConfirmEmail(e.target.value)}
-				/>
-				<ClassicyButton disabled={emailBusy} onClickFunc={sendEmailLink}>
-					Send Confirmation Link
-				</ClassicyButton>
-				{emailMsg && <div>{emailMsg}</div>}
-			</div>
-
-			{user?.provider === "default" && (
-				<div>
+	if (user?.provider === "default") {
+		tabs.push({
+			title: "Password",
+			children: (
+				<div className={styles.tabPanel}>
 					<ClassicyInput
 						id="profile-new-password"
 						labelTitle="New Password"
@@ -291,7 +311,9 @@ export const ProfileEditor: React.FC = () => {
 					</ClassicyButton>
 					{passwordMsg && <div>{passwordMsg}</div>}
 				</div>
-			)}
-		</div>
-	);
+			),
+		});
+	}
+
+	return <ClassicyTabs tabs={tabs} />;
 };


### PR DESCRIPTION
Closes #257

The signed-in Account view crammed the identity header, avatar controls, and every profile field set into one flat column. This groups the like fields under Classicy tabs (Profile / About You / Email / Password), fills the window body with the Platinum system-03 surface (the same fill the Appearance Manager control panel uses), and turns the profile image into a bevel button that opens the avatar picker — replacing the separate `<img>` + "Upload/Change Avatar" button pair.

- `Account.tsx`: system-03 content wrapper, identity header with a `ClassicyBevelButton` avatar (aria-label preserved as Upload/Change Avatar), hidden `ClassicyFileInput` still reachable by id for the picker.
- `ProfileEditor.tsx`: sections regrouped into `ClassicyTabs`; Password tab appended only for default-provider accounts.
- `Account.module.scss`: new module for the layout.
- `ProfileEditor.test.tsx`: select the owning tab before exercising fields that now live in inactive (hidden) panels.

### Verification
- `tsc -b`, `eslint .` — clean (only pre-existing warnings in unrelated files).
- `vitest run` — full frontend suite green (1251 tests).
- Production build succeeds; drove the signed-in view in a real browser to confirm the tinted body, bevel-button avatar, and tab switching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yqtfKFwmGsXGaytymtxvs