### PR TITLE
feat(alerts): Alerts Manager control panel in the Apple menu

### DIFF
--- a/packages/frontend/src/Applications/Alerts/Alerts.test.tsx
+++ b/packages/frontend/src/Applications/Alerts/Alerts.test.tsx
@@ -1,8 +1,12 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AlertItem } from "../../Providers/MediaStream/MediaStreamContext";
 import { MediaStreamContext } from "../../Providers/MediaStream/MediaStreamContext";
+import {
+	resetAlertsSettingsForTests,
+	setAlertsEnabled,
+} from "./alertsSettings";
 
 // Seeded Alerts.app data handed to useAppManager; toggled per test to exercise
 // the subscribe-on-mount gate (mirrors News.tsx's isRunning gate).
@@ -54,6 +58,8 @@ import { Alerts } from "./Alerts";
 afterEach(() => {
 	cleanup();
 	mockAppRunning.value = true;
+	window.localStorage.clear();
+	resetAlertsSettingsForTests();
 });
 
 const mk = (
@@ -160,5 +166,37 @@ describe("Alerts extension", () => {
 
 		expect(screen.getByText("now").tagName).toBe("B");
 		expect(screen.getByText(/Evacuate/)).not.toBeNull();
+	});
+});
+
+describe("Alerts extension: enabled/disabled gating", () => {
+	it("does not subscribe or render a modal while alerts are disabled", () => {
+		setAlertsEnabled(false);
+		const { subscribeAlerts } = renderWithAlerts([
+			mk(1, "Suppressed", "2001-09-11T12:40:00Z"),
+		]);
+		expect(subscribeAlerts).not.toHaveBeenCalled();
+		expect(screen.queryByRole("alertdialog")).toBeNull();
+	});
+
+	it("hides a visible modal and unsubscribes the moment alerts are disabled", () => {
+		const { subscribeAlerts, unsubscribeAlerts } = renderWithAlerts([
+			mk(1, "Visible", "2001-09-11T12:40:00Z"),
+		]);
+		expect(subscribeAlerts).toHaveBeenCalledWith("Alerts.app");
+		expect(screen.getByRole("alertdialog")).not.toBeNull();
+
+		act(() => setAlertsEnabled(false));
+		expect(screen.queryByRole("alertdialog")).toBeNull();
+		expect(unsubscribeAlerts).toHaveBeenCalledWith("Alerts.app");
+	});
+
+	it("re-subscribes when alerts are re-enabled", () => {
+		const { subscribeAlerts } = renderWithAlerts([]);
+		expect(subscribeAlerts).toHaveBeenCalledTimes(1);
+
+		act(() => setAlertsEnabled(false));
+		act(() => setAlertsEnabled(true));
+		expect(subscribeAlerts).toHaveBeenCalledTimes(2);
 	});
 });

--- a/packages/frontend/src/Applications/Alerts/Alerts.tsx
+++ b/packages/frontend/src/Applications/Alerts/Alerts.tsx
@@ -5,6 +5,7 @@ import {
 	type AlertItem,
 	MediaStreamContext,
 } from "../../Providers/MediaStream/MediaStreamContext";
+import { useAlertsEnabled } from "./alertsSettings";
 
 const appId = "Alerts.app";
 const appName = "Alerts";
@@ -28,18 +29,19 @@ export const Alerts: React.FC = () => {
 	const isRunning = useAppManager(
 		(s) => appId in (s.System.Manager.Applications.apps ?? {}),
 	);
+	const enabled = useAlertsEnabled();
 	const { alertItems, subscribeAlerts, unsubscribeAlerts } =
 		useContext(MediaStreamContext);
 
 	const [dismissed, setDismissed] = useState<Set<number>>(() => new Set());
 
-	// The extension is always mounted; subscribe once the app entry exists and
-	// stay subscribed for as long as it does.
+	// The extension is always mounted; subscribe while the app entry exists AND
+	// the user hasn't turned alerts off in the Alerts Manager control panel.
 	useEffect(() => {
-		if (!isRunning) return;
+		if (!isRunning || !enabled) return;
 		subscribeAlerts(appId);
 		return () => unsubscribeAlerts(appId);
-	}, [isRunning, subscribeAlerts, unsubscribeAlerts]);
+	}, [isRunning, enabled, subscribeAlerts, unsubscribeAlerts]);
 
 	// Earliest revealed-but-undismissed alert, by start_date. Rendering only
 	// this one gives the "one modal at a time" queue: OK dismisses it, the
@@ -68,7 +70,7 @@ export const Alerts: React.FC = () => {
 			extension
 			addSystemMenu={false}
 		>
-			{current && (
+			{enabled && current && (
 				<ClassicyAlert
 					key={current.id}
 					id={`${appId}_alert_${current.id}`}

--- a/packages/frontend/src/Applications/Alerts/AlertsManager.test.tsx
+++ b/packages/frontend/src/Applications/Alerts/AlertsManager.test.tsx
@@ -1,0 +1,74 @@
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Captures the props ClassicyApp is rendered with so the test can assert the
+// Apple-menu/no-desktop-icon contract without classicy's desktop chrome.
+const appProps = vi.hoisted(() => ({ current: {} as Record<string, unknown> }));
+
+vi.mock("classicy", async (importOriginal) => ({
+	...(await importOriginal<typeof import("classicy")>()),
+	ClassicyApp: ({
+		children,
+		...props
+	}: { children?: React.ReactNode } & Record<string, unknown>) => {
+		appProps.current = props;
+		return <div>{children}</div>;
+	},
+	ClassicyWindow: ({ children }: { children?: React.ReactNode }) => (
+		<div>{children}</div>
+	),
+	useAppManagerDispatch: () => vi.fn(),
+	useClassicyAboutMenu: () => ({
+		aboutMenuItem: { id: "about" },
+		aboutWindow: null,
+	}),
+	useClassicyWindowClose: () => vi.fn(),
+}));
+
+import { AlertsManager } from "./AlertsManager";
+import { getAlertsEnabled, resetAlertsSettingsForTests, setAlertsEnabled } from "./alertsSettings";
+
+afterEach(() => {
+	cleanup();
+	window.localStorage.clear();
+	resetAlertsSettingsForTests();
+});
+
+describe("Alerts Manager control panel", () => {
+	it("registers as an Apple-menu app with no desktop icon", () => {
+		render(<AlertsManager />);
+		expect(appProps.current.id).toBe("AlertsManager.app");
+		expect(appProps.current.noDesktopIcon).toBe(true);
+		expect(appProps.current.addSystemMenu).toBe(true);
+	});
+
+	it("shows the checkbox checked while alerts are enabled", () => {
+		render(<AlertsManager />);
+		const checkbox = screen.getByLabelText("Show Alerts") as HTMLInputElement;
+		expect(checkbox.checked).toBe(true);
+	});
+
+	it("reflects a persisted disabled state", () => {
+		setAlertsEnabled(false);
+		render(<AlertsManager />);
+		const checkbox = screen.getByLabelText("Show Alerts") as HTMLInputElement;
+		expect(checkbox.checked).toBe(false);
+	});
+
+	it("toggling the checkbox flips and persists the store", () => {
+		render(<AlertsManager />);
+		const checkbox = screen.getByLabelText("Show Alerts");
+
+		act(() => {
+			fireEvent.click(checkbox);
+		});
+		expect(getAlertsEnabled()).toBe(false);
+		expect(window.localStorage.getItem("rt911AlertsEnabled")).toBe("false");
+
+		act(() => {
+			fireEvent.click(checkbox);
+		});
+		expect(getAlertsEnabled()).toBe(true);
+	});
+});

--- a/packages/frontend/src/Applications/Alerts/AlertsManager.tsx
+++ b/packages/frontend/src/Applications/Alerts/AlertsManager.tsx
@@ -1,0 +1,109 @@
+import {
+	ClassicyApp,
+	ClassicyButton,
+	ClassicyCheckbox,
+	ClassicyControlGroup,
+	ClassicyIcons,
+	ClassicyWindow,
+	closeWindowMenuItemHelper,
+	quitAppHelper,
+	quitMenuItemHelper,
+	useAppManagerDispatch,
+	useClassicyAboutMenu,
+	useClassicyWindowClose,
+} from "classicy";
+import type React from "react";
+import { setAlertsEnabled, useAlertsEnabled } from "./alertsSettings";
+
+const APP_ID = "AlertsManager.app";
+const APP_NAME = "Alerts Manager";
+const WINDOW_ID = "AlertsManager_1";
+const appIcon = ClassicyIcons.applications.internetExplorer
+	.documentWarning as string;
+
+/**
+ * Control panel for the Alerts extension: an Apple-menu app (no desktop icon)
+ * whose single checkbox writes the shared alertsSettings store. While off, the
+ * extension unsubscribes from the alerts channel entirely — alerts whose
+ * moment passes are skipped, not queued (see the design doc,
+ * plans/2026-07-20-alerts-manager-design.md).
+ */
+export const AlertsManager: React.FC = () => {
+	const enabled = useAlertsEnabled();
+	const desktopEventDispatch = useAppManagerDispatch();
+
+	const { aboutMenuItem, aboutWindow } = useClassicyAboutMenu(
+		APP_ID,
+		APP_NAME,
+		appIcon,
+	);
+	const windowClose = useClassicyWindowClose(APP_ID);
+
+	const quitApp = () => {
+		desktopEventDispatch(quitAppHelper(APP_ID, APP_NAME, appIcon));
+	};
+
+	// Mac OS 8 HIG control-panel menu bar. The About entry is discovery data:
+	// ClassicyDesktopMenuBar hoists it into the Apple menu and strips it from
+	// this menu before rendering. No Edit menu — there are no entry fields.
+	const appMenu = [
+		{
+			id: `${APP_ID}_file`,
+			title: "File",
+			menuChildren: [
+				{ ...aboutMenuItem, title: `About ${APP_NAME}` },
+				{
+					...closeWindowMenuItemHelper(`${APP_ID}_close_window`, () =>
+						windowClose(WINDOW_ID, quitAppHelper(APP_ID, APP_NAME, appIcon)),
+					),
+					keyboardShortcut: "⌥W",
+				},
+				{ id: "spacer" },
+				{
+					...quitMenuItemHelper(APP_ID, APP_NAME, appIcon),
+					keyboardShortcut: "⌥Q",
+				},
+			],
+		},
+	];
+
+	return (
+		<ClassicyApp
+			id={APP_ID}
+			name={APP_NAME}
+			icon={appIcon}
+			defaultWindow={WINDOW_ID}
+			noDesktopIcon={true}
+			addSystemMenu={true}
+		>
+			<ClassicyWindow
+				id={WINDOW_ID}
+				title={APP_NAME}
+				appId={APP_ID}
+				icon={appIcon}
+				closable={true}
+				resizable={false}
+				zoomable={false}
+				scrollable={false}
+				collapsable={false}
+				initialSize={[280, 130]}
+				initialPosition={[320, 80]}
+				modal={false}
+				appMenu={appMenu}
+			>
+				<ClassicyControlGroup label={"Alerts"}>
+					<ClassicyCheckbox
+						id={"show_alerts"}
+						label={"Show Alerts"}
+						checked={enabled}
+						onClickFunc={(checked: boolean) => setAlertsEnabled(checked)}
+					/>
+				</ClassicyControlGroup>
+				<ClassicyButton isDefault={false} onClickFunc={quitApp}>
+					Quit
+				</ClassicyButton>
+			</ClassicyWindow>
+			{aboutWindow}
+		</ClassicyApp>
+	);
+};

--- a/packages/frontend/src/Applications/Alerts/alertsSettings.test.ts
+++ b/packages/frontend/src/Applications/Alerts/alertsSettings.test.ts
@@ -55,18 +55,27 @@ describe("alertsSettings store", () => {
 	});
 
 	it("falls back to enabled when localStorage reads throw (private-mode Safari)", () => {
-		vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
-			throw new Error("denied");
-		});
+		// window.localStorage in this test environment is an own-property
+		// polyfill (see vitest.setup.ts), not a Storage.prototype instance, so
+		// the spy must target the instance itself to actually intercept calls.
+		const getItemSpy = vi
+			.spyOn(window.localStorage, "getItem")
+			.mockImplementation(() => {
+				throw new Error("denied");
+			});
 		resetAlertsSettingsForTests();
+		expect(getItemSpy).toHaveBeenCalledWith(KEY);
 		expect(getAlertsEnabled()).toBe(true);
 	});
 
 	it("keeps working in-memory when localStorage writes throw", () => {
-		vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
-			throw new Error("denied");
-		});
+		const setItemSpy = vi
+			.spyOn(window.localStorage, "setItem")
+			.mockImplementation(() => {
+				throw new Error("denied");
+			});
 		setAlertsEnabled(false);
+		expect(setItemSpy).toHaveBeenCalledWith(KEY, "false");
 		expect(getAlertsEnabled()).toBe(false);
 	});
 });

--- a/packages/frontend/src/Applications/Alerts/alertsSettings.test.ts
+++ b/packages/frontend/src/Applications/Alerts/alertsSettings.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	getAlertsEnabled,
@@ -10,6 +10,7 @@ import {
 const KEY = "rt911AlertsEnabled";
 
 afterEach(() => {
+	cleanup();
 	vi.restoreAllMocks();
 	window.localStorage.clear();
 	resetAlertsSettingsForTests();

--- a/packages/frontend/src/Applications/Alerts/alertsSettings.test.ts
+++ b/packages/frontend/src/Applications/Alerts/alertsSettings.test.ts
@@ -1,0 +1,71 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	getAlertsEnabled,
+	resetAlertsSettingsForTests,
+	setAlertsEnabled,
+	useAlertsEnabled,
+} from "./alertsSettings";
+
+const KEY = "rt911AlertsEnabled";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	window.localStorage.clear();
+	resetAlertsSettingsForTests();
+});
+
+describe("alertsSettings store", () => {
+	it("defaults to enabled when localStorage has no value", () => {
+		expect(getAlertsEnabled()).toBe(true);
+	});
+
+	it("hydrates disabled state from a persisted \"false\"", () => {
+		window.localStorage.setItem(KEY, "false");
+		resetAlertsSettingsForTests();
+		expect(getAlertsEnabled()).toBe(false);
+	});
+
+	it("treats any value other than the literal \"false\" as enabled", () => {
+		window.localStorage.setItem(KEY, "garbage");
+		resetAlertsSettingsForTests();
+		expect(getAlertsEnabled()).toBe(true);
+	});
+
+	it("setAlertsEnabled persists to localStorage and updates the getter", () => {
+		setAlertsEnabled(false);
+		expect(getAlertsEnabled()).toBe(false);
+		expect(window.localStorage.getItem(KEY)).toBe("false");
+
+		setAlertsEnabled(true);
+		expect(getAlertsEnabled()).toBe(true);
+		expect(window.localStorage.getItem(KEY)).toBe("true");
+	});
+
+	it("useAlertsEnabled re-renders subscribers when the flag flips", () => {
+		const { result } = renderHook(() => useAlertsEnabled());
+		expect(result.current).toBe(true);
+
+		act(() => setAlertsEnabled(false));
+		expect(result.current).toBe(false);
+
+		act(() => setAlertsEnabled(true));
+		expect(result.current).toBe(true);
+	});
+
+	it("falls back to enabled when localStorage reads throw (private-mode Safari)", () => {
+		vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+			throw new Error("denied");
+		});
+		resetAlertsSettingsForTests();
+		expect(getAlertsEnabled()).toBe(true);
+	});
+
+	it("keeps working in-memory when localStorage writes throw", () => {
+		vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+			throw new Error("denied");
+		});
+		setAlertsEnabled(false);
+		expect(getAlertsEnabled()).toBe(false);
+	});
+});

--- a/packages/frontend/src/Applications/Alerts/alertsSettings.ts
+++ b/packages/frontend/src/Applications/Alerts/alertsSettings.ts
@@ -1,0 +1,46 @@
+import { useSyncExternalStore } from "react";
+
+/**
+ * Desktop-wide "show alerts" preference, written by the Alerts Manager control
+ * panel and read by the Alerts extension. Lives outside React (plus a
+ * localStorage mirror) because the two apps mount independently under
+ * ClassicyDesktop with no shared ancestor that owns this state.
+ */
+const STORAGE_KEY = "rt911AlertsEnabled";
+
+const readStored = (): boolean => {
+	try {
+		return window.localStorage.getItem(STORAGE_KEY) !== "false";
+	} catch {
+		return true;
+	}
+};
+
+let enabled = readStored();
+const listeners = new Set<() => void>();
+
+export const getAlertsEnabled = (): boolean => enabled;
+
+export const setAlertsEnabled = (value: boolean): void => {
+	if (enabled === value) return;
+	enabled = value;
+	try {
+		window.localStorage.setItem(STORAGE_KEY, String(value));
+	} catch {
+		// Storage unavailable (private-mode Safari): setting is session-only.
+	}
+	for (const listener of listeners) listener();
+};
+
+const subscribe = (listener: () => void): (() => void) => {
+	listeners.add(listener);
+	return () => listeners.delete(listener);
+};
+
+export const useAlertsEnabled = (): boolean =>
+	useSyncExternalStore(subscribe, getAlertsEnabled);
+
+/** Test-only: re-hydrate the module cache after tests mutate localStorage. */
+export const resetAlertsSettingsForTests = (): void => {
+	enabled = readStored();
+};

--- a/packages/frontend/src/Desktop.tsx
+++ b/packages/frontend/src/Desktop.tsx
@@ -8,6 +8,7 @@ import { HyperCardClockBridge } from "./Applications/HyperCard/extensions/HyperC
 import { HyperCardStackAuthBridge } from "./Applications/HyperCard/extensions/stackProviderAuth";
 import { Account } from "./Applications/Account/Account";
 import { Alerts } from "./Applications/Alerts/Alerts";
+import { AlertsManager } from "./Applications/Alerts/AlertsManager";
 import { Browser } from "./Applications/Browser/Browser";
 import { Feedback } from "./Applications/Feedback/Feedback";
 import { FlightTracker } from "./Applications/FlightTracker/FlightTracker";
@@ -27,6 +28,7 @@ export default function Desktop() {
 	return (
 		<ClassicyDesktop>
 			<Alerts />
+			<AlertsManager />
 			<HyperCardClockBridge />
 			<HyperCardStackAuthBridge />
 			<Browser />

--- a/packages/frontend/vitest.setup.ts
+++ b/packages/frontend/vitest.setup.ts
@@ -26,3 +26,38 @@ class ResizeObserverStub {
 globalThis.ResizeObserver =
 	globalThis.ResizeObserver ??
 	(ResizeObserverStub as unknown as typeof ResizeObserver);
+
+// jsdom requires --localstorage-file; polyfill in-memory localStorage for tests.
+try {
+	if (!window.localStorage || typeof window.localStorage.getItem !== "function") {
+		throw new Error("localStorage not available");
+	}
+} catch {
+	const store: Record<string, string> = {};
+
+	Object.defineProperty(window, "localStorage", {
+		value: {
+			getItem(key: string): string | null {
+				return store[key] ?? null;
+			},
+			setItem(key: string, value: string): void {
+				store[key] = value;
+			},
+			removeItem(key: string): void {
+				delete store[key];
+			},
+			clear(): void {
+				for (const key in store) delete store[key];
+			},
+			key(index: number): string | null {
+				const keys = Object.keys(store);
+				return keys[index] ?? null;
+			},
+			get length(): number {
+				return Object.keys(store).length;
+			},
+		},
+		writable: false,
+		configurable: true,
+	});
+}

--- a/packages/frontend/vitest.setup.ts
+++ b/packages/frontend/vitest.setup.ts
@@ -27,9 +27,13 @@ globalThis.ResizeObserver =
 	globalThis.ResizeObserver ??
 	(ResizeObserverStub as unknown as typeof ResizeObserver);
 
-// jsdom's default url (http://localhost:3000) requires --localstorage-file
-// to provide localStorage. Tests accessing window.localStorage throw
-// SecurityError: "Cannot initialize local storage without a `--localstorage-file` path".
+// Node 25 ships a native globalThis.localStorage that throws when
+// unconfigured: SecurityError: "Cannot initialize local storage without a
+// `--localstorage-file` path". vitest's populateGlobal/getWindowKeys only
+// copies a jsdom window key onto the global when that key isn't already
+// present on the global — "Storage" is in its always-copy KEYS list, but
+// "localStorage" is not, so Node's throwing implementation shadows jsdom's
+// working one inside tests.
 // Polyfill in-memory localStorage to unblock test suites that need it.
 try {
 	if (!window.localStorage || typeof window.localStorage.getItem !== "function") {

--- a/packages/frontend/vitest.setup.ts
+++ b/packages/frontend/vitest.setup.ts
@@ -27,7 +27,10 @@ globalThis.ResizeObserver =
 	globalThis.ResizeObserver ??
 	(ResizeObserverStub as unknown as typeof ResizeObserver);
 
-// jsdom requires --localstorage-file; polyfill in-memory localStorage for tests.
+// jsdom's default url (http://localhost:3000) requires --localstorage-file
+// to provide localStorage. Tests accessing window.localStorage throw
+// SecurityError: "Cannot initialize local storage without a `--localstorage-file` path".
+// Polyfill in-memory localStorage to unblock test suites that need it.
 try {
 	if (!window.localStorage || typeof window.localStorage.getItem !== "function") {
 		throw new Error("localStorage not available");

--- a/plans/2026-07-20-alerts-manager-design.md
+++ b/plans/2026-07-20-alerts-manager-design.md
@@ -1,0 +1,131 @@
+# Alerts Manager — design
+
+Date: 2026-07-20
+Status: approved
+
+## What
+
+A new Classicy app, **Alerts Manager** (`AlertsManager.app`), modeled on Classicy's
+built-in Date and Time Manager control panel. It has **no desktop icon** but
+appears in the **Apple menu** (`noDesktopIcon={true}` + `addSystemMenu={true}`),
+and presents a single checkbox — **"Show Alerts"** — that turns the Alerts
+extension's modals on or off desktop-wide.
+
+## Why
+
+The Alerts extension (`packages/frontend/src/Applications/Alerts/Alerts.tsx`) is a
+silent background extension that pops a `ClassicyAlert` modal whenever the virtual
+clock crosses an `alert_items` row's `start_date`. There is currently no way for a
+user to opt out of these interruptions. A control panel in the Apple menu — the
+Mac OS 8 place for system-wide settings — is the idiomatic fix.
+
+## Decisions (user-approved)
+
+1. **Skip missed alerts.** While alerts are off, the extension **unsubscribes**
+   from the `alerts` WebSocket channel entirely (no traffic). The channel is
+   fire-on-cross / no-snapshot, so alerts whose moment passes during the off
+   window never show, matching the product's live-broadcast semantics.
+2. **Persist the setting.** The flag survives reloads via `localStorage`
+   (key `rt911AlertsEnabled`). Default is **on**.
+3. **Shared state lives in a tiny rt911-local store** (Approach A below), not in
+   Classicy state or MediaStreamContext.
+
+### Approaches considered
+
+- **A (chosen): rt911-local external store.** ~30-line module with
+  `useSyncExternalStore` + `localStorage`. Both the manager (writer) and the
+  extension (reader) import the same hook. No classicy release, no provider
+  re-renders, trivially testable.
+- **B: extend Classicy app-manager state** with a generic app-data event riding
+  `classicyDesktopState` persistence. Idiomatic but needs a classicy release +
+  version bump for one boolean — overkill.
+- **C: flag in MediaStreamContext.** The provider owns alert plumbing, but this
+  is a UI preference, not stream state, and toggling would re-render every
+  stream consumer.
+
+## Components
+
+All new code lives beside the extension in
+`packages/frontend/src/Applications/Alerts/`.
+
+### `alertsSettings.ts` (new)
+
+External store for one boolean:
+
+- `getAlertsEnabled(): boolean` — reads cache; first read hydrates from
+  `localStorage` inside try/catch (private-mode Safari throws → default `true`).
+  Any value other than the literal `"false"` means enabled.
+- `setAlertsEnabled(v: boolean): void` — updates cache, best-effort persists,
+  notifies subscribers.
+- `useAlertsEnabled(): boolean` — `useSyncExternalStore` over the above.
+
+### `AlertsManager.tsx` (new)
+
+Structure copied from `ClassicyDateAndTimeManager`:
+
+- `APP_ID = "AlertsManager.app"`, `APP_NAME = "Alerts Manager"`, one window
+  `AlertsManager_1`.
+- `ClassicyApp` props: `noDesktopIcon={true}`, `addSystemMenu={true}`,
+  `defaultWindow="AlertsManager_1"` → Apple-menu entry, no desktop icon.
+- Small fixed-size, non-resizable `ClassicyWindow` containing a
+  `ClassicyControlGroup` ("Alerts") with one `ClassicyCheckbox`
+  ("Show Alerts") bound to the store, plus a Quit `ClassicyButton`.
+- App menu: File (About / Close Window ⌥W / spacer / Quit ⌥Q) + Edit, via the
+  same `useClassicyAboutMenu` / `useClassicyWindowClose` / `useClassicyEditMenu`
+  hooks and helpers the Date and Time Manager uses.
+- Icon: reuse a bundled `ClassicyIcons` control-panel icon (rendered in the
+  Apple menu and About window only).
+
+### `Alerts.tsx` (changed)
+
+- Read `const enabled = useAlertsEnabled()`.
+- Subscribe effect gates on `isRunning && enabled`; toggling off runs the
+  cleanup → `unsubscribeAlerts(appId)`, which (as the last subscriber) sends the
+  channel unsubscribe and clears the alert buffer
+  (`MediaStreamProvider.tsx:487`).
+- Modal renders only when `enabled` — a visible alert disappears the instant
+  the user toggles off. It is *not* auto-dismissed, but re-appearing on
+  re-enable is acceptable only if it is still in `alertItems`; since dismissal
+  state is untouched, an alert visible at toggle-off that remains in the
+  provider's revealed list will re-surface on toggle-on within the same
+  session. This is intended: the user never acknowledged it.
+
+### `Desktop.tsx` (changed)
+
+Mount `<AlertsManager />` alongside the other apps.
+
+## Data flow
+
+```
+ClassicyCheckbox ──setAlertsEnabled──▶ alertsSettings store ──▶ localStorage
+                                            │
+                              useAlertsEnabled() (useSyncExternalStore)
+                                            ▼
+                       Alerts.tsx effect: subscribe/unsubscribe + render gate
+```
+
+## Error handling
+
+- `localStorage` get/set wrapped in try/catch; failures degrade to in-memory
+  session behavior with default on.
+- No new WS message types; unsubscribe path already exists and is idempotent.
+
+## Testing
+
+Vitest, following the existing Alerts.test.tsx mocking pattern (and the
+project's no-auto-cleanup rule — `afterEach(cleanup)` in new files):
+
+1. `alertsSettings.test.ts` — default true; persists and re-hydrates; notifies
+   subscribers; tolerates throwing localStorage.
+2. `AlertsManager.test.tsx` — checkbox reflects store; clicking flips store;
+   app registers with `noDesktopIcon` + system menu props.
+3. `Alerts.test.tsx` (extend) — disabled → no `subscribeAlerts`, no modal;
+   toggle off while modal visible → modal unmounts and `unsubscribeAlerts`
+   called; re-enable → `subscribeAlerts` called again.
+
+## Out of scope
+
+- Muting the existing in-app `ClassicyAlert`s other apps raise (this gates only
+  the Alerts extension's stream-driven modals).
+- Any backend/streamer change.
+- Mobile (iPod shell) — the extension is desktop-only today.

--- a/plans/2026-07-20-alerts-manager-design.md
+++ b/plans/2026-07-20-alerts-manager-design.md
@@ -80,15 +80,20 @@ Structure copied from `ClassicyDateAndTimeManager`:
 
 - Read `const enabled = useAlertsEnabled()`.
 - Subscribe effect gates on `isRunning && enabled`; toggling off runs the
-  cleanup → `unsubscribeAlerts(appId)`, which (as the last subscriber) sends the
-  channel unsubscribe and clears the alert buffer
-  (`MediaStreamProvider.tsx:487`).
+  cleanup → `unsubscribeAlerts(appId)`, which (as the last subscriber, since
+  `Alerts.app` is the alerts channel's only subscriber) sends the channel
+  unsubscribe and clears **both** the un-revealed buffer and the revealed
+  `alertItems` list (`setAlertItems([])`, `MediaStreamProvider.tsx:484-487`).
 - Modal renders only when `enabled` — a visible alert disappears the instant
-  the user toggles off. It is *not* auto-dismissed, but re-appearing on
-  re-enable is acceptable only if it is still in `alertItems`; since dismissal
-  state is untouched, an alert visible at toggle-off that remains in the
-  provider's revealed list will re-surface on toggle-on within the same
-  session. This is intended: the user never acknowledged it.
+  the user toggles off. It is *not* auto-dismissed, but because
+  `unsubscribeAlerts` clears `alertItems` entirely, an alert visible at
+  toggle-off is dropped permanently rather than merely hidden: re-enabling
+  within the same session does **not** bring it back, since nothing remains
+  in `alertItems` to re-render and the channel is fire-on-cross with no
+  snapshot to re-deliver it. This is intended and consistent with the
+  approved "skip missed alerts" semantics — the user never acknowledged it,
+  and the product treats a missed alert the same whether alerts were off when
+  it fired or the user simply didn't see it before toggling off.
 
 ### `Desktop.tsx` (changed)
 

--- a/plans/2026-07-20-alerts-manager-plan.md
+++ b/plans/2026-07-20-alerts-manager-plan.md
@@ -1,0 +1,626 @@
+# Alerts Manager Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** An "Alerts Manager" control panel in the Apple menu (no desktop icon) with a single "Show Alerts" checkbox that enables/disables the Alerts extension's stream-driven modals.
+
+**Architecture:** A ~30-line external store (`useSyncExternalStore` + `localStorage`) is the single source of truth for one boolean. The new `AlertsManager.app` (modeled on Classicy's `ClassicyDateAndTimeManager`) writes it; the existing `Alerts.tsx` extension reads it to gate both its `alerts`-channel subscription and its modal rendering. Spec: `plans/2026-07-20-alerts-manager-design.md`.
+
+**Tech Stack:** React 19 + TypeScript + Vite, `classicy` component library, Vitest + Testing Library.
+
+## Global Constraints
+
+- Work in worktree `/home/robbiebyrd/rt911/.claude/worktrees/alerts-manager` (branch `feat/alerts-manager`, off `main`). All paths below are relative to `packages/frontend/` in that worktree unless noted.
+- localStorage key: `rt911AlertsEnabled`. Default when absent/unreadable: **enabled (`true`)**. Only the literal string `"false"` means disabled.
+- App identity: `APP_ID = "AlertsManager.app"`, `APP_NAME = "Alerts Manager"`, window `AlertsManager_1`. Checkbox label copy: **"Show Alerts"**.
+- New test files MUST call `afterEach(cleanup)` — this project's Vitest has no RTL auto-cleanup.
+- Never fully replace the `classicy` mock — always spread `importOriginal` and override only named components (full replacement breaks when a component adds imports).
+- The pre-commit hook bumps `classicy` and stages `pnpm-lock.yaml`; a lockfile change riding along in commits is expected. Do not hand-edit the classicy version.
+- Run tests from the worktree root with `pnpm --filter @rt911/frontend exec vitest run <path>`.
+
+---
+
+### Task 1: `alertsSettings` external store
+
+**Files:**
+- Create: `packages/frontend/src/Applications/Alerts/alertsSettings.ts`
+- Test: `packages/frontend/src/Applications/Alerts/alertsSettings.test.ts`
+
+**Interfaces:**
+- Consumes: nothing (leaf module).
+- Produces (used by Tasks 2 & 3):
+  - `getAlertsEnabled(): boolean`
+  - `setAlertsEnabled(value: boolean): void`
+  - `useAlertsEnabled(): boolean` (React hook)
+  - `resetAlertsSettingsForTests(): void` — re-hydrates the module cache from `localStorage`; tests call it after mutating/clearing storage.
+
+- [ ] **Step 1: One-time setup — install deps in the fresh worktree**
+
+```bash
+cd /home/robbiebyrd/rt911/.claude/worktrees/alerts-manager && pnpm install
+```
+
+Expected: completes without error (pnpm links the monorepo packages).
+
+- [ ] **Step 2: Write the failing test**
+
+Create `packages/frontend/src/Applications/Alerts/alertsSettings.test.ts`:
+
+```ts
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	getAlertsEnabled,
+	resetAlertsSettingsForTests,
+	setAlertsEnabled,
+	useAlertsEnabled,
+} from "./alertsSettings";
+
+const KEY = "rt911AlertsEnabled";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	window.localStorage.clear();
+	resetAlertsSettingsForTests();
+});
+
+describe("alertsSettings store", () => {
+	it("defaults to enabled when localStorage has no value", () => {
+		expect(getAlertsEnabled()).toBe(true);
+	});
+
+	it("hydrates disabled state from a persisted \"false\"", () => {
+		window.localStorage.setItem(KEY, "false");
+		resetAlertsSettingsForTests();
+		expect(getAlertsEnabled()).toBe(false);
+	});
+
+	it("treats any value other than the literal \"false\" as enabled", () => {
+		window.localStorage.setItem(KEY, "garbage");
+		resetAlertsSettingsForTests();
+		expect(getAlertsEnabled()).toBe(true);
+	});
+
+	it("setAlertsEnabled persists to localStorage and updates the getter", () => {
+		setAlertsEnabled(false);
+		expect(getAlertsEnabled()).toBe(false);
+		expect(window.localStorage.getItem(KEY)).toBe("false");
+
+		setAlertsEnabled(true);
+		expect(getAlertsEnabled()).toBe(true);
+		expect(window.localStorage.getItem(KEY)).toBe("true");
+	});
+
+	it("useAlertsEnabled re-renders subscribers when the flag flips", () => {
+		const { result } = renderHook(() => useAlertsEnabled());
+		expect(result.current).toBe(true);
+
+		act(() => setAlertsEnabled(false));
+		expect(result.current).toBe(false);
+
+		act(() => setAlertsEnabled(true));
+		expect(result.current).toBe(true);
+	});
+
+	it("falls back to enabled when localStorage reads throw (private-mode Safari)", () => {
+		vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+			throw new Error("denied");
+		});
+		resetAlertsSettingsForTests();
+		expect(getAlertsEnabled()).toBe(true);
+	});
+
+	it("keeps working in-memory when localStorage writes throw", () => {
+		vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+			throw new Error("denied");
+		});
+		setAlertsEnabled(false);
+		expect(getAlertsEnabled()).toBe(false);
+	});
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+cd /home/robbiebyrd/rt911/.claude/worktrees/alerts-manager && pnpm --filter @rt911/frontend exec vitest run src/Applications/Alerts/alertsSettings.test.ts
+```
+
+Expected: FAIL — cannot resolve `./alertsSettings`.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `packages/frontend/src/Applications/Alerts/alertsSettings.ts`:
+
+```ts
+import { useSyncExternalStore } from "react";
+
+/**
+ * Desktop-wide "show alerts" preference, written by the Alerts Manager control
+ * panel and read by the Alerts extension. Lives outside React (plus a
+ * localStorage mirror) because the two apps mount independently under
+ * ClassicyDesktop with no shared ancestor that owns this state.
+ */
+const STORAGE_KEY = "rt911AlertsEnabled";
+
+const readStored = (): boolean => {
+	try {
+		return window.localStorage.getItem(STORAGE_KEY) !== "false";
+	} catch {
+		return true;
+	}
+};
+
+let enabled = readStored();
+const listeners = new Set<() => void>();
+
+export const getAlertsEnabled = (): boolean => enabled;
+
+export const setAlertsEnabled = (value: boolean): void => {
+	if (enabled === value) return;
+	enabled = value;
+	try {
+		window.localStorage.setItem(STORAGE_KEY, String(value));
+	} catch {
+		// Storage unavailable (private-mode Safari): setting is session-only.
+	}
+	for (const listener of listeners) listener();
+};
+
+const subscribe = (listener: () => void): (() => void) => {
+	listeners.add(listener);
+	return () => listeners.delete(listener);
+};
+
+export const useAlertsEnabled = (): boolean =>
+	useSyncExternalStore(subscribe, getAlertsEnabled);
+
+/** Test-only: re-hydrate the module cache after tests mutate localStorage. */
+export const resetAlertsSettingsForTests = (): void => {
+	enabled = readStored();
+};
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+cd /home/robbiebyrd/rt911/.claude/worktrees/alerts-manager && pnpm --filter @rt911/frontend exec vitest run src/Applications/Alerts/alertsSettings.test.ts
+```
+
+Expected: PASS (7 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/robbiebyrd/rt911/.claude/worktrees/alerts-manager && git add packages/frontend/src/Applications/Alerts/alertsSettings.ts packages/frontend/src/Applications/Alerts/alertsSettings.test.ts && git commit -m "feat(alerts): persisted alertsEnabled external store
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Gate the Alerts extension on the flag
+
+**Files:**
+- Modify: `packages/frontend/src/Applications/Alerts/Alerts.tsx` (subscribe effect ~lines 38-42; render gate ~line 71)
+- Test: `packages/frontend/src/Applications/Alerts/Alerts.test.tsx` (extend)
+
+**Interfaces:**
+- Consumes: `useAlertsEnabled()`, and in tests `setAlertsEnabled(value)` / `resetAlertsSettingsForTests()` from Task 1.
+- Produces: behavior only — no exports change.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `packages/frontend/src/Applications/Alerts/Alerts.test.tsx`, add the store import after the existing `MediaStreamContext` import (line 5):
+
+```ts
+import {
+	resetAlertsSettingsForTests,
+	setAlertsEnabled,
+} from "./alertsSettings";
+```
+
+Extend the existing `afterEach` (lines 54-57) to reset the store:
+
+```ts
+afterEach(() => {
+	cleanup();
+	mockAppRunning.value = true;
+	window.localStorage.clear();
+	resetAlertsSettingsForTests();
+});
+```
+
+Add `act` to the existing `@testing-library/react` import on line 1:
+
+```ts
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+```
+
+Append a new describe block at the end of the file:
+
+```tsx
+describe("Alerts extension: enabled/disabled gating", () => {
+	it("does not subscribe or render a modal while alerts are disabled", () => {
+		setAlertsEnabled(false);
+		const { subscribeAlerts } = renderWithAlerts([
+			mk(1, "Suppressed", "2001-09-11T12:40:00Z"),
+		]);
+		expect(subscribeAlerts).not.toHaveBeenCalled();
+		expect(screen.queryByRole("alertdialog")).toBeNull();
+	});
+
+	it("hides a visible modal and unsubscribes the moment alerts are disabled", () => {
+		const { subscribeAlerts, unsubscribeAlerts } = renderWithAlerts([
+			mk(1, "Visible", "2001-09-11T12:40:00Z"),
+		]);
+		expect(subscribeAlerts).toHaveBeenCalledWith("Alerts.app");
+		expect(screen.getByRole("alertdialog")).not.toBeNull();
+
+		act(() => setAlertsEnabled(false));
+		expect(screen.queryByRole("alertdialog")).toBeNull();
+		expect(unsubscribeAlerts).toHaveBeenCalledWith("Alerts.app");
+	});
+
+	it("re-subscribes when alerts are re-enabled", () => {
+		const { subscribeAlerts } = renderWithAlerts([]);
+		expect(subscribeAlerts).toHaveBeenCalledTimes(1);
+
+		act(() => setAlertsEnabled(false));
+		act(() => setAlertsEnabled(true));
+		expect(subscribeAlerts).toHaveBeenCalledTimes(2);
+	});
+});
+```
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+```bash
+cd /home/robbiebyrd/rt911/.claude/worktrees/alerts-manager && pnpm --filter @rt911/frontend exec vitest run src/Applications/Alerts/Alerts.test.tsx
+```
+
+Expected: the 6 pre-existing tests PASS; the 3 new tests FAIL (subscribe called / modal rendered despite disabled).
+
+- [ ] **Step 3: Implement the gate**
+
+In `packages/frontend/src/Applications/Alerts/Alerts.tsx`:
+
+Add the import after the `MediaStreamContext` import block (line 7):
+
+```ts
+import { useAlertsEnabled } from "./alertsSettings";
+```
+
+Read the flag next to the existing `isRunning` selector (after line 30):
+
+```ts
+const enabled = useAlertsEnabled();
+```
+
+Replace the subscribe effect (lines 38-42) — disabling runs the cleanup, and
+`unsubscribeAlerts` as the last subscriber unsubscribes the WS channel and
+clears the un-revealed buffer (`MediaStreamProvider.tsx:484-487`), so alerts
+that fire while off are skipped (fire-on-cross channel, no snapshot):
+
+```ts
+// The extension is always mounted; subscribe while the app entry exists AND
+// the user hasn't turned alerts off in the Alerts Manager control panel.
+useEffect(() => {
+	if (!isRunning || !enabled) return;
+	subscribeAlerts(appId);
+	return () => unsubscribeAlerts(appId);
+}, [isRunning, enabled, subscribeAlerts, unsubscribeAlerts]);
+```
+
+Gate the modal render (line 71) — change:
+
+```tsx
+{current && (
+```
+
+to:
+
+```tsx
+{enabled && current && (
+```
+
+- [ ] **Step 4: Run tests to verify all pass**
+
+```bash
+cd /home/robbiebyrd/rt911/.claude/worktrees/alerts-manager && pnpm --filter @rt911/frontend exec vitest run src/Applications/Alerts/Alerts.test.tsx
+```
+
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/robbiebyrd/rt911/.claude/worktrees/alerts-manager && git add packages/frontend/src/Applications/Alerts/Alerts.tsx packages/frontend/src/Applications/Alerts/Alerts.test.tsx && git commit -m "feat(alerts): gate extension subscription and modal on alertsEnabled
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Alerts Manager app + Desktop mount
+
+**Files:**
+- Create: `packages/frontend/src/Applications/Alerts/AlertsManager.tsx`
+- Modify: `packages/frontend/src/Desktop.tsx` (imports ~line 10, JSX ~line 29)
+- Test: `packages/frontend/src/Applications/Alerts/AlertsManager.test.tsx`
+
+**Interfaces:**
+- Consumes: `useAlertsEnabled()` / `setAlertsEnabled(value)` from Task 1; classicy exports `ClassicyApp`, `ClassicyWindow`, `ClassicyButton`, `ClassicyCheckbox`, `ClassicyControlGroup`, `ClassicyIcons`, `useAppManagerDispatch`, `useClassicyAboutMenu`, `useClassicyWindowClose`, `closeWindowMenuItemHelper`, `quitAppHelper`, `quitMenuItemHelper` (all verified exported from the package index).
+- Produces: `export const AlertsManager: React.FC` (mounted in `Desktop.tsx`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/frontend/src/Applications/Alerts/AlertsManager.test.tsx`.
+ClassicyApp/ClassicyWindow are replaced with prop-capturing pass-throughs
+(their real implementations need the full desktop context); the menu hooks are
+stubbed for the same reason. `ClassicyCheckbox`/`ClassicyControlGroup`/
+`ClassicyButton` render for real — `useClassicyAnalytics` inside the checkbox
+no-ops without a provider.
+
+```tsx
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Captures the props ClassicyApp is rendered with so the test can assert the
+// Apple-menu/no-desktop-icon contract without classicy's desktop chrome.
+const appProps = vi.hoisted(() => ({ current: {} as Record<string, unknown> }));
+
+vi.mock("classicy", async (importOriginal) => ({
+	...(await importOriginal<typeof import("classicy")>()),
+	ClassicyApp: ({
+		children,
+		...props
+	}: { children?: React.ReactNode } & Record<string, unknown>) => {
+		appProps.current = props;
+		return <div>{children}</div>;
+	},
+	ClassicyWindow: ({ children }: { children?: React.ReactNode }) => (
+		<div>{children}</div>
+	),
+	useAppManagerDispatch: () => vi.fn(),
+	useClassicyAboutMenu: () => ({
+		aboutMenuItem: { id: "about" },
+		aboutWindow: null,
+	}),
+	useClassicyWindowClose: () => vi.fn(),
+}));
+
+import { AlertsManager } from "./AlertsManager";
+import { getAlertsEnabled, resetAlertsSettingsForTests, setAlertsEnabled } from "./alertsSettings";
+
+afterEach(() => {
+	cleanup();
+	window.localStorage.clear();
+	resetAlertsSettingsForTests();
+});
+
+describe("Alerts Manager control panel", () => {
+	it("registers as an Apple-menu app with no desktop icon", () => {
+		render(<AlertsManager />);
+		expect(appProps.current.id).toBe("AlertsManager.app");
+		expect(appProps.current.noDesktopIcon).toBe(true);
+		expect(appProps.current.addSystemMenu).toBe(true);
+	});
+
+	it("shows the checkbox checked while alerts are enabled", () => {
+		render(<AlertsManager />);
+		const checkbox = screen.getByLabelText("Show Alerts") as HTMLInputElement;
+		expect(checkbox.checked).toBe(true);
+	});
+
+	it("reflects a persisted disabled state", () => {
+		setAlertsEnabled(false);
+		render(<AlertsManager />);
+		const checkbox = screen.getByLabelText("Show Alerts") as HTMLInputElement;
+		expect(checkbox.checked).toBe(false);
+	});
+
+	it("toggling the checkbox flips and persists the store", () => {
+		render(<AlertsManager />);
+		const checkbox = screen.getByLabelText("Show Alerts");
+
+		act(() => {
+			fireEvent.click(checkbox);
+		});
+		expect(getAlertsEnabled()).toBe(false);
+		expect(window.localStorage.getItem("rt911AlertsEnabled")).toBe("false");
+
+		act(() => {
+			fireEvent.click(checkbox);
+		});
+		expect(getAlertsEnabled()).toBe(true);
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /home/robbiebyrd/rt911/.claude/worktrees/alerts-manager && pnpm --filter @rt911/frontend exec vitest run src/Applications/Alerts/AlertsManager.test.tsx
+```
+
+Expected: FAIL — cannot resolve `./AlertsManager`.
+
+- [ ] **Step 3: Write the component**
+
+Create `packages/frontend/src/Applications/Alerts/AlertsManager.tsx`.
+Structure mirrors classicy's `ClassicyDateAndTimeManager` (the Apple-menu
+control-panel idiom: `noDesktopIcon` + `addSystemMenu`). No Edit menu — this
+panel has no text-entry fields. The icon is the same bundled warning icon the
+Alerts extension declares, tying the pair together in the Apple menu / About
+window (the only places it renders).
+
+```tsx
+import {
+	ClassicyApp,
+	ClassicyButton,
+	ClassicyCheckbox,
+	ClassicyControlGroup,
+	ClassicyIcons,
+	ClassicyWindow,
+	closeWindowMenuItemHelper,
+	quitAppHelper,
+	quitMenuItemHelper,
+	useAppManagerDispatch,
+	useClassicyAboutMenu,
+	useClassicyWindowClose,
+} from "classicy";
+import type React from "react";
+import { setAlertsEnabled, useAlertsEnabled } from "./alertsSettings";
+
+const APP_ID = "AlertsManager.app";
+const APP_NAME = "Alerts Manager";
+const WINDOW_ID = "AlertsManager_1";
+const appIcon = ClassicyIcons.applications.internetExplorer
+	.documentWarning as string;
+
+/**
+ * Control panel for the Alerts extension: an Apple-menu app (no desktop icon)
+ * whose single checkbox writes the shared alertsSettings store. While off, the
+ * extension unsubscribes from the alerts channel entirely — alerts whose
+ * moment passes are skipped, not queued (see the design doc,
+ * plans/2026-07-20-alerts-manager-design.md).
+ */
+export const AlertsManager: React.FC = () => {
+	const enabled = useAlertsEnabled();
+	const desktopEventDispatch = useAppManagerDispatch();
+
+	const { aboutMenuItem, aboutWindow } = useClassicyAboutMenu(
+		APP_ID,
+		APP_NAME,
+		appIcon,
+	);
+	const windowClose = useClassicyWindowClose(APP_ID);
+
+	const quitApp = () => {
+		desktopEventDispatch(quitAppHelper(APP_ID, APP_NAME, appIcon));
+	};
+
+	// Mac OS 8 HIG control-panel menu bar. The About entry is discovery data:
+	// ClassicyDesktopMenuBar hoists it into the Apple menu and strips it from
+	// this menu before rendering. No Edit menu — there are no entry fields.
+	const appMenu = [
+		{
+			id: `${APP_ID}_file`,
+			title: "File",
+			menuChildren: [
+				{ ...aboutMenuItem, title: `About ${APP_NAME}` },
+				{
+					...closeWindowMenuItemHelper(`${APP_ID}_close_window`, () =>
+						windowClose(WINDOW_ID, quitAppHelper(APP_ID, APP_NAME, appIcon)),
+					),
+					keyboardShortcut: "⌥W",
+				},
+				{ id: "spacer" },
+				{
+					...quitMenuItemHelper(APP_ID, APP_NAME, appIcon),
+					keyboardShortcut: "⌥Q",
+				},
+			],
+		},
+	];
+
+	return (
+		<ClassicyApp
+			id={APP_ID}
+			name={APP_NAME}
+			icon={appIcon}
+			defaultWindow={WINDOW_ID}
+			noDesktopIcon={true}
+			addSystemMenu={true}
+		>
+			<ClassicyWindow
+				id={WINDOW_ID}
+				title={APP_NAME}
+				appId={APP_ID}
+				icon={appIcon}
+				closable={true}
+				resizable={false}
+				zoomable={false}
+				scrollable={false}
+				collapsable={false}
+				initialSize={[280, 130]}
+				initialPosition={[320, 80]}
+				modal={false}
+				appMenu={appMenu}
+			>
+				<ClassicyControlGroup label={"Alerts"}>
+					<ClassicyCheckbox
+						id={"show_alerts"}
+						label={"Show Alerts"}
+						checked={enabled}
+						onClickFunc={(checked: boolean) => setAlertsEnabled(checked)}
+					/>
+				</ClassicyControlGroup>
+				<ClassicyButton isDefault={false} onClickFunc={quitApp}>
+					Quit
+				</ClassicyButton>
+			</ClassicyWindow>
+			{aboutWindow}
+		</ClassicyApp>
+	);
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd /home/robbiebyrd/rt911/.claude/worktrees/alerts-manager && pnpm --filter @rt911/frontend exec vitest run src/Applications/Alerts/AlertsManager.test.tsx
+```
+
+Expected: PASS (4 tests). If `getByLabelText` fails because `ClassicyControlLabel` renders the label without an htmlFor association in this version, switch the queries to `container.querySelector('input#show_alerts')` — do not weaken the assertions.
+
+- [ ] **Step 5: Mount in Desktop.tsx**
+
+In `packages/frontend/src/Desktop.tsx`, add the import directly under the `Alerts` import (line 10):
+
+```ts
+import { AlertsManager } from "./Applications/Alerts/AlertsManager";
+```
+
+and mount it directly under `<Alerts />` (line 29):
+
+```tsx
+			<Alerts />
+			<AlertsManager />
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/robbiebyrd/rt911/.claude/worktrees/alerts-manager && git add packages/frontend/src/Applications/Alerts/AlertsManager.tsx packages/frontend/src/Applications/Alerts/AlertsManager.test.tsx packages/frontend/src/Desktop.tsx && git commit -m "feat(alerts): Alerts Manager control panel in the Apple menu
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Full verification
+
+**Files:** none new.
+
+**Interfaces:** n/a — runs the same checks CI requires (`tsc -b`, `eslint .`, `vitest run`).
+
+- [ ] **Step 1: Run the full frontend check suite**
+
+```bash
+cd /home/robbiebyrd/rt911/.claude/worktrees/alerts-manager && pnpm build && pnpm lint && pnpm test
+```
+
+Expected: `tsc -b && vite build` succeeds, eslint clean, all vitest suites pass (baseline on main was green; only the three Alerts suites changed).
+
+- [ ] **Step 2: Fix anything that fails, re-run until green, then commit any fixes**
+
+If all three commands passed with no changes, skip the commit. Otherwise:
+
+```bash
+cd /home/robbiebyrd/rt911/.claude/worktrees/alerts-manager && git add -A && git commit -m "fix(alerts): verification fixes
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```

--- a/plans/2026-07-20-alerts-manager-plan.md
+++ b/plans/2026-07-20-alerts-manager-plan.md
@@ -299,8 +299,10 @@ const enabled = useAlertsEnabled();
 
 Replace the subscribe effect (lines 38-42) — disabling runs the cleanup, and
 `unsubscribeAlerts` as the last subscriber unsubscribes the WS channel and
-clears the un-revealed buffer (`MediaStreamProvider.tsx:484-487`), so alerts
-that fire while off are skipped (fire-on-cross channel, no snapshot):
+clears both the un-revealed buffer and the revealed `alertItems` list
+(`setAlertItems([])`, `MediaStreamProvider.tsx:484-487`), so alerts that fire
+while off — and any alert still visible-but-unacknowledged at the moment of
+toggle-off — are skipped/dropped (fire-on-cross channel, no snapshot):
 
 ```ts
 // The extension is always mounted; subscribe while the app entry exists AND

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 18.1.0
       classicy:
         specifier: latest
-        version: 0.45.0(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30)
+        version: 0.45.1(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30)
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -1847,8 +1847,8 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
-  classicy@0.45.0:
-    resolution: {integrity: sha512-9jFcMHH5bo4xptvcbGQmSmytKrHNU+UKxj3rcoTH4CX53Jxb5UE9xqR7QV1grwYMGiJSQtiNZkDiM4elCvdi8w==}
+  classicy@0.45.1:
+    resolution: {integrity: sha512-1tPLwS5dWhYcSdbaxYOtF6K1szWmkYLQbdkA9Tr9CyKQlFpf/ohfn4a6CyAJno0VOUQgdaunmhJVWWXq+NvK2w==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -5849,7 +5849,7 @@ snapshots:
       readdirp: 5.0.0
     optional: true
 
-  classicy@0.45.0(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30):
+  classicy@0.45.1(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30):
     dependencies:
       '@analytics/google-tag-manager': 0.6.0
       '@mdxeditor/editor': 3.55.0(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30)


### PR DESCRIPTION
## Summary

Adds an **Alerts Manager** control panel — an Apple-menu app with **no desktop icon** (`noDesktopIcon` + `addSystemMenu`, the `ClassicyDateAndTimeManager` idiom) containing a single **"Show Alerts"** checkbox that turns the Alerts extension's stream-driven modals on or off.

- **`alertsSettings.ts`** — ~30-line external store (`useSyncExternalStore` + `localStorage` key `rt911AlertsEnabled`, default on, persists across reloads, safe on throwing storage).
- **`Alerts.tsx`** — gates both the `alerts`-channel subscription and the modal on the flag. While off the extension **unsubscribes entirely** (no WS traffic); since the channel is fire-on-cross/no-snapshot, alerts whose moment passes while off are skipped — matching live-broadcast semantics. A visible-but-unacknowledged alert at toggle-off is dropped permanently (provider clears both buffer and revealed list).
- **`AlertsManager.tsx`** — the control panel window (File menu with About/Close ⌥W/Quit ⌥Q, fixed-size window, Quit button), mounted in `Desktop.tsx`.
- **`vitest.setup.ts`** — in-memory localStorage polyfill: Node 25's native throwing `localStorage` shadows jsdom's inside vitest (`populateGlobal` skips keys already on the global), so tests need one.

Design doc: `plans/2026-07-20-alerts-manager-design.md` · Plan: `plans/2026-07-20-alerts-manager-plan.md`

## Test plan

- [x] `alertsSettings` store: default/hydration/persistence/hook reactivity + mutation-verified throwing-storage coverage
- [x] `Alerts` extension gating: no subscribe + no modal while disabled; unsubscribe + modal unmount on toggle-off; re-subscribe on re-enable
- [x] `AlertsManager`: Apple-menu/no-desktop-icon registration props, checkbox reflects + flips + persists the store
- [x] Full frontend suite 1370/1370 across 156 files; `pnpm build` green; eslint 0 errors (6 pre-existing warnings in untouched files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)