### PR TITLE
fix(subtitles): retry Wasabi read resets; fail loudly on channel-lookup miss

### DIFF
--- a/packages/tools/video-grabber/tests/test_transcribe_flows.py
+++ b/packages/tools/video-grabber/tests/test_transcribe_flows.py
@@ -155,3 +155,21 @@ def test_build_channel_cues_mixed_tzinfo_naive_window_start_aware_air_date():
     assert len(cues) == 1
     assert cues[0].text == "Mixed tz cue"
     assert abs(cues[0].start - 3601.0) < 1e-6
+
+
+# ---- build-channel-subtitles must fail loudly on a channel-lookup miss ------
+#
+# The lookup matches tv_channels on the content marker {"channel_stream": slug}.
+# CCTV4's marker sat on the stale "cctv3" long after everything else moved to
+# "cctv4", so the flow took its early-return and reported COMPLETED while
+# writing nothing — a fully transcribed 345-program channel silently had no
+# subtitles. A miss is a misconfiguration, not a no-op.
+
+
+def test_build_channel_subtitles_raises_when_channel_lookup_misses():
+    from unittest.mock import MagicMock, patch
+
+    with patch.object(flows, "Config", return_value=MagicMock()), \
+         patch.object(flows, "get_tv_channel_start_date", return_value=None):
+        with pytest.raises(ValueError, match="no tv_channels row"):
+            flows.build_channel_subtitles_flow("cctv4")

--- a/packages/tools/video-grabber/tests/test_wasabi_read_text.py
+++ b/packages/tools/video-grabber/tests/test_wasabi_read_text.py
@@ -1,0 +1,76 @@
+"""
+read_text retries transient Wasabi connection resets.
+
+Wasabi drops connections under concurrent read load, surfacing as
+ResponseStreamingError("IncompleteRead(0 bytes read, N more expected)") — the
+body read dies before any payload arrives. boto3's own retry layer does not
+cover it (the failure is past the point botocore retries), so a single reset
+used to kill an entire build-channel-subtitles run that reads one SRT per
+program. These tests pin the retry, its bound, and that real errors still fail
+fast.
+"""
+import pytest
+from botocore.exceptions import ClientError, ResponseStreamingError
+from tenacity import wait_none
+
+from video_grabber.config import Config
+from video_grabber.storage import wasabi
+
+
+@pytest.fixture
+def cfg(monkeypatch):
+    monkeypatch.setenv("WASABI_BUCKET", "test-bucket")
+    monkeypatch.setenv("WASABI_ACCESS_KEY_ID", "test")
+    monkeypatch.setenv("WASABI_SECRET_ACCESS_KEY", "test")
+    return Config()
+
+
+class _Body:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def read(self) -> bytes:
+        return self._data
+
+
+class _FlakyS3:
+    """Raises ``fail_times`` streaming resets, then serves the body."""
+
+    def __init__(self, fail_times: int, exc: Exception | None = None):
+        self.fail_times = fail_times
+        self.calls = 0
+        self._exc = exc or ResponseStreamingError(
+            error="('Connection broken: IncompleteRead(0 bytes read, 40 more expected)')"
+        )
+
+    def get_object(self, **_kw):
+        self.calls += 1
+        if self.calls <= self.fail_times:
+            raise self._exc
+        return {"Body": _Body(b"cue text")}
+
+
+# Strip the backoff so the retry logic is exercised without the wall-clock wait.
+_read_text_nowait = wasabi.read_text.retry_with(wait=wait_none())
+
+
+def test_read_text_retries_transient_reset_then_succeeds(cfg):
+    s3 = _FlakyS3(fail_times=2)
+    assert _read_text_nowait("subtitles/programs/x.srt", cfg, s3=s3) == "cue text"
+    assert s3.calls == 3  # two resets, then the good read
+
+
+def test_read_text_gives_up_after_five_attempts(cfg):
+    s3 = _FlakyS3(fail_times=99)
+    with pytest.raises(ResponseStreamingError):
+        _read_text_nowait("subtitles/programs/x.srt", cfg, s3=s3)
+    assert s3.calls == 5  # stop_after_attempt(5), then reraise
+
+
+def test_read_text_does_not_retry_real_errors(cfg):
+    """A missing key is a genuine failure — retrying it just wastes time."""
+    missing = ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject")
+    s3 = _FlakyS3(fail_times=99, exc=missing)
+    with pytest.raises(ClientError):
+        _read_text_nowait("subtitles/programs/missing.srt", cfg, s3=s3)
+    assert s3.calls == 1

--- a/packages/tools/video-grabber/video_grabber/storage/wasabi.py
+++ b/packages/tools/video-grabber/video_grabber/storage/wasabi.py
@@ -10,9 +10,33 @@ Key behaviors:
 import boto3
 from boto3.s3.transfer import TransferConfig
 from botocore.config import Config as BotoCoreConfig
+from botocore.exceptions import (
+    ConnectionError as BotoConnectionError,
+    ReadTimeoutError,
+    ResponseStreamingError,
+)
 from pathlib import Path
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_random_exponential,
+)
 
 from video_grabber.config import Config
+
+# Wasabi resets connections under concurrent read load: the body read then dies
+# with ResponseStreamingError("IncompleteRead(0 bytes read, N more expected)"),
+# i.e. the connection breaks before any payload arrives. boto3's own retry layer
+# does NOT cover this — the failure happens after the response starts streaming,
+# past the point botocore will retry. Callers that read many objects in a loop
+# (build-channel-subtitles reads one SRT per program, ~500 for a big channel)
+# otherwise lose the whole run to a single reset.
+_TRANSIENT_S3_ERRORS = (
+    ResponseStreamingError,
+    BotoConnectionError,
+    ReadTimeoutError,
+)
 
 _CONTENT_TYPES: dict[str, tuple[str, str]] = {
     ".m3u8": ("application/vnd.apple.mpegurl", "max-age=5"),
@@ -89,8 +113,18 @@ def upload_text(content: str, key: str, cfg: Config, *, s3=None) -> None:
     )
 
 
+# Full-jitter backoff so parallel channel builds don't retry in lockstep and
+# re-create the same load spike that broke the connection. When the caller
+# doesn't supply a client, each attempt builds a fresh one, so a retry never
+# reuses the pool that just failed.
+@retry(
+    stop=stop_after_attempt(5),
+    wait=wait_random_exponential(multiplier=1, max=20),
+    retry=retry_if_exception_type(_TRANSIENT_S3_ERRORS),
+    reraise=True,
+)
 def read_text(key: str, cfg: Config, *, s3=None) -> str:
-    """Read an object's body as a UTF-8 string."""
+    """Read an object's body as a UTF-8 string. Retries transient S3 resets."""
     s3 = s3 or _make_s3_client(cfg)
     obj = s3.get_object(Bucket=cfg.wasabi_bucket, Key=key)
     return obj["Body"].read().decode("utf-8")

--- a/packages/tools/video-grabber/video_grabber/transcribe/flows.py
+++ b/packages/tools/video-grabber/video_grabber/transcribe/flows.py
@@ -216,8 +216,16 @@ def build_channel_subtitles_flow(channel_slug: str) -> None:
     cfg = Config()
     window_start = get_tv_channel_start_date(channel_slug, cfg)
     if window_start is None:
-        logger.warning("build-channel-subtitles: no tv_channels row for %s; skipping", channel_slug)
-        return
+        # Hard failure, not a skip. This lookup matches tv_channels on the
+        # content marker {"channel_stream": <slug>}; a stale marker (CCTV4 sat
+        # on "cctv3" long after everything else moved to "cctv4") silently
+        # produced a COMPLETED run that wrote nothing, hiding a fully
+        # transcribed channel with no subtitles. Fail loudly instead.
+        raise ValueError(
+            f"build-channel-subtitles: no tv_channels row matches "
+            f'content marker {{"channel_stream": "{channel_slug}"}} — '
+            "refusing to report success without writing subtitles"
+        )
 
     with get_db() as db:
         rows = db.execute(sa.text("""
@@ -229,7 +237,13 @@ def build_channel_subtitles_flow(channel_slug: str) -> None:
             ORDER BY p.air_date
         """), {"slug": channel_slug}).mappings().all()
         if not rows:
-            logger.info("build-channel-subtitles: %s has no done programs yet", channel_slug)
+            # Legitimate mid-rollout state (nothing transcribed yet), so not an
+            # error — but warn, so an unexpectedly empty channel is visible
+            # rather than buried at info level in a "successful" run.
+            logger.warning(
+                "build-channel-subtitles: %s has no done programs with an srt_key; "
+                "wrote nothing", channel_slug,
+            )
             return
 
     programs = [(r["air_date"], wasabi.read_text(r["srt_key"], cfg)) for r in rows]


### PR DESCRIPTION
Two problems surfaced while building per-channel subtitle tracks for all 23 TV channels (now **23/23 complete**). Both were silent or misleading.

## 1. Transient Wasabi resets killed entire builds
Reads failed with `ResponseStreamingError: IncompleteRead(0 bytes read, N more expected)` — the connection breaks **before any payload arrives**. boto3's retry layer doesn't cover it (the failure is past the point botocore retries), so a single reset lost a whole run. A large channel reads ~500 SRTs (one per program), so the blast radius was total.

**It was concurrency, not size.** The 5 largest channels failed 7 times across two batches when run in parallel — but a *solo* run of the same channel did **200+ reads with zero failures**. Running them serially, every one succeeded first try.

`read_text` now retries the transient S3 errors with full-jitter backoff (the same tenacity convention already used in `usenet/downloader.py` and `pipeline/downloader.py`), building a fresh client per attempt so a retry never reuses the pool that just failed.

## 2. `build-channel-subtitles` reported COMPLETED while writing nothing
The `tv_channels` lookup matches on the content marker `{"channel_stream": <slug>}`. **CCTV4's marker sat on the stale `"cctv3"`** long after everything else moved to `cctv4`, so the flow hit its early-return and "succeeded" — a fully transcribed **345-program** channel silently had no subtitles, and nothing in the run surfaced it.

A lookup miss is a misconfiguration, so it now **raises**. The separate "no done programs" case stays non-fatal (legitimate mid-rollout) but is now warned instead of buried at info level inside an otherwise-successful run.

## Tests
- retry succeeds after resets, gives up at 5 attempts, and **does not** retry real errors (a missing key still fails fast)
- the flow raises on a lookup miss

`348 passed`, ruff clean. (The 12 errors are `test_migrations.py`'s documented no-local-Postgres gap — CI provides `postgres:16`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)