### PR TITLE
feat(flighttracker): 8-bit plane sprites in radar map style

### DIFF
--- a/packages/frontend/src/Applications/FlightTracker/FlightMap.test.tsx
+++ b/packages/frontend/src/Applications/FlightTracker/FlightMap.test.tsx
@@ -169,7 +169,8 @@ import {
 import { motionPointsToGeoJSON, updateMotion, type MotionBuffer } from "./flightMotion";
 import { TRACK_LINE_COLOR, TRACK_SHADOW_COLOR } from "./flightMapStyle";
 import { loadAircraftIconSvg } from "./aircraftIcons";
-import { buildPlaneImage } from "./flightIcons";
+import { buildPlaneImage, PLANE_ICON_PX } from "./flightIcons";
+import type { BasemapStyleId } from "../../lib/basemap/basemapStyles";
 
 const pos = (over: Partial<FlightPosition>): FlightPosition => ({
 	id: 1, flight: "AA1002", start_date: "2001-09-11T13:00:00Z",
@@ -1294,12 +1295,15 @@ describe("FlightMap", () => {
 			);
 		});
 
-		const renderWithFamily = (familyOf?: (flight: string, startDate: string) => string) =>
+		const renderWithFamily = (
+			familyOf?: (flight: string, startDate: string) => string,
+			mapStyle: BasemapStyleId = "classic",
+		) =>
 			render(
 				<FlightMap positions={[pos({ id: 5, flight: "AA11" })]} basemapUrls={TEST_URLS}
 					trackGeoJSON={null} nowMs={Date.parse("2001-09-11T13:00:00Z")} playing={false}
 					onSelectFlight={() => {}} onClearSelection={() => {}}
-					darkMap={false} mapStyle="classic" pinColor="#3a3a3a" notablePinColor="#c0202a" observerPinColor="#0f766e"
+					darkMap={false} mapStyle={mapStyle} pinColor="#3a3a3a" notablePinColor="#c0202a" observerPinColor="#0f766e"
 					radarSweep={false} trailMultiplier={1} aircraftFamilyOf={familyOf} />,
 			);
 
@@ -1342,8 +1346,19 @@ describe("FlightMap", () => {
 			expect(map.images["plane-b767"]).toBeTruthy();
 			expect(map.images["plane-notable-b767"]).toBeTruthy();
 			// Sizes: regular at FAMILY_ICON_PX.b767=15, notable at round(32*15/12)=40.
-			expect(buildPlaneImage).toHaveBeenCalledWith('<svg data-family="b767"/>', "#3a3a3a", 15);
-			expect(buildPlaneImage).toHaveBeenCalledWith('<svg data-family="b767"/>', "#c0202a", 40);
+			// Trailing flag is the 8-bit variant — off outside radar.
+			expect(buildPlaneImage).toHaveBeenCalledWith('<svg data-family="b767"/>', "#3a3a3a", 15, false);
+			expect(buildPlaneImage).toHaveBeenCalledWith('<svg data-family="b767"/>', "#c0202a", 40, false);
+		});
+
+		it("rasterizes the 8-bit variant in radar mode, for family and generic icons alike", async () => {
+			renderWithFamily(() => "b767", "radar");
+			await act(async () => { FakeMap.last!.fire("load"); });
+			// Every icon built while radar is the active style is pixellated —
+			// the generic fallback too, or planes change art mid-fetch.
+			expect(buildPlaneImage).toHaveBeenCalledWith('<svg data-family="b767"/>', "#3a3a3a", 15, true);
+			expect(buildPlaneImage).toHaveBeenCalledWith(expect.any(String), "#3a3a3a", PLANE_ICON_PX, true);
+			expect(vi.mocked(buildPlaneImage).mock.calls.every((c) => c[3] === true)).toBe(true);
 		});
 
 		it("never fetches an icon for the generic family", async () => {

--- a/packages/frontend/src/Applications/FlightTracker/FlightMap.test.tsx
+++ b/packages/frontend/src/Applications/FlightTracker/FlightMap.test.tsx
@@ -169,7 +169,7 @@ import {
 import { motionPointsToGeoJSON, updateMotion, type MotionBuffer } from "./flightMotion";
 import { TRACK_LINE_COLOR, TRACK_SHADOW_COLOR } from "./flightMapStyle";
 import { loadAircraftIconSvg } from "./aircraftIcons";
-import { buildPlaneImage, PLANE_ICON_PX } from "./flightIcons";
+import { buildPlaneImage, iconDisplayPx, PLANE_ICON_PX } from "./flightIcons";
 import type { BasemapStyleId } from "../../lib/basemap/basemapStyles";
 
 const pos = (over: Partial<FlightPosition>): FlightPosition => ({
@@ -1356,9 +1356,14 @@ describe("FlightMap", () => {
 			await act(async () => { FakeMap.last!.fire("load"); });
 			// Every icon built while radar is the active style is pixellated —
 			// the generic fallback too, or planes change art mid-fetch.
-			expect(buildPlaneImage).toHaveBeenCalledWith('<svg data-family="b767"/>', "#3a3a3a", 15, true);
-			expect(buildPlaneImage).toHaveBeenCalledWith(expect.any(String), "#3a3a3a", PLANE_ICON_PX, true);
 			expect(vi.mocked(buildPlaneImage).mock.calls.every((c) => c[3] === true)).toBe(true);
+			// Regular icons are scaled up for grid room: b767 15 -> 23, generic
+			// 12 -> 18. Notables keep their unscaled 40 (round(32*15/12)).
+			expect(buildPlaneImage).toHaveBeenCalledWith('<svg data-family="b767"/>', "#3a3a3a", 23, true);
+			expect(buildPlaneImage).toHaveBeenCalledWith('<svg data-family="b767"/>', "#c0202a", 40, true);
+			expect(buildPlaneImage).toHaveBeenCalledWith(
+				expect.any(String), "#3a3a3a", iconDisplayPx(PLANE_ICON_PX, true), true,
+			);
 		});
 
 		it("never fetches an icon for the generic family", async () => {

--- a/packages/frontend/src/Applications/FlightTracker/FlightMap.tsx
+++ b/packages/frontend/src/Applications/FlightTracker/FlightMap.tsx
@@ -4,7 +4,7 @@ import { type FC, type Ref, useEffect, useImperativeHandle, useRef, useState } f
 import { MapCompass } from "./MapCompass";
 import type { FlightPosition } from "../../Providers/MediaStream/MediaStreamContext";
 import type { FlightFeatureCollection } from "./flightGeoJSON";
-import { basemapPalette, TERRAIN_SOURCE } from "../../lib/basemap/basemapStyles";
+import { basemapPalette, pixelPlanes, TERRAIN_SOURCE } from "../../lib/basemap/basemapStyles";
 import {
 	type BasemapStyleId,
 	type BasemapUrls,
@@ -101,12 +101,13 @@ async function installPlaneIcons(
 	pinColor: string,
 	notablePinColor: string,
 	observerPinColor: string,
+	pixelate: boolean,
 ) {
 	try {
 		const [regular, notable, observer] = await Promise.all([
-			buildPlaneImage(planeSvg, pinColor, PLANE_ICON_PX),
-			buildPlaneImage(planeSvg, notablePinColor, PLANE_NOTABLE_ICON_PX),
-			buildPlaneImage(planeSvg, observerPinColor, PLANE_NOTABLE_ICON_PX),
+			buildPlaneImage(planeSvg, pinColor, PLANE_ICON_PX, pixelate),
+			buildPlaneImage(planeSvg, notablePinColor, PLANE_NOTABLE_ICON_PX, pixelate),
+			buildPlaneImage(planeSvg, observerPinColor, PLANE_NOTABLE_ICON_PX, pixelate),
 		]);
 		if (map.hasImage(PLANE_ICON_ID)) map.updateImage(PLANE_ICON_ID, regular);
 		else map.addImage(PLANE_ICON_ID, regular, { pixelRatio: 2 });
@@ -128,12 +129,13 @@ async function installFamilyIcon(
 	pinColor: string,
 	notablePinColor: string,
 	observerPinColor: string,
+	pixelate: boolean,
 ) {
 	try {
 		const [regular, notable, observer] = await Promise.all([
-			buildPlaneImage(svg, pinColor, familyIconPx(family)),
-			buildPlaneImage(svg, notablePinColor, familyNotableIconPx(family)),
-			buildPlaneImage(svg, observerPinColor, familyNotableIconPx(family)),
+			buildPlaneImage(svg, pinColor, familyIconPx(family), pixelate),
+			buildPlaneImage(svg, notablePinColor, familyNotableIconPx(family), pixelate),
+			buildPlaneImage(svg, observerPinColor, familyNotableIconPx(family), pixelate),
 		]);
 		const id = familyIconId(family);
 		const notableId = familyNotableIconId(family);
@@ -185,7 +187,7 @@ function requestFamilyIcons(
 	requested: Set<string>,
 	loaded: Map<string, string>,
 	mapRef: { current: maplibregl.Map | null },
-	colorsRef: { current: { pinColor: string; notablePinColor: string; observerPinColor: string } },
+	colorsRef: { current: FlightMapColors },
 ) {
 	for (const f of fc.features) {
 		const family = f.properties.family;
@@ -198,7 +200,7 @@ function requestFamilyIcons(
 			void installFamilyIcon(
 				map, family, svg,
 				colorsRef.current.pinColor, colorsRef.current.notablePinColor,
-				colorsRef.current.observerPinColor,
+				colorsRef.current.observerPinColor, pixelPlanes(colorsRef.current.mapStyle),
 			);
 		});
 	}
@@ -692,6 +694,7 @@ export const FlightMap: FC<FlightMapProps> = ({
 			});
 			void installPlaneIcons(
 				map, colors.pinColor, colors.notablePinColor, colors.observerPinColor,
+				pixelPlanes(colors.mapStyle),
 			);
 			// Cluster mode (issue #222): a second, pre-clustered source — MapLibre
 			// fixes the cluster option at addSource time, so toggling is a
@@ -1034,9 +1037,14 @@ export const FlightMap: FC<FlightMapProps> = ({
 		const map = mapRef.current;
 		if (!map || !loadedRef.current) return;
 		applyMapColors(map, { mapStyle, darkMap, pinColor, notablePinColor, observerPinColor, terrain });
-		void installPlaneIcons(map, pinColor, notablePinColor, observerPinColor);
+		// mapStyle is already a dep, so switching to/from radar re-rasterizes
+		// every registered icon into (or out of) its 8-bit variant for free.
+		const pixelate = pixelPlanes(mapStyle);
+		void installPlaneIcons(map, pinColor, notablePinColor, observerPinColor, pixelate);
 		for (const [family, svg] of loadedIconSvgsRef.current) {
-			void installFamilyIcon(map, family, svg, pinColor, notablePinColor, observerPinColor);
+			void installFamilyIcon(
+				map, family, svg, pinColor, notablePinColor, observerPinColor, pixelate,
+			);
 		}
 		planes3DRef.current?.setColors(pinColor, notablePinColor, observerPinColor);
 		replayTrail3DRef.current?.setColors(pinColor, notablePinColor, observerPinColor);

--- a/packages/frontend/src/Applications/FlightTracker/FlightMap.tsx
+++ b/packages/frontend/src/Applications/FlightTracker/FlightMap.tsx
@@ -30,6 +30,7 @@ import {
 	familyNotableIconId,
 	familyNotableIconPx,
 	familyObserverIconId,
+	iconDisplayPx,
 } from "./flightIcons";
 import {
 	type FlightMotion,
@@ -105,7 +106,7 @@ async function installPlaneIcons(
 ) {
 	try {
 		const [regular, notable, observer] = await Promise.all([
-			buildPlaneImage(planeSvg, pinColor, PLANE_ICON_PX, pixelate),
+			buildPlaneImage(planeSvg, pinColor, iconDisplayPx(PLANE_ICON_PX, pixelate), pixelate),
 			buildPlaneImage(planeSvg, notablePinColor, PLANE_NOTABLE_ICON_PX, pixelate),
 			buildPlaneImage(planeSvg, observerPinColor, PLANE_NOTABLE_ICON_PX, pixelate),
 		]);
@@ -133,7 +134,7 @@ async function installFamilyIcon(
 ) {
 	try {
 		const [regular, notable, observer] = await Promise.all([
-			buildPlaneImage(svg, pinColor, familyIconPx(family), pixelate),
+			buildPlaneImage(svg, pinColor, iconDisplayPx(familyIconPx(family), pixelate), pixelate),
 			buildPlaneImage(svg, notablePinColor, familyNotableIconPx(family), pixelate),
 			buildPlaneImage(svg, observerPinColor, familyNotableIconPx(family), pixelate),
 		]);

--- a/packages/frontend/src/Applications/FlightTracker/flightIcons.test.ts
+++ b/packages/frontend/src/Applications/FlightTracker/flightIcons.test.ts
@@ -3,7 +3,9 @@ import {
 	PLANE_ICON_PX,
 	PLANE_NOTABLE_ICON_PX,
 	PIXEL_ALPHA_THRESHOLD,
+	PIXEL_GRID_MIN,
 	colorizeSvg,
+	iconDisplayPx,
 	FAMILY_ICON_PX,
 	familyIconId,
 	familyIconPx,
@@ -90,6 +92,29 @@ describe("pixelGrid", () => {
 
 	it("gives bigger icons more blocks, not bigger blocks forever", () => {
 		expect(pixelGrid(PLANE_NOTABLE_ICON_PX)).toBeGreaterThan(pixelGrid(PLANE_ICON_PX));
+	});
+});
+
+describe("iconDisplayPx", () => {
+	it("leaves sizes untouched outside radar mode", () => {
+		for (const px of Object.values(FAMILY_ICON_PX)) {
+			expect(iconDisplayPx(px, false)).toBe(px);
+		}
+	});
+
+	it("buys the small families real grid cells in radar mode", () => {
+		// The whole point of the scale-up: at grid 8 a silhouette is a blob.
+		// Every family must clear that floor once scaled.
+		for (const px of Object.values(FAMILY_ICON_PX)) {
+			expect(pixelGrid(iconDisplayPx(px, true)), `${px}px`).toBeGreaterThan(PIXEL_GRID_MIN);
+		}
+	});
+
+	it("keeps regular icons smaller than notables, so the hierarchy survives", () => {
+		// Notables are NOT scaled — they already sit at the grid cap. A regular
+		// plane that outgrew them would break the highlight read.
+		const biggest = Math.max(...Object.values(FAMILY_ICON_PX));
+		expect(iconDisplayPx(biggest, true)).toBeLessThan(PLANE_NOTABLE_ICON_PX);
 	});
 });
 

--- a/packages/frontend/src/Applications/FlightTracker/flightIcons.test.ts
+++ b/packages/frontend/src/Applications/FlightTracker/flightIcons.test.ts
@@ -2,12 +2,15 @@ import { describe, expect, it } from "vitest";
 import {
 	PLANE_ICON_PX,
 	PLANE_NOTABLE_ICON_PX,
+	PIXEL_ALPHA_THRESHOLD,
 	colorizeSvg,
 	FAMILY_ICON_PX,
 	familyIconId,
 	familyIconPx,
 	familyNotableIconId,
 	familyNotableIconPx,
+	pixelGrid,
+	snapAlpha,
 } from "./flightIcons";
 import type { AircraftFamily } from "./aircraftModels";
 
@@ -66,5 +69,53 @@ describe("family icon sizing and ids", () => {
 	it("falls back to the generic sizes for unknown families", () => {
 		expect(familyIconPx("nonsense")).toBe(PLANE_ICON_PX);
 		expect(familyNotableIconPx("nonsense")).toBe(PLANE_NOTABLE_ICON_PX);
+	});
+});
+
+describe("pixelGrid", () => {
+	it("stays coarse enough to read as blocks at every family size", () => {
+		// Every regular family size rasterizes at 2x, so a grid of N over
+		// displayPx*2 device px gives blocks of (displayPx*2)/N. Below ~2
+		// device px the blocks stop being visible and it just looks blurry.
+		for (const px of Object.values(FAMILY_ICON_PX)) {
+			expect((px * 2) / pixelGrid(px), `${px}px`).toBeGreaterThanOrEqual(2);
+		}
+	});
+
+	it("clamps to the 8-16 sprite band", () => {
+		expect(pixelGrid(1)).toBe(8); // floor: never fewer than 8 blocks
+		expect(pixelGrid(9)).toBeGreaterThanOrEqual(8);
+		expect(pixelGrid(999)).toBe(16); // cap: a 16x16 sprite is the ceiling
+	});
+
+	it("gives bigger icons more blocks, not bigger blocks forever", () => {
+		expect(pixelGrid(PLANE_NOTABLE_ICON_PX)).toBeGreaterThan(pixelGrid(PLANE_ICON_PX));
+	});
+});
+
+describe("snapAlpha", () => {
+	// Downsampling antialiases, so the small grid arrives with soft gray edge
+	// pixels. 8-bit art has hard alpha: every pixel is fully in or fully out.
+	const rgba = (...px: number[][]) => new Uint8ClampedArray(px.flat());
+
+	it("drives every pixel to fully opaque or fully clear", () => {
+		const data = rgba([255, 0, 0, 0], [255, 0, 0, 90], [255, 0, 0, 200], [255, 0, 0, 255]);
+		snapAlpha(data, PIXEL_ALPHA_THRESHOLD);
+		expect([...data].filter((_, i) => i % 4 === 3)).toEqual([0, 0, 255, 255]);
+	});
+
+	it("leaves color channels alone (getImageData is non-premultiplied)", () => {
+		const data = rgba([12, 34, 56, 200]);
+		snapAlpha(data, PIXEL_ALPHA_THRESHOLD);
+		expect([...data].slice(0, 3)).toEqual([12, 34, 56]);
+	});
+
+	it("keeps thin swept wings: a low threshold preserves faint coverage", () => {
+		// A wingtip that only half-covers its cell lands near a=128. Threshold
+		// must sit below that or wide-body wings vanish in radar mode.
+		expect(PIXEL_ALPHA_THRESHOLD).toBeLessThan(128);
+		const wingtip = rgba([255, 255, 255, 128]);
+		snapAlpha(wingtip, PIXEL_ALPHA_THRESHOLD);
+		expect(wingtip[3]).toBe(255);
 	});
 });

--- a/packages/frontend/src/Applications/FlightTracker/flightIcons.ts
+++ b/packages/frontend/src/Applications/FlightTracker/flightIcons.ts
@@ -16,25 +16,76 @@ export const PLANE_NOTABLE_ICON_PX = 32;
 export const colorizeSvg = (svg: string, fill: string): string =>
 	svg.replace("<svg ", `<svg fill="${fill}" `);
 
+// --- 8-bit ("radar" map style) variant -------------------------------------
+// Radar mode renders the same silhouettes as chunky pixel art. The art is
+// vector, so this is a resample, not a blow-up of an already-small bitmap:
+// rasterize the SVG down onto a coarse grid, hard-edge the alpha, then scale
+// back up with nearest-neighbour. Only the bitmap changes — the symbol layers,
+// icon ids and sizes are identical, so nothing downstream knows about it.
+
+// Sprite resolution. Proportional so a 32px notable gets more blocks than a
+// 9px regional jet, clamped to the 8-16 band: below 8 the silhouette stops
+// being recognisable, above 16 the blocks are too fine to read as pixel art.
+export const PIXEL_GRID_MIN = 8;
+export const PIXEL_GRID_MAX = 16;
+export const pixelGrid = (displayPx: number): number =>
+	Math.min(PIXEL_GRID_MAX, Math.max(PIXEL_GRID_MIN, Math.round(displayPx * 0.75)));
+
+// Downsampling antialiases, leaving soft gray edges that read as "blurry",
+// not "8-bit". Snapping alpha to 0/255 restores hard pixel edges. Deliberately
+// below the half-covered 128 midpoint: a wingtip that only partly fills its
+// cell should survive, or wide-bodies lose their wings entirely.
+export const PIXEL_ALPHA_THRESHOLD = 96;
+
+export const snapAlpha = (data: Uint8ClampedArray, threshold: number): void => {
+	// RGB is left alone: getImageData is non-premultiplied, so a partly
+	// transparent pixel already carries the full-strength pin color.
+	for (let i = 3; i < data.length; i += 4) {
+		data[i] = data[i] >= threshold ? 255 : 0;
+	}
+};
+
+const makeCanvas = (size: number): [HTMLCanvasElement, CanvasRenderingContext2D] => {
+	const canvas = document.createElement("canvas");
+	canvas.width = size;
+	canvas.height = size;
+	const ctx = canvas.getContext("2d");
+	if (!ctx) throw new Error("2d canvas unavailable");
+	return [canvas, ctx];
+};
+
 export const buildPlaneImage = (
 	svg: string,
 	fill: string,
 	displayPx: number,
+	pixelate = false,
 ): Promise<ImageData> =>
 	new Promise((resolve, reject) => {
 		const px = displayPx * 2;
 		const img = new Image();
 		img.onload = () => {
-			const canvas = document.createElement("canvas");
-			canvas.width = px;
-			canvas.height = px;
-			const ctx = canvas.getContext("2d");
-			if (!ctx) {
-				reject(new Error("2d canvas unavailable"));
-				return;
+			try {
+				const [, ctx] = makeCanvas(px);
+				if (!pixelate) {
+					ctx.drawImage(img, 0, 0, px, px);
+					resolve(ctx.getImageData(0, 0, px, px));
+					return;
+				}
+				// Rasterize onto the coarse grid on its own canvas — drawing a
+				// canvas onto an overlapping region of itself is not reliable.
+				const grid = pixelGrid(displayPx);
+				const [gridCanvas, gridCtx] = makeCanvas(grid);
+				gridCtx.drawImage(img, 0, 0, grid, grid);
+				const cells = gridCtx.getImageData(0, 0, grid, grid);
+				snapAlpha(cells.data, PIXEL_ALPHA_THRESHOLD);
+				gridCtx.putImageData(cells, 0, 0);
+				// Nearest-neighbour back up to the real icon size.
+				ctx.imageSmoothingEnabled = false;
+				ctx.drawImage(gridCanvas, 0, 0, px, px);
+				resolve(ctx.getImageData(0, 0, px, px));
+			} catch (err) {
+				reject(err);
 			}
-			ctx.drawImage(img, 0, 0, px, px);
-			resolve(ctx.getImageData(0, 0, px, px));
 		};
 		img.onerror = () => reject(new Error("plane icon SVG failed to load"));
 		img.src = `data:image/svg+xml,${encodeURIComponent(colorizeSvg(svg, fill))}`;

--- a/packages/frontend/src/Applications/FlightTracker/flightIcons.ts
+++ b/packages/frontend/src/Applications/FlightTracker/flightIcons.ts
@@ -37,6 +37,18 @@ export const pixelGrid = (displayPx: number): number =>
 // cell should survive, or wide-bodies lose their wings entirely.
 export const PIXEL_ALPHA_THRESHOLD = 96;
 
+// Regular icons are scaled up in radar mode. At their normal 9-16px an 8-block
+// grid has nowhere near enough cells to hold a readable airliner — the small
+// families collapse into a blob. Scaling up buys grid cells (a 9px CRJ goes
+// from grid 8 to grid 11, a 15px 767 reaches the grid-16 cap) at the cost of a
+// busier scope. Notables/observers already sit at 32px+, comfortably at the
+// cap, so they keep their existing size and the regular < notable size
+// hierarchy survives.
+export const PIXEL_SIZE_SCALE = 1.5;
+
+export const iconDisplayPx = (basePx: number, pixelate: boolean): number =>
+	pixelate ? Math.round(basePx * PIXEL_SIZE_SCALE) : basePx;
+
 export const snapAlpha = (data: Uint8ClampedArray, threshold: number): void => {
 	// RGB is left alone: getImageData is non-premultiplied, so a partly
 	// transparent pixel already carries the full-strength pin color.

--- a/packages/frontend/src/lib/basemap/basemapStyles.ts
+++ b/packages/frontend/src/lib/basemap/basemapStyles.ts
@@ -46,6 +46,13 @@ export function effectiveTone(mapStyle: BasemapStyleId, darkMap: boolean): Basem
 	return darkMap ? "dark" : "light";
 }
 
+// Radar draws its aircraft as 8-bit sprites to match the CRT scope treatment.
+// Only the rasterized icon bitmap changes (see flightIcons.buildPlaneImage);
+// icon ids, sizes and the symbol layers are identical across styles.
+export function pixelPlanes(mapStyle: BasemapStyleId): boolean {
+	return mapStyle === "radar";
+}
+
 export interface BasemapPalette {
 	background: string;
 	land: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 18.1.0
       classicy:
         specifier: latest
-        version: 0.46.0(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30)
+        version: 0.47.0(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30)
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -1847,8 +1847,8 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
-  classicy@0.46.0:
-    resolution: {integrity: sha512-LXvLNkXrv11En9FjZz7q3dodV4m3v81/D4tNwAovcbeu3rUXjTW+H78XZBicIRcwbG0rWsSknJBqk15KeKu6Bw==}
+  classicy@0.47.0:
+    resolution: {integrity: sha512-Tz2ai3vEQfUhRGUxLCPVypQqcA1gpULGlDsRzt/waSDdNYVbKMgoNaKePC/1MbTjv9w8yledpWvajdM/Yz6asA==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -5849,7 +5849,7 @@ snapshots:
       readdirp: 5.0.0
     optional: true
 
-  classicy@0.46.0(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30):
+  classicy@0.47.0(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30):
     dependencies:
       '@analytics/google-tag-manager': 0.6.0
       '@mdxeditor/editor': 3.55.0(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30)


### PR DESCRIPTION
Radar mode now renders the 2D plane icons as chunky pixel art, matching the CRT phosphor treatment the basemap already had. Previously radar only swapped the palette — the aircraft art was identical to classic/satellite.

## How it works

The plane art is vector, so this is a **resample, not a blow-up of an already-small bitmap**:

1. Rasterize the family SVG down onto a coarse grid (8–16 cells, proportional to icon size)
2. Snap alpha to 0/255 so edges are hard — smooth downsampling antialiases, which reads as "blurry", not "8-bit"
3. Scale back up with `imageSmoothingEnabled = false`

It slots into `buildPlaneImage`, the single existing icon-bitmap seam. **Only the bitmap changes** — icon ids, the symbol layers, the `icon-rotate` expression and the `coalesce` family fallback are all untouched, so nothing downstream knows the mode exists. The re-theme effect already had `mapStyle` in its dep array, so toggling radar re-rasterizes every registered icon for free.

## Two decisions worth reviewing

**The alpha threshold (96) sits below the half-covered 128 midpoint.** A wingtip that only partly fills its cell has to survive thresholding, or wide-bodies lose their wings outright. Pinned by a test.

**Regular icons scale 1.5× in radar mode; notables/observers do not.** At their normal 9–16px the sprites had nowhere near enough cells to hold a readable airliner — a 9px CRJ collapsed into a plus-shaped blob, a 12px 737 grew a one-pixel tail spike that looked like a glitch. Both were *less* legible than the smooth art they replaced. Scaling buys the cells back (CRJ grid 8→11; 767 and up hit the grid-16 cap). Notables already sit at 32px+ and hit the cap unaided, so scaling them would only erode the size hierarchy that makes the highlight read — a test pins `regular < notable`.

## Verification

- `tsc -b` clean, `eslint .` 0 errors, **1415/1415 vitest** (12 new)
- Rendered the real `plane.svg` through the pipeline at every family size, smooth vs 8-bit, plus a 47° rotation check

Rotation held up better than expected. GPU bilinear sampling does soften a rotated sprite, but at these block sizes it's a minor edge effect — so the pre-baked heading-bucket approach (registering N rotated variants and dropping `icon-rotate`) was **not** needed.

## Known limitation

The preview rasterized the generic `plane.svg` at every size, so it validates the sizing fix but not how distinct the ~100 per-family silhouettes stay from one another at grid 11–16. That's only observable against real family art on the deployed map — worth a look post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnhE6P81JhB2ePneazHwMi