### PR TITLE
feat(flighttracker): pixelate the 3D aircraft in radar map style

### DIFF
--- a/packages/frontend/src/Applications/FlightTracker/FlightMap.test.tsx
+++ b/packages/frontend/src/Applications/FlightTracker/FlightMap.test.tsx
@@ -863,6 +863,37 @@ describe("FlightMap", () => {
 		expect(map.layout["flights-dots"]?.visibility).toBe("visible");
 	});
 
+	it("pixelates the 3D aircraft in radar mode and leaves them smooth otherwise", () => {
+		const view = (mapStyle: "classic" | "radar") =>
+			render(
+				<FlightMap positions={[pos({ id: 5, flight: "DL404", alt_ft: 31_000 })]}
+					basemapUrls={TEST_URLS} trackGeoJSON={null} nowMs={0} playing={false}
+					onSelectFlight={() => {}} onClearSelection={() => {}}
+					darkMap={false} mapStyle={mapStyle} pinColor="#3a3a3a" notablePinColor="#c0202a" observerPinColor="#0f766e"
+					radarSweep={false} trailMultiplier={1} />,
+			);
+		const modelOf = (m: typeof FakeMap.last) =>
+			m!.layers.find((l) => l.id === "planes-3d-model")!
+				.__raw as import("./planes3DLayer").Planes3DLayer;
+		const replayOf = (m: typeof FakeMap.last) =>
+			m!.layers.find((l) => l.id === "replay-trails-3d-model")!
+				.__raw as import("./planes3DLayer").Planes3DLayer;
+
+		view("radar");
+		const radarMap = FakeMap.last!;
+		radarMap.fire("load");
+		// Both mesh layers (aircraft + replay spheres) enter the 8-bit path.
+		expect(modelOf(radarMap).pixelate).toBe(true);
+		expect(replayOf(radarMap).pixelate).toBe(true);
+
+		cleanup();
+		view("classic");
+		const classicMap = FakeMap.last!;
+		classicMap.fire("load");
+		expect(modelOf(classicMap).pixelate).toBe(false);
+		expect(replayOf(classicMap).pixelate).toBe(false);
+	});
+
 	it("darkens the ground track line into a shadow while pitched", () => {
 		render(
 			<FlightMap positions={[]} basemapUrls={TEST_URLS} trackGeoJSON={null}

--- a/packages/frontend/src/Applications/FlightTracker/FlightMap.tsx
+++ b/packages/frontend/src/Applications/FlightTracker/FlightMap.tsx
@@ -813,6 +813,7 @@ export const FlightMap: FC<FlightMapProps> = ({
 			// its colors follow the pin pair like every other plane layer.
 			const planes3D = new Planes3DLayer();
 			planes3D.setColors(colors.pinColor, colors.notablePinColor, colors.observerPinColor);
+			planes3D.setPixelate(pixelPlanes(colors.mapStyle));
 			planes3DRef.current = planes3D;
 			map.addLayer(planes3D);
 			// Loop-mode replay-trail spheres (issue #242): same instanced-mesh layer with
@@ -824,6 +825,7 @@ export const FlightMap: FC<FlightMapProps> = ({
 				opacity: REPLAY_TRAIL_OPACITY,
 			});
 			replayTrail3D.setColors(colors.pinColor, colors.notablePinColor, colors.observerPinColor);
+			replayTrail3D.setPixelate(pixelPlanes(colors.mapStyle));
 			replayTrail3DRef.current = replayTrail3D;
 			map.addLayer(replayTrail3D);
 			// Smooth 3D track tube: splined selected-flight path with per-vertex
@@ -1049,6 +1051,10 @@ export const FlightMap: FC<FlightMapProps> = ({
 		}
 		planes3DRef.current?.setColors(pinColor, notablePinColor, observerPinColor);
 		replayTrail3DRef.current?.setColors(pinColor, notablePinColor, observerPinColor);
+		// The 3D meshes get the same radar 8-bit treatment as the 2D icons, via a
+		// low-res render pass rather than a re-rasterize (see Planes3DLayer).
+		planes3DRef.current?.setPixelate(pixelate);
+		replayTrail3DRef.current?.setPixelate(pixelate);
 		trailTubeRef.current?.setColor(trailColor(mapStyle, darkMap));
 	}, [mapStyle, darkMap, pinColor, notablePinColor, observerPinColor, terrain]);
 

--- a/packages/frontend/src/Applications/FlightTracker/planes3DLayer.test.ts
+++ b/packages/frontend/src/Applications/FlightTracker/planes3DLayer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { buildSphereMesh } from "./plane3dMesh";
-import { Planes3DLayer } from "./planes3DLayer";
+import { PIXEL_BLOCK_PX, Planes3DLayer, pixelBufferSize } from "./planes3DLayer";
 
 // The GL surface needs a real context (covered by eye in the browser); what's
 // testable in jsdom is the config plumbing that lets one class back both the
@@ -20,5 +20,38 @@ describe("Planes3DLayer config", () => {
 		});
 		expect(layer.id).toBe("replay-trails-3d-model");
 		expect(layer.opacity).toBe(0.4);
+	});
+});
+
+// Radar mode renders the meshes into a low-res offscreen buffer and
+// nearest-neighbour upscales, so the aircraft read as 8-bit like the 2D icons.
+describe("Planes3DLayer pixelation", () => {
+	it("is off by default and toggles via setPixelate", () => {
+		const layer = new Planes3DLayer();
+		expect(layer.pixelate).toBe(false);
+		layer.setPixelate(true);
+		expect(layer.pixelate).toBe(true);
+		layer.setPixelate(false);
+		expect(layer.pixelate).toBe(false);
+	});
+});
+
+describe("pixelBufferSize", () => {
+	it("divides the drawing buffer into whole blocks, rounding up", () => {
+		// A 4px block over an 800x600 buffer → 200x150 low-res target.
+		expect(pixelBufferSize(800, 600, 4)).toEqual({ width: 200, height: 150 });
+		// Non-multiples round up so the whole canvas is covered.
+		expect(pixelBufferSize(801, 599, 4)).toEqual({ width: 201, height: 150 });
+	});
+
+	it("never collapses to a zero-sized buffer", () => {
+		// Pre-layout / hidden canvas reports 0; a 0-dim texture is a GL error.
+		expect(pixelBufferSize(0, 0, PIXEL_BLOCK_PX)).toEqual({ width: 1, height: 1 });
+	});
+
+	it("larger blocks yield a coarser buffer (chunkier pixels)", () => {
+		expect(pixelBufferSize(800, 600, 8).width).toBeLessThan(
+			pixelBufferSize(800, 600, 4).width,
+		);
 	});
 });

--- a/packages/frontend/src/Applications/FlightTracker/planes3DLayer.ts
+++ b/packages/frontend/src/Applications/FlightTracker/planes3DLayer.ts
@@ -67,6 +67,49 @@ void main() {
 }
 `;
 
+// Radar-mode 8-bit pass: draw the meshes into a low-res offscreen buffer, then
+// upscale it over the map with a NEAREST-sampled fullscreen triangle so the
+// aircraft read as chunky pixels — the screen-space analog of the 2D icons'
+// grid quantization. The triangle is generated from gl_VertexID (no attribute
+// buffers), and v_uv maps the visible [-1,1] clip square onto [0,1] texcoords.
+const BLIT_VERTEX = `#version 300 es
+out vec2 v_uv;
+void main() {
+	vec2 pos = vec2(float((gl_VertexID << 1) & 2), float(gl_VertexID & 2));
+	v_uv = pos;
+	gl_Position = vec4(pos * 2.0 - 1.0, 0.0, 1.0);
+}
+`;
+const BLIT_FRAGMENT = `#version 300 es
+precision mediump float;
+uniform sampler2D u_tex;
+in vec2 v_uv;
+out vec4 fragColor;
+void main() {
+	fragColor = texture(u_tex, v_uv); // already premultiplied from the mesh pass
+}
+`;
+
+// Device pixels per pixelated block. ~4 matches the 2D radar icons' grain
+// (they quantize to ~2-4 device px/cell). One knob — bump for chunkier.
+export const PIXEL_BLOCK_PX = 4;
+
+/**
+ * Low-res offscreen target size for a given drawing buffer and block size.
+ * Rounds up so the whole canvas is covered, and clamps to 1×1 so a pre-layout
+ * (0-sized) canvas never asks GL for a zero-dimension texture.
+ */
+export function pixelBufferSize(
+	drawingBufferWidth: number,
+	drawingBufferHeight: number,
+	block: number,
+): { width: number; height: number } {
+	return {
+		width: Math.max(1, Math.ceil(drawingBufferWidth / block)),
+		height: Math.max(1, Math.ceil(drawingBufferHeight / block)),
+	};
+}
+
 const A_POS = 0;
 const A_NORMAL = 1;
 const I_DATA0 = 2;
@@ -134,9 +177,26 @@ export class Planes3DLayer implements CustomLayerInterface {
 	private colorNotable: [number, number, number] = [0.75, 0.13, 0.16];
 	private colorObserver: [number, number, number] = [0.06, 0.46, 0.43];
 
+	/** Radar-mode 8-bit toggle. Off = today's direct-to-framebuffer path. */
+	pixelate = false;
+	// Offscreen target + blit program, allocated lazily on first pixelated
+	// render and resized when the drawing buffer changes.
+	private fbo: WebGLFramebuffer | null = null;
+	private fboTex: WebGLTexture | null = null;
+	private fboDepth: WebGLRenderbuffer | null = null;
+	private fboW = 0;
+	private fboH = 0;
+	private blit: { program: WebGLProgram; uTex: WebGLUniformLocation | null } | null = null;
+
 	setVisible(visible: boolean): void {
 		if (this.visible === visible) return;
 		this.visible = visible;
+		this.map?.triggerRepaint();
+	}
+
+	setPixelate(pixelate: boolean): void {
+		if (this.pixelate === pixelate) return;
+		this.pixelate = pixelate;
 		this.map?.triggerRepaint();
 	}
 
@@ -218,12 +278,84 @@ export class Planes3DLayer implements CustomLayerInterface {
 				gl.deleteBuffer(nrm);
 			}
 			for (const b of this.batches) if (b.buffer) gl.deleteBuffer(b.buffer);
+			if (this.blit) gl.deleteProgram(this.blit.program);
+			if (this.fbo) gl.deleteFramebuffer(this.fbo);
+			if (this.fboTex) gl.deleteTexture(this.fboTex);
+			if (this.fboDepth) gl.deleteRenderbuffer(this.fboDepth);
 		}
 		this.programs.clear();
 		this.meshes.clear();
 		this.batches = [];
+		this.blit = null;
+		this.fbo = this.fboTex = this.fboDepth = null;
+		this.fboW = this.fboH = 0;
 		this.map = null;
 		this.gl = null;
+	}
+
+	// Allocate (or resize) the low-res color+depth target and compile the blit
+	// program. Returns false on any GL failure so render() falls back to the
+	// direct path instead of throwing into maplibre.
+	private setupPixelTargets(gl: WebGL2RenderingContext): boolean {
+		const { width, height } = pixelBufferSize(
+			gl.drawingBufferWidth,
+			gl.drawingBufferHeight,
+			PIXEL_BLOCK_PX,
+		);
+		if (!this.blit) {
+			const compile = (type: number, src: string): WebGLShader | null => {
+				const s = gl.createShader(type);
+				if (!s) return null;
+				gl.shaderSource(s, src);
+				gl.compileShader(s);
+				if (!gl.getShaderParameter(s, gl.COMPILE_STATUS)) {
+					console.warn("planes-3d blit compile failed:", gl.getShaderInfoLog(s));
+					gl.deleteShader(s);
+					return null;
+				}
+				return s;
+			};
+			const vs = compile(gl.VERTEX_SHADER, BLIT_VERTEX);
+			const fs = compile(gl.FRAGMENT_SHADER, BLIT_FRAGMENT);
+			const program = gl.createProgram();
+			if (!vs || !fs || !program) return false;
+			gl.attachShader(program, vs);
+			gl.attachShader(program, fs);
+			gl.linkProgram(program);
+			gl.deleteShader(vs);
+			gl.deleteShader(fs);
+			if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+				console.warn("planes-3d blit link failed:", gl.getProgramInfoLog(program));
+				gl.deleteProgram(program);
+				return false;
+			}
+			this.blit = { program, uTex: gl.getUniformLocation(program, "u_tex") };
+		}
+		if (!this.fbo) {
+			this.fbo = gl.createFramebuffer();
+			this.fboTex = gl.createTexture();
+			this.fboDepth = gl.createRenderbuffer();
+		}
+		if (!this.fbo || !this.fboTex || !this.fboDepth) return false;
+		if (width !== this.fboW || height !== this.fboH) {
+			gl.bindTexture(gl.TEXTURE_2D, this.fboTex);
+			gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+			// NEAREST both ways is the whole point — hard blocks, no smoothing.
+			gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+			gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+			gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+			gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+			gl.bindRenderbuffer(gl.RENDERBUFFER, this.fboDepth);
+			gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, width, height);
+			gl.bindFramebuffer(gl.FRAMEBUFFER, this.fbo);
+			gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, this.fboTex, 0);
+			gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, this.fboDepth);
+			gl.bindTexture(gl.TEXTURE_2D, null);
+			gl.bindRenderbuffer(gl.RENDERBUFFER, null);
+			this.fboW = width;
+			this.fboH = height;
+		}
+		return true;
 	}
 
 	private getProgram(args: CustomRenderMethodInput): ProgramInfo | null {
@@ -281,6 +413,64 @@ ${VERTEX_BODY}`;
 		if (!gl || !this.visible || this.instanceCount === 0) return;
 		const info = this.getProgram(args);
 		if (!info) return;
+
+		// Radar 8-bit path: draw the meshes into the low-res target, then upscale
+		// it over the map with NEAREST. Its own depth buffer preserves plane↔plane
+		// occlusion; occlusion against the basemap is intentionally dropped (a
+		// radar scope shows every contact, and radar mode uses flat hillshade, not
+		// 3D terrain geometry). Any GL setup failure falls back to the direct draw.
+		if (this.pixelate) {
+			// Capture maplibre's framebuffer + viewport BEFORE touching any GL
+			// target: setupPixelTargets binds our own fbo when it (re)allocates,
+			// so reading the binding after it would capture ours and the blit
+			// would then draw into the texture it samples — a feedback loop.
+			const prevFbo = gl.getParameter(gl.FRAMEBUFFER_BINDING) as WebGLFramebuffer | null;
+			const vp = gl.getParameter(gl.VIEWPORT) as Int32Array;
+			if (this.setupPixelTargets(gl)) {
+				gl.bindFramebuffer(gl.FRAMEBUFFER, this.fbo);
+				gl.viewport(0, 0, this.fboW, this.fboH);
+				gl.enable(gl.DEPTH_TEST);
+				gl.depthFunc(gl.LEQUAL);
+				gl.depthMask(true);
+				gl.clearColor(0, 0, 0, 0);
+				gl.clearDepth(1);
+				gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+				this.drawBatches(gl, info, args);
+				gl.bindFramebuffer(gl.FRAMEBUFFER, prevFbo);
+				gl.viewport(vp[0], vp[1], vp[2], vp[3]);
+				this.blitPixels(gl);
+				return;
+			}
+		}
+		this.drawBatches(gl, info, args);
+	}
+
+	// Composite the low-res target over maplibre's framebuffer with a
+	// NEAREST-sampled fullscreen triangle. Premultiplied-over blend matches the
+	// mesh fragment output; depth writes are masked off so maplibre's own depth
+	// buffer is untouched, and standard 3D depth state is restored afterward.
+	private blitPixels(gl: WebGL2RenderingContext): void {
+		const b = this.blit;
+		if (!b || !this.fboTex) return;
+		gl.useProgram(b.program);
+		gl.activeTexture(gl.TEXTURE0);
+		gl.bindTexture(gl.TEXTURE_2D, this.fboTex);
+		if (b.uTex) gl.uniform1i(b.uTex, 0);
+		gl.disable(gl.DEPTH_TEST);
+		gl.depthMask(false);
+		gl.enable(gl.BLEND);
+		gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+		gl.drawArrays(gl.TRIANGLES, 0, 3);
+		gl.bindTexture(gl.TEXTURE_2D, null);
+		gl.enable(gl.DEPTH_TEST);
+		gl.depthMask(true);
+	}
+
+	private drawBatches(
+		gl: WebGL2RenderingContext,
+		info: ProgramInfo,
+		args: CustomRenderMethodInput,
+	): void {
 		gl.useProgram(info.program);
 
 		// MapLibre's projection uniforms (names fixed by the injected prelude);


### PR DESCRIPTION
Follow-up to the 2D radar pixel icons (#300): the pitched 3D aircraft now get the same 8-bit treatment in radar mode. Previously radar's 3D view stayed smooth-shaded, so tilting the camera broke the retro look.

## How it works

The 3D planes are hand-rolled WebGL2 instanced meshes (`Planes3DLayer`) with no bitmap to quantize, so "pixelated" has to be done in **screen space** — the same idea as the 2D icons' grid, one level down the pipeline:

1. Draw the instanced meshes into a **low-res offscreen framebuffer** — one block per ~4 device px (`PIXEL_BLOCK_PX`, a fixed device-pixel size so blocks stay constant across zoom/pitch/monitor).
2. **NEAREST-upscale** that texture back over the map with a fullscreen triangle → hard pixel blocks.

Gated by `setPixelate(pixelPlanes(mapStyle))`, wired right beside the existing `setColors` at layer creation and in the re-theme effect, so it flips with the map style for free (`mapStyle` was already an effect dep). Both `Planes3DLayer` instances (aircraft + loop-replay spheres) get it; the track tube / trail ribbons stay crisp (scoped out deliberately — see below).

## The one real tradeoff

The offscreen pass keeps **its own depth buffer**, so plane-to-plane occlusion is preserved. Occlusion **against the basemap is intentionally dropped**: a pixelated plane composites on top. This is fine — and arguably right — because radar is a flat-hillshade scope with no 3D terrain geometry, and a radar scope should show every contact. State is saved/restored around the pass; any GL setup failure falls back to the direct draw and never throws into maplibre.

## Scope

- **In:** the aircraft meshes + loop-replay spheres (both `Planes3DLayer` instances).
- **Out (follow-up):** the altitude track-tube and trail ribbons (`TrackTube3DLayer`, a separate class). Smallest blast radius for the FBO work; the tube reads as an instrument overlay.

## Verification

- `tsc -b` clean, `eslint .` 0 errors, **1431/1431 vitest** (5 new).
- The FBO/blit can't be meaningfully unit-tested in jsdom, so the pure pieces (`pixelBufferSize`, `setPixelate` plumbing, the FlightMap wiring via the FakeMap harness) are unit-tested, and **the actual render was verified on a real GPU** in a browser harness: a real MapLibre map + the real `Planes3DLayer` + hand-packed instances, toggling pixelate on/off.

Caught one real bug during that verification (invisible to the unit tests): a framebuffer **feedback loop** — `setupPixelTargets` leaves the FBO bound when it reallocates, and the code captured "maplibre's framebuffer" *after* that, so the blit drew into the texture it sampled. Fixed by capturing the binding before any GL-target manipulation. Confirmed 0 GL errors and clean smooth↔pixelated toggling afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnhE6P81JhB2ePneazHwMi