### PR TITLE
feat(frontend): add pre-boot About / content-warning screen

### DIFF
--- a/packages/frontend/src/Desktop.tsx
+++ b/packages/frontend/src/Desktop.tsx
@@ -1,5 +1,5 @@
 import "maplibre-gl/dist/maplibre-gl.css";
-import { ClassicyDesktop } from "classicy";
+import { ClassicyButton, ClassicyDesktop, ClassicyWindowFrame } from "classicy";
 // Side effect: register the Directus-collection HyperCard extension parts and
 // stacks with classicy's HyperCard plugin registries. The HyperCard app itself
 // is bundled in classicy and auto-mounted by ClassicyDesktop.
@@ -23,10 +23,54 @@ import { TimeMachine } from "./Applications/TimeMachine/TimeMachine";
 import { TV } from "./Applications/TV/TV";
 import { Weather } from "./Applications/Weather/Weather";
 
+/**
+ * The "power on" screen shown before the boot sequence: an About panel that
+ * doubles as a content warning, so nobody reaches the September 11 media
+ * without first acknowledging what it is. Rendered by ClassicyDesktop's
+ * pre-boot overlay (once per browser-tab session); calling `powerOn`
+ * dismisses it and starts the boot chime + startup parade.
+ */
+function PreBootAbout({ powerOn }: { powerOn: () => void }) {
+	return (
+		<ClassicyWindowFrame title="9/11 in Realtime" width={560}>
+			<h1>About 9/11 in Realtime</h1>
+			<p>
+				9/11 in Realtime is a multimedia experiment for teachers, with the
+				purpose of helping their students truly understand and absorb the
+				events of September 11, 2001. We've collected media—video, audio and
+				other items—available from the days before and after the September 11
+				attacks, synchronized them together and built a tool to help students
+				be immersed in the events of the day.
+			</p>
+			<p>
+				<b>
+					THE FOLLOWING WEBSITE MAY CONTAIN VISUALS, AUDIO AND OTHER CONTENT
+					THAT SOME VIEWERS MAY FIND EXTREMELY DISTURBING.
+				</b>
+			</p>
+			<p>
+				<b>
+					THIS TOOL IS INTENDED TO BE USED ALONGSIDE A CAREFULLY RESEARCHED AND
+					APPROPRIATE CURRICULUM.
+				</b>
+			</p>
+			<p>
+				For questions regarding this project, please{" "}
+				<a href="mailto:robbiebyrd@keepinghistory.org">email Robbie Byrd</a>.
+			</p>
+			<ClassicyButton isDefault onClickFunc={powerOn}>
+				POWER ON
+			</ClassicyButton>
+		</ClassicyWindowFrame>
+	);
+}
+
 /** The desktop branch: the Mac OS 8 desktop and every desktop app. */
 export default function Desktop() {
 	return (
-		<ClassicyDesktop>
+		<ClassicyDesktop
+			preBootScreen={(powerOn) => <PreBootAbout powerOn={powerOn} />}
+		>
 			<Alerts />
 			<AlertsManager />
 			<HyperCardClockBridge />


### PR DESCRIPTION
## What

Adds a pre-boot "power on" screen shown before the Mac OS 8 boot sequence, using ClassicyDesktop's new `preBootScreen` render-prop (classicy 0.50.0).

The screen is an About panel that doubles as a **content warning** — students can't reach the September 11 media without first seeing what the tool is and acknowledging the nature of the material. A default `POWER ON` button calls the library-provided `powerOn()` to dismiss the overlay and kick off the boot chime + startup parade.

## Details

- New `PreBootAbout` component in `Desktop.tsx` built from the presentational `ClassicyWindowFrame` + `ClassicyButton` (no store/window-manager coupling — safe to render before any app exists).
- Wired via `preBootScreen={(powerOn) => <PreBootAbout powerOn={powerOn} />}` on `ClassicyDesktop`.
- Copy per project owner; fixed a `TTHIS` typo → `THIS` and normalized `--` to em-dashes.

## Notes

- Classicy shows the overlay **once per browser-tab session** (same contract as `startupScreen`), so a same-tab reload won't re-show it.
- `tsc -b` and `eslint` pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)