### PR TITLE
feat(fs-sync): sync per-user Classicy filesystem to Wasabi via Directus

### DIFF
--- a/packages/frontend/src/Providers/Auth/AuthProvider.tsx
+++ b/packages/frontend/src/Providers/Auth/AuthProvider.tsx
@@ -6,6 +6,7 @@ import { identifyUser } from "../../openreplay";
 import { fetchMe, loginEmail, logout, providerLoginUrl, type AuthUser,
 	register as apiRegister,
 } from "./authApi";
+import { runBeforeSignOutHooks } from "./beforeSignOut";
 import { AuthContext, type AuthContextValue, type AuthStatus } from "./AuthContext";
 
 export const AuthProvider: FC<{ children: ReactNode }> = ({ children }) => {
@@ -57,6 +58,7 @@ export const AuthProvider: FC<{ children: ReactNode }> = ({ children }) => {
 	}, []);
 
 	const signOut = useCallback(async () => {
+		await runBeforeSignOutHooks(); // flush pending server writes while the cookie is still valid
 		await logout(); // best-effort; authApi swallows its own failures
 		setUser(null);
 		setStatus("anonymous");

--- a/packages/frontend/src/Providers/Auth/beforeSignOut.test.ts
+++ b/packages/frontend/src/Providers/Auth/beforeSignOut.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from "vitest";
+import { registerBeforeSignOut, runBeforeSignOutHooks } from "./beforeSignOut";
+
+describe("beforeSignOut hooks", () => {
+	it("runs registered hooks and honors unregister", async () => {
+		const a = vi.fn().mockResolvedValue(undefined);
+		const b = vi.fn().mockResolvedValue(undefined);
+		const offA = registerBeforeSignOut(a);
+		registerBeforeSignOut(b);
+		await runBeforeSignOutHooks();
+		expect(a).toHaveBeenCalledTimes(1);
+		expect(b).toHaveBeenCalledTimes(1);
+		offA();
+		await runBeforeSignOutHooks();
+		expect(a).toHaveBeenCalledTimes(1); // not called again
+		expect(b).toHaveBeenCalledTimes(2);
+	});
+	it("swallows a rejecting hook so sign-out is never blocked", async () => {
+		registerBeforeSignOut(() => Promise.reject(new Error("boom")));
+		const ok = vi.fn().mockResolvedValue(undefined);
+		registerBeforeSignOut(ok);
+		await expect(runBeforeSignOutHooks()).resolves.toBeUndefined();
+		expect(ok).toHaveBeenCalled();
+	});
+});

--- a/packages/frontend/src/Providers/Auth/beforeSignOut.ts
+++ b/packages/frontend/src/Providers/Auth/beforeSignOut.ts
@@ -1,0 +1,25 @@
+// Generic hooks that run BEFORE AuthProvider clears the Directus session cookie.
+// Lets features (e.g. filesystem sync) flush pending server writes while the
+// session is still valid, without AuthProvider depending on those features.
+type BeforeSignOutHook = () => Promise<void> | void;
+
+const hooks = new Set<BeforeSignOutHook>();
+
+/** Register a hook; returns an unregister function. */
+export function registerBeforeSignOut(fn: BeforeSignOutHook): () => void {
+	hooks.add(fn);
+	return () => hooks.delete(fn);
+}
+
+/** Run all hooks concurrently. A failing hook is logged and swallowed — sign-out must never be blocked. */
+export async function runBeforeSignOutHooks(): Promise<void> {
+	await Promise.all(
+		[...hooks].map(async (fn) => {
+			try {
+				await fn();
+			} catch (err) {
+				console.warn("beforeSignOut hook failed", err);
+			}
+		}),
+	);
+}

--- a/packages/frontend/src/Providers/FilesystemSync/FilesystemSyncProvider.test.tsx
+++ b/packages/frontend/src/Providers/FilesystemSync/FilesystemSyncProvider.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup, act } from "@testing-library/react";
+
+const reconcileWithAdapters = vi.fn();
+const load = vi.fn();
+const snapshot = vi.fn(() => JSON.stringify({ "Macintosh HD": { _type: "directory" } }));
+const dispatch = vi.fn();
+vi.mock("classicy", () => ({
+	useClassicyFileSystem: () => ({ reconcileWithAdapters, load, snapshot }),
+	dispatch: (...a: unknown[]) => dispatch(...a),
+}));
+
+const authState: { status: string; user: unknown } = { status: "loading", user: null };
+vi.mock("../Auth/AuthContext", () => ({ useAuth: () => authState }));
+
+const setSyncUser = vi.fn();
+const pushCurrentTree = vi.fn().mockResolvedValue(undefined);
+vi.mock("./directusFilesystemAdapter", () => ({
+	setSyncUser: (...a: unknown[]) => setSyncUser(...a),
+	pushCurrentTree: (...a: unknown[]) => pushCurrentTree(...a),
+}));
+
+let registeredHook: (() => Promise<void> | void) | null = null;
+vi.mock("../Auth/beforeSignOut", () => ({
+	registerBeforeSignOut: (fn: () => Promise<void> | void) => {
+		registeredHook = fn;
+		return () => { registeredHook = null; };
+	},
+}));
+
+vi.mock("../../data/DefaultFileSystem", () => ({ DefaultFileSystem: { "Macintosh HD": { _type: "drive" } } }));
+
+import { FilesystemSyncProvider } from "./FilesystemSyncProvider";
+
+const user = { id: "u1", email: "a@b.c" };
+
+const rerenderWith = (status: string, u: unknown) => {
+	authState.status = status;
+	authState.user = u;
+	return render(
+		<FilesystemSyncProvider>
+			<div>child</div>
+		</FilesystemSyncProvider>,
+	);
+};
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	authState.status = "loading";
+	authState.user = null;
+	registeredHook = null;
+});
+afterEach(cleanup);
+
+describe("FilesystemSyncProvider", () => {
+	it("mirrors the user into the adapter and renders children", () => {
+		const { getByText } = rerenderWith("signedIn", user);
+		expect(setSyncUser).toHaveBeenCalledWith(user);
+		expect(getByText("child")).toBeTruthy();
+	});
+
+	it("on login with a remote tree, reconciles and bumps the desktop", async () => {
+		reconcileWithAdapters.mockResolvedValue(true);
+		await act(async () => {
+			rerenderWith("signedIn", user);
+		});
+		expect(reconcileWithAdapters).toHaveBeenCalled();
+		expect(dispatch).toHaveBeenCalledWith({ type: "ClassicyDesktopFileSystemVersionBump" });
+		expect(pushCurrentTree).not.toHaveBeenCalled();
+	});
+
+	it("on first login with no remote tree, seeds the account from the local desktop", async () => {
+		reconcileWithAdapters.mockResolvedValue(false);
+		await act(async () => {
+			rerenderWith("signedIn", user);
+		});
+		expect(pushCurrentTree).toHaveBeenCalledTimes(1);
+	});
+
+	it("registers a pre-sign-out flush that pushes the current tree", async () => {
+		rerenderWith("signedIn", user);
+		expect(registeredHook).toBeTypeOf("function");
+		await act(async () => {
+			await registeredHook?.();
+		});
+		expect(pushCurrentTree).toHaveBeenCalled();
+	});
+});

--- a/packages/frontend/src/Providers/FilesystemSync/FilesystemSyncProvider.test.tsx
+++ b/packages/frontend/src/Providers/FilesystemSync/FilesystemSyncProvider.test.tsx
@@ -75,6 +75,26 @@ describe("FilesystemSyncProvider", () => {
 			rerenderWith("signedIn", user);
 		});
 		expect(pushCurrentTree).toHaveBeenCalledTimes(1);
+		expect(dispatch).not.toHaveBeenCalled();
+	});
+
+	it("logs and does not reject when the seed push fails on login", async () => {
+		reconcileWithAdapters.mockResolvedValue(false);
+		pushCurrentTree.mockRejectedValueOnce(new Error("net"));
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		await act(async () => {
+			rerenderWith("signedIn", user);
+		});
+
+		expect(pushCurrentTree).toHaveBeenCalledTimes(1);
+		expect(dispatch).not.toHaveBeenCalled();
+		expect(warnSpy).toHaveBeenCalledWith(
+			"FilesystemSyncProvider: login-transition sync failed",
+			expect.any(Error),
+		);
+
+		warnSpy.mockRestore();
 	});
 
 	it("registers a pre-sign-out flush that pushes the current tree", async () => {

--- a/packages/frontend/src/Providers/FilesystemSync/FilesystemSyncProvider.tsx
+++ b/packages/frontend/src/Providers/FilesystemSync/FilesystemSyncProvider.tsx
@@ -1,0 +1,47 @@
+// Bridges React auth state to the (non-React) Classicy filesystem adapter.
+// Boot-time reconcile runs before auth resolves, and email login doesn't remount,
+// so this component owns the login-pull / first-login-seed / logout-reset
+// transitions and the pre-sign-out flush. Mount it INSIDE AuthProvider.
+import { type FC, type ReactNode, useEffect, useRef } from "react";
+import { dispatch, useClassicyFileSystem } from "classicy";
+import type { ClassicyFileSystemEntry } from "classicy";
+import { useAuth } from "../Auth/AuthContext";
+import { registerBeforeSignOut } from "../Auth/beforeSignOut";
+import { DefaultFileSystem } from "../../data/DefaultFileSystem";
+import { pushCurrentTree, setSyncUser } from "./directusFilesystemAdapter";
+
+const bumpDesktop = () => dispatch({ type: "ClassicyDesktopFileSystemVersionBump" });
+
+export const FilesystemSyncProvider: FC<{ children: ReactNode }> = ({ children }) => {
+	const { status, user } = useAuth();
+	const fs = useClassicyFileSystem();
+	const prev = useRef<{ signedIn: boolean }>({ signedIn: false });
+
+	// Best-effort flush BEFORE the session cookie is cleared on sign-out.
+	useEffect(
+		() => registerBeforeSignOut(() => pushCurrentTree(JSON.parse(fs.snapshot()) as ClassicyFileSystemEntry)),
+		[fs],
+	);
+
+	useEffect(() => {
+		setSyncUser(user);
+		const wasSignedIn = prev.current.signedIn;
+		const nowSignedIn = status === "signedIn";
+
+		if (!wasSignedIn && nowSignedIn && user) {
+			void (async () => {
+				const replaced = await fs.reconcileWithAdapters();
+				if (replaced) bumpDesktop();
+				else await pushCurrentTree(JSON.parse(fs.snapshot()) as ClassicyFileSystemEntry); // seed account
+			})();
+		} else if (wasSignedIn && !nowSignedIn) {
+			// Tree already flushed by the pre-sign-out hook; reset to the anonymous default.
+			fs.load(JSON.stringify(DefaultFileSystem));
+			bumpDesktop();
+		}
+
+		prev.current.signedIn = nowSignedIn;
+	}, [status, user, fs]);
+
+	return <>{children}</>;
+};

--- a/packages/frontend/src/Providers/FilesystemSync/FilesystemSyncProvider.tsx
+++ b/packages/frontend/src/Providers/FilesystemSync/FilesystemSyncProvider.tsx
@@ -30,9 +30,14 @@ export const FilesystemSyncProvider: FC<{ children: ReactNode }> = ({ children }
 
 		if (!wasSignedIn && nowSignedIn && user) {
 			void (async () => {
-				const replaced = await fs.reconcileWithAdapters();
-				if (replaced) bumpDesktop();
-				else await pushCurrentTree(JSON.parse(fs.snapshot()) as ClassicyFileSystemEntry); // seed account
+				try {
+					const replaced = await fs.reconcileWithAdapters();
+					if (replaced) bumpDesktop();
+					else await pushCurrentTree(JSON.parse(fs.snapshot()) as ClassicyFileSystemEntry); // seed account
+				} catch (err) {
+					// Network/Directus failure: leave lastPushedHash unchanged so the next snapshot retries.
+					console.warn("FilesystemSyncProvider: login-transition sync failed", err);
+				}
 			})();
 		} else if (wasSignedIn && !nowSignedIn) {
 			// Tree already flushed by the pre-sign-out hook; reset to the anonymous default.

--- a/packages/frontend/src/Providers/FilesystemSync/directusFilesystemAdapter.test.ts
+++ b/packages/frontend/src/Providers/FilesystemSync/directusFilesystemAdapter.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { ClassicyFileSystemSnapshot } from "classicy";
+import {
+	directusFilesystemAdapter,
+	setSyncUser,
+	getSyncUser,
+	getCachedFileId,
+	pushCurrentTree,
+	__resetFilesystemSyncStateForTests,
+} from "./directusFilesystemAdapter";
+import * as api from "./directusFilesystemApi";
+
+const user = { id: "u1", email: "a@b.c" } as never;
+const tree = { "Macintosh HD": { _type: "directory" } } as never;
+const snap = (hash: string): ClassicyFileSystemSnapshot =>
+	({ tree, hash, seq: 1, storageKey: "classicyStorage", timestamp: "t" }) as ClassicyFileSystemSnapshot;
+
+beforeEach(() => __resetFilesystemSyncStateForTests());
+afterEach(() => vi.restoreAllMocks());
+
+describe("setSyncUser/getSyncUser", () => {
+	it("holds the current user", () => {
+		setSyncUser(user);
+		expect(getSyncUser()).toBe(user);
+		setSyncUser(null);
+		expect(getSyncUser()).toBeNull();
+	});
+});
+
+describe("onSnapshot", () => {
+	it("does nothing when anonymous", async () => {
+		const push = vi.spyOn(api, "pushTree");
+		await directusFilesystemAdapter.onSnapshot?.(snap("h1"));
+		expect(push).not.toHaveBeenCalled();
+	});
+	it("pushes once, then dedupes an identical hash", async () => {
+		const push = vi.spyOn(api, "pushTree").mockResolvedValue("file-1");
+		setSyncUser(user);
+		await directusFilesystemAdapter.onSnapshot?.(snap("h1"));
+		await directusFilesystemAdapter.onSnapshot?.(snap("h1")); // same hash -> skipped
+		expect(push).toHaveBeenCalledTimes(1);
+		expect(getCachedFileId("u1")).toBe("file-1");
+	});
+	it("does not advance dedupe state when the push fails (so it retries)", async () => {
+		const push = vi.spyOn(api, "pushTree").mockRejectedValueOnce(new Error("net")).mockResolvedValueOnce("file-1");
+		setSyncUser(user);
+		await expect(directusFilesystemAdapter.onSnapshot?.(snap("h1"))).rejects.toThrow();
+		await directusFilesystemAdapter.onSnapshot?.(snap("h1")); // retried, not deduped
+		expect(push).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("reconcile", () => {
+	it("returns useLocal when anonymous (no network)", async () => {
+		const idSpy = vi.spyOn(api, "fetchFilesystemFileId");
+		await expect(directusFilesystemAdapter.reconcile?.(snap("h1"))).resolves.toEqual({ action: "useLocal" });
+		expect(idSpy).not.toHaveBeenCalled();
+	});
+	it("replaces with the remote tree and caches the file id", async () => {
+		vi.spyOn(api, "fetchFilesystemFileId").mockResolvedValue("file-9");
+		vi.spyOn(api, "downloadTree").mockResolvedValue(tree);
+		setSyncUser(user);
+		await expect(directusFilesystemAdapter.reconcile?.(snap("h1"))).resolves.toEqual({ action: "replace", tree });
+		expect(getCachedFileId("u1")).toBe("file-9");
+	});
+	it("returns useLocal when there is no remote file", async () => {
+		vi.spyOn(api, "fetchFilesystemFileId").mockResolvedValue(null);
+		setSyncUser(user);
+		await expect(directusFilesystemAdapter.reconcile?.(snap("h1"))).resolves.toEqual({ action: "useLocal" });
+	});
+});
+
+describe("pushCurrentTree", () => {
+	it("no-ops when anonymous and pushes for the current user otherwise", async () => {
+		const push = vi.spyOn(api, "pushTree").mockResolvedValue("file-1");
+		await pushCurrentTree(tree);
+		expect(push).not.toHaveBeenCalled();
+		setSyncUser(user);
+		await pushCurrentTree(tree);
+		expect(push).toHaveBeenCalledTimes(1);
+		expect(getCachedFileId("u1")).toBe("file-1");
+	});
+});

--- a/packages/frontend/src/Providers/FilesystemSync/directusFilesystemAdapter.ts
+++ b/packages/frontend/src/Providers/FilesystemSync/directusFilesystemAdapter.ts
@@ -54,7 +54,7 @@ export const directusFilesystemAdapter: ClassicyFileSystemAdapter = {
 		lastPushedHash.set(user.id, snapshot.hash);
 	},
 
-	async reconcile(_local: ClassicyFileSystemSnapshot): Promise<ClassicyFileSystemReconcileResult> {
+	async reconcile(): Promise<ClassicyFileSystemReconcileResult> {
 		const user = currentUser;
 		if (!user) return { action: "useLocal" }; // anonymous: keep local, no network
 		const fileId = await fetchFilesystemFileId();

--- a/packages/frontend/src/Providers/FilesystemSync/directusFilesystemAdapter.ts
+++ b/packages/frontend/src/Providers/FilesystemSync/directusFilesystemAdapter.ts
@@ -1,0 +1,67 @@
+// The Classicy filesystem adapter: pushes debounced snapshots to Directus (Wasabi)
+// and pulls the tree back on reconcile. Registration is global/non-React
+// (see app.tsx); it learns "who is signed in" from FilesystemSyncProvider via
+// setSyncUser. Per-user caches keep pushes cheap and correct across user switches.
+import type {
+	ClassicyFileSystemAdapter,
+	ClassicyFileSystemEntry,
+	ClassicyFileSystemReconcileResult,
+	ClassicyFileSystemSnapshot,
+} from "classicy";
+import type { AuthUser } from "../Auth/authApi";
+import { downloadTree, fetchFilesystemFileId, pushTree } from "./directusFilesystemApi";
+
+let currentUser: AuthUser | null = null;
+const lastPushedHash = new Map<string, string>();
+const cachedFileId = new Map<string, string>();
+
+export function setSyncUser(user: AuthUser | null): void {
+	currentUser = user;
+}
+export function getSyncUser(): AuthUser | null {
+	return currentUser;
+}
+export function getCachedFileId(userId: string): string | null {
+	return cachedFileId.get(userId) ?? null;
+}
+
+/** Push the tree for the current user (dedupe-free). No-op when anonymous. */
+export async function pushCurrentTree(tree: ClassicyFileSystemEntry): Promise<void> {
+	const user = currentUser;
+	if (!user) return;
+	const id = await pushTree(tree, cachedFileId.get(user.id) ?? null);
+	cachedFileId.set(user.id, id);
+}
+
+/** Test-only: clear module state between cases. */
+export function __resetFilesystemSyncStateForTests(): void {
+	currentUser = null;
+	lastPushedHash.clear();
+	cachedFileId.clear();
+}
+
+export const directusFilesystemAdapter: ClassicyFileSystemAdapter = {
+	id: "rt911-directus-wasabi",
+
+	async onSnapshot(snapshot: ClassicyFileSystemSnapshot): Promise<void> {
+		const user = currentUser;
+		if (!user) return; // anonymous: browser-local only
+		if (lastPushedHash.get(user.id) === snapshot.hash) return; // unchanged since last push
+		// pushTree throws on failure -> we never advance lastPushedHash, so the
+		// next snapshot retries. classicy isolates the throw from the filesystem.
+		const id = await pushTree(snapshot.tree, cachedFileId.get(user.id) ?? null);
+		cachedFileId.set(user.id, id);
+		lastPushedHash.set(user.id, snapshot.hash);
+	},
+
+	async reconcile(_local: ClassicyFileSystemSnapshot): Promise<ClassicyFileSystemReconcileResult> {
+		const user = currentUser;
+		if (!user) return { action: "useLocal" }; // anonymous: keep local, no network
+		const fileId = await fetchFilesystemFileId();
+		if (!fileId) return { action: "useLocal" }; // first login: local seeds the account
+		const tree = await downloadTree(fileId);
+		if (!tree) return { action: "useLocal" }; // corrupt/missing remote: fall back to local
+		cachedFileId.set(user.id, fileId);
+		return { action: "replace", tree };
+	},
+};

--- a/packages/frontend/src/Providers/FilesystemSync/directusFilesystemApi.test.ts
+++ b/packages/frontend/src/Providers/FilesystemSync/directusFilesystemApi.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+import { fetchFilesystemFileId, downloadTree, pushTree } from "./directusFilesystemApi";
+import { DIRECTUS_URL } from "../Playlist/loadPlaylist";
+
+const res = (body: unknown, ok = true, status = 200): Response =>
+	({ ok, status, json: async () => body, text: async () => JSON.stringify(body) }) as Response;
+
+const tree = { "Macintosh HD": { _type: "directory" } } as never;
+
+describe("fetchFilesystemFileId", () => {
+	it("returns the linked file id from /users/me", async () => {
+		const fetchFn = vi.fn().mockResolvedValue(res({ data: { filesystem: "file-1" } }));
+		await expect(fetchFilesystemFileId(fetchFn)).resolves.toBe("file-1");
+		expect(fetchFn).toHaveBeenCalledWith(
+			`${DIRECTUS_URL}/users/me?fields=filesystem`,
+			expect.objectContaining({ credentials: "include" }),
+		);
+	});
+	it("returns null when unlinked or request fails", async () => {
+		await expect(fetchFilesystemFileId(vi.fn().mockResolvedValue(res({ data: { filesystem: null } })))).resolves.toBeNull();
+		await expect(fetchFilesystemFileId(vi.fn().mockResolvedValue(res({}, false, 401)))).resolves.toBeNull();
+	});
+});
+
+describe("downloadTree", () => {
+	it("downloads and returns a valid tree from /assets/{id}", async () => {
+		const fetchFn = vi.fn().mockResolvedValue(res(tree));
+		await expect(downloadTree("file-1", fetchFn)).resolves.toEqual(tree);
+		expect(fetchFn).toHaveBeenCalledWith(
+			`${DIRECTUS_URL}/assets/file-1`,
+			expect.objectContaining({ credentials: "include" }),
+		);
+	});
+	it("returns null on non-ok, unparseable, or invalid content", async () => {
+		await expect(downloadTree("x", vi.fn().mockResolvedValue(res({}, false, 404)))).resolves.toBeNull();
+		const garbage = { ok: true, status: 200, text: async () => "not json" } as Response;
+		await expect(downloadTree("x", vi.fn().mockResolvedValue(garbage))).resolves.toBeNull();
+	});
+});
+
+describe("pushTree", () => {
+	it("overwrites the known file via PATCH /files/{id} and returns the same id", async () => {
+		const fetchFn = vi.fn().mockResolvedValue(res({ data: { id: "file-1" } }));
+		await expect(pushTree(tree, "file-1", fetchFn)).resolves.toBe("file-1");
+		expect(fetchFn).toHaveBeenCalledWith(
+			`${DIRECTUS_URL}/files/file-1`,
+			expect.objectContaining({ method: "PATCH", credentials: "include" }),
+		);
+	});
+	it("creates a new file then links it to the user when no id is known", async () => {
+		const fetchFn = vi
+			.fn()
+			.mockResolvedValueOnce(res({ data: { filesystem: null } })) // discovery: /users/me
+			.mockResolvedValueOnce(res({ data: { id: "new-file" } }))    // POST /files
+			.mockResolvedValueOnce(res({ data: {} }));                    // PATCH /users/me
+		await expect(pushTree(tree, null, fetchFn)).resolves.toBe("new-file");
+		expect(fetchFn.mock.calls[1][0]).toBe(`${DIRECTUS_URL}/files`);
+		expect(fetchFn.mock.calls[1][1]).toMatchObject({ method: "POST", credentials: "include" });
+		expect(fetchFn.mock.calls[2][0]).toBe(`${DIRECTUS_URL}/users/me`);
+		expect(JSON.parse((fetchFn.mock.calls[2][1] as RequestInit).body as string)).toEqual({ filesystem: "new-file" });
+	});
+	it("throws when the overwrite request fails", async () => {
+		await expect(pushTree(tree, "file-1", vi.fn().mockResolvedValue(res({}, false, 500)))).rejects.toThrow();
+	});
+});

--- a/packages/frontend/src/Providers/FilesystemSync/directusFilesystemApi.ts
+++ b/packages/frontend/src/Providers/FilesystemSync/directusFilesystemApi.ts
@@ -1,0 +1,72 @@
+// Pure Directus REST helpers for the per-user filesystem blob. No module state:
+// identity rides the httpOnly session cookie (credentials:"include"), the same
+// stance as authApi.ts. The tree is stored as a single JSON file in directus_files
+// (Wasabi-backed) and pointed to by the `filesystem` m2o field on directus_users.
+import { isValidFileSystemEntry } from "classicy";
+import type { ClassicyFileSystemEntry } from "classicy";
+import { DIRECTUS_URL } from "../Playlist/loadPlaylist";
+
+const FILE_FIELD = "filesystem";
+
+/** The current user's linked filesystem file id, or null if unlinked/unauthenticated. */
+export async function fetchFilesystemFileId(fetchFn: typeof fetch = fetch): Promise<string | null> {
+	const r = await fetchFn(`${DIRECTUS_URL}/users/me?fields=${FILE_FIELD}`, { credentials: "include" });
+	if (!r.ok) return null;
+	const body = (await r.json()) as { data?: { filesystem?: string | null } };
+	return body.data?.filesystem ?? null;
+}
+
+/** Download + validate the tree at a Directus file id. Null if missing/unparseable/invalid. */
+export async function downloadTree(
+	fileId: string,
+	fetchFn: typeof fetch = fetch,
+): Promise<ClassicyFileSystemEntry | null> {
+	const r = await fetchFn(`${DIRECTUS_URL}/assets/${fileId}`, { credentials: "include" });
+	if (!r.ok) return null;
+	try {
+		const parsed = JSON.parse(await r.text()) as ClassicyFileSystemEntry;
+		return isValidFileSystemEntry(parsed) ? parsed : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Persist the tree for the current user. Overwrites `knownFileId` in place when
+ * given (same Wasabi object); otherwise discovers an existing link, else creates
+ * a new file and links it via PATCH /users/me. Returns the file id used.
+ * Throws if a request fails so the caller can retry (and not advance dedupe state).
+ */
+export async function pushTree(
+	tree: ClassicyFileSystemEntry,
+	knownFileId: string | null,
+	fetchFn: typeof fetch = fetch,
+): Promise<string> {
+	const blob = new Blob([JSON.stringify(tree)], { type: "application/json" });
+	const form = new FormData();
+	form.append("file", blob, "filesystem.json");
+
+	const id = knownFileId ?? (await fetchFilesystemFileId(fetchFn));
+	if (id) {
+		// PATCH /files/{id} with multipart replaces the stored bytes in place.
+		const r = await fetchFn(`${DIRECTUS_URL}/files/${id}`, {
+			method: "PATCH",
+			credentials: "include",
+			body: form,
+		});
+		if (!r.ok) throw new Error(`filesystem overwrite failed: ${r.status}`);
+		return id;
+	}
+
+	const created = await fetchFn(`${DIRECTUS_URL}/files`, { method: "POST", credentials: "include", body: form });
+	if (!created.ok) throw new Error(`filesystem create failed: ${created.status}`);
+	const newId = ((await created.json()) as { data: { id: string } }).data.id;
+	const linked = await fetchFn(`${DIRECTUS_URL}/users/me`, {
+		method: "PATCH",
+		credentials: "include",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ [FILE_FIELD]: newId }),
+	});
+	if (!linked.ok) throw new Error(`filesystem link failed: ${linked.status}`);
+	return newId;
+}

--- a/packages/frontend/src/app.tsx
+++ b/packages/frontend/src/app.tsx
@@ -2,7 +2,9 @@ import { Component, lazy, StrictMode, Suspense, type ReactNode } from "react";
 import { createRoot } from "react-dom/client";
 import "./app.css";
 import "classicy/dist/classicy.css";
-import { ClassicyAppManagerProvider } from "classicy";
+import { ClassicyAppManagerProvider, registerClassicyFileSystemAdapter } from "classicy";
+import { directusFilesystemAdapter } from "./Providers/FilesystemSync/directusFilesystemAdapter";
+import { FilesystemSyncProvider } from "./Providers/FilesystemSync/FilesystemSyncProvider";
 import { DefaultFileSystem } from "./data/DefaultFileSystem";
 // Desktop is imported EAGERLY on purpose: mounting ClassicyDesktop lazily
 // (a tick after ClassicyAppManagerProvider) corrupts classicy's manager
@@ -19,6 +21,10 @@ import { PlaylistProvider } from "./Providers/Playlist/PlaylistProvider";
 import { initTracker } from "./openreplay";
 
 initTracker();
+
+// Sync the signed-in user's filesystem to Directus/Wasabi. Snapshot mode with a
+// 3s debounce so rapid edits coalesce into one upload; anonymous users are a no-op.
+registerClassicyFileSystemAdapter(directusFilesystemAdapter, { snapshotDebounceMs: 3000 });
 
 const IpodShell = lazy(() => import("./Mobile/IpodShell"));
 
@@ -94,17 +100,19 @@ createRoot(rootElement).render(
 		>
 			<PlaylistProvider>
 				<AuthProvider>
-					<MediaStreamProvider>
-						<Suspense fallback={null}>
-							{mobile ? (
-								<MobileFallbackBoundary>
-									<IpodShell />
-								</MobileFallbackBoundary>
-							) : (
-								<Desktop />
-							)}
-						</Suspense>
-					</MediaStreamProvider>
+					<FilesystemSyncProvider>
+						<MediaStreamProvider>
+							<Suspense fallback={null}>
+								{mobile ? (
+									<MobileFallbackBoundary>
+										<IpodShell />
+									</MobileFallbackBoundary>
+								) : (
+									<Desktop />
+								)}
+							</Suspense>
+						</MediaStreamProvider>
+					</FilesystemSyncProvider>
 				</AuthProvider>
 			</PlaylistProvider>
 		</ClassicyAppManagerProvider>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 18.1.0
       classicy:
         specifier: latest
-        version: 0.49.1(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30)
+        version: 0.50.0(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30)
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -1847,8 +1847,8 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
-  classicy@0.49.1:
-    resolution: {integrity: sha512-uBVQVsweRfHzq4ucerhQBbvHHWl5va/VE/N3/Knm2+3xYp46bh/o5QDkRrF+ePZcC7Cmy2uFgjeMKjKnR6YO4w==}
+  classicy@0.50.0:
+    resolution: {integrity: sha512-kWGtbaHbtcH5+wS/8L6XOAw5KBgsq28QjwllijVyiaNNTE0HA1oBayy+dWxr1zc6s5KKoYkmwbGPYlXP4LlKMA==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -5849,7 +5849,7 @@ snapshots:
       readdirp: 5.0.0
     optional: true
 
-  classicy@0.49.1(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30):
+  classicy@0.50.0(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30):
     dependencies:
       '@analytics/google-tag-manager': 0.6.0
       '@mdxeditor/editor': 3.55.0(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30)


### PR DESCRIPTION
## What & why

Signed-in users' Classicy virtual filesystem (desktop, documents, saved work) currently persists **only** to `localStorage` — anonymous and browser-local, lost on clearing storage or switching browsers/devices. This syncs a signed-in user's filesystem to a per-user **Wasabi-backed Directus file** so it follows them and is never lost on login/logout.

**Follow-me semantics:** remote wins on login (server copy replaces local); on logout the tree is flushed to the server *before* the session cookie is cleared, then the desktop resets to the anonymous default. Anonymous users stay purely browser-local (zero network).

Design: `docs/superpowers/specs/2026-07-21-filesystem-wasabi-sync-design.md` · Plan: `docs/superpowers/plans/2026-07-21-filesystem-wasabi-sync.md` (both gitignored/local).

## How it works

Two pieces bridged at the React↔non-React seam:
- **`directusFilesystemAdapter`** — a Classicy `ClassicyFileSystemAdapter` registered globally at app entry. `onSnapshot` pushes debounced (3s) tree snapshots to Directus `/files` (hash-dedupe, anonymous no-op, retry-on-failure by not advancing dedupe state); `reconcile` pulls the remote tree on boot. Per-user module state keyed by `user.id`.
- **`FilesystemSyncProvider`** — React glue inside `AuthProvider`: mirrors `useAuth().user` into the adapter, drives login-pull / first-login-seed / logout-reset, and registers a pre-sign-out flush.
- **`beforeSignOut` seam** — generic hook registry; `runBeforeSignOutHooks()` runs as the **first** line of `AuthProvider.signOut`, *before* Directus `logout()` clears the cookie (otherwise the flush would 401). This is the load-bearing ordering decision.

Storage mirrors the existing `uploadAvatar` precedent: one `filesystem` m2o field on `directus_users` → `directus_files`. No S3/Wasabi credentials ever reach the browser — all writes go through Directus with `credentials:"include"`.

## Commits (6, TDD per task)
- `feat(fs-sync): Directus filesystem blob API (load/push tree)`
- `feat(fs-sync): Classicy adapter with per-user push/reconcile`
- `feat(auth): pre-sign-out hook registry, run before cookie clear`
- `feat(fs-sync): FilesystemSyncProvider glue (login pull, logout reset, pre-signout flush)`
- `fix(fs-sync): guard login-transition seed push against unhandled rejection`
- `feat(fs-sync): register adapter + mount FilesystemSyncProvider`

## Tests
Full frontend suite green: **1453 passing**. New coverage: adapter branch matrix (dedupe, anonymous-skip, create-vs-update, reconcile replace/useLocal/corrupt-fallback, seed-fail), glue transitions (login pull vs seed "never both", logout reset, pre-signout flush ordering), and the beforeSignOut registry (unregister, error-swallowing). Reviewed per-task + a whole-branch review (no Critical/Important code defects).

## ⛔ DO NOT MERGE until these gates clear (else frontend CI goes red)
1. **Publish `~/classicy`** with the adapter API (`registerClassicyFileSystemAdapter` + the `ClassicyFileSystem*Adapter`/validation exports). This branch dev-links a local classicy build; published `0.43.7` lacks the API, and `.husky/pre-commit` bumps the pin to `latest`. Confirm the `latest` pin resolves the adapter API before landing.
2. **Create the `filesystem` field** (Many-to-One → `directus_files`) on `directus_users` in Directus (mirrors `avatar`). Authenticated users' existing `/files` create/update permission already covers it (avatar relies on it).
3. **Live smoke test:** `use:local` → dev server → sign in → verify seed (`POST /files` + `PATCH /users/me`), overwrite (`PATCH /files/{id}` — **confirm it replaces content**; documented fallback = POST-new→repoint→delete-old), reconcile on reload, and that the logout flush fires *before* `/auth/logout`.

## Known acceptable minors (from review, not blocking)
- Login-with-remote does one redundant idempotent PATCH of identical bytes (echo-push) — harmless; a clean fix would couple to classicy's internal hash, so left as-is.
- `pushTree` errors carry bare status (not the Directus body); two test-hygiene nits (`resetAllMocks`, reset the beforeSignOut hooks Set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnhE6P81JhB2ePneazHwMi
