### PR TITLE
test(e2e): dismiss pre-boot power-on overlay so desktop specs pass

### DIFF
--- a/packages/frontend/e2e/fixtures/index.ts
+++ b/packages/frontend/e2e/fixtures/index.ts
@@ -1,1 +1,27 @@
-export { test, expect } from '@playwright/test';
+import { test as base, expect } from "@playwright/test";
+
+// Shared e2e fixtures. Extend here (per packages/frontend/CLAUDE.md) rather than
+// duplicating setup across specs.
+//
+// The desktop boots behind a pre-boot "power on" About / content-warning overlay
+// (ClassicyDesktop's `preBootScreen`). Until POWER ON is clicked the desktop app
+// icons aren't rendered, so any spec that opens an app via icon double-click would
+// hang waiting for an icon that doesn't exist yet. Register a locator handler on
+// the `page` fixture: whenever an action is blocked and the overlay is showing,
+// Playwright auto-clicks POWER ON, boots, and retries the action. Specs that never
+// reach the desktop (the iPod shell) never trigger it, so it adds no overhead there.
+export const test = base.extend({
+	// `runTest` is Playwright's fixture callback (conventionally named `use`);
+	// renamed so eslint's react-hooks rule doesn't mistake it for React's `use`.
+	page: async ({ page }, runTest) => {
+		await page.addLocatorHandler(
+			page.getByRole("button", { name: "POWER ON" }),
+			async (button) => {
+				await button.click();
+			},
+		);
+		await runTest(page);
+	},
+});
+
+export { expect };


### PR DESCRIPTION
## Problem

The Playwright e2e job has been failing on `main` — **5 failed / 4 passed** — with every desktop-app spec (`account`, `feedback`, `playlist-editor` ×2, `playlist`) timing out at `getByRole('button', { name: … }).dblclick()`. Because e2e is `continue-on-error`, the workflow stayed green and the breakage went unnoticed.

## Root cause

PR #303 ("pre-boot About / content-warning screen") wired classicy 0.50.0's `preBootScreen` prop on `ClassicyDesktop` to a **"POWER ON" overlay**. Until POWER ON is clicked, the desktop **app icons are not rendered** (only `.classicyDesktop` and the POWER ON button exist). The specs assert `.classicyDesktop` is visible (still true, so that passes) and then double-click an app icon — which never appears, so the action hangs to timeout.

Confirmed by a controlled A/B: the identical `playlist-editor` dblclick test **passes** against a desktop with no overlay and **fails with the exact timeout** against a desktop showing the overlay. The breakage window on `main` (`df3e396e`…`0254d456`) contains exactly PR #303, and classicy was already 0.50.0 before it (so the classicy bump isn't the cause).

## Fix

Extend the shared `page` fixture (`e2e/fixtures/index.ts`, the sanctioned seam per `packages/frontend/CLAUDE.md`) with a Playwright **`addLocatorHandler`** for the POWER ON button. When any action is blocked by the overlay, Playwright auto-clicks POWER ON, boots, and retries the action — no per-spec changes.

- **Overlay-agnostic:** if no pre-boot screen appears (the iPod shell, or if the About screen is later removed), the handler never fires — zero overhead, no behavior change.
- The fixture callback is named `runTest` (not the conventional `use`) so eslint's `react-hooks` rule doesn't mistake it for React 19's `use` hook.

## Verification

Full e2e suite against a fresh `main` dev server (with the overlay present):

```
9 passed (15.7s)
```

vs. the pre-fix `5 failed / 4 passed`. Fixture lints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnhE6P81JhB2ePneazHwMi
