### PR TITLE
feat(feedback): autofill identity, remember GitHub handle, inline labels

### DIFF
--- a/packages/frontend/src/Applications/Feedback/Feedback.module.scss
+++ b/packages/frontend/src/Applications/Feedback/Feedback.module.scss
@@ -1,9 +1,39 @@
+// Two columns: labels, then controls. Every field except Description passes
+// labelPosition="left", and `display: contents` dissolves each control's own
+// holder so its label and input land directly in this grid — that's what lets
+// `max-content` size one shared label column to whichever label is longest.
+// A hard-coded width can't do the job: classicy scales type off --ui-font-size,
+// which the Appearance control panel changes at runtime.
 .fbForm {
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    align-items: center;
     gap: 8px;
     padding: 12px;
     min-width: 440px;
+
+    :global(.classicyLabelLeft) {
+        display: contents;
+    }
+
+    :global(.classicyLabelLeft) > :global(.classicyControlLabelHolder) {
+        justify-content: flex-end;
+        white-space: nowrap;
+    }
+
+    // Attachments stacks a button over the chosen-file list, so its label reads
+    // better pinned to the top of that stack than centred against all of it.
+    :global(.classicyFileInputHolder.classicyLabelLeft) > * {
+        align-self: start;
+    }
+
+    // Description keeps its label above, and the button/error rows have no
+    // label at all: all of them run the full width.
+    > :global(.classicyTextEditorHolder),
+    .fbActions,
+    .fbError {
+        grid-column: 1 / -1;
+    }
 }
 
 .fbActions {

--- a/packages/frontend/src/Applications/Feedback/Feedback.test.tsx
+++ b/packages/frontend/src/Applications/Feedback/Feedback.test.tsx
@@ -1,0 +1,142 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthUser } from "../../Providers/Auth/authApi";
+import type { FeedbackDefaults } from "./feedbackSettings";
+
+const dispatched = vi.hoisted(() => [] as Array<Record<string, unknown>>);
+const appData    = vi.hoisted(() => ({ current: undefined as Record<string, unknown> | undefined }));
+const authUser   = vi.hoisted(() => ({ current: null as AuthUser | null }));
+const formProps  = vi.hoisted(() => [] as Array<{ defaults: FeedbackDefaults }>);
+const submitted  = vi.hoisted(() => ({ github: "octocat" }));
+
+vi.mock("classicy", () => ({
+	ClassicyApp: (props: { children?: React.ReactNode }) => <div>{props.children}</div>,
+	ClassicyWindow: (props: { children?: React.ReactNode }) => <div>{props.children}</div>,
+	// FeedbackSuccess renders once a report goes through.
+	ClassicyButton: (props: { children?: React.ReactNode; onClickFunc?: () => void }) => (
+		<button type="button" onClick={props.onClickFunc}>{props.children}</button>
+	),
+	ClassicyIcons: { applications: {} },
+	registerClassicyIcons: (icons: Record<string, unknown>) => icons,
+	registerAppEventHandler: () => {},
+	quitMenuItemHelper: () => ({ id: "quit" }),
+	useAppManager: (selector: (s: unknown) => unknown) =>
+		selector({
+			System: {
+				Manager: { Applications: { apps: { "Feedback.app": { data: appData.current } } } },
+			},
+		}),
+	useAppManagerDispatch: () => (action: Record<string, unknown>) => {
+		dispatched.push(action);
+	},
+}));
+
+vi.mock("../../Providers/Auth/AuthContext", () => ({
+	useAuth: () => ({ status: authUser.current ? "signedIn" : "anonymous", user: authUser.current }),
+}));
+
+vi.mock("./useFeedback", () => ({
+	FEEDBACK_APP_ID: "Feedback.app",
+	useFeedback: () => ({
+		state: { submitting: false, error: null },
+		captureScreenshot: vi.fn(),
+		submit: vi.fn().mockResolvedValue("https://github.com/x/y/issues/1"),
+	}),
+}));
+
+// Stubbed so this file tests the container's wiring (identity in, persistence
+// out) rather than re-testing the form — FeedbackForm.test.tsx covers that.
+vi.mock("./FeedbackForm", () => ({
+	FeedbackForm: (props: {
+		defaults: FeedbackDefaults;
+		onSubmit: (fields: Record<string, string>, files: File[]) => Promise<void>;
+	}) => {
+		formProps.push(props);
+		return (
+			<button
+				type="button"
+				onClick={() =>
+					void props.onSubmit(
+						{
+							name: "Ada", email: "ada@example.com", github: submitted.github,
+							title: "T", description: "D",
+						},
+						[],
+					)
+				}
+			>
+				stub-submit
+			</button>
+		);
+	},
+}));
+
+const { Feedback } = await import("./Feedback");
+
+const makeUser = (over: Partial<AuthUser> = {}): AuthUser => ({
+	id: "1", email: "ada@example.com", first_name: "Ada", last_name: "Lovelace",
+	avatar: null, provider: "default", city: null, state: null, country: null,
+	school_name: null, educator_role: null, grade_levels: null, subjects: null,
+	...over,
+});
+
+const latestDefaults = () => formProps[formProps.length - 1].defaults;
+
+beforeEach(() => {
+	dispatched.length = 0;
+	formProps.length  = 0;
+	appData.current   = undefined;
+	authUser.current  = null;
+	submitted.github  = "octocat";
+});
+
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+});
+
+describe("Feedback", () => {
+	it("hands the signed-in user's name and email to the form", () => {
+		authUser.current = makeUser();
+		render(<Feedback />);
+		expect(latestDefaults()).toMatchObject({ name: "Ada Lovelace", email: "ada@example.com" });
+	});
+
+	it("leaves name and email blank for an anonymous visitor", () => {
+		render(<Feedback />);
+		expect(latestDefaults()).toMatchObject({ name: "", email: "" });
+	});
+
+	it("hands the remembered github handle to the form", () => {
+		appData.current = { github: "octocat" };
+		render(<Feedback />);
+		expect(latestDefaults().github).toBe("octocat");
+	});
+
+	it("remembers the github handle a report was sent under", async () => {
+		render(<Feedback />);
+		fireEvent.click(screen.getByRole("button", { name: "stub-submit" }));
+		await waitFor(() =>
+			expect(dispatched).toContainEqual({
+				type: "ClassicyAppFeedbackSetGithub",
+				github: "octocat",
+			}),
+		);
+	});
+
+	it("remembers a github handle the reporter cleared", async () => {
+		// Persisting "" is the point: the next report must not silently resurrect
+		// the handle they just deleted.
+		appData.current  = { github: "octocat" };
+		submitted.github = "";
+		render(<Feedback />);
+		fireEvent.click(screen.getByRole("button", { name: "stub-submit" }));
+		await waitFor(() =>
+			expect(dispatched).toContainEqual({
+				type: "ClassicyAppFeedbackSetGithub",
+				github: "",
+			}),
+		);
+	});
+});

--- a/packages/frontend/src/Applications/Feedback/Feedback.tsx
+++ b/packages/frontend/src/Applications/Feedback/Feedback.tsx
@@ -4,11 +4,16 @@ import {
 	ClassicyWindow,
 	quitMenuItemHelper,
 	registerClassicyIcons,
+	useAppManager,
+	useAppManagerDispatch,
 } from "classicy";
 import appIconPng from "./app.png";
 import type React from "react";
 import { useCallback, useMemo, useState } from "react";
+import { useAuth } from "../../Providers/Auth/AuthContext";
 import { FeedbackForm } from "./FeedbackForm";
+import "./FeedbackContext";
+import { feedbackDefaults, feedbackSetGithub, readStoredGithub } from "./feedbackSettings";
 import { FeedbackSuccess } from "./FeedbackSuccess";
 import { FEEDBACK_APP_ID, useFeedback } from "./useFeedback";
 import type { FeedbackFields } from "./useFeedback";
@@ -34,6 +39,23 @@ export const Feedback: React.FC = () => {
 
 	const { state, captureScreenshot, submit } = useFeedback();
 
+	// Identity is read live rather than snapshotted: `user` is null until
+	// AuthProvider's session check returns, which happens well after this app
+	// mounts (Desktop.tsx renders it at boot, not on window-open).
+	const { user } = useAuth();
+	const appData = useAppManager(
+		(s) =>
+			s.System.Manager.Applications.apps[appId]?.data as
+				| Record<string, unknown>
+				| undefined,
+	);
+	const desktopEventDispatch = useAppManagerDispatch();
+
+	const defaults = useMemo(
+		() => feedbackDefaults(user, readStoredGithub(appData)),
+		[user, appData],
+	);
+
 	const appMenu = useMemo(
 		() => [
 			{
@@ -48,10 +70,14 @@ export const Feedback: React.FC = () => {
 	const handleSubmit = useCallback(
 		async (fields: FeedbackFields, attachments: File[]) => {
 			const url = await submit(fields, attachments);
+			// Remember the handle the report actually went out under — including
+			// an empty one, so clearing the field sticks instead of falling back
+			// to the previously remembered handle on the next report.
+			desktopEventDispatch(feedbackSetGithub(fields.github));
 			setIssueUrl(url);
 			setView("success");
 		},
-		[submit],
+		[submit, desktopEventDispatch],
 	);
 
 	const handleReset = useCallback(() => {
@@ -88,6 +114,7 @@ export const Feedback: React.FC = () => {
 						submitting={state.submitting}
 						error={state.error}
 						onCaptureScreenshot={captureScreenshot}
+						defaults={defaults}
 					/>
 				) : (
 					<FeedbackSuccess issueUrl={issueUrl} onReset={handleReset} />

--- a/packages/frontend/src/Applications/Feedback/FeedbackContext.test.ts
+++ b/packages/frontend/src/Applications/Feedback/FeedbackContext.test.ts
@@ -1,0 +1,51 @@
+import type { ActionMessage, ClassicyStore } from "classicy";
+import { describe, expect, it } from "vitest";
+import { classicyFeedbackEventHandler } from "./FeedbackContext";
+import { feedbackSetGithub, readStoredGithub } from "./feedbackSettings";
+
+// A minimal store shaped like the slice the handler touches.
+function storeWith(data: Record<string, unknown> | undefined): ClassicyStore {
+	return {
+		System: {
+			Manager: { Applications: { apps: { "Feedback.app": { data } } } },
+		},
+	} as unknown as ClassicyStore;
+}
+
+const dataOf = (ds: ClassicyStore) =>
+	ds.System.Manager.Applications.apps["Feedback.app"].data as Record<string, unknown>;
+
+describe("classicyFeedbackEventHandler", () => {
+	it("writes the github handle into the Feedback.app data slice", () => {
+		const out = classicyFeedbackEventHandler(
+			storeWith({ existing: true }),
+			feedbackSetGithub("octocat") as ActionMessage,
+		);
+		expect(dataOf(out)).toEqual({ existing: true, github: "octocat" });
+	});
+
+	it("stores an empty handle rather than dropping the key", () => {
+		// Round-trips as "" (cleared), not undefined (never entered) — otherwise
+		// the next open would resurrect the handle the user just deleted.
+		const out = classicyFeedbackEventHandler(
+			storeWith({ github: "octocat" }),
+			feedbackSetGithub("") as ActionMessage,
+		);
+		expect(readStoredGithub(dataOf(out))).toBe("");
+	});
+
+	it("ignores actions it does not own", () => {
+		const out = classicyFeedbackEventHandler(
+			storeWith({ github: "octocat" }),
+			{ type: "SomethingElse" } as ActionMessage,
+		);
+		expect(dataOf(out)).toEqual({ github: "octocat" });
+	});
+
+	it("no-ops when the app is not mounted", () => {
+		const ds = { System: { Manager: { Applications: { apps: {} } } } } as unknown as ClassicyStore;
+		expect(() =>
+			classicyFeedbackEventHandler(ds, feedbackSetGithub("octocat") as ActionMessage),
+		).not.toThrow();
+	});
+});

--- a/packages/frontend/src/Applications/Feedback/FeedbackContext.ts
+++ b/packages/frontend/src/Applications/Feedback/FeedbackContext.ts
@@ -1,0 +1,27 @@
+import type { ActionMessage, ClassicyStore } from "classicy";
+import { registerAppEventHandler } from "classicy";
+import { FEEDBACK_APP_ID } from "./useFeedback";
+
+// Persists the reporter's GitHub handle into the app's data slice. classicy
+// routes any action whose type starts with "ClassicyAppFeedback" here
+// (registered below), and the resulting store is localStorage-backed.
+export const classicyFeedbackEventHandler = (
+	ds: ClassicyStore,
+	action: ActionMessage,
+) => {
+	const app = ds.System.Manager.Applications.apps[FEEDBACK_APP_ID];
+	if (!app) return ds;
+	const appData = app.data ?? {};
+
+	switch (action.type) {
+		case "ClassicyAppFeedbackSetGithub":
+			// Always writes the key, including for "" — see readStoredGithub on why
+			// "cleared" has to be distinguishable from "never entered".
+			app.data = { ...appData, github: action.github as string };
+			return ds;
+		default:
+			return ds;
+	}
+};
+
+registerAppEventHandler("ClassicyAppFeedback", classicyFeedbackEventHandler);

--- a/packages/frontend/src/Applications/Feedback/FeedbackForm.test.tsx
+++ b/packages/frontend/src/Applications/Feedback/FeedbackForm.test.tsx
@@ -1,6 +1,7 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { FeedbackFields } from "./useFeedback";
+import type { FeedbackDefaults } from "./feedbackSettings";
 import { FeedbackForm } from "./FeedbackForm";
 
 afterEach(() => {
@@ -13,6 +14,24 @@ let warnSpy: ReturnType<typeof vi.spyOn>;
 beforeAll(() => { warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {}); });
 afterAll(() => { warnSpy.mockRestore(); });
 
+const noop = vi.fn();
+const BLANK: FeedbackDefaults = { name: "", email: "", github: "" };
+
+type FormProps = Parameters<typeof FeedbackForm>[0];
+
+function props(over: Partial<FormProps> = {}): FormProps {
+    return {
+        onSubmit:            noop,
+        submitting:          false,
+        error:               null,
+        onCaptureScreenshot: noop,
+        defaults:            BLANK,
+        ...over,
+    };
+}
+
+const renderForm = (over: Partial<FormProps> = {}) => render(<FeedbackForm {...props(over)} />);
+
 function fillRequired() {
     fireEvent.change(screen.getByLabelText("Name"),        { target: { value: "Alice" } });
     fireEvent.change(screen.getByLabelText("Email"),       { target: { value: "alice@example.com" } });
@@ -20,29 +39,34 @@ function fillRequired() {
     fireEvent.change(screen.getByLabelText("Description"), { target: { value: "Something broke" } });
 }
 
-const noop = vi.fn();
+// classicy puts the labelPosition class on the control's outermost holder, which
+// is the input's parent for text fields but its grandparent for the file input.
+const holderOf = (labelText: string | RegExp) =>
+    screen.getByLabelText(labelText).closest(
+        ".classicyInputHolder, .classicyTextEditorHolder, .classicyFileInputHolder",
+    ) as HTMLElement;
 
 describe("FeedbackForm", () => {
     it("submit button is disabled when required fields are empty", () => {
-        render(<FeedbackForm onSubmit={noop} submitting={false} error={null} onCaptureScreenshot={noop} />);
+        renderForm();
         expect((screen.getByRole("button", { name: /send feedback/i }) as HTMLButtonElement).disabled).toBe(true);
     });
 
     it("submit button is enabled when all required fields are filled", () => {
-        render(<FeedbackForm onSubmit={noop} submitting={false} error={null} onCaptureScreenshot={noop} />);
+        renderForm();
         fillRequired();
         expect((screen.getByRole("button", { name: /send feedback/i }) as HTMLButtonElement).disabled).toBe(false);
     });
 
     it("submit button shows 'Sending…' and is disabled while submitting", () => {
-        render(<FeedbackForm onSubmit={noop} submitting={true} error={null} onCaptureScreenshot={noop} />);
+        renderForm({ submitting: true });
         const btn = screen.getByRole("button", { name: /sending/i }) as HTMLButtonElement;
         expect(btn.disabled).toBe(true);
     });
 
     it("calls onSubmit with form fields and empty attachments on submit", async () => {
         const onSubmit = vi.fn().mockResolvedValue(undefined);
-        render(<FeedbackForm onSubmit={onSubmit} submitting={false} error={null} onCaptureScreenshot={noop} />);
+        renderForm({ onSubmit });
         fillRequired();
         fireEvent.change(screen.getByLabelText(/github/i), { target: { value: "alice" } });
         fireEvent.click(screen.getByRole("button", { name: /send feedback/i }));
@@ -56,12 +80,12 @@ describe("FeedbackForm", () => {
     });
 
     it("shows inline error message when error prop is set", () => {
-        render(<FeedbackForm onSubmit={noop} submitting={false} error="GitHub API error" onCaptureScreenshot={noop} />);
+        renderForm({ error: "GitHub API error" });
         expect(screen.getByText("GitHub API error")).not.toBeNull();
     });
 
     it("adds a file to the attachment list when selected via file input", async () => {
-        render(<FeedbackForm onSubmit={noop} submitting={false} error={null} onCaptureScreenshot={noop} />);
+        renderForm();
         const file = new File(["content"], "photo.png", { type: "image/png" });
         const input = screen.getByLabelText(/attachments/i) as HTMLInputElement;
         Object.defineProperty(input, "files", { value: [file], configurable: true });
@@ -70,7 +94,7 @@ describe("FeedbackForm", () => {
     });
 
     it("removes a file when its remove button is clicked", async () => {
-        render(<FeedbackForm onSubmit={noop} submitting={false} error={null} onCaptureScreenshot={noop} />);
+        renderForm();
         const file = new File(["content"], "photo.png", { type: "image/png" });
         const input = screen.getByLabelText(/attachments/i) as HTMLInputElement;
         Object.defineProperty(input, "files", { value: [file], configurable: true });
@@ -81,7 +105,7 @@ describe("FeedbackForm", () => {
     });
 
     it("shows a validation error when more than 5 files are selected", async () => {
-        render(<FeedbackForm onSubmit={noop} submitting={false} error={null} onCaptureScreenshot={noop} />);
+        renderForm();
         const files = Array.from({ length: 6 }, (_, i) => new File(["x"], `f${i}.png`, { type: "image/png" }));
         const input = screen.getByLabelText(/attachments/i) as HTMLInputElement;
         Object.defineProperty(input, "files", { value: files, configurable: true });
@@ -90,7 +114,7 @@ describe("FeedbackForm", () => {
     });
 
     it("shows a validation error when a file exceeds 5 MB", async () => {
-        render(<FeedbackForm onSubmit={noop} submitting={false} error={null} onCaptureScreenshot={noop} />);
+        renderForm();
         const big = new File([new Uint8Array(6 * 1024 * 1024)], "big.png", { type: "image/png" });
         const input = screen.getByLabelText(/attachments/i) as HTMLInputElement;
         Object.defineProperty(input, "files", { value: [big], configurable: true });
@@ -101,7 +125,7 @@ describe("FeedbackForm", () => {
     it("calls onCaptureScreenshot and appends the result to attachments", async () => {
         const screenshotFile = new File(["png"], "screenshot.png", { type: "image/png" });
         const onCapture = vi.fn().mockResolvedValue(screenshotFile);
-        render(<FeedbackForm onSubmit={noop} submitting={false} error={null} onCaptureScreenshot={onCapture} />);
+        renderForm({ onCaptureScreenshot: onCapture });
         fireEvent.click(screen.getByRole("button", { name: /capture screenshot/i }));
         await waitFor(() => expect(screen.getByText("screenshot.png")).not.toBeNull());
         expect(onCapture).toHaveBeenCalledOnce();
@@ -109,9 +133,78 @@ describe("FeedbackForm", () => {
 
     it("does not call onSubmit when submit button is clicked with empty fields", async () => {
         const onSubmit = vi.fn();
-        render(<FeedbackForm onSubmit={onSubmit} submitting={false} error={null} onCaptureScreenshot={noop} />);
+        renderForm({ onSubmit });
         fireEvent.click(screen.getByRole("button", { name: /send feedback/i }));
         await new Promise<void>((r) => setTimeout(r, 0));
         expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    describe("pre-filled identity", () => {
+        it("prefills name, email and github from defaults", () => {
+            renderForm({ defaults: { name: "Ada Lovelace", email: "ada@example.com", github: "octocat" } });
+            expect((screen.getByLabelText("Name") as HTMLInputElement).value).toBe("Ada Lovelace");
+            expect((screen.getByLabelText("Email") as HTMLInputElement).value).toBe("ada@example.com");
+            expect((screen.getByLabelText(/github/i) as HTMLInputElement).value).toBe("octocat");
+        });
+
+        it("is submittable straight away when identity supplies the required fields", () => {
+            renderForm({ defaults: { name: "Ada Lovelace", email: "ada@example.com", github: "" } });
+            fireEvent.change(screen.getByLabelText("Title"),       { target: { value: "Bug report" } });
+            fireEvent.change(screen.getByLabelText("Description"), { target: { value: "Something broke" } });
+            expect((screen.getByRole("button", { name: /send feedback/i }) as HTMLButtonElement).disabled).toBe(false);
+        });
+
+        it("adopts defaults that resolve after the form has mounted", () => {
+            // The Feedback app mounts at desktop boot, long before AuthProvider's
+            // session check returns — so identity almost always arrives late.
+            const { rerender } = renderForm();
+            expect((screen.getByLabelText("Name") as HTMLInputElement).value).toBe("");
+            rerender(
+                <FeedbackForm
+                    {...props({ defaults: { name: "Ada Lovelace", email: "ada@example.com", github: "octocat" } })}
+                />,
+            );
+            expect((screen.getByLabelText("Name") as HTMLInputElement).value).toBe("Ada Lovelace");
+            expect((screen.getByLabelText(/github/i) as HTMLInputElement).value).toBe("octocat");
+        });
+
+        it("does not overwrite a field the reporter already typed into", () => {
+            const { rerender } = renderForm();
+            fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Grace" } });
+            rerender(
+                <FeedbackForm
+                    {...props({ defaults: { name: "Ada Lovelace", email: "ada@example.com", github: "" } })}
+                />,
+            );
+            expect((screen.getByLabelText("Name") as HTMLInputElement).value).toBe("Grace");
+            // …while an untouched field still picks the late default up.
+            expect((screen.getByLabelText("Email") as HTMLInputElement).value).toBe("ada@example.com");
+        });
+
+        it("keeps a field the reporter cleared empty when a default arrives", () => {
+            const { rerender } = renderForm({ defaults: { name: "Ada Lovelace", email: "", github: "octocat" } });
+            fireEvent.change(screen.getByLabelText(/github/i), { target: { value: "" } });
+            rerender(
+                <FeedbackForm
+                    {...props({ defaults: { name: "Ada Lovelace", email: "ada@example.com", github: "octocat" } })}
+                />,
+            );
+            expect((screen.getByLabelText(/github/i) as HTMLInputElement).value).toBe("");
+        });
+    });
+
+    describe("label layout", () => {
+        it("sets the single-line field labels beside their input", () => {
+            renderForm();
+            for (const label of ["Name", "Email", /github/i, "Title"] as const) {
+                expect(holderOf(label).className).toContain("classicyLabelLeft");
+            }
+            expect(holderOf(/attachments/i).className).toContain("classicyLabelLeft");
+        });
+
+        it("leaves the Description label above its textarea", () => {
+            renderForm();
+            expect(holderOf("Description").className).toContain("classicyLabelAbove");
+        });
     });
 });

--- a/packages/frontend/src/Applications/Feedback/FeedbackForm.tsx
+++ b/packages/frontend/src/Applications/Feedback/FeedbackForm.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
     ClassicyButton,
     ClassicyFileInput,
@@ -8,17 +8,47 @@ import {
     ClassicyTextEditor,
 } from "classicy";
 import type { FeedbackFields } from "./useFeedback";
+import type { FeedbackDefaults } from "./feedbackSettings";
 import styles from "./Feedback.module.scss";
 
 const MAX_FILES    = 5;
 const MAX_FILE_MB  = 5;
 const ACCEPT = "image/jpeg,image/png,image/gif,image/webp,application/pdf,text/plain";
 
-interface FeedbackFormProps {
+export interface FeedbackFormProps {
     onSubmit:             (fields: FeedbackFields, attachments: File[]) => Promise<void>;
     submitting:           boolean;
     error:                string | null;
     onCaptureScreenshot:  () => Promise<File>;
+    /** Pre-fill values (signed-in identity, remembered GitHub handle). */
+    defaults:             FeedbackDefaults;
+}
+
+/**
+ * A text field that tracks `initial` until the reporter types into it, then owns
+ * its own value forever.
+ *
+ * Plain `useState(initial)` won't do: this app is mounted at desktop boot
+ * (Desktop.tsx renders it unconditionally), so the form's first render happens
+ * well before AuthProvider's session check resolves — the identity always
+ * arrives late. Re-seeding on every `initial` change won't do either: that
+ * overwrites whatever the reporter was already typing when auth lands, and
+ * refills a field they deliberately cleared.
+ */
+function useSeededField(initial: string): [string, (value: string) => void] {
+    const [value, setValue] = useState(initial);
+    const [dirty, setDirty] = useState(false);
+
+    useEffect(() => {
+        if (!dirty) setValue(initial);
+    }, [initial, dirty]);
+
+    const change = useCallback((next: string) => {
+        setDirty(true);
+        setValue(next);
+    }, []);
+
+    return [value, change];
 }
 
 export const FeedbackForm: React.FC<FeedbackFormProps> = ({
@@ -26,10 +56,11 @@ export const FeedbackForm: React.FC<FeedbackFormProps> = ({
     submitting,
     error,
     onCaptureScreenshot,
+    defaults,
 }) => {
-    const [name,        setName]        = useState("");
-    const [email,       setEmail]       = useState("");
-    const [github,      setGithub]      = useState("");
+    const [name,        setName]        = useSeededField(defaults.name);
+    const [email,       setEmail]       = useSeededField(defaults.email);
+    const [github,      setGithub]      = useSeededField(defaults.github);
     const [title,       setTitle]       = useState("");
     const [description, setDescription] = useState("");
     const [attachments, setAttachments] = useState<File[]>([]);
@@ -62,27 +93,33 @@ export const FeedbackForm: React.FC<FeedbackFormProps> = ({
             <ClassicyInput
                 id="fb-name"
                 labelTitle="Name"
+                labelPosition="left"
                 prefillValue={name}
                 onChangeFunc={(e) => setName(e.target.value)}
             />
             <ClassicyInput
                 id="fb-email"
                 labelTitle="Email"
+                labelPosition="left"
                 prefillValue={email}
                 onChangeFunc={(e) => setEmail(e.target.value)}
             />
             <ClassicyInput
                 id="fb-github"
                 labelTitle="GitHub username (optional)"
+                labelPosition="left"
                 prefillValue={github}
                 onChangeFunc={(e) => setGithub(e.target.value)}
             />
             <ClassicyInput
                 id="fb-title"
                 labelTitle="Title"
+                labelPosition="left"
                 prefillValue={title}
                 onChangeFunc={(e) => setTitle(e.target.value)}
             />
+            {/* Description keeps its label above: a multi-line box next to a
+                one-line label column reads badly and wastes the editor's width. */}
             <ClassicyTextEditor
                 id="fb-description"
                 labelTitle="Description"
@@ -95,6 +132,7 @@ export const FeedbackForm: React.FC<FeedbackFormProps> = ({
                 ref={fileInputRef}
                 id="fb-files"
                 labelTitle="Attachments"
+                labelPosition="left"
                 accept={ACCEPT}
                 multiple
                 maxFiles={MAX_FILES}

--- a/packages/frontend/src/Applications/Feedback/feedbackSettings.test.ts
+++ b/packages/frontend/src/Applications/Feedback/feedbackSettings.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import type { AuthUser } from "../../Providers/Auth/authApi";
+import {
+	feedbackDefaults,
+	feedbackSetGithub,
+	readStoredGithub,
+} from "./feedbackSettings";
+
+const makeUser = (over: Partial<AuthUser> = {}): AuthUser => ({
+	id: "1",
+	email: "ada@example.com",
+	first_name: "Ada",
+	last_name: "Lovelace",
+	avatar: null,
+	provider: "default",
+	city: null,
+	state: null,
+	country: null,
+	school_name: null,
+	educator_role: null,
+	grade_levels: null,
+	subjects: null,
+	...over,
+});
+
+describe("readStoredGithub", () => {
+	it("returns undefined when the app has never stored a handle", () => {
+		expect(readStoredGithub(undefined)).toBeUndefined();
+		expect(readStoredGithub({})).toBeUndefined();
+	});
+
+	it("returns an empty string the user deliberately saved", () => {
+		// The whole point of the undefined/"" split: a cleared handle must stay
+		// cleared instead of falling back to the previously remembered one.
+		expect(readStoredGithub({ github: "" })).toBe("");
+	});
+
+	it("returns the stored handle", () => {
+		expect(readStoredGithub({ github: "octocat" })).toBe("octocat");
+	});
+
+	it("ignores a non-string value from a hand-edited localStorage snapshot", () => {
+		expect(readStoredGithub({ github: 42 })).toBeUndefined();
+	});
+});
+
+describe("feedbackSetGithub", () => {
+	it("builds a ClassicyAppFeedback-namespaced action carrying the handle", () => {
+		expect(feedbackSetGithub("octocat")).toEqual({
+			type: "ClassicyAppFeedbackSetGithub",
+			github: "octocat",
+		});
+	});
+});
+
+describe("feedbackDefaults", () => {
+	it("fills name and email from the signed-in user", () => {
+		expect(feedbackDefaults(makeUser(), undefined)).toEqual({
+			name: "Ada Lovelace",
+			email: "ada@example.com",
+			github: "",
+		});
+	});
+
+	it("uses just the first name when there is no last name", () => {
+		expect(feedbackDefaults(makeUser({ last_name: null }), undefined).name).toBe("Ada");
+	});
+
+	it("leaves the name blank when the account has no name on it", () => {
+		// Deliberately not the email: this field is asking who the person is, and
+		// the email already has its own field right below it.
+		expect(
+			feedbackDefaults(makeUser({ first_name: null, last_name: null }), undefined).name,
+		).toBe("");
+	});
+
+	it("leaves name and email blank for an anonymous visitor", () => {
+		expect(feedbackDefaults(null, undefined)).toEqual({ name: "", email: "", github: "" });
+	});
+
+	it("prefills the remembered github handle", () => {
+		expect(feedbackDefaults(null, "octocat").github).toBe("octocat");
+	});
+
+	it("keeps github blank when the user previously cleared it", () => {
+		expect(feedbackDefaults(makeUser(), "").github).toBe("");
+	});
+});

--- a/packages/frontend/src/Applications/Feedback/feedbackSettings.ts
+++ b/packages/frontend/src/Applications/Feedback/feedbackSettings.ts
@@ -1,0 +1,50 @@
+import type { ActionMessage } from "classicy";
+import type { AuthUser } from "../../Providers/Auth/authApi";
+
+/** The three fields the form can pre-fill on the user's behalf. */
+export interface FeedbackDefaults {
+	name:   string;
+	email:  string;
+	github: string;
+}
+
+/**
+ * Remember the GitHub handle the reporter last sent feedback under. classicy
+ * snapshots app data to localStorage, so persisting is just a dispatch — see
+ * README/readmeSettings.ts for the same pattern.
+ */
+export const feedbackSetGithub = (github: string): ActionMessage => ({
+	type: "ClassicyAppFeedbackSetGithub",
+	github,
+});
+
+/**
+ * `undefined` and `""` mean different things here and must stay distinct:
+ * `undefined` = never entered a handle (no stored opinion), `""` = entered one
+ * and later cleared it. Collapsing them (e.g. `stored || ""` on write, or a
+ * truthiness check on read) would resurrect an old handle after the user
+ * deliberately wiped the field.
+ *
+ * Stored state comes from localStorage, so a hand-edited or stale snapshot
+ * could hold anything — anything that isn't a string reads as "never entered".
+ */
+export const readStoredGithub = (
+	data: Record<string, unknown> | undefined,
+): string | undefined =>
+	typeof data?.github === "string" ? data.github : undefined;
+
+/**
+ * Pre-fill values for a freshly-opened form. Name/email come from the Directus
+ * session (nothing to remember — signing in *is* the source of truth), while
+ * github is device-local because it isn't part of the account profile.
+ */
+export const feedbackDefaults = (
+	user: AuthUser | null,
+	storedGithub: string | undefined,
+): FeedbackDefaults => ({
+	// Blank rather than the email when the account carries no name: the field
+	// asks who the reporter is, and email has its own field directly below.
+	name:   [user?.first_name, user?.last_name].filter(Boolean).join(" "),
+	email:  user?.email ?? "",
+	github: storedGithub ?? "",
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 18.1.0
       classicy:
         specifier: latest
-        version: 0.62.0(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30)
+        version: 0.63.0(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30)
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -1847,8 +1847,8 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
-  classicy@0.62.0:
-    resolution: {integrity: sha512-YMBRcIXJCwcwVpjUUKRhMujIprJ5WCAB+zXjDJglrEzz8Qk7bSASrYVf25hohEsRP5nrW+sXnmoVZu/vOBkRhw==}
+  classicy@0.63.0:
+    resolution: {integrity: sha512-3DSWn4pRog1cyuHvPTAaIYsw9/jjdIt328xmlArYdcDXVAYmnafszMcR7uvhaDO68VkjoPSkERIQMhtNP2MIBQ==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -5849,7 +5849,7 @@ snapshots:
       readdirp: 5.0.0
     optional: true
 
-  classicy@0.62.0(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30):
+  classicy@0.63.0(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/dlv@1.1.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30):
     dependencies:
       '@analytics/google-tag-manager': 0.6.0
       '@mdxeditor/editor': 3.55.0(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yjs@13.6.30)


### PR DESCRIPTION
Three changes to the Feedback app.

## 1. Autofill name and email for signed-in users

`Feedback.tsx` reads `useAuth()` and derives defaults via a new pure helper, `feedbackSettings.ts:feedbackDefaults()` — name is `first_name + last_name`, email is the account email. It deliberately does *not* fall back to the email for a nameless account, since email has its own field directly below.

The non-obvious part is *when* identity arrives. `Desktop.tsx:82` mounts `<Feedback/>` at desktop boot, so the form's first render happens well before `AuthProvider`'s session check returns — a plain `useState(defaults.name)` would never see it. So `FeedbackForm` seeds each field through a small `useSeededField` hook: **follow the default until the reporter's first keystroke, then stop**. That one dirty bit is what keeps a late-resolving `ada@example.com` from stomping something half-typed, and from refilling a field the reporter deliberately cleared.

## 2. Remember the GitHub handle, including when cleared

New `feedbackSettings.ts` + `FeedbackContext.ts`, mirroring the existing `README/readmeSettings.ts` + `ReadmeContext.ts` pattern — classicy snapshots `apps["Feedback.app"].data` to localStorage, so persistence is just a dispatch on successful submit. No storage code.

The "even if they change it to an empty string" requirement drives a three-state model:

| stored | meaning |
|---|---|
| `undefined` | never entered a handle — no opinion |
| `""` | entered one, then deliberately cleared it |
| `"octocat"` | a handle |

`readStoredGithub` returns `undefined` for anything non-string, and the handler always writes the key, so `""` round-trips instead of collapsing back to "no opinion" and resurrecting the old handle on the next report.

## 3. Labels beside their inputs

`labelPosition="left"` on Name / Email / GitHub / Title / Attachments. Description keeps its label above — a multi-line box beside a one-line label column reads badly and wastes the editor's width.

The form is now a grid with `display: contents` on the classicy control holders, so `grid-template-columns: max-content 1fr` auto-sizes one shared label column. A hard-coded column width was my first attempt and it misaligned the long `GitHub username (optional)` label by 19px; it also can't be right in principle, because classicy scales type off `--ui-font-size`, which the Appearance control panel changes at runtime.

## Verification

- 1712 tests / 196 files pass; `tsc -b` clean; `eslint` clean on the touched files. 23 new tests, each written before its implementation and watched fail first.
- Driven in the real desktop via Playwright: measured every left-labelled row landing on one edge (`labelRight: 470`, `ctlLeft: 478`) with no label wrapping.
- End-to-end persistence, the one link the unit tests mock out: submitted a report against a stubbed feedback endpoint, confirmed `github: "gracehopper"` reached localStorage and survived a full page reload, then cleared the field, resubmitted, and confirmed it came back `""` rather than the previous handle.

Two things I could not exercise at runtime, both environment limits rather than code ones: the **signed-in** autofill path (api-beta's CORS rejects localhost, so local dev is always anonymous — covered by unit tests on the mapping and on late arrival), and **mobile**, which uses `IpodShell` and never renders this form.

The `pnpm-lock.yaml` hunk is the usual `.husky/pre-commit` classicy auto-bump (0.62.0 → 0.63.0) riding along; the test run above was against 0.63.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)