### PR TITLE
Apex cutover Phase 1: repoint frontend at api/stream hostnames

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,11 @@ env:
   FE_VITE_PROXY_PROTOCOL: "https:"
   FE_VITE_PROXY_HOST: "timemachine.911realtime.org"
   FE_VITE_PROXY_PORT: "443"
-  FE_VITE_MEDIA_STREAM_URL: "wss://stream-beta.911realtime.org/stream"
+  FE_VITE_MEDIA_STREAM_URL: "wss://stream.911realtime.org/stream"
   FE_VITE_OPENREPLAY_PROJECT_KEY: "fsiCRmSeFQkdKxDDwD0C"
   FE_VITE_OPENREPLAY_INGEST_URL: "https://openreplay.911realtime.org/ingest"
-  FE_VITE_FEEDBACK_URL: "https://stream-beta.911realtime.org"
+  FE_VITE_FEEDBACK_URL: "https://stream.911realtime.org"
+  FE_VITE_DIRECTUS_URL: "https://api.911realtime.org"
 
 jobs:
   # Type-check, lint and unit-test the frontend. The Docker image build only runs
@@ -139,6 +140,7 @@ jobs:
             VITE_OPENREPLAY_PROJECT_KEY=${{ env.FE_VITE_OPENREPLAY_PROJECT_KEY }}
             VITE_OPENREPLAY_INGEST_URL=${{ env.FE_VITE_OPENREPLAY_INGEST_URL }}
             VITE_FEEDBACK_URL=${{ env.FE_VITE_FEEDBACK_URL }}
+            VITE_DIRECTUS_URL=${{ env.FE_VITE_DIRECTUS_URL }}
           tags: |
             ghcr.io/keeping-history/rt911-frontend:${{ github.sha }}
             ghcr.io/keeping-history/rt911-frontend:${{ github.event_name == 'pull_request' && github.sha || github.ref_name }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -7,7 +7,7 @@ name: Deploy PR preview
 #
 # The preview is compiled against the PRODUCTION backends (same FE_* values as
 # build.yml bakes into the deployed image), so a preview is a real client of
-# stream-beta / api-beta / files.911realtime.org. Two deliberate differences
+# stream / api / files.911realtime.org. Two deliberate differences
 # from the prod image build:
 #   - OpenReplay vars are left unset so preview sessions don't pollute prod
 #     session recordings (the tracker is disabled when the key is absent).
@@ -37,9 +37,9 @@ env:
   VITE_PROXY_PROTOCOL: "https:"
   VITE_PROXY_HOST: "timemachine.911realtime.org"
   VITE_PROXY_PORT: "443"
-  VITE_MEDIA_STREAM_URL: "wss://stream-beta.911realtime.org/stream"
-  VITE_FEEDBACK_URL: "https://stream-beta.911realtime.org"
-  VITE_DIRECTUS_URL: "https://api-beta.911realtime.org"
+  VITE_MEDIA_STREAM_URL: "wss://stream.911realtime.org/stream"
+  VITE_FEEDBACK_URL: "https://stream.911realtime.org"
+  VITE_DIRECTUS_URL: "https://api.911realtime.org"
 
 jobs:
   deploy-preview:

--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -60,20 +60,26 @@ CACHE_CLEAR_TOKEN=dev-token
 # VITE_PROXY_HOST=localhost
 # VITE_PROXY_PORT=8765
 
+# Every default below lives in src/lib/endpoints.ts, and all of them are the
+# PRODUCTION hosts — an image built without these build args still reaches a
+# real backend instead of a dead one. Point them at localhost to develop
+# against a local streamer.
+
 # WebSocket endpoint for the live media stream provider (MediaStreamProvider).
 # Use ws:// for plain HTTP and wss:// behind TLS.
-# Default: ws://localhost:8080/stream
-VITE_MEDIA_STREAM_URL=wss://stream-beta.911realtime.org/stream
+# Default: wss://stream.911realtime.org/stream
+VITE_MEDIA_STREAM_URL=wss://stream.911realtime.org/stream
 
-# HTTP base URL of the streamer service, used by the Feedback app to POST /feedback.
-# Default: http://localhost:8080
+# HTTP base URL of the streamer service, used by the Feedback app to POST
+# /feedback. The streamer serves this from the same host as the WebSocket.
+# Default: https://stream.911realtime.org
 VITE_FEEDBACK_URL=http://localhost:8080
 
 # Directus REST base URL, read directly (anonymously) by the Time Machine app to
 # load tm_bookmarks. Unlike playback data this is static reference data, so it is
 # fetched over REST rather than streamed. No trailing slash.
-# Default: https://api-beta.911realtime.org
-VITE_DIRECTUS_URL=https://api-beta.911realtime.org
+# Default: https://api.911realtime.org
+VITE_DIRECTUS_URL=https://api.911realtime.org
 
 # Self-hosted PMTiles vector basemap for the Flight Tracker app, read via the
 # pmtiles:// protocol (HTTP range requests). Served from the file-proxy on

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -25,13 +25,19 @@ ARG VITE_MEDIA_STREAM_URL
 ARG VITE_OPENREPLAY_PROJECT_KEY
 ARG VITE_OPENREPLAY_INGEST_URL
 ARG VITE_FEEDBACK_URL
+ARG VITE_DIRECTUS_URL
+# An ARG with no --build-arg becomes an EMPTY STRING here, not an unset
+# variable. src/lib/endpoints.ts treats empty as absent for exactly this
+# reason; without that, a forgotten build-arg would compile a relative URL
+# into the bundle rather than falling back to the production host.
 ENV VITE_PROXY_PROTOCOL=$VITE_PROXY_PROTOCOL \
     VITE_PROXY_HOST=$VITE_PROXY_HOST \
     VITE_PROXY_PORT=$VITE_PROXY_PORT \
     VITE_MEDIA_STREAM_URL=$VITE_MEDIA_STREAM_URL \
     VITE_OPENREPLAY_PROJECT_KEY=$VITE_OPENREPLAY_PROJECT_KEY \
     VITE_OPENREPLAY_INGEST_URL=$VITE_OPENREPLAY_INGEST_URL \
-    VITE_FEEDBACK_URL=$VITE_FEEDBACK_URL
+    VITE_FEEDBACK_URL=$VITE_FEEDBACK_URL \
+    VITE_DIRECTUS_URL=$VITE_DIRECTUS_URL
 # Transpile-only production build. We run `vite build` directly rather than the
 # package's `tsc -b && vite build` script: Vite/esbuild strips types and emits a
 # correct bundle, so the deployable image isn't gated on the branch's in-progress

--- a/packages/frontend/src/Applications/Feedback/useFeedback.test.ts
+++ b/packages/frontend/src/Applications/Feedback/useFeedback.test.ts
@@ -10,6 +10,7 @@ vi.mock("../../openreplay", () => ({
 }));
 
 import html2canvas from "html2canvas-pro";
+import { FEEDBACK_URL } from "../../lib/endpoints";
 import { getSessionURL } from "../../openreplay";
 import { useFeedback } from "./useFeedback";
 
@@ -139,8 +140,11 @@ describe("useFeedback", () => {
 			description: "Here is what happened",
 		};
 
-		it("POSTs to VITE_FEEDBACK_URL/feedback with FormData containing all fields", async () => {
-			vi.stubEnv("VITE_FEEDBACK_URL", "http://localhost:8080");
+		// FEEDBACK_URL is resolved once at module load (Vite inlines the value at
+		// build time), so vi.stubEnv cannot influence it from here. Assert against
+		// the constant itself; fromEnv's fallback rules are covered in
+		// lib/endpoints.test.ts.
+		it("POSTs to FEEDBACK_URL/feedback with FormData containing all fields", async () => {
 			mockGetSessionURL.mockReturnValue("https://openreplay.test/s/abc");
 			vi.mocked(global.fetch).mockResolvedValue(
 				new Response(JSON.stringify({ ok: true, issueUrl: "https://github.com/issues/1" }), { status: 200 }),
@@ -153,7 +157,7 @@ describe("useFeedback", () => {
 			});
 
 			expect(global.fetch).toHaveBeenCalledWith(
-				"http://localhost:8080/feedback",
+				`${FEEDBACK_URL}/feedback`,
 				expect.objectContaining({ method: "POST" }),
 			);
 			expect(issueUrl).toBe("https://github.com/issues/1");
@@ -228,22 +232,5 @@ describe("useFeedback", () => {
 			expect(result.current.state.submitting).toBe(false);
 		});
 
-		it("falls back to http://localhost:8080 when VITE_FEEDBACK_URL is unset", async () => {
-			vi.stubEnv("VITE_FEEDBACK_URL", "");
-			mockGetSessionURL.mockReturnValue(undefined);
-			vi.mocked(global.fetch).mockResolvedValue(
-				new Response(JSON.stringify({ ok: true, issueUrl: "https://github.com/issues/4" }), { status: 200 }),
-			);
-
-			const { result } = renderHook(() => useFeedback());
-			await act(async () => {
-				await result.current.submit(fields, []);
-			});
-
-			expect(vi.mocked(global.fetch)).toHaveBeenCalledWith(
-				"http://localhost:8080/feedback",
-				expect.anything(),
-			);
-		});
 	});
 });

--- a/packages/frontend/src/Applications/Feedback/useFeedback.ts
+++ b/packages/frontend/src/Applications/Feedback/useFeedback.ts
@@ -1,5 +1,6 @@
 import html2canvas from "html2canvas-pro";
 import { useCallback, useState } from "react";
+import { FEEDBACK_URL } from "../../lib/endpoints";
 import { getSessionURL } from "../../openreplay";
 
 // Also the `id` of <ClassicyApp> in Feedback.tsx. Classicy gives every window
@@ -68,10 +69,8 @@ export function useFeedback(): {
 			body.append("attachments[]", file);
 		}
 
-		const base = import.meta.env.VITE_FEEDBACK_URL || "http://localhost:8080";
-
 		try {
-			const res = await fetch(`${base}/feedback`, { method: "POST", body });
+			const res = await fetch(`${FEEDBACK_URL}/feedback`, { method: "POST", body });
 			const json = await res.json() as { ok?: boolean; issueUrl?: string; error?: string };
 
 			if (!res.ok) {

--- a/packages/frontend/src/Applications/FlightTracker/useAltitudeProfile.ts
+++ b/packages/frontend/src/Applications/FlightTracker/useAltitudeProfile.ts
@@ -3,12 +3,10 @@ import type { AltitudeSample } from "./flightAltitude";
 import type { TrackSelection } from "./useFlightTrack";
 import { flightDateOf } from "./useFlightTrack";
 import { prevUtcDay } from "./flightFilter";
+import { DIRECTUS_URL } from "../../lib/endpoints";
 
-// Directus REST base — same anonymous static-reference-data path useFlightTrack
-// uses. flight_positions is public-read (issue #224's grant).
-const DIRECTUS_URL =
-	(import.meta.env.VITE_DIRECTUS_URL as string | undefined) ??
-	"https://api-beta.911realtime.org";
+// Read over REST on the same anonymous static-reference-data path
+// useFlightTrack uses. flight_positions is public-read (issue #224's grant).
 
 export function profileUrl(flight: string, flightDate: string): string {
 	const params = new URLSearchParams({

--- a/packages/frontend/src/Applications/FlightTracker/useFlightTrack.ts
+++ b/packages/frontend/src/Applications/FlightTracker/useFlightTrack.ts
@@ -1,11 +1,9 @@
 import { useEffect, useRef, useState } from "react";
+import { DIRECTUS_URL } from "../../lib/endpoints";
 
-// Directus REST base, read anonymously — same static-reference-data path the
-// Time Machine bookmarks use (see TimeMachine/useBookmarks.ts). Track geometry
-// is static per flight, so it is fetched over REST, not streamed.
-const DIRECTUS_URL =
-	(import.meta.env.VITE_DIRECTUS_URL as string | undefined) ??
-	"https://api-beta.911realtime.org";
+// Track geometry is static per flight, so it is fetched over REST, not
+// streamed — the same static-reference-data path the Time Machine bookmarks
+// use (see TimeMachine/useBookmarks.ts).
 
 // Rich curated metadata, present only on the four notable flights (AA11,
 // UA175, AA77, UA93). Every key is optional — the panel renders what exists.

--- a/packages/frontend/src/Applications/FlightTracker/useMapPois.ts
+++ b/packages/frontend/src/Applications/FlightTracker/useMapPois.ts
@@ -1,10 +1,6 @@
 import { useEffect, useState } from "react";
+import { DIRECTUS_URL } from "../../lib/endpoints";
 import type { MapPoi } from "./mapPois";
-
-// Same anonymous-read Directus base as useNotableCrashSites/useFlightTrack.
-const DIRECTUS_URL =
-	(import.meta.env.VITE_DIRECTUS_URL as string | undefined) ??
-	"https://api-beta.911realtime.org";
 
 const FIELDS =
 	"id,name,layer,category,detail_title,lat,lon,iata,icao,city,region,details";

--- a/packages/frontend/src/Applications/FlightTracker/useNotableCrashSites.ts
+++ b/packages/frontend/src/Applications/FlightTracker/useNotableCrashSites.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import type { FlightPosition } from "../../Providers/MediaStream/MediaStreamContext";
+import { DIRECTUS_URL } from "../../lib/endpoints";
 import { NOTABLE_FLIGHTS } from "./notableFlights";
 
 // The four notables' final moments, straight from the same flight_positions
@@ -11,10 +12,8 @@ import { NOTABLE_FLIGHTS } from "./notableFlights";
 // seeks. Two samples (not one) so the motion buffer derives the true final
 // heading instead of pointing north after a seek-past-crash.
 //
-// Same anonymous-read Directus base as useFlightTrack/useAltitudeProfile.
-const DIRECTUS_URL =
-	(import.meta.env.VITE_DIRECTUS_URL as string | undefined) ??
-	"https://api-beta.911realtime.org";
+// Read over REST on the same anonymous path useFlightTrack/useAltitudeProfile
+// use.
 
 // All four notables flew (and crashed) on 9/11; their BTS-local flight_date
 // never straddles UTC midnight, so no prevUtcDay fallback is needed here.

--- a/packages/frontend/src/Applications/FlightTracker/useRouteIndex.ts
+++ b/packages/frontend/src/Applications/FlightTracker/useRouteIndex.ts
@@ -1,15 +1,13 @@
 import { useEffect, useMemo, useState } from "react";
+import { DIRECTUS_URL } from "../../lib/endpoints";
 import type { FlightPosition } from "../../Providers/MediaStream/MediaStreamContext";
 import { prevUtcDay, routeKey, type RouteIndex, type RouteIndexRow } from "./flightFilter";
 import { flightDateOf } from "./useFlightTrack";
 
-// Same anonymous-read Directus base as useFlightTrack; the route index is the
-// bulk sibling of that per-flight fetch — every flight_tracks row for a date,
-// small fields only (no geometry), so airport/tail filters can see all
-// airborne flights at once instead of issuing hundreds of per-flight requests.
-const DIRECTUS_URL =
-	(import.meta.env.VITE_DIRECTUS_URL as string | undefined) ??
-	"https://api-beta.911realtime.org";
+// The route index is the bulk sibling of useFlightTrack's per-flight fetch —
+// every flight_tracks row for a date, small fields only (no geometry), so
+// airport/tail filters can see all airborne flights at once instead of issuing
+// hundreds of per-flight requests.
 
 // Row counts vary by an order of magnitude between dates, so multi-page walks
 // are routine, not an edge case: 2001-09-11 has ~1,950 rows (one page) but

--- a/packages/frontend/src/Applications/HyperCard/extensions/directusCollections.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/directusCollections.ts
@@ -9,8 +9,8 @@
 // bypasses the streamer entirely).
 
 // Same env seam every other Directus caller uses; re-exported for parts.
-export { DIRECTUS_URL } from "../../../Providers/Playlist/loadPlaylist";
-import { DIRECTUS_URL } from "../../../Providers/Playlist/loadPlaylist";
+export { DIRECTUS_URL } from "../../../lib/endpoints";
+import { DIRECTUS_URL } from "../../../lib/endpoints";
 
 /**
  * A minimal registry describing which Directus collections HyperCard stacks may

--- a/packages/frontend/src/Applications/PlaylistEditor/directusQueue.ts
+++ b/packages/frontend/src/Applications/PlaylistEditor/directusQueue.ts
@@ -1,8 +1,7 @@
-// Serialized Directus REST access. api-beta MIXES the response bodies of
-// concurrent browser fetches (verified 2026-07-15), so every REST call in the
-// editor and its volume goes through this single global chain.
-export const DIRECTUS_URL: string =
-	import.meta.env?.VITE_DIRECTUS_URL ?? "https://api-beta.911realtime.org";
+// Serialized Directus REST access. The Directus API MIXES the response bodies
+// of concurrent browser fetches (verified 2026-07-15), so every REST call in
+// the editor and its volume goes through this single global chain.
+import { DIRECTUS_URL } from "../../lib/endpoints";
 
 let chain: Promise<unknown> = Promise.resolve();
 

--- a/packages/frontend/src/Applications/README/useReadmeArticles.ts
+++ b/packages/frontend/src/Applications/README/useReadmeArticles.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { DIRECTUS_URL } from "../../lib/endpoints";
 
 export interface ReadmeTag {
 	id:    number;
@@ -84,9 +85,6 @@ export interface ReadmeArticlesState {
 
 // Same direct-REST pattern as TimeMachine/useBookmarks.ts: reference data that
 // bypasses the streamer entirely.
-const DIRECTUS_URL =
-	(import.meta.env.VITE_DIRECTUS_URL as string | undefined) ?? "https://api-beta.911realtime.org";
-
 export const ARTICLES_URL =
 	`${DIRECTUS_URL}/items/readme_articles` +
 	"?filter[status][_eq]=published&sort=-date_created" +

--- a/packages/frontend/src/Applications/TimeMachine/bookmarksApi.ts
+++ b/packages/frontend/src/Applications/TimeMachine/bookmarksApi.ts
@@ -3,7 +3,7 @@
 // credentials:"include" sends the Directus session cookie; the collection's
 // own-rows policy (user_created = $CURRENT_USER) enforces isolation server-side.
 import { AuthRequiredError, ForbiddenError } from "../../Providers/Auth/authApi";
-import { DIRECTUS_URL } from "../../Providers/Playlist/loadPlaylist";
+import { DIRECTUS_URL } from "../../lib/endpoints";
 
 export interface PersonalBookmark {
 	id: number;

--- a/packages/frontend/src/Applications/TimeMachine/useBookmarks.ts
+++ b/packages/frontend/src/Applications/TimeMachine/useBookmarks.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useAuth } from "../../Providers/Auth/AuthContext";
 import type { PersonalBookmark } from "./bookmarksApi";
-import { DIRECTUS_URL } from "../../Providers/Playlist/loadPlaylist";
+import { DIRECTUS_URL } from "../../lib/endpoints";
 
 // A global (admin) Time Machine bookmark: a labelled moment the clock can jump
 // to. `start_date` is a bare UTC wall-clock Directus datetime. `category` groups

--- a/packages/frontend/src/Providers/Auth/authApi.test.ts
+++ b/packages/frontend/src/Providers/Auth/authApi.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { avatarUrl, fetchMe, isHostOf, loginEmail, logout, providerLoginUrl, register, registrationLandingUrl, uploadAvatar, verifyRegistration } from "./authApi";
-import { DIRECTUS_URL } from "../Playlist/loadPlaylist";
+import { DIRECTUS_URL } from "../../lib/endpoints";
 
 const jsonResponse = (body: unknown, status = 200) =>
 	new Response(JSON.stringify(body), { status });

--- a/packages/frontend/src/Providers/Auth/authApi.test.ts
+++ b/packages/frontend/src/Providers/Auth/authApi.test.ts
@@ -230,12 +230,12 @@ describe("registrationLandingUrl", () => {
 			"https://911realtime.org/",
 		);
 	});
-	it("falls back to beta elsewhere, with boundary-safe matching", () => {
+	it("falls back to the apex elsewhere, with boundary-safe matching", () => {
 		expect(registrationLandingUrl("localhost", "http://localhost:5173")).toBe(
-			"https://beta.911realtime.org/",
+			"https://911realtime.org/",
 		);
 		expect(registrationLandingUrl("evil911realtime.org", "https://evil911realtime.org")).toBe(
-			"https://beta.911realtime.org/",
+			"https://911realtime.org/",
 		);
 	});
 });

--- a/packages/frontend/src/Providers/Auth/authApi.ts
+++ b/packages/frontend/src/Providers/Auth/authApi.ts
@@ -161,14 +161,15 @@ export function isHostOf(hostname: string, domain: string): boolean {
 }
 
 // Registration verification links must land on an allow-listed URL
-// (USER_REGISTER_URL_ALLOW_LIST). Production origin by default; the frontend's
-// own origin when it's already on the product domain (future root-domain move).
+// (USER_REGISTER_URL_ALLOW_LIST). The frontend's own origin when it is already
+// on the product domain; the apex otherwise, for builds served elsewhere such
+// as the GitHub Pages PR previews.
 // Parameterized for tests — callers never pass arguments in production code.
 export function registrationLandingUrl(
 	hostname: string = window.location.hostname,
 	origin: string = window.location.origin,
 ): string {
-	return isHostOf(hostname, "911realtime.org") ? `${origin}/` : "https://beta.911realtime.org/";
+	return isHostOf(hostname, "911realtime.org") ? `${origin}/` : "https://911realtime.org/";
 }
 
 /**

--- a/packages/frontend/src/Providers/Auth/authApi.ts
+++ b/packages/frontend/src/Providers/Auth/authApi.ts
@@ -1,7 +1,7 @@
 // Directus session-cookie auth. httpOnly cookies only — never read/write
 // localStorage or any client-side store here; every request rides
 // credentials:"include" and the browser-held Directus session cookie.
-import { DIRECTUS_URL } from "../Playlist/loadPlaylist";
+import { DIRECTUS_URL } from "../../lib/endpoints";
 
 export interface AuthUser {
 	id: string;

--- a/packages/frontend/src/Providers/Auth/playlistApi.ts
+++ b/packages/frontend/src/Providers/Auth/playlistApi.ts
@@ -2,7 +2,7 @@
 // teacher's Directus session cookie; permissions return a teacher's own rows
 // plus everyone's published rows, so listMine filters client-side.
 import { parsePlaylist } from "../Playlist/parsePlaylist";
-import { DIRECTUS_URL } from "../Playlist/loadPlaylist";
+import { DIRECTUS_URL } from "../../lib/endpoints";
 import { AuthRequiredError, ForbiddenError } from "./authApi";
 
 export interface PlaylistSummary {

--- a/packages/frontend/src/Providers/Auth/profileApi.ts
+++ b/packages/frontend/src/Providers/Auth/profileApi.ts
@@ -7,7 +7,7 @@ import {
 	ForbiddenError,
 	type AuthUser,
 } from "./authApi";
-import { DIRECTUS_URL } from "../Playlist/loadPlaylist";
+import { DIRECTUS_URL } from "../../lib/endpoints";
 
 export interface ProfilePatch {
 	first_name?: string | null;

--- a/packages/frontend/src/Providers/Auth/stackApi.ts
+++ b/packages/frontend/src/Providers/Auth/stackApi.ts
@@ -2,7 +2,7 @@
 // user's Directus session cookie; the Teacher policy's permissions are
 // own-rows-only, so list needs no client-side filter (unlike playlistApi).
 import { validateStack } from "classicy";
-import { DIRECTUS_URL } from "../Playlist/loadPlaylist";
+import { DIRECTUS_URL } from "../../lib/endpoints";
 import { AuthRequiredError, ForbiddenError } from "./authApi";
 
 export interface StackSummary {

--- a/packages/frontend/src/Providers/Auth/usernameApi.ts
+++ b/packages/frontend/src/Providers/Auth/usernameApi.ts
@@ -10,14 +10,7 @@
  * same moment; the unique index decides, and the save still handles
  * UsernameTakenError. This only exists to catch the common case early.
  */
-
-// Derived from the WebSocket URL so there is one place to point at an
-// environment. The streamer serves both from the same host.
-const STREAM_BASE: string = (
-	(import.meta.env.VITE_MEDIA_STREAM_URL as string | undefined) ?? "ws://localhost:8080/stream"
-)
-	.replace(/^ws/, "http")
-	.replace(/\/stream$/, "");
+import { CHAT_BASE } from "../../lib/endpoints";
 
 export type UsernameCheck = "available" | "taken" | "unknown";
 
@@ -34,7 +27,7 @@ export async function checkUsername(
 ): Promise<UsernameCheck> {
 	try {
 		const res = await fetchFn(
-			`${STREAM_BASE}/chat/username-available?name=${encodeURIComponent(name)}`,
+			`${CHAT_BASE}/chat/username-available?name=${encodeURIComponent(name)}`,
 			{ credentials: "include", signal },
 		);
 		if (!res.ok) return "unknown";

--- a/packages/frontend/src/Providers/FilesystemSync/directusFilesystemApi.test.ts
+++ b/packages/frontend/src/Providers/FilesystemSync/directusFilesystemApi.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { fetchFilesystemFileId, downloadTree, pushTree } from "./directusFilesystemApi";
-import { DIRECTUS_URL } from "../Playlist/loadPlaylist";
+import { DIRECTUS_URL } from "../../lib/endpoints";
 
 const res = (body: unknown, ok = true, status = 200): Response =>
 	({ ok, status, json: async () => body, text: async () => JSON.stringify(body) }) as Response;

--- a/packages/frontend/src/Providers/FilesystemSync/directusFilesystemApi.ts
+++ b/packages/frontend/src/Providers/FilesystemSync/directusFilesystemApi.ts
@@ -4,7 +4,7 @@
 // (Wasabi-backed) and pointed to by the `filesystem` m2o field on directus_users.
 import { isValidFileSystemEntry } from "classicy";
 import type { ClassicyFileSystemEntry } from "classicy";
-import { DIRECTUS_URL } from "../Playlist/loadPlaylist";
+import { DIRECTUS_URL } from "../../lib/endpoints";
 
 const FILE_FIELD = "filesystem";
 

--- a/packages/frontend/src/Providers/MediaStream/MediaStreamProvider.tsx
+++ b/packages/frontend/src/Providers/MediaStream/MediaStreamProvider.tsx
@@ -24,6 +24,7 @@ import {
 	type WsClockMessage,
 	type WsHeartbeatAckMessage,
 } from "./MediaStreamContext";
+import { STREAM_URL } from "../../lib/endpoints";
 import { trackAck } from "./ackTracking";
 import { decodeWireMessage } from "./wireCodec";
 import { drainDue, partitionByDue } from "./revealBuffer";
@@ -46,10 +47,6 @@ function mergeById<T extends { id: number }>(prev: T[], incoming: T[]): T[] {
 	for (const item of incoming) byId.set(item.id, item);
 	return Array.from(byId.values());
 }
-
-const WS_URL: string =
-	(import.meta.env.VITE_MEDIA_STREAM_URL as string | undefined) ??
-	"ws://localhost:8080/stream";
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
 
@@ -1015,7 +1012,7 @@ export const MediaStreamProvider: FC<MediaStreamProviderProps> = ({
 	useEffect(() => {
 		let active = true;
 		let heartbeatId: ReturnType<typeof setInterval>;
-		const ws = new WebSocket(WS_URL);
+		const ws = new WebSocket(STREAM_URL);
 		// Must be set synchronously at construction (not in onopen) so the first
 		// binary frame arrives as an ArrayBuffer, not a Blob.
 		ws.binaryType = "arraybuffer";

--- a/packages/frontend/src/Providers/Playlist/loadPlaylist.ts
+++ b/packages/frontend/src/Providers/Playlist/loadPlaylist.ts
@@ -1,12 +1,9 @@
 // Resolve-my-playlist seam. Today: id in the URL, anonymous Directus read.
 // A future auth layer replaces only this module ("whatever playlist my teacher
 // assigned"), leaving the provider/engine untouched.
+import { DIRECTUS_URL } from "../../lib/endpoints";
 import { parsePlaylist } from "./parsePlaylist";
 import type { PlaylistDefinition } from "./playlistTypes";
-
-export const DIRECTUS_URL: string =
-	(import.meta.env.VITE_DIRECTUS_URL as string | undefined) ??
-	"https://api-beta.911realtime.org";
 
 // uuid-shaped: letters, digits, hyphens. Anything else is ignored (no fetch).
 const ID_RE = /^[A-Za-z0-9-]{1,64}$/;

--- a/packages/frontend/src/lib/endpoints.test.ts
+++ b/packages/frontend/src/lib/endpoints.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { chatHttpBase } from "./endpoints";
+
+describe("chatHttpBase", () => {
+	it("converts a wss stream URL to an https base", () => {
+		expect(chatHttpBase("wss://stream.911realtime.org/stream")).toBe(
+			"https://stream.911realtime.org",
+		);
+	});
+
+	it("converts a plain ws URL to http for local development", () => {
+		expect(chatHttpBase("ws://localhost:8080/stream")).toBe("http://localhost:8080");
+	});
+
+	// The rewrite must not fire on a host that merely starts with "ws".
+	it("only rewrites the scheme, never the host", () => {
+		expect(chatHttpBase("wss://ws.example.org/stream")).toBe("https://ws.example.org");
+	});
+
+	// Only a trailing /stream is the path to strip.
+	it("leaves a stream segment alone when it is not the final path element", () => {
+		expect(chatHttpBase("wss://example.org/stream/v2")).toBe("https://example.org/stream/v2");
+	});
+});

--- a/packages/frontend/src/lib/endpoints.test.ts
+++ b/packages/frontend/src/lib/endpoints.test.ts
@@ -1,5 +1,25 @@
 import { describe, expect, it } from "vitest";
-import { chatHttpBase } from "./endpoints";
+import { chatHttpBase, fromEnv } from "./endpoints";
+
+describe("fromEnv", () => {
+	it("uses the configured value when one is set", () => {
+		expect(fromEnv("https://api.example.org", "https://fallback.example")).toBe(
+			"https://api.example.org",
+		);
+	});
+
+	it("falls back when the variable is undefined", () => {
+		expect(fromEnv(undefined, "https://fallback.example")).toBe("https://fallback.example");
+	});
+
+	// The case that matters in production: the Dockerfile's ENV VITE_X=$VITE_X
+	// assigns "" when the build arg was never passed, so an empty string has to
+	// mean absent. Treating it as present yields a relative URL that quietly
+	// targets the page's own origin.
+	it("falls back on an empty string, not just on undefined", () => {
+		expect(fromEnv("", "https://fallback.example")).toBe("https://fallback.example");
+	});
+});
 
 describe("chatHttpBase", () => {
 	it("converts a wss stream URL to an https base", () => {

--- a/packages/frontend/src/lib/endpoints.ts
+++ b/packages/frontend/src/lib/endpoints.ts
@@ -14,18 +14,34 @@
  * quietly using the default below.
  */
 
+/**
+ * An unset build arg reaches the bundle as an EMPTY STRING, not as undefined:
+ * the Dockerfile's `ENV VITE_X=$VITE_X` assigns "" when `--build-arg VITE_X`
+ * was never passed. `??` would accept that empty string and yield a relative
+ * URL that silently targets the page's own origin, so absence has to mean
+ * "empty or missing", not just "missing".
+ */
+export function fromEnv(value: unknown, fallback: string): string {
+	return typeof value === "string" && value !== "" ? value : fallback;
+}
+
 /** Directus REST base, read anonymously for static reference data. No trailing slash. */
-export const DIRECTUS_URL: string =
-	(import.meta.env.VITE_DIRECTUS_URL as string | undefined) ?? "https://api.911realtime.org";
+export const DIRECTUS_URL: string = fromEnv(
+	import.meta.env.VITE_DIRECTUS_URL,
+	"https://api.911realtime.org",
+);
 
 /** Streamer WebSocket endpoint. */
-export const STREAM_URL: string =
-	(import.meta.env.VITE_MEDIA_STREAM_URL as string | undefined) ??
-	"wss://stream.911realtime.org/stream";
+export const STREAM_URL: string = fromEnv(
+	import.meta.env.VITE_MEDIA_STREAM_URL,
+	"wss://stream.911realtime.org/stream",
+);
 
 /** Streamer HTTP base, used by the Feedback app to POST /feedback. */
-export const FEEDBACK_URL: string =
-	(import.meta.env.VITE_FEEDBACK_URL as string | undefined) ?? "https://stream.911realtime.org";
+export const FEEDBACK_URL: string = fromEnv(
+	import.meta.env.VITE_FEEDBACK_URL,
+	"https://stream.911realtime.org",
+);
 
 /**
  * The HTTP origin serving the streamer's REST endpoints, derived from the

--- a/packages/frontend/src/lib/endpoints.ts
+++ b/packages/frontend/src/lib/endpoints.ts
@@ -1,0 +1,40 @@
+/**
+ * Every backend base URL the browser talks to, in one place.
+ *
+ * These are read from `import.meta.env` at module load, which means Vite
+ * inlines them at BUILD time — a deployed bundle cannot be repointed without a
+ * rebuild. The defaults below are the production hosts, so an image built
+ * without the VITE_* variables set still reaches production rather than
+ * silently falling back to a dead hostname.
+ *
+ * Adding a variable here is not enough on its own: it also needs an ARG and an
+ * ENV line in packages/frontend/Dockerfile and a build-args entry in
+ * .github/workflows/build.yml. Docker ignores a build-arg with no matching ARG
+ * without failing, so a missing declaration shows up only as production
+ * quietly using the default below.
+ */
+
+/** Directus REST base, read anonymously for static reference data. No trailing slash. */
+export const DIRECTUS_URL: string =
+	(import.meta.env.VITE_DIRECTUS_URL as string | undefined) ?? "https://api.911realtime.org";
+
+/** Streamer WebSocket endpoint. */
+export const STREAM_URL: string =
+	(import.meta.env.VITE_MEDIA_STREAM_URL as string | undefined) ??
+	"wss://stream.911realtime.org/stream";
+
+/** Streamer HTTP base, used by the Feedback app to POST /feedback. */
+export const FEEDBACK_URL: string =
+	(import.meta.env.VITE_FEEDBACK_URL as string | undefined) ?? "https://stream.911realtime.org";
+
+/**
+ * The HTTP origin serving the streamer's REST endpoints, derived from the
+ * WebSocket URL so there is exactly one place to point at an environment. The
+ * streamer serves both from the same host.
+ */
+export function chatHttpBase(streamUrl: string): string {
+	return streamUrl.replace(/^ws/, "http").replace(/\/stream$/, "");
+}
+
+/** Base for the streamer's chat REST endpoints, e.g. /chat/username-available. */
+export const CHAT_BASE: string = chatHttpBase(STREAM_URL);

--- a/plans/2026-07-25-apex-domain-cutover-design.md
+++ b/plans/2026-07-25-apex-domain-cutover-design.md
@@ -1,6 +1,8 @@
 # Apex Domain Cutover — Design
 
 **Date:** 2026-07-25
+**Revised:** 2026-07-27 — account for the IM Buddies app and the chat streamer
+endpoints, which landed after this design was first written.
 **Status:** Approved, pending implementation plan
 
 Move the production site from `beta.911realtime.org` to the apex `911realtime.org`,
@@ -52,7 +54,7 @@ Two facts about the existing setup shape the whole plan:
 | `www.911realtime.org` | proxied, never reaches origin | Cloudflare 301 to apex, path and query preserved |
 | `beta.911realtime.org` | proxied, never reaches origin | Cloudflare 301 to apex, path and query preserved |
 | `api.911realtime.org` | cluster, proxied | Directus |
-| `stream.911realtime.org` | cluster, proxied | streamer WSS and `/feedback` |
+| `stream.911realtime.org` | cluster, proxied | streamer: `/stream` WSS, `/chat/username-available`, `/feedback`, `/clock`, `/health`, `/ready` |
 | `files.911realtime.org` | unchanged | file-proxy |
 | `api-beta`, `stream-beta` | DNS records deleted | — |
 | `admin`, `cdn`, `cdn1-3`, `openreplay`, `timemachine` | untouched | out of scope |
@@ -88,6 +90,53 @@ name such as `staging.`.
 cluster out of the path entirely, so no ingress, certificate, or middleware is
 needed for `www` or `beta` in the end state.
 
+**Trim the compiled-in chat origin list in cleanup, not at cutover.** See below.
+
+## Chat origin gates
+
+The IM Buddies system, which landed after this design was first written, puts
+two *independent* origin gates in front of the streamer host. Both must accept
+the apex, and they are updated through different mechanisms.
+
+`stream.911realtime.org` now serves `/stream` (WebSocket), `/feedback`,
+`/clock`, `/health`, `/ready`, and — new — `/chat/username-available`.
+
+**Gate 1: the Traefik `streamer-cors` middleware.** Already carries
+`accessControlAllowCredentials: true`, because `checkUsername` calls the
+endpoint with `credentials: "include"` so the streamer can resolve the Directus
+session cookie. Its `accessControlAllowOriginList` still names `beta` and must
+gain the apex. Credentialed CORS cannot use a wildcard, so this list is the only
+thing standing between the apex and a dropped response.
+
+**Gate 2: the Go `OriginAllowlist`** (`handler.NewOriginAllowlist`), which gates
+*identity* on both `/stream` and `/chat/username-available`. An untrusted origin
+still streams media anonymously; it simply cannot turn a session cookie into a
+chat identity.
+
+Two properties of gate 2 matter for this cutover:
+
+- **`CHAT_TRUSTED_ORIGINS` is deliberately unset in production**
+  (`apps/rt911/streamer.yaml` documents why). The production trust list is
+  therefore *compiled into the streamer image*. Unlike every other allowlist
+  here, it cannot be corrected by editing a configmap — a wrong value requires
+  an image rebuild and redeploy. If a faster escape hatch is wanted during the
+  cutover window, `CHAT_TRUSTED_ORIGINS` can be set temporarily to add an origin
+  without a rebuild; note the file's warning against reintroducing it to name
+  the streamer's *own* host, which is a different and unsafe use.
+- **`beta` must stay in the list until cleanup.** Steps 5 through 7 keep `beta`
+  serving the SPA from the cluster, and that SPA dials `stream.911realtime.org`
+  with `Origin: https://beta.911realtime.org`. Trimming `beta` in the cutover PR
+  would deny identity to everyone still on `beta` and sign them out of chat
+  mid-window.
+
+**The failure mode here is silent.** `checkUsername` returns `"unknown"` for
+anything that is not a clear yes or no — including a CORS rejection — and the UI
+treats `"unknown"` as "no opinion" rather than surfacing an error. A broken
+origin list does not throw; the sign-on and Account screens simply stop warning
+about names that are already taken, and the unique index catches it later. This
+will pass a smoke test that only checks the page loads, so the verification
+section below asserts on a *positive* `available`/`taken` answer.
+
 ## Change set
 
 ### rt911 repository
@@ -109,10 +158,15 @@ source files. Editing only the CI configuration would miss production entirely.
   - `src/Applications/FlightTracker/useNotableCrashSites.ts`
   - `src/Applications/FlightTracker/useAltitudeProfile.ts`
 - `src/Providers/Auth/authApi.ts` — the fallback landing origin becomes the apex.
-- `packages/backend/internal/handler/origin.go` — trim `DefaultTrustedOrigins`
-  to the apex plus `keeping-history.github.io`. `www` and `beta` become dead
-  entries once the edge redirects them. This file landed on `main` in commit
-  `3c232a64`.
+- `packages/backend/internal/handler/origin.go` — **no change during the
+  cutover.** `DefaultTrustedOrigins` already lists the apex, `www`, `beta`, and
+  `keeping-history.github.io`, which is exactly the set needed while `beta` is
+  still serving. Trimming `www` and `beta` is deferred to the cleanup phase; see
+  "Chat origin gates" below for why doing it earlier signs users out of chat.
+- `src/Providers/Auth/usernameApi.ts` — derives its HTTP base by rewriting
+  `VITE_MEDIA_STREAM_URL` (`ws`→`http`, stripping the trailing `/stream`). This
+  transform moves into `endpoints.ts` rather than staying duplicated, so
+  `STREAM_URL` and the chat REST base come from one place.
 - `.github/workflows/build.yml` — point `FE_VITE_MEDIA_STREAM_URL` and
   `FE_VITE_FEEDBACK_URL` at `stream.911realtime.org`, and **add**
   `FE_VITE_DIRECTUS_URL` for `api.911realtime.org`.
@@ -128,7 +182,10 @@ source files. Editing only the CI configuration would miss production entirely.
 - `apps/rt911/frontend.yaml` — Ingress host and TLS SAN to the apex.
 - `apps/rt911/directus.yaml` — three `api-beta` host blocks to `api`.
 - `apps/rt911/streamer.yaml` — Ingress host to `stream`; the `streamer-cors`
-  middleware's `accessControlAllowOriginList` to the apex.
+  middleware's `accessControlAllowOriginList` gains the apex and keeps `beta`
+  until cleanup, matching the compiled-in Go list. `accessControlAllowCredentials`
+  is already `true` and needs no change. The chat LLM provider keys
+  (`ANTHROPIC_API_KEY` and friends) are outbound-only and unaffected.
 - `apps/rt911/configmap.yaml` — `PUBLIC_URL`, `CORS_ORIGIN`,
   `AUTH_GOOGLE_REDIRECT_ALLOW_LIST`, `AUTH_APPLE_REDIRECT_ALLOW_LIST`, and
   `USER_REGISTER_URL_ALLOW_LIST`. `SESSION_COOKIE_DOMAIN` is already correct and
@@ -186,8 +243,10 @@ These are manual and block the cutover.
    serves the application end to end.
 7. **Cloudflare** — create the 301 Redirect Rule for `www` and `beta`. Only now
    does `beta` stop reaching the origin.
-8. **Cleanup commit** — drop `beta` from the frontend ingress; delete the
-   `api-beta` and `stream-beta` DNS records.
+8. **Cleanup commit** — drop `beta` from the frontend ingress; remove `beta` and
+   `www` from the `streamer-cors` origin list and from `DefaultTrustedOrigins`
+   in `origin.go` (an rt911 change, so it ships as an image rebuild, not a
+   config edit); delete the `api-beta` and `stream-beta` DNS records.
 
 Steps 5 and 6 leave no frontend gap, because `beta` continues to serve from the
 cluster until step 7.
@@ -199,7 +258,16 @@ cluster until step 7.
 - `www` and `beta` return 301 with a `Location` that preserves path and query.
 - A WSS handshake succeeds against `stream.911realtime.org`.
 - A CORS preflight from the apex origin to `api.911realtime.org` succeeds.
-- Full Google **and** Apple sign-in round trips complete.
+- Full Google **and** Apple sign-in round trips complete. IM Buddies derives
+  chat identity from the resulting session cookie, so a broken OAuth redirect
+  degrades chat to anonymous rather than only breaking login.
+- **`/chat/username-available` returns a real `available` or `taken` from the
+  apex origin — not `"unknown"`.** This is the canary for both origin gates;
+  see "Chat origin gates". Check a name known to be taken, so a wrong answer is
+  distinguishable from a missing one.
+- IM Buddies signs on from the apex, the buddy roster is non-empty, and a
+  message round-trips to a buddy and back.
+- During steps 5 through 7, the same two chat checks still pass from `beta`.
 - The session cookie is set on `.911realtime.org`, and chat identity resolves
   from the apex origin.
 - `go test ./...`, `pnpm test`, `tsc -b`, and `eslint .` all pass.
@@ -208,6 +276,15 @@ cluster until step 7.
 
 Revert the infra commit and let ArgoCD re-sync, then remove the Redirect Rule.
 The old GCS origin is not a rollback target — it is being decommissioned.
+
+One asymmetry to plan for: everything in this cutover is revertible by editing
+infra config **except the chat origin allowlist**, which is compiled into the
+streamer image. Because the cutover PR leaves `DefaultTrustedOrigins` alone,
+that asymmetry costs nothing during the risky window — the list already covers
+both the apex and `beta`. It only becomes live at step 8, which is why the trim
+belongs there and not earlier. If chat identity does break unexpectedly
+mid-cutover, setting `CHAT_TRUSTED_ORIGINS` on the streamer Deployment adds an
+origin without waiting for a rebuild.
 
 This is why step 7 is last. Before it, `beta.911realtime.org` is a fully working
 escape hatch. After it, the 301 is cached in browsers and cannot be cleanly

--- a/plans/2026-07-25-apex-domain-cutover-design.md
+++ b/plans/2026-07-25-apex-domain-cutover-design.md
@@ -172,13 +172,21 @@ source files. Editing only the CI configuration would miss production entirely.
   `FE_VITE_DIRECTUS_URL` for `api.911realtime.org`.
 - `.github/workflows/pr-preview.yml` — the same three variables.
 - `packages/frontend/.env` and `.env.example`.
-- Tests asserting on `beta` origins in `authApi.test.ts`,
-  `AuthProvider.test.tsx`, and `origin_test.go`.
+- `authApi.test.ts` — the two assertions covering the off-domain fallback.
+  `origin_test.go` changes in the cleanup phase, not the cutover.
+  `AuthProvider.test.tsx` needs **no** change despite naming `beta`: it uses
+  that hostname only as a stand-in origin to prove `signInWithProvider` strips
+  the query string, an assertion that holds for any hostname.
 
 ### infra repository
 
-- New `Certificate` resources for the apex, `api`, and `stream`, applied ahead
-  of any traffic change so the TLS secrets exist before the ingresses switch.
+- The new hostnames added to each Ingress's `tls.hosts` **without** touching
+  `rules.host`, ahead of any traffic change. cert-manager's ingress-shim owns
+  the `rt911-frontend-tls`, `rt911-api-tls`, and `rt911-streamer-tls`
+  Certificates (it names them after `secretName`), so extending `tls.hosts`
+  re-issues each cert with the extra SAN while routing stays put. Standalone
+  `Certificate` resources are deliberately avoided: they would contend with
+  ingress-shim for ownership of the same secret.
 - `apps/rt911/frontend.yaml` — Ingress host and TLS SAN to the apex.
 - `apps/rt911/directus.yaml` — three `api-beta` host blocks to `api`.
 - `apps/rt911/streamer.yaml` — Ingress host to `stream`; the `streamer-cors`
@@ -229,8 +237,9 @@ These are manual and block the cutover.
 ## Cutover sequence
 
 1. Complete the prerequisites above.
-2. **infra commit A** — `Certificate` resources only. No traffic change. Wait
-   for all three TLS secrets to report `Ready`.
+2. **infra commit A** — extend each Ingress's `tls.hosts` with its new
+   hostname, leaving `rules.host` unchanged. No traffic change. Wait for all
+   three Certificates to report `Ready` with the new SAN present.
 3. **Cloudflare** — create the `stream` record, repoint `api` to the cluster.
    Traefik returns 404 for both; harmless.
 4. **rt911 PR merged to `main`** — CI builds the image with the new backend URLs

--- a/plans/2026-07-25-apex-domain-cutover-design.md
+++ b/plans/2026-07-25-apex-domain-cutover-design.md
@@ -251,6 +251,16 @@ These are manual and block the cutover.
 Steps 5 and 6 leave no frontend gap, because `beta` continues to serve from the
 cluster until step 7.
 
+**`beta` during that window is gap-filler, not a tested fallback.** It exists so
+that no request 404s between the ingress switch and the DNS flip, and it is
+expected to work — both origin gates deliberately retain `beta` until cleanup,
+so chat from `beta` should behave exactly as it does from the apex. It is not
+separately verified, and step 7 should follow step 6 as soon as the apex checks
+pass rather than pausing to re-test a hostname that is being retired. The
+consequence to accept knowingly: if the apex is healthy but `beta` is not, that
+is discovered by a user on a bookmark during a window of a few minutes, not by
+this checklist.
+
 ## Verification
 
 - The apex returns 200 with the SPA, and `index.html` carries `no-store` as
@@ -267,7 +277,6 @@ cluster until step 7.
   distinguishable from a missing one.
 - IM Buddies signs on from the apex, the buddy roster is non-empty, and a
   message round-trips to a buddy and back.
-- During steps 5 through 7, the same two chat checks still pass from `beta`.
 - The session cookie is set on `.911realtime.org`, and chat identity resolves
   from the apex origin.
 - `go test ./...`, `pnpm test`, `tsc -b`, and `eslint .` all pass.
@@ -286,9 +295,11 @@ belongs there and not earlier. If chat identity does break unexpectedly
 mid-cutover, setting `CHAT_TRUSTED_ORIGINS` on the streamer Deployment adds an
 origin without waiting for a rebuild.
 
-This is why step 7 is last. Before it, `beta.911realtime.org` is a fully working
-escape hatch. After it, the 301 is cached in browsers and cannot be cleanly
-withdrawn.
+Step 7 is last because the 301 is the one irreversible act in the sequence —
+browsers cache it near-indefinitely, so it cannot be cleanly withdrawn. That is
+the reason for the ordering, not a tested `beta` fallback: as noted above,
+`beta` is expected to work during the window but is not verified. Rollback runs
+through reverting the infra commit, not through diverting users to `beta`.
 
 ## Out of scope
 

--- a/plans/2026-07-25-apex-domain-cutover-design.md
+++ b/plans/2026-07-25-apex-domain-cutover-design.md
@@ -1,0 +1,222 @@
+# Apex Domain Cutover — Design
+
+**Date:** 2026-07-25
+**Status:** Approved, pending implementation plan
+
+Move the production site from `beta.911realtime.org` to the apex `911realtime.org`,
+rename the backend hostnames off their `-beta` suffixes, and redirect the old
+public names to the apex.
+
+## Goal
+
+`911realtime.org` becomes the canonical and only public address for the desktop
+SPA. `www.911realtime.org` and `beta.911realtime.org` permanently redirect to it.
+The Directus and streamer hostnames drop their `-beta` suffix in the same
+cutover.
+
+The old apex site — a static bundle in a Google Cloud Storage bucket behind a
+Google load balancer at `34.117.146.46` — is decommissioned manually and is out
+of scope. It is explicitly **not** a rollback target.
+
+## Current state
+
+The Cloudflare zone `911realtime.org` (`08e515063f366be3278cb3de2380469c`, Free
+plan) proxies every public record.
+
+| Name | Type | Value | Serves |
+|---|---|---|---|
+| `911realtime.org` | A | `34.117.146.46` | old GCS site |
+| `www` | A | `34.117.146.46` | old GCS site |
+| `beta` | CNAME | `dev.keepinghistory.org` | the SPA (cluster) |
+| `api-beta` | CNAME | `dev.keepinghistory.org` | Directus (cluster) |
+| `stream-beta` | CNAME | `dev.keepinghistory.org` | streamer (cluster) |
+| `files` | CNAME | `dev.keepinghistory.org` | file-proxy (cluster) |
+| `api` | CNAME | `admin.911realtime.org` | old stack leftover |
+| `admin`, `cdn`, `cdn1-3` | A/CNAME | Google / Shopify | old stack, out of scope |
+
+Two facts about the existing setup shape the whole plan:
+
+- **cert-manager solves `911realtime.org` names via DNS-01 through Cloudflare**
+  (`cluster/cert-manager/cluster-issuers.yaml`), not HTTP-01. Certificates can
+  therefore be issued for hostnames whose DNS does not yet point at the cluster,
+  which removes certificate issuance from the critical path.
+- **The session cookie domain is already `.911realtime.org`**
+  (`apps/rt911/configmap.yaml`), not `beta.911realtime.org`. Signed-in sessions
+  survive the move without re-authentication.
+
+## Target state
+
+| Hostname | Resolves to | Serves |
+|---|---|---|
+| `911realtime.org` | cluster, proxied | the SPA — the only frontend host on the origin |
+| `www.911realtime.org` | proxied, never reaches origin | Cloudflare 301 to apex, path and query preserved |
+| `beta.911realtime.org` | proxied, never reaches origin | Cloudflare 301 to apex, path and query preserved |
+| `api.911realtime.org` | cluster, proxied | Directus |
+| `stream.911realtime.org` | cluster, proxied | streamer WSS and `/feedback` |
+| `files.911realtime.org` | unchanged | file-proxy |
+| `api-beta`, `stream-beta` | DNS records deleted | — |
+| `admin`, `cdn`, `cdn1-3`, `openreplay`, `timemachine` | untouched | out of scope |
+
+## Decisions
+
+**Rename the backend hostnames in the same cutover.** `api-beta` becomes `api`
+and `stream-beta` becomes `stream`, rather than leaving them and renaming later.
+This costs a coordinated frontend image rebuild and OAuth console changes, but
+avoids leaving the `-beta` names permanent by default.
+
+**Hard cut on the backend hostnames — no dual-serve grace period.** The
+ingresses switch to the new hosts only; `api-beta` and `stream-beta` stop
+resolving to the cluster at cutover. Because `VITE_MEDIA_STREAM_URL` is baked
+into the frontend image at build time, a browser tab that was already open when
+ArgoCD syncs holds JavaScript that dials `stream-beta`, and that session drops
+until the user reloads. This is accepted; the sequencing below confines the
+window to the sync itself rather than a sustained outage.
+
+The hard cut applies to the **backend** hostnames only. The frontend's `beta`
+host is retained for two steps of the sequence below, so that the public site
+never 404s between the ingress switch and the DNS flip. It is removed in the
+final cleanup commit, once the edge redirect makes it unreachable anyway.
+
+**301 permanent redirects, preserving path and query.** `beta` and `www` both
+redirect to the apex at the Cloudflare edge, so the request never reaches the
+cluster. 301 consolidates search-engine signal onto the apex. Browsers cache
+301s near-indefinitely, so `beta.911realtime.org` cannot later serve something
+different for returning visitors. A future pre-production host must use a fresh
+name such as `staging.`.
+
+**Redirect at the edge, not in Traefik.** Cloudflare Redirect Rules keep the
+cluster out of the path entirely, so no ingress, certificate, or middleware is
+needed for `www` or `beta` in the end state.
+
+## Change set
+
+### rt911 repository
+
+`VITE_DIRECTUS_URL` is set in `pr-preview.yml` but not in `build.yml`, so the
+production Directus URL comes from a hardcoded fallback duplicated across eight
+source files. Editing only the CI configuration would miss production entirely.
+
+- **New `packages/frontend/src/lib/endpoints.ts`** — one module exporting
+  `DIRECTUS_URL`, `STREAM_URL`, and `FEEDBACK_URL`, each reading
+  `import.meta.env` with an apex-era default. It replaces the duplicated
+  `?? "https://api-beta.911realtime.org"` fallbacks in:
+  - `src/Providers/Playlist/loadPlaylist.ts`
+  - `src/Applications/PlaylistEditor/directusQueue.ts`
+  - `src/Applications/README/useReadmeArticles.ts`
+  - `src/Applications/FlightTracker/useRouteIndex.ts`
+  - `src/Applications/FlightTracker/useFlightTrack.ts`
+  - `src/Applications/FlightTracker/useMapPois.ts`
+  - `src/Applications/FlightTracker/useNotableCrashSites.ts`
+  - `src/Applications/FlightTracker/useAltitudeProfile.ts`
+- `src/Providers/Auth/authApi.ts` — the fallback landing origin becomes the apex.
+- `packages/backend/internal/handler/origin.go` — trim `DefaultTrustedOrigins`
+  to the apex plus `keeping-history.github.io`. `www` and `beta` become dead
+  entries once the edge redirects them. This file landed on `main` in commit
+  `3c232a64`.
+- `.github/workflows/build.yml` — point `FE_VITE_MEDIA_STREAM_URL` and
+  `FE_VITE_FEEDBACK_URL` at `stream.911realtime.org`, and **add**
+  `FE_VITE_DIRECTUS_URL` for `api.911realtime.org`.
+- `.github/workflows/pr-preview.yml` — the same three variables.
+- `packages/frontend/.env` and `.env.example`.
+- Tests asserting on `beta` origins in `authApi.test.ts`,
+  `AuthProvider.test.tsx`, and `origin_test.go`.
+
+### infra repository
+
+- New `Certificate` resources for the apex, `api`, and `stream`, applied ahead
+  of any traffic change so the TLS secrets exist before the ingresses switch.
+- `apps/rt911/frontend.yaml` — Ingress host and TLS SAN to the apex.
+- `apps/rt911/directus.yaml` — three `api-beta` host blocks to `api`.
+- `apps/rt911/streamer.yaml` — Ingress host to `stream`; the `streamer-cors`
+  middleware's `accessControlAllowOriginList` to the apex.
+- `apps/rt911/configmap.yaml` — `PUBLIC_URL`, `CORS_ORIGIN`,
+  `AUTH_GOOGLE_REDIRECT_ALLOW_LIST`, `AUTH_APPLE_REDIRECT_ALLOW_LIST`, and
+  `USER_REGISTER_URL_ALLOW_LIST`. `SESSION_COOKIE_DOMAIN` is already correct and
+  does not change.
+
+### Cloudflare
+
+- The apex `A` record replaced by a proxied `CNAME` to `dev.keepinghistory.org`,
+  relying on Cloudflare's CNAME flattening.
+- `www` likewise repointed off the dead GCS address. Its origin value is
+  functionally irrelevant once the Redirect Rule is live — the edge answers
+  before contacting an origin — but the record must stay **proxied** for the
+  rule to run at all, and pointing it at a decommissioned IP in the meantime
+  invites a confusing failure mode.
+- `api` repointed from `admin.911realtime.org` to the cluster.
+- `stream` created as a proxied `CNAME` to `dev.keepinghistory.org`.
+- A Redirect Rule matching `www.911realtime.org` and `beta.911realtime.org`,
+  issuing a 301 to the apex with the request URI appended.
+- `api-beta` and `stream-beta` deleted after cutover.
+
+## Prerequisites
+
+These are manual and block the cutover.
+
+1. **Google Cloud Console** — add
+   `https://api.911realtime.org/auth/login/google/callback` to the OAuth
+   client's authorized redirect URIs. Directus derives this URI from
+   `PUBLIC_URL`; without the console change, Google sign-in fails at cutover.
+2. **Apple Developer** — add the equivalent return URL to the Services ID. The
+   zone-level `apple-domain` TXT record remains valid.
+3. **A Cloudflare API token scoped to Zone → Dynamic Redirect → Edit.** The
+   existing cert-manager token is DNS-edit only and returns an authentication
+   error against the rulesets API. DNS work can use the existing token;
+   Redirect Rules cannot.
+4. **Confirm the zone's SSL mode**, and confirm the zone-wide "Cache everything"
+   rule left over from the 2026-07-24 cache incident does not cache the apex's
+   `index.html`. nginx sends `no-store` on that path, but a Cloudflare Cache
+   Rule overrides origin headers, and a stale `index.html` 404s on its old
+   hashed bundle after every deploy.
+
+## Cutover sequence
+
+1. Complete the prerequisites above.
+2. **infra commit A** — `Certificate` resources only. No traffic change. Wait
+   for all three TLS secrets to report `Ready`.
+3. **Cloudflare** — create the `stream` record, repoint `api` to the cluster.
+   Traefik returns 404 for both; harmless.
+4. **rt911 PR merged to `main`** — CI builds the image with the new backend URLs
+   and pushes it to GHCR.
+5. **infra commit B**, one ArgoCD sync — ingress hosts switched, configmap
+   origins updated, frontend image tag bumped. The frontend ingress **retains
+   `beta` as a second host** at this step. This is the open-tab break window for
+   the hard-cut backends.
+6. **Cloudflare** — repoint the apex and `www` at the cluster. Verify the apex
+   serves the application end to end.
+7. **Cloudflare** — create the 301 Redirect Rule for `www` and `beta`. Only now
+   does `beta` stop reaching the origin.
+8. **Cleanup commit** — drop `beta` from the frontend ingress; delete the
+   `api-beta` and `stream-beta` DNS records.
+
+Steps 5 and 6 leave no frontend gap, because `beta` continues to serve from the
+cluster until step 7.
+
+## Verification
+
+- The apex returns 200 with the SPA, and `index.html` carries `no-store` as
+  observed at the edge.
+- `www` and `beta` return 301 with a `Location` that preserves path and query.
+- A WSS handshake succeeds against `stream.911realtime.org`.
+- A CORS preflight from the apex origin to `api.911realtime.org` succeeds.
+- Full Google **and** Apple sign-in round trips complete.
+- The session cookie is set on `.911realtime.org`, and chat identity resolves
+  from the apex origin.
+- `go test ./...`, `pnpm test`, `tsc -b`, and `eslint .` all pass.
+
+## Rollback
+
+Revert the infra commit and let ArgoCD re-sync, then remove the Redirect Rule.
+The old GCS origin is not a rollback target — it is being decommissioned.
+
+This is why step 7 is last. Before it, `beta.911realtime.org` is a fully working
+escape hatch. After it, the 301 is cached in browsers and cannot be cleanly
+withdrawn.
+
+## Out of scope
+
+- Decommissioning the old GCS bucket and its load balancer.
+- The `admin`, `cdn`, and `cdn1-3` DNS records.
+- Per-path SEO mapping from old-site URLs. nginx serves `index.html` for every
+  path (`packages/frontend/nginx.conf`), so old deep links boot the desktop SPA
+  rather than hard-404ing.

--- a/plans/2026-07-27-apex-domain-cutover-plan.md
+++ b/plans/2026-07-27-apex-domain-cutover-plan.md
@@ -1,0 +1,1097 @@
+# Apex Domain Cutover Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Serve the desktop SPA from `911realtime.org`, rename the backend hosts to `api.911realtime.org` and `stream.911realtime.org`, and 301 `www` and `beta` to the apex.
+
+**Architecture:** Two repositories and one control plane. The rt911 repo change is pure refactor plus CI config — it centralizes every backend URL into `src/lib/endpoints.ts` and repoints the compiled-in defaults. The infra repo change flips Ingress hosts and origin allowlists. Cloudflare changes are DNS records plus one Redirect Rule. Certificate issuance happens through DNS-01 ahead of any traffic change, so TLS is never on the critical path.
+
+**Tech Stack:** Vite + React + TypeScript (vitest), Go (streamer), Kubernetes manifests via ArgoCD, Cloudflare API v4.
+
+Design doc: `plans/2026-07-25-apex-domain-cutover-design.md`. Read it before starting — particularly the "Chat origin gates" section, which explains why `beta` stays in two allowlists until the very last task.
+
+## Global Constraints
+
+- **Zone ID:** `08e515063f366be3278cb3de2380469c` (`911realtime.org`, Free plan, all public records proxied).
+- **Cluster CNAME target:** `dev.keepinghistory.org`.
+- **Kubernetes namespace:** `rt911`.
+- **Deployment is GitOps.** ArgoCD has `automated.selfHeal: true`. Never run `kubectl apply`, `kubectl set image`, or `kubectl edit` against rt911 resources — it is reverted within seconds. All cluster changes land as commits to `github.com/Keeping-History/infra`.
+- **The infra repo is a separate checkout** at `/home/robbiebyrd/infra`. It is not a submodule of rt911.
+- **Do not reorder Phase 2 tasks.** Each is a precondition for the next; the ordering is what keeps the site reachable throughout.
+- **`beta.911realtime.org` must remain in `DefaultTrustedOrigins` and in the `streamer-cors` origin list until Task 13.** Removing it earlier signs out every user still on `beta` during the cutover window.
+- **Frontend env vars are baked in at Docker build time.** A new `VITE_*` variable requires an `ARG` **and** an `ENV` line in `packages/frontend/Dockerfile`, plus a `build-args` entry in `.github/workflows/build.yml`. Docker silently ignores a `build-args` entry with no matching `ARG`.
+- Tests: `pnpm --filter @rt911/frontend exec vitest run <path>`. Full gate: `pnpm test && pnpm lint && pnpm build` from the repo root, and `go test ./...` from `packages/backend/`.
+
+## File Structure
+
+**Created:**
+- `packages/frontend/src/lib/endpoints.ts` — the single origin for every backend base URL the browser talks to. Exports `DIRECTUS_URL`, `STREAM_URL`, `FEEDBACK_URL`, `CHAT_BASE`, and the pure helper `chatHttpBase()`.
+- `packages/frontend/src/lib/endpoints.test.ts` — unit tests for `chatHttpBase()`, the only logic in that module.
+
+**Modified (rt911):** seven modules that each declare their own `DIRECTUS_URL`; nine modules that import it from `loadPlaylist.ts`; `usernameApi.ts`, `MediaStreamProvider.tsx`, `useFeedback.ts`, `authApi.ts`; `Dockerfile`; both workflow files; `.env` and `.env.example`; and in the final task, `origin.go`.
+
+**Modified (infra):** `apps/rt911/frontend.yaml`, `directus.yaml`, `streamer.yaml`, `configmap.yaml`.
+
+---
+
+## Phase 0 — Prerequisites
+
+### Task 1: Manual prerequisites
+
+These are console operations outside both repositories. Every one of them blocks the cutover. Nothing in Phase 2 may start until all four are confirmed.
+
+**Files:** none.
+
+**Interfaces:**
+- Produces: a Cloudflare API token with redirect permissions, exported as `$CF_REDIRECT_TOKEN` for Task 12; OAuth providers that accept the new callback URL.
+
+- [ ] **Step 1: Add the Google OAuth redirect URI**
+
+In Google Cloud Console → APIs & Services → Credentials → the rt911 OAuth 2.0 Client ID, add this to *Authorized redirect URIs*, keeping the existing `api-beta` entry:
+
+```
+https://api.911realtime.org/auth/login/google/callback
+```
+
+Directus derives this URI from `PUBLIC_URL`. The moment Task 10 changes `PUBLIC_URL`, Google starts receiving a `redirect_uri` it has never seen and fails closed with `redirect_uri_mismatch`. Keeping both entries means neither ordering breaks.
+
+- [ ] **Step 2: Add the Apple OAuth return URL**
+
+In the Apple Developer portal → Certificates, Identifiers & Profiles → the `org.911realtime.auth` Services ID → Configure → Return URLs, add:
+
+```
+https://api.911realtime.org/auth/login/apple/callback
+```
+
+The zone's `apple-domain=keugYYnIdg5DNIzv` TXT record is zone-level and needs no change.
+
+- [ ] **Step 3: Create a Cloudflare token that can write Redirect Rules**
+
+The existing cert-manager token is DNS-edit only. Verify that for yourself — this should fail:
+
+```bash
+CF_DNS_TOKEN=$(kubectl get secret -n cert-manager cloudflare-api-token -o jsonpath='{.data.api-token}' | base64 -d)
+curl -sS -H "Authorization: Bearer $CF_DNS_TOKEN" \
+  "https://api.cloudflare.com/client/v4/zones/08e515063f366be3278cb3de2380469c/rulesets" \
+  | python3 -m json.tool | head -5
+```
+
+Expected: `"success": false` with an `Authentication error`.
+
+In the Cloudflare dashboard → My Profile → API Tokens → Create Token → Custom token, grant **Zone → Dynamic Redirect → Edit** on zone `911realtime.org`. Export it for Task 12:
+
+```bash
+export CF_REDIRECT_TOKEN=<the new token>
+curl -sS -H "Authorization: Bearer $CF_REDIRECT_TOKEN" \
+  "https://api.cloudflare.com/client/v4/zones/08e515063f366be3278cb3de2380469c/rulesets" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['success'])"
+```
+
+Expected: `True`.
+
+- [ ] **Step 4: Confirm the zone's SSL mode and cache rules**
+
+In the dashboard → SSL/TLS → Overview, note the encryption mode. If it is **Full (strict)**, an Ingress serving a hostname whose certificate has not been issued returns a 526 to users — which is exactly what Task 8 exists to prevent, so confirm Task 8's verification passes before Task 10.
+
+In → Caching → Cache Rules, check for the zone-wide "Cache everything" rule from the 2026-07-24 incident. Confirm it does not apply to `/index.html` on the apex. nginx sends `Cache-Control: no-store` for that path, but a Cache Rule overrides origin headers, and a stale `index.html` 404s on its old hashed asset bundle after every deploy.
+
+- [ ] **Step 5: Record completion**
+
+No commit. Confirm all four are done before proceeding.
+
+---
+
+## Phase 1 — rt911 repository
+
+One PR. Tasks 2 through 7 are a pure refactor plus configuration: no behavior changes on the currently-live `beta` site, because every default it introduces is only read when the corresponding `VITE_*` variable is unset, and Task 7 sets them all explicitly.
+
+### Task 2: Create the endpoints module
+
+**Files:**
+- Create: `packages/frontend/src/lib/endpoints.ts`
+- Test: `packages/frontend/src/lib/endpoints.test.ts`
+
+**Interfaces:**
+- Produces: `DIRECTUS_URL: string`, `STREAM_URL: string`, `FEEDBACK_URL: string`, `CHAT_BASE: string`, and `chatHttpBase(streamUrl: string): string`. Tasks 3 through 6 import from here.
+
+The constants are plain environment reads evaluated once at module load; the only logic worth testing is `chatHttpBase`, which converts the WebSocket URL into the HTTP base the chat REST endpoint lives on. That transform currently sits inline in `usernameApi.ts` and is the piece that would silently break if someone changed the stream URL format.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/frontend/src/lib/endpoints.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { chatHttpBase } from "./endpoints";
+
+describe("chatHttpBase", () => {
+	it("converts a wss stream URL to an https base", () => {
+		expect(chatHttpBase("wss://stream.911realtime.org/stream")).toBe(
+			"https://stream.911realtime.org",
+		);
+	});
+
+	it("converts a plain ws URL to http for local development", () => {
+		expect(chatHttpBase("ws://localhost:8080/stream")).toBe("http://localhost:8080");
+	});
+
+	// The rewrite must not fire on a host that merely starts with "ws".
+	it("only rewrites the scheme, never the host", () => {
+		expect(chatHttpBase("wss://ws.example.org/stream")).toBe("https://ws.example.org");
+	});
+
+	// Only a trailing /stream is the path to strip.
+	it("leaves a stream segment alone when it is not the final path element", () => {
+		expect(chatHttpBase("wss://example.org/stream/v2")).toBe("https://example.org/stream/v2");
+	});
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `pnpm --filter @rt911/frontend exec vitest run src/lib/endpoints.test.ts`
+Expected: FAIL — `Failed to resolve import "./endpoints"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/frontend/src/lib/endpoints.ts`:
+
+```typescript
+/**
+ * Every backend base URL the browser talks to, in one place.
+ *
+ * These are read from `import.meta.env` at module load, which means Vite
+ * inlines them at BUILD time — a deployed bundle cannot be repointed without a
+ * rebuild. The defaults below are the production hosts, so an image built
+ * without the VITE_* variables set still reaches production rather than
+ * silently falling back to a dead hostname.
+ *
+ * Adding a variable here is not enough on its own: it also needs an ARG and an
+ * ENV line in packages/frontend/Dockerfile and a build-args entry in
+ * .github/workflows/build.yml. Docker ignores a build-arg with no matching ARG
+ * without failing, so a missing declaration shows up only as production
+ * quietly using the default below.
+ */
+
+/** Directus REST base, read anonymously for static reference data. No trailing slash. */
+export const DIRECTUS_URL: string =
+	(import.meta.env.VITE_DIRECTUS_URL as string | undefined) ?? "https://api.911realtime.org";
+
+/** Streamer WebSocket endpoint. */
+export const STREAM_URL: string =
+	(import.meta.env.VITE_MEDIA_STREAM_URL as string | undefined) ??
+	"wss://stream.911realtime.org/stream";
+
+/** Streamer HTTP base, used by the Feedback app to POST /feedback. */
+export const FEEDBACK_URL: string =
+	(import.meta.env.VITE_FEEDBACK_URL as string | undefined) ?? "https://stream.911realtime.org";
+
+/**
+ * The HTTP origin serving the streamer's REST endpoints, derived from the
+ * WebSocket URL so there is exactly one place to point at an environment. The
+ * streamer serves both from the same host.
+ */
+export function chatHttpBase(streamUrl: string): string {
+	return streamUrl.replace(/^ws/, "http").replace(/\/stream$/, "");
+}
+
+/** Base for the streamer's chat REST endpoints, e.g. /chat/username-available. */
+export const CHAT_BASE: string = chatHttpBase(STREAM_URL);
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run: `pnpm --filter @rt911/frontend exec vitest run src/lib/endpoints.test.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/frontend/src/lib/endpoints.ts packages/frontend/src/lib/endpoints.test.ts
+git commit -m "feat(frontend): add a single module for backend base URLs"
+```
+
+### Task 3: Move the shared DIRECTUS_URL out of loadPlaylist
+
+**Files:**
+- Modify: `packages/frontend/src/Providers/Playlist/loadPlaylist.ts:7-9`
+- Modify (import line only): `src/Providers/Auth/playlistApi.ts:5`, `src/Providers/Auth/authApi.ts:4`, `src/Providers/Auth/authApi.test.ts:3`, `src/Providers/Auth/stackApi.ts:5`, `src/Providers/Auth/profileApi.ts:10`, `src/Providers/FilesystemSync/directusFilesystemApi.ts:7`, `src/Providers/FilesystemSync/directusFilesystemApi.test.ts:3`, `src/Applications/TimeMachine/useBookmarks.ts:4`, `src/Applications/TimeMachine/bookmarksApi.ts:6`, `src/Applications/HyperCard/extensions/directusCollections.ts:13`
+
+**Interfaces:**
+- Consumes: `DIRECTUS_URL` from Task 2.
+- Produces: `loadPlaylist.ts` no longer exports `DIRECTUS_URL`.
+
+`loadPlaylist.ts` is the de-facto shared constant already — ten modules import `DIRECTUS_URL` from it, which is an odd home for a playlist loader. Moving it to `endpoints.ts` is what lets Task 4 collapse the duplicates.
+
+- [ ] **Step 1: Delete the declaration from loadPlaylist.ts**
+
+Remove these lines (currently 7-9):
+
+```typescript
+export const DIRECTUS_URL: string =
+	(import.meta.env.VITE_DIRECTUS_URL as string | undefined) ??
+	"https://api-beta.911realtime.org";
+```
+
+`loadPlaylist.ts` uses `DIRECTUS_URL` itself, so add an import at the top of the file alongside its existing imports:
+
+```typescript
+import { DIRECTUS_URL } from "../../lib/endpoints";
+```
+
+- [ ] **Step 2: Run the type checker to enumerate every broken import**
+
+Run: `pnpm --filter @rt911/frontend exec tsc -b --force`
+Expected: FAIL, one error per module still importing `DIRECTUS_URL` from `loadPlaylist`. Use this list to drive the next step rather than trusting the list in **Files** above.
+
+- [ ] **Step 3: Repoint each importer**
+
+In each file the type checker named, change the import source to `endpoints`. The relative depth differs per file — let the type checker confirm each one. For files under `src/Providers/Auth/`:
+
+```typescript
+import { DIRECTUS_URL } from "../../lib/endpoints";
+```
+
+For files under `src/Applications/TimeMachine/`:
+
+```typescript
+import { DIRECTUS_URL } from "../../lib/endpoints";
+```
+
+For `src/Applications/HyperCard/extensions/directusCollections.ts`:
+
+```typescript
+import { DIRECTUS_URL } from "../../../lib/endpoints";
+```
+
+Where a file imports `DIRECTUS_URL` alongside other symbols from `loadPlaylist`, split it into two imports rather than removing the original line.
+
+- [ ] **Step 4: Verify the type checker is clean and tests pass**
+
+Run: `pnpm --filter @rt911/frontend exec tsc -b --force && pnpm --filter @rt911/frontend exec vitest run`
+Expected: no type errors; the full suite passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/frontend/src
+git commit -m "refactor(frontend): source DIRECTUS_URL from the endpoints module"
+```
+
+### Task 4: Collapse the seven duplicate DIRECTUS_URL declarations
+
+**Files:**
+- Modify: `src/Applications/FlightTracker/useRouteIndex.ts:10-12`, `useFlightTrack.ts:6-8`, `useMapPois.ts:5-7`, `useNotableCrashSites.ts:15-17`, `useAltitudeProfile.ts:9-11`
+- Modify: `src/Applications/README/useReadmeArticles.ts:87-88`
+- Modify: `src/Applications/PlaylistEditor/directusQueue.ts:4-5`
+
+**Interfaces:**
+- Consumes: `DIRECTUS_URL` from Task 2.
+
+Each of these declares its own private copy with a hardcoded `api-beta` fallback. These are the copies that would have kept production on the old hostname even after the CI variable was added.
+
+- [ ] **Step 1: Replace each local declaration with an import**
+
+In the five FlightTracker hooks, delete the local `const DIRECTUS_URL = ...` block and add:
+
+```typescript
+import { DIRECTUS_URL } from "../../lib/endpoints";
+```
+
+Keep each file's surrounding explanatory comment — it documents why that hook reads Directus over REST instead of the stream, which is still true. Only the declaration goes.
+
+In `src/Applications/README/useReadmeArticles.ts`, delete lines 87-88 and add the same import.
+
+In `src/Applications/PlaylistEditor/directusQueue.ts`, delete lines 4-5 and add the same import. Note this file's declaration uses `import.meta.env?.VITE_DIRECTUS_URL` with an optional chain rather than a cast; the replacement is identical to the others.
+
+- [ ] **Step 2: Verify no hardcoded fallback survives**
+
+Run:
+
+```bash
+grep -rn "api-beta.911realtime.org\"" --include="*.ts" --include="*.tsx" packages/frontend/src
+```
+
+Expected: no output. Any remaining hit is a declaration this task missed.
+
+- [ ] **Step 3: Run the type checker and the full suite**
+
+Run: `pnpm --filter @rt911/frontend exec tsc -b --force && pnpm --filter @rt911/frontend exec vitest run`
+Expected: no type errors; full suite passes. The FlightTracker tests exercise these hooks' URL construction, so a wrong import path surfaces here.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/frontend/src
+git commit -m "refactor(frontend): collapse seven duplicate Directus base URLs"
+```
+
+### Task 5: Point the streamer consumers at the endpoints module
+
+**Files:**
+- Modify: `src/Providers/Auth/usernameApi.ts:15-21`
+- Modify: `src/Providers/MediaStream/MediaStreamProvider.tsx:50-52`
+- Modify: `src/Applications/Feedback/useFeedback.ts:71`
+
+**Interfaces:**
+- Consumes: `STREAM_URL`, `FEEDBACK_URL`, `CHAT_BASE` from Task 2.
+
+- [ ] **Step 1: Replace usernameApi's inline derivation**
+
+In `src/Providers/Auth/usernameApi.ts`, delete this block:
+
+```typescript
+// Derived from the WebSocket URL so there is one place to point at an
+// environment. The streamer serves both from the same host.
+const STREAM_BASE: string = (
+	(import.meta.env.VITE_MEDIA_STREAM_URL as string | undefined) ?? "ws://localhost:8080/stream"
+)
+	.replace(/^ws/, "http")
+	.replace(/\/stream$/, "");
+```
+
+Add at the top of the file:
+
+```typescript
+import { CHAT_BASE } from "../../lib/endpoints";
+```
+
+Then update the single use site (currently line 37) from `${STREAM_BASE}` to `${CHAT_BASE}`:
+
+```typescript
+		const res = await fetchFn(
+			`${CHAT_BASE}/chat/username-available?name=${encodeURIComponent(name)}`,
+			{ credentials: "include", signal },
+		);
+```
+
+Leave the file's leading doc comment untouched — it explains why this endpoint exists at all and is still accurate.
+
+- [ ] **Step 2: Replace MediaStreamProvider's declaration**
+
+In `src/Providers/MediaStream/MediaStreamProvider.tsx`, delete:
+
+```typescript
+const WS_URL: string =
+	(import.meta.env.VITE_MEDIA_STREAM_URL as string | undefined) ??
+	"ws://localhost:8080/stream";
+```
+
+Add to the file's imports:
+
+```typescript
+import { STREAM_URL } from "../../lib/endpoints";
+```
+
+Then replace every `WS_URL` reference in the file with `STREAM_URL`. Find them with:
+
+```bash
+grep -n "WS_URL" packages/frontend/src/Providers/MediaStream/MediaStreamProvider.tsx
+```
+
+- [ ] **Step 3: Replace useFeedback's inline default**
+
+In `src/Applications/Feedback/useFeedback.ts`, change line 71 from:
+
+```typescript
+		const base = import.meta.env.VITE_FEEDBACK_URL || "http://localhost:8080";
+```
+
+to use the shared constant. Add to the imports:
+
+```typescript
+import { FEEDBACK_URL } from "../../lib/endpoints";
+```
+
+and replace the `base` local with `FEEDBACK_URL` at its use site on the following line:
+
+```typescript
+			const res = await fetch(`${FEEDBACK_URL}/feedback`, { method: "POST", body });
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `pnpm --filter @rt911/frontend exec tsc -b --force && pnpm --filter @rt911/frontend exec vitest run`
+Expected: no type errors; full suite passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/frontend/src
+git commit -m "refactor(frontend): source streamer URLs from the endpoints module"
+```
+
+### Task 6: Repoint the registration landing fallback
+
+**Files:**
+- Modify: `packages/frontend/src/Providers/Auth/authApi.ts:171`
+- Test: `packages/frontend/src/Providers/Auth/authApi.test.ts:226-238`
+
+**Interfaces:**
+- Produces: no signature change; `registrationLandingUrl` keeps its two optional parameters.
+
+`registrationLandingUrl` already returns the caller's own origin whenever the page is on the product domain, so the apex is handled correctly today. Only the fallback — used when the page is somewhere else, such as a GitHub Pages preview — names `beta`.
+
+- [ ] **Step 1: Update the failing assertion first**
+
+In `packages/frontend/src/Providers/Auth/authApi.test.ts`, change the two assertions that expect the `beta` fallback. The off-domain case (currently around line 237):
+
+```typescript
+		expect(registrationLandingUrl("evil911realtime.org", "https://evil911realtime.org")).toBe(
+			"https://911realtime.org/",
+		);
+```
+
+Leave the `beta.911realtime.org` and `911realtime.org` cases alone — both are hosts of the product domain, so both correctly return their own origin, and that behavior does not change.
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `pnpm --filter @rt911/frontend exec vitest run src/Providers/Auth/authApi.test.ts`
+Expected: FAIL — received `"https://beta.911realtime.org/"`, expected `"https://911realtime.org/"`.
+
+- [ ] **Step 3: Update the implementation**
+
+In `packages/frontend/src/Providers/Auth/authApi.ts`, change line 171:
+
+```typescript
+	return isHostOf(hostname, "911realtime.org") ? `${origin}/` : "https://911realtime.org/";
+```
+
+Update the comment three lines above it, which says "future root-domain move" — that move is this change:
+
+```typescript
+// Registration verification links must land on an allow-listed URL
+// (USER_REGISTER_URL_ALLOW_LIST). The frontend's own origin when it's already
+// on the product domain; the apex otherwise, for previews served elsewhere.
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run: `pnpm --filter @rt911/frontend exec vitest run src/Providers/Auth/authApi.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/frontend/src/Providers/Auth
+git commit -m "fix(frontend): land off-domain registration links on the apex"
+```
+
+### Task 7: Repoint the build-time configuration
+
+**Files:**
+- Modify: `packages/frontend/Dockerfile:21-34`
+- Modify: `.github/workflows/build.yml:24-31` and `:135-141`
+- Modify: `.github/workflows/pr-preview.yml:37-42`
+- Modify: `packages/frontend/.env` and `packages/frontend/.env.example`
+
+**Interfaces:**
+- Consumes: the `VITE_*` names defined in Task 2.
+
+This is the task that actually changes what a deployed bundle talks to. Everything before it was a refactor.
+
+- [ ] **Step 1: Declare the new build arg in the Dockerfile**
+
+`VITE_DIRECTUS_URL` has never been a build arg — production has been relying on the source fallback. Docker ignores a `build-args` entry with no matching `ARG` **without failing**, so this step must come before the workflow change or the workflow change does nothing.
+
+In `packages/frontend/Dockerfile`, add to the `ARG` block (after line 27):
+
+```dockerfile
+ARG VITE_DIRECTUS_URL
+```
+
+and extend the `ENV` block, adding a continuation to the previous line:
+
+```dockerfile
+ENV VITE_PROXY_PROTOCOL=$VITE_PROXY_PROTOCOL \
+    VITE_PROXY_HOST=$VITE_PROXY_HOST \
+    VITE_PROXY_PORT=$VITE_PROXY_PORT \
+    VITE_MEDIA_STREAM_URL=$VITE_MEDIA_STREAM_URL \
+    VITE_OPENREPLAY_PROJECT_KEY=$VITE_OPENREPLAY_PROJECT_KEY \
+    VITE_OPENREPLAY_INGEST_URL=$VITE_OPENREPLAY_INGEST_URL \
+    VITE_FEEDBACK_URL=$VITE_FEEDBACK_URL \
+    VITE_DIRECTUS_URL=$VITE_DIRECTUS_URL
+```
+
+- [ ] **Step 2: Repoint the production workflow**
+
+In `.github/workflows/build.yml`, update the `env:` block (lines 24-31) to:
+
+```yaml
+env:
+  # Public backend URLs compiled into the frontend bundle.
+  FE_VITE_PROXY_PROTOCOL: "https:"
+  FE_VITE_PROXY_HOST: "timemachine.911realtime.org"
+  FE_VITE_PROXY_PORT: "443"
+  FE_VITE_MEDIA_STREAM_URL: "wss://stream.911realtime.org/stream"
+  FE_VITE_OPENREPLAY_PROJECT_KEY: "fsiCRmSeFQkdKxDDwD0C"
+  FE_VITE_OPENREPLAY_INGEST_URL: "https://openreplay.911realtime.org/ingest"
+  FE_VITE_FEEDBACK_URL: "https://stream.911realtime.org"
+  FE_VITE_DIRECTUS_URL: "https://api.911realtime.org"
+```
+
+and add the matching line to the `build-args` block (after line 141):
+
+```yaml
+            VITE_DIRECTUS_URL=${{ env.FE_VITE_DIRECTUS_URL }}
+```
+
+- [ ] **Step 3: Repoint the preview workflow**
+
+In `.github/workflows/pr-preview.yml`, update lines 40-42:
+
+```yaml
+  VITE_MEDIA_STREAM_URL: "wss://stream.911realtime.org/stream"
+  VITE_FEEDBACK_URL: "https://stream.911realtime.org"
+  VITE_DIRECTUS_URL: "https://api.911realtime.org"
+```
+
+- [ ] **Step 4: Update the local env files**
+
+In both `packages/frontend/.env` and `packages/frontend/.env.example`, change:
+
+```
+VITE_MEDIA_STREAM_URL=wss://stream.911realtime.org/stream
+```
+
+In `.env.example` only, also update the commented default under the `VITE_DIRECTUS_URL` block:
+
+```
+# Default: https://api.911realtime.org
+VITE_DIRECTUS_URL=https://api.911realtime.org
+```
+
+- [ ] **Step 5: Verify no stale hostname remains outside tests and docs**
+
+Run:
+
+```bash
+grep -rn "stream-beta\|api-beta" --include="*.ts" --include="*.tsx" --include="*.yml" \
+  --include="*.env*" --include="Dockerfile" packages/ .github/ | grep -v node_modules
+```
+
+Expected: only prose comments referencing the historical `api-beta` response-mixing bug. No assignment, no URL literal.
+
+- [ ] **Step 6: Run the full gate**
+
+Run from the repo root: `pnpm build && pnpm lint && pnpm test`
+Expected: all pass.
+
+- [ ] **Step 7: Commit and open the PR**
+
+```bash
+git add packages/frontend/Dockerfile packages/frontend/.env packages/frontend/.env.example .github/workflows
+git commit -m "build: point the frontend bundle at the apex-era backend hosts"
+git push -u origin HEAD
+gh pr create --title "Apex cutover: repoint frontend at api/stream hostnames" \
+  --body "Implements Phase 1 of plans/2026-07-27-apex-domain-cutover-plan.md. No infra or DNS change — the new hostnames do not resolve to the cluster until Phase 2, so this PR must NOT be merged until Task 8 and Task 9 are done."
+```
+
+**Do not merge this PR yet.** Merging triggers a build and an ArgoCD image bump; the new hostnames must exist first. Task 11 is where it merges.
+
+---
+
+## Phase 2 — Cutover
+
+Ordered and not interchangeable. Tasks 8 through 10 are reversible; Task 12 is not.
+
+### Task 8: Extend the TLS certificates
+
+**Files:**
+- Modify (infra): `apps/rt911/frontend.yaml:57`, `apps/rt911/directus.yaml:208,298,322`, `apps/rt911/streamer.yaml:138`
+
+Adds the new hostnames to each Ingress's `tls.hosts` while leaving `rules.host` alone. cert-manager's ingress-shim owns these Certificates and names them after `secretName`, so extending `tls.hosts` re-issues each cert with the extra SAN. Routing is untouched, so this is a no-op for users.
+
+Standalone `Certificate` resources are deliberately not used here: they would contend with ingress-shim for ownership of the same secret.
+
+- [ ] **Step 1: Extend each tls.hosts list**
+
+In `/home/robbiebyrd/infra`, edit `apps/rt911/frontend.yaml`:
+
+```yaml
+  tls:
+    - hosts: [beta.911realtime.org, 911realtime.org]
+      secretName: rt911-frontend-tls
+```
+
+`apps/rt911/streamer.yaml`:
+
+```yaml
+  tls:
+    - hosts: [stream-beta.911realtime.org, stream.911realtime.org]
+      secretName: rt911-streamer-tls
+```
+
+`apps/rt911/directus.yaml` — three separate `tls:` blocks at lines 208, 298 and 322. Each becomes:
+
+```yaml
+    - hosts: [api-beta.911realtime.org, api.911realtime.org]
+```
+
+Leave every `rules.host` and `- host:` line untouched in all three files. Confirm before committing:
+
+```bash
+cd /home/robbiebyrd/infra && git diff | grep "^[-+].*host:" 
+```
+
+Expected: no output. Only `hosts: [...]` array lines should appear in the diff.
+
+- [ ] **Step 2: Commit and push**
+
+```bash
+cd /home/robbiebyrd/infra
+git add apps/rt911/frontend.yaml apps/rt911/directus.yaml apps/rt911/streamer.yaml
+git commit -m "rt911: add apex-era hostnames to the TLS SAN lists"
+git push
+```
+
+- [ ] **Step 3: Wait for ArgoCD to sync and cert-manager to re-issue**
+
+```bash
+kubectl get certificate -n rt911 -w
+```
+
+Wait until all three report `READY=True` again. Re-issuance takes roughly one to three minutes per cert via DNS-01.
+
+- [ ] **Step 4: Verify each certificate actually carries the new SAN**
+
+A `READY=True` that predates the change proves nothing — check the SANs:
+
+```bash
+for s in rt911-frontend-tls rt911-api-tls rt911-streamer-tls; do
+  echo "--- $s"
+  kubectl get secret -n rt911 $s -o jsonpath='{.data.tls\.crt}' | base64 -d \
+    | openssl x509 -noout -text | grep -A1 "Subject Alternative Name"
+done
+```
+
+Expected: `911realtime.org` in the frontend cert, `api.911realtime.org` in the api cert, `stream.911realtime.org` in the streamer cert — each **alongside** its existing `-beta` name.
+
+If a SAN is missing, do not proceed. Task 10 depends on these certs existing.
+
+### Task 9: Pre-stage the DNS records
+
+**Files:** none — Cloudflare API.
+
+Creates `stream` and repoints `api`. Neither hostname is in any Ingress `rules.host` yet, so Traefik returns 404 for both. That is expected and harmless; it makes the records real so Task 10 has nothing left to wait on.
+
+- [ ] **Step 1: Export the DNS token**
+
+```bash
+export CF_DNS_TOKEN=$(kubectl get secret -n cert-manager cloudflare-api-token -o jsonpath='{.data.api-token}' | base64 -d)
+export ZONE=08e515063f366be3278cb3de2380469c
+```
+
+- [ ] **Step 2: Create the stream record**
+
+```bash
+curl -sS -X POST -H "Authorization: Bearer $CF_DNS_TOKEN" -H "Content-Type: application/json" \
+  "https://api.cloudflare.com/client/v4/zones/$ZONE/dns_records" \
+  --data '{"type":"CNAME","name":"stream","content":"dev.keepinghistory.org","proxied":true,"ttl":1}' \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['success'], d['result']['name'] if d['success'] else d['errors'])"
+```
+
+Expected: `True stream.911realtime.org`.
+
+- [ ] **Step 3: Repoint the api record**
+
+`api.911realtime.org` currently CNAMEs to `admin.911realtime.org`, part of the old stack. Its record ID is `152c825a28aa3c73b7c4126c2b915a06`:
+
+```bash
+curl -sS -X PATCH -H "Authorization: Bearer $CF_DNS_TOKEN" -H "Content-Type: application/json" \
+  "https://api.cloudflare.com/client/v4/zones/$ZONE/dns_records/152c825a28aa3c73b7c4126c2b915a06" \
+  --data '{"content":"dev.keepinghistory.org","proxied":true}' \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['success'], d['result']['content'] if d['success'] else d['errors'])"
+```
+
+Expected: `True dev.keepinghistory.org`.
+
+- [ ] **Step 4: Verify both resolve to the Cloudflare edge**
+
+```bash
+dig +short stream.911realtime.org @1.1.1.1
+dig +short api.911realtime.org @1.1.1.1
+```
+
+Expected: Cloudflare anycast addresses (`104.21.*` / `172.67.*`) for both, matching what `beta.911realtime.org` returns.
+
+### Task 10: Switch the ingress hosts and origin allowlists
+
+**Files:**
+- Modify (infra): `apps/rt911/frontend.yaml`, `directus.yaml`, `streamer.yaml`, `configmap.yaml`
+
+This is the step where users notice something. The backends hard-cut: a tab already open holds JavaScript that dials `stream-beta` and loses its stream until reloaded.
+
+**Merge the Task 7 PR first** so the new image exists in GHCR before the backend hostnames move.
+
+- [ ] **Step 1: Merge the Phase 1 PR and wait for the image**
+
+```bash
+gh pr merge --squash --auto
+gh run watch
+```
+
+Wait for the build workflow to push `ghcr.io/keeping-history/rt911-frontend:main`.
+
+- [ ] **Step 2: Switch the routing hosts**
+
+In `/home/robbiebyrd/infra/apps/rt911/frontend.yaml`, change the rule host to the apex while **keeping `beta` in `tls.hosts`**:
+
+```yaml
+  tls:
+    - hosts: [beta.911realtime.org, 911realtime.org]
+      secretName: rt911-frontend-tls
+  rules:
+    - host: 911realtime.org
+```
+
+Then add a second rule block for `beta`, duplicating the path block, so the site stays reachable on both until Task 12:
+
+```yaml
+    - host: beta.911realtime.org
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: rt911-frontend
+                port:
+                  number: 80
+```
+
+In `streamer.yaml` and `directus.yaml`, change each `- host:` line to the new hostname. Unlike the frontend, these do **not** keep a second rule — this is the hard cut.
+
+- [ ] **Step 3: Update the streamer CORS origin list**
+
+In `apps/rt911/streamer.yaml`, the `streamer-cors` middleware. Add the apex and keep `beta`:
+
+```yaml
+    accessControlAllowOriginList:
+      - "https://911realtime.org"
+      # Retained until the edge redirect lands (see the cutover plan, Task 13):
+      # the SPA is still served from beta until then, and a page loaded there
+      # sends Origin: https://beta.911realtime.org to this host.
+      - "https://beta.911realtime.org"
+      # rt911 PR-preview site (GitHub Pages) — previews POST /feedback here.
+      - "https://keeping-history.github.io"
+```
+
+Leave `accessControlAllowCredentials: true` as it is — `/chat/username-available` needs it.
+
+- [ ] **Step 4: Update the Directus origin and redirect allowlists**
+
+In `apps/rt911/configmap.yaml`, keeping the `beta` entries alongside the new ones for the same reason:
+
+```yaml
+  PUBLIC_URL: "https://api.911realtime.org"
+  CORS_ORIGIN: "https://911realtime.org,https://beta.911realtime.org,https://keeping-history.github.io"
+  AUTH_GOOGLE_REDIRECT_ALLOW_LIST: "https://911realtime.org,https://911realtime.org/,https://beta.911realtime.org,https://beta.911realtime.org/"
+  AUTH_APPLE_REDIRECT_ALLOW_LIST: "https://911realtime.org,https://911realtime.org/,https://beta.911realtime.org,https://beta.911realtime.org/"
+  USER_REGISTER_URL_ALLOW_LIST: "https://911realtime.org/,https://911realtime.org,https://beta.911realtime.org/,https://beta.911realtime.org"
+```
+
+Leave `SESSION_COOKIE_DOMAIN: ".911realtime.org"` alone — it is already correct and is why sessions survive the move.
+
+Do **not** touch `packages/backend/internal/handler/origin.go`. It already lists both the apex and `beta`, which is exactly the set needed now.
+
+- [ ] **Step 5: Commit, push, and watch the sync**
+
+```bash
+cd /home/robbiebyrd/infra
+git add apps/rt911/
+git commit -m "rt911: serve the SPA from the apex, rename api/stream hosts"
+git push
+kubectl rollout status deployment/rt911-directus -n rt911
+```
+
+Directus restarts to pick up the new configmap. The streamer restarts only if its own manifest changed.
+
+- [ ] **Step 6: Verify the old frontend host still works**
+
+```bash
+curl -sS -o /dev/null -w "%{http_code}\n" https://beta.911realtime.org/
+```
+
+Expected: `200`. The apex is not live yet — that is Task 11.
+
+### Task 11: Flip the apex and www records
+
+**Files:** none — Cloudflare API.
+
+- [ ] **Step 1: Replace the apex A record with a proxied CNAME**
+
+Cloudflare flattens a CNAME at the apex. The existing A record `5a6e2d873a9934ce849bb593397257b4` points at the old Google load balancer and must be replaced rather than patched, because the type changes:
+
+```bash
+curl -sS -X PUT -H "Authorization: Bearer $CF_DNS_TOKEN" -H "Content-Type: application/json" \
+  "https://api.cloudflare.com/client/v4/zones/$ZONE/dns_records/5a6e2d873a9934ce849bb593397257b4" \
+  --data '{"type":"CNAME","name":"911realtime.org","content":"dev.keepinghistory.org","proxied":true,"ttl":1}' \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['success'], d['result']['content'] if d['success'] else d['errors'])"
+```
+
+Expected: `True dev.keepinghistory.org`.
+
+- [ ] **Step 2: Repoint www off the decommissioned address**
+
+Record ID `c061645c13698aa7aef55d282ac172dd`. Once Task 12 lands, the edge answers before contacting any origin, so this value is never used — but it must stay **proxied** for the Redirect Rule to run, and pointing at a dead IP in the meantime invites a confusing failure:
+
+```bash
+curl -sS -X PUT -H "Authorization: Bearer $CF_DNS_TOKEN" -H "Content-Type: application/json" \
+  "https://api.cloudflare.com/client/v4/zones/$ZONE/dns_records/c061645c13698aa7aef55d282ac172dd" \
+  --data '{"type":"CNAME","name":"www","content":"dev.keepinghistory.org","proxied":true,"ttl":1}' \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['success'], d['result']['content'] if d['success'] else d['errors'])"
+```
+
+- [ ] **Step 3: Verify the apex serves the SPA**
+
+```bash
+curl -sS -o /dev/null -w "%{http_code}\n" https://911realtime.org/
+curl -sSI https://911realtime.org/index.html | grep -i "cache-control"
+```
+
+Expected: `200`, and `cache-control: no-store, must-revalidate`. If the cache header is missing or shows a max-age, the zone-wide Cache Rule from Task 1 Step 4 is overriding nginx — fix that before continuing, or every future deploy serves a stale `index.html`.
+
+- [ ] **Step 4: Verify the backends from the apex origin**
+
+The chat CORS canary. A CORS failure here returns `"unknown"` in the UI rather than an error, so assert on a real answer rather than on the request merely completing.
+
+Get a username that definitely exists straight from the database:
+
+```bash
+TAKEN=$(kubectl exec -n rt911 deploy/rt911-directus -- \
+  psql "$DATABASE_URL" -tAc \
+  "select username from directus_users where username is not null limit 1")
+echo "using: $TAKEN"
+```
+
+If that pod has no `psql`, use your own signed-in screen name instead — any name you can confirm exists works.
+
+```bash
+curl -sS -H "Origin: https://911realtime.org" \
+  "https://stream.911realtime.org/chat/username-available?name=$TAKEN"
+```
+
+Expected: `{"available":false}`.
+
+Three distinct failures to watch for, all of which mean stop: a CORS rejection, a 404 (the route is not reachable at this hostname), or `{"available":true}` for a name you just read out of the users table — the last means the endpoint is answering but not seeing the database.
+
+Also check a name that certainly does not exist, so a stuck `false` is distinguishable from a real answer:
+
+```bash
+curl -sS -H "Origin: https://911realtime.org" \
+  "https://stream.911realtime.org/chat/username-available?name=zzz-not-a-real-name-9137"
+```
+
+Expected: `{"available":true}`.
+
+Check the preflight carries both required headers:
+
+```bash
+curl -sS -X OPTIONS -o /dev/null -D - \
+  -H "Origin: https://911realtime.org" \
+  -H "Access-Control-Request-Method: GET" \
+  "https://stream.911realtime.org/chat/username-available" 2>&1 | grep -i "access-control-allow"
+```
+
+Expected: both `access-control-allow-origin: https://911realtime.org` and `access-control-allow-credentials: true`. Credentialed CORS requires an explicit origin; if the origin echoes as `*`, the browser drops the response.
+
+Check Directus:
+
+```bash
+curl -sS -o /dev/null -w "%{http_code}\n" \
+  -H "Origin: https://911realtime.org" \
+  "https://api.911realtime.org/items/readme_articles?limit=1"
+```
+
+Expected: `200`.
+
+- [ ] **Step 5: Verify interactively in a browser**
+
+Load `https://911realtime.org/`, then confirm:
+- The desktop boots and TV or Radio plays — proves the WebSocket reached `stream.911realtime.org`.
+- Sign in with Google, and again with Apple. Both must complete the round trip. IM Buddies derives chat identity from the resulting session cookie, so a broken redirect degrades chat to anonymous rather than throwing a visible error.
+- Open IM Buddies, sign on, confirm the buddy roster is **not empty**, and send a message that gets a reply.
+
+An empty roster with a working sign-on is the known `LoadProfiles` failure signature, not a cutover problem — but it must be distinguished before continuing.
+
+Do not proceed to Task 12 until all of these pass. Task 12 is the irreversible one.
+
+### Task 12: Create the redirect rule
+
+**Files:** none — Cloudflare API.
+
+Uses `$CF_REDIRECT_TOKEN` from Task 1. **This is the irreversible step**: browsers cache a 301 near-indefinitely, so `beta.911realtime.org` cannot cleanly serve anything else afterward.
+
+- [ ] **Step 1: Read the existing rules in the phase before writing**
+
+The entrypoint endpoint is a **PUT that replaces every rule in the phase**. Check what is already there:
+
+```bash
+curl -sS -H "Authorization: Bearer $CF_REDIRECT_TOKEN" \
+  "https://api.cloudflare.com/client/v4/zones/$ZONE/rulesets/phases/http_request_dynamic_redirect/entrypoint" \
+  | python3 -m json.tool
+```
+
+If this returns rules, add them to the payload in the next step rather than overwriting them. A `success: false` with "could not find" means the phase is empty, which is the expected case.
+
+- [ ] **Step 2: Create the rule**
+
+`http.request.uri.path` carries the path only; `preserve_query_string` re-attaches the query. Using `http.request.uri` here instead would duplicate the query string.
+
+```bash
+curl -sS -X PUT -H "Authorization: Bearer $CF_REDIRECT_TOKEN" -H "Content-Type: application/json" \
+  "https://api.cloudflare.com/client/v4/zones/$ZONE/rulesets/phases/http_request_dynamic_redirect/entrypoint" \
+  --data '{
+    "rules": [{
+      "action": "redirect",
+      "description": "Apex consolidation: www + beta -> 911realtime.org",
+      "expression": "(http.host eq \"www.911realtime.org\") or (http.host eq \"beta.911realtime.org\")",
+      "action_parameters": {
+        "from_value": {
+          "status_code": 301,
+          "target_url": {
+            "expression": "concat(\"https://911realtime.org\", http.request.uri.path)"
+          },
+          "preserve_query_string": true
+        }
+      }
+    }]
+  }' | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['success'], d.get('errors'))"
+```
+
+Expected: `True None`.
+
+- [ ] **Step 3: Verify both redirects preserve path and query**
+
+```bash
+curl -sSI "https://beta.911realtime.org/some/path?x=1&y=2" | grep -i "^HTTP/\|^location"
+curl -sSI "https://www.911realtime.org/some/path?x=1&y=2" | grep -i "^HTTP/\|^location"
+```
+
+Expected for both: `HTTP/2 301` and `location: https://911realtime.org/some/path?x=1&y=2`.
+
+A `location` missing the query string means `preserve_query_string` did not apply. A doubled query (`?x=1&y=2?x=1&y=2`) means the target expression used `http.request.uri` instead of `http.request.uri.path`.
+
+- [ ] **Step 4: Confirm the apex did not start redirecting to itself**
+
+```bash
+curl -sS -o /dev/null -w "%{http_code}\n" https://911realtime.org/
+```
+
+Expected: `200`, not `301`. A redirect loop here means the expression matched the apex.
+
+### Task 13: Cleanup
+
+Only run this once the apex has been healthy for as long as you want the safety margin to be. Everything here removes a fallback.
+
+**Files:**
+- Modify: `packages/backend/internal/handler/origin.go`, `packages/backend/internal/handler/origin_test.go`
+- Modify (infra): `apps/rt911/frontend.yaml`, `apps/rt911/streamer.yaml`, `apps/rt911/configmap.yaml`
+
+- [ ] **Step 1: Update the Go allowlist test first**
+
+In `packages/backend/internal/handler/origin_test.go`, the table currently asserts `beta` is trusted. Change that case and its neighbours to assert the opposite:
+
+```go
+		{"beta is retired", "https://beta.911realtime.org", false},
+		{"http scheme is a different origin", "http://911realtime.org", false},
+		{"port makes a different origin", "https://911realtime.org:8443", false},
+		{"path is not part of an origin", "https://911realtime.org/app", false},
+		{"trailing slash is tolerated", "https://911realtime.org/", true},
+		{"whitespace is trimmed", "  https://911realtime.org  ", true},
+```
+
+Also update the standalone assertion near line 49 from `beta` to the apex:
+
+```go
+	if !a.Trusted("https://911realtime.org") {
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run from `packages/backend/`: `go test ./internal/handler/ -run TestOrigin -v`
+Expected: FAIL — `beta` still reports trusted.
+
+- [ ] **Step 3: Trim the compiled-in allowlist**
+
+In `packages/backend/internal/handler/origin.go`:
+
+```go
+var DefaultTrustedOrigins = []string{
+	"https://911realtime.org",
+	"https://keeping-history.github.io",
+}
+```
+
+`www` goes too: it 301s at the edge and can never produce a browser origin.
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run from `packages/backend/`: `go test ./internal/handler/ -v`
+Expected: PASS.
+
+Then run the whole backend suite, since `DefaultTrustedOrigins` is referenced by the WebSocket handler's tests as well:
+
+Run from `packages/backend/`: `go test ./...`
+Expected: PASS across all packages.
+
+- [ ] **Step 5: Commit and merge**
+
+```bash
+git add packages/backend/internal/handler
+git commit -m "chore(chat): retire the beta origin from the chat allowlist"
+git push
+```
+
+This ships as a streamer image rebuild, not a config edit — `CHAT_TRUSTED_ORIGINS` is deliberately unset in production, so the trust list lives only in the binary. Wait for the build and the ArgoCD image bump before Step 6.
+
+- [ ] **Step 6: Remove beta from the infra manifests**
+
+In `/home/robbiebyrd/infra`:
+
+- `apps/rt911/frontend.yaml` — delete the `beta.911realtime.org` rule block added in Task 10, and reduce `tls.hosts` to `[911realtime.org]`.
+- `apps/rt911/streamer.yaml` — drop `https://beta.911realtime.org` from `accessControlAllowOriginList` and reduce `tls.hosts` to `[stream.911realtime.org]`.
+- `apps/rt911/directus.yaml` — reduce all three `tls.hosts` blocks to `[api.911realtime.org]`.
+- `apps/rt911/configmap.yaml` — drop every `beta.911realtime.org` entry from `CORS_ORIGIN`, both `AUTH_*_REDIRECT_ALLOW_LIST`s, and `USER_REGISTER_URL_ALLOW_LIST`.
+
+```bash
+cd /home/robbiebyrd/infra
+git add apps/rt911/
+git commit -m "rt911: retire the beta hostname"
+git push
+```
+
+- [ ] **Step 7: Delete the retired DNS records**
+
+```bash
+for id in e19180da2f41980cd17b04692ed4934e 6be8e5ac008203e664fa30676cd01bb9; do
+  curl -sS -X DELETE -H "Authorization: Bearer $CF_DNS_TOKEN" \
+    "https://api.cloudflare.com/client/v4/zones/$ZONE/dns_records/$id" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['success'])"
+done
+```
+
+Those IDs are `api-beta.911realtime.org` and `stream-beta.911realtime.org`.
+
+Keep the `beta.911realtime.org` record (`775d3ac6c3e933aa30885b56e7f0af1a`) — deleting it would break the Redirect Rule, which needs a proxied record to run on.
+
+- [ ] **Step 8: Final verification**
+
+```bash
+curl -sS -o /dev/null -w "apex %{http_code}\n" https://911realtime.org/
+curl -sSI https://beta.911realtime.org/ | grep -i "^location"
+dig +short api-beta.911realtime.org @1.1.1.1
+```
+
+Expected: `apex 200`; a `location` header pointing at the apex; and no output from the `dig` — `api-beta` no longer resolves.
+
+Then reconfirm in a browser that IM Buddies still signs on from the apex and the roster loads, since Step 3 changed the gate that governs it.
+
+---
+
+## Out of scope
+
+- Decommissioning the old GCS bucket and its Google load balancer.
+- The `admin`, `cdn`, `cdn1`, `cdn2`, and `cdn3` DNS records.
+- Removing the `api-beta` response-mixing comments from source. They document a live Directus behaviour that is unrelated to the hostname.


### PR DESCRIPTION
Implements **Phase 1** of `plans/2026-07-27-apex-domain-cutover-plan.md` (design: `plans/2026-07-25-apex-domain-cutover-design.md`).

## ⚠️ Do not merge yet

The new hostnames `api.911realtime.org` and `stream.911realtime.org` **do not resolve to the cluster yet**. Merging triggers a build and an ArgoCD image bump, which would point the live site at hosts that 404.

Merge only after Tasks 8 and 9 of the plan are done (TLS SANs extended, DNS pre-staged). That is Task 10.

## What this changes

Centralizes every backend base URL into `src/lib/endpoints.ts` and repoints the compiled-in defaults from `api-beta`/`stream-beta` to `api`/`stream`.

- **New `src/lib/endpoints.ts`** — one home for `DIRECTUS_URL`, `STREAM_URL`, `FEEDBACK_URL`, `CHAT_BASE`. Replaces eight duplicated declarations plus the `DIRECTUS_URL` that had been living in `loadPlaylist.ts` and imported by ten unrelated modules.
- **`VITE_DIRECTUS_URL` is now a real build arg.** It never was one, so production had been reading the hardcoded source fallback. Adding it to `build-args` alone would have been silently ignored — Docker does not fail on a `--build-arg` with no matching `ARG`.
- Registration links now land on the apex when the page is served off-domain (previews). Already-on-domain behaviour is unchanged.
- `origin.go` is deliberately **untouched**: it already lists both the apex and `beta`, which is the set needed while `beta` still serves. Trimming it is Task 13.

## Bug found and fixed during implementation

An unset Docker build arg reaches the bundle as an **empty string**, not `undefined` — `ENV VITE_X=$VITE_X` assigns `""` when the arg was never passed. The original `useFeedback` used `||` (which treats `""` as absent); the other seven sites used `??` (which does not). Consolidating on `??` would have compiled a **relative URL** into the bundle on a forgotten build arg, silently targeting the page's own origin.

`fromEnv()` treats empty as absent, restoring `||` semantics across all four URLs. Covered by a test that was mutation-checked to confirm it fails when the guard is removed.

## Verification

- `pnpm build` ✅ · `pnpm lint` ✅ (0 errors) · `pnpm test` ✅ 1852 passed / 209 files
- Built bundle inspected: exactly one occurrence each of `api.911realtime.org`, `stream.911realtime.org`, `wss://stream.911realtime.org/stream`; zero occurrences of the `-beta` hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)