### PR TITLE
feat(account): Special tab — delete my data / delete my account

### DIFF
--- a/packages/directus-extensions/profile-api/src/index.js
+++ b/packages/directus-extensions/profile-api/src/index.js
@@ -11,7 +11,6 @@
 // internal node_modules layout across Directus upgrades.
 const crypto = require("node:crypto");
 
-const CONFIRM_BASE_URL = "https://beta.911realtime.org/?confirm-email=";
 const TOKEN_TTL_SECONDS = 24 * 3600;
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -59,20 +58,102 @@ function verify(token, secret) {
 
 const errors = (res, status, message) => res.status(status).json({ errors: [{ message }] });
 
+// Collections whose rows belong to one user and go with them. Every one of
+// these is keyed by `user_created`; chat_messages is handled separately
+// because it is written by the Go streamer, not Directus, and keys on "user".
+const OWNED_COLLECTIONS = ["playlists", "stacks", "tm_bookmarks_personal"];
+
+// Profile fields blanked by a data wipe. `email` is absent deliberately — it
+// is the login identity, and the account survives a data wipe.
+const PROFILE_FIELDS = [
+	"first_name", "last_name", "username", "city", "state", "country",
+	"school_name", "educator_role", "grade_levels", "subjects",
+	"avatar", "filesystem",
+];
+
+// Foreign keys onto directus_users declared ON DELETE NO ACTION. Postgres
+// REJECTS the user delete while any of them still points at the row — this is
+// not a data-loss risk, it is a hard failure, and it fires for every account
+// that has ever uploaded an avatar. Nulling them is idempotent, so a retried
+// deletion is safe. tm_bookmarks_personal is the sixth such FK and resolves
+// itself: eraseOwnedData deletes those rows outright, which is why data
+// erasure must run BEFORE the row delete rather than after.
+const BLOCKING_REFS = [
+	["directus_files", "uploaded_by"],
+	["directus_files", "modified_by"],
+	["directus_notifications", "sender"],
+	["directus_versions", "user_updated"],
+	["directus_comments", "user_updated"],
+];
+
 module.exports = {
 	id: "profile",
 	handler: (router, context) => {
-		const { services, getSchema, env, logger } = context;
-		const { UsersService, MailService } = services;
+		const { services, getSchema, env, logger, database } = context;
+		const { ItemsService, UsersService, MailService } = services;
 
 		// Service-level access: ownership/identity checks happen explicitly in
 		// each route against req.accountability — never trust the body for "who".
 		const admin = { admin: true, role: null };
 
+		// The desktop app's own origin, NOT Directus's PUBLIC_URL — that one
+		// holds the API's URL (api.911realtime.org), and mailing a confirmation
+		// link there would send people into the REST API instead of the app.
+		const confirmBaseUrl = `${env.RT911_APP_URL || "https://911realtime.org"}/?confirm-email=`;
+
 		async function emailTaken(email) {
 			const users = new UsersService({ schema: await getSchema(), accountability: admin });
 			const rows = await users.readByQuery({ filter: { email: { _eq: email } }, limit: 1 });
 			return rows.length > 0;
+		}
+
+		// Deletes everything this user owns, EXCEPT their directus_files (kept
+		// by product requirement) and their chat_blocks (moderation standing
+		// must outlive a data wipe, or a blocked student clears their own
+		// cool-down and the supporting evidence in one click).
+		//
+		// Each group is wrapped independently rather than aborting on the first
+		// error: someone who asked to be forgotten should have as much removed
+		// as possible, and the caller reports what remains.
+		async function eraseOwnedData(userId, schema) {
+			const deleted = {};
+			const failed = [];
+
+			for (const collection of OWNED_COLLECTIONS) {
+				try {
+					const items = new ItemsService(collection, { schema, accountability: admin });
+					const rows = await items.readByQuery({
+						filter: { user_created: { _eq: userId } },
+						fields: ["id"],
+						limit: -1,
+					});
+					if (rows.length > 0) await items.deleteMany(rows.map((r) => r.id));
+					deleted[collection] = rows.length;
+				} catch (err) {
+					logger.error(err, `profile-api: could not erase ${collection} for ${userId}`);
+					failed.push(collection);
+				}
+			}
+
+			try {
+				// Query builder, not raw SQL: knex quotes identifiers, and "user"
+				// is a reserved word that resolves to CURRENT_USER unquoted --
+				// matching the wrong rows without erroring.
+				deleted.chat_messages = await database("chat_messages").where("user", userId).del();
+			} catch (err) {
+				logger.error(err, `profile-api: could not erase chat_messages for ${userId}`);
+				failed.push("chat_messages");
+			}
+
+			return { deleted, failed };
+		}
+
+		// Nulls every profile field, leaving the account signed-in-able.
+		async function blankProfile(userId, schema) {
+			const patch = {};
+			for (const field of PROFILE_FIELDS) patch[field] = null;
+			const users = new UsersService({ schema, accountability: admin });
+			await users.updateOne(userId, patch);
 		}
 
 		router.post("/email-change", async (req, res) => {
@@ -96,7 +177,7 @@ module.exports = {
 					text:
 						"A change of the email address on your 911realtime.org teacher account " +
 						"was requested. If this was you, confirm it by opening this link within " +
-						`24 hours:\n\n${CONFIRM_BASE_URL}${token}\n\nIf this wasn't you, ignore this message.`,
+						`24 hours:\n\n${confirmBaseUrl}${token}\n\nIf this wasn't you, ignore this message.`,
 				});
 				logger.info(`profile-api: email-change link sent for user ${userId}`);
 				return res.sendStatus(204);
@@ -127,6 +208,60 @@ module.exports = {
 			} catch (err) {
 				logger.error(err, "profile-api: email-change confirm failed");
 				return errors(res, 500, "Could not apply the email change.");
+			}
+		});
+
+		router.post("/delete-data", async (req, res) => {
+			try {
+				const userId = req.accountability && req.accountability.user;
+				if (!userId) return errors(res, 401, "You must be signed in.");
+				const schema = await getSchema();
+				const result = await eraseOwnedData(userId, schema);
+				try {
+					await blankProfile(userId, schema);
+					result.deleted.profile = 1;
+				} catch (err) {
+					logger.error(err, `profile-api: could not blank profile for ${userId}`);
+					result.failed.push("profile");
+				}
+				logger.info(`profile-api: data erased for user ${userId}`);
+				return res.status(200).json({ data: result });
+			} catch (err) {
+				logger.error(err, "profile-api: delete-data failed");
+				return errors(res, 500, "Could not delete your data.");
+			}
+		});
+
+		router.post("/delete-account", async (req, res) => {
+			try {
+				const userId = req.accountability && req.accountability.user;
+				if (!userId) return errors(res, 401, "You must be signed in.");
+				const schema = await getSchema();
+
+				const result = await eraseOwnedData(userId, schema);
+				try {
+					await blankProfile(userId, schema);
+				} catch (err) {
+					// Not fatal: the row is about to be deleted anyway. Logged so a
+					// partial failure is still visible if the delete then fails too
+					// and the account survives scrubbed.
+					logger.error(err, `profile-api: could not blank profile for ${userId}`);
+				}
+
+				// Must happen before deleteOne -- see BLOCKING_REFS.
+				for (const [table, column] of BLOCKING_REFS) {
+					await database(table).where(column, userId).update({ [column]: null });
+				}
+
+				const users = new UsersService({ schema, accountability: admin });
+				await users.deleteOne(userId);
+
+				result.deleted.account = 1;
+				logger.info(`profile-api: account deleted for user ${userId}`);
+				return res.status(200).json({ data: result });
+			} catch (err) {
+				logger.error(err, "profile-api: delete-account failed");
+				return errors(res, 500, "Could not delete your account.");
 			}
 		});
 	},

--- a/packages/directus-extensions/profile-api/src/index.test.mjs
+++ b/packages/directus-extensions/profile-api/src/index.test.mjs
@@ -24,7 +24,15 @@ function makeJwt(payload, secret = SECRET) {
 }
 const nowSec = () => Math.floor(Date.now() / 1000);
 
-function makeHarness({ existingEmails = [] } = {}) {
+function makeHarness({
+	existingEmails = [],
+	// Rows each owned collection reports for the user, keyed by collection.
+	ownedRows = {},
+	// Collections whose ItemsService should throw, to exercise partial failure.
+	failCollections = [],
+	// When true, deleting the directus_users row throws (the FK-violation case).
+	failUserDelete = false,
+} = {}) {
 	const routes = {};
 	const router = {
 		post: (path, fn) => {
@@ -33,6 +41,9 @@ function makeHarness({ existingEmails = [] } = {}) {
 	};
 	const sent = [];
 	const updated = [];
+	// Every mutation in call order, so tests can assert ORDERING and not just
+	// occurrence -- nulling the blocking FKs after deleteOne would be useless.
+	const ops = [];
 	class UsersService {
 		async readByQuery(q) {
 			const email = q?.filter?.email?._eq;
@@ -40,7 +51,26 @@ function makeHarness({ existingEmails = [] } = {}) {
 		}
 		async updateOne(id, patch) {
 			updated.push({ id, patch });
+			ops.push({ op: "updateUser", id });
 			return id;
+		}
+		async deleteOne(id) {
+			if (failUserDelete) throw new Error("update or delete on table violates foreign key constraint");
+			ops.push({ op: "deleteUser", id });
+			return id;
+		}
+	}
+	class ItemsService {
+		constructor(collection) {
+			this.collection = collection;
+		}
+		async readByQuery() {
+			if (failCollections.includes(this.collection)) throw new Error("boom");
+			return ownedRows[this.collection] ?? [];
+		}
+		async deleteMany(ids) {
+			ops.push({ op: "deleteItems", collection: this.collection, ids });
+			return ids;
 		}
 	}
 	class MailService {
@@ -48,9 +78,27 @@ function makeHarness({ existingEmails = [] } = {}) {
 			sent.push(msg);
 		}
 	}
+	// Minimal knex stand-in: database(table).where(col, val).del() / .update(patch)
+	const database = (table) => ({
+		_col: undefined,
+		where(col, val) {
+			this._col = col;
+			this._val = val;
+			return this;
+		},
+		async del() {
+			ops.push({ op: "del", table, col: this._col, val: this._val });
+			return (ownedRows[table] ?? []).length;
+		},
+		async update(patch) {
+			ops.push({ op: "nullRef", table, col: this._col, patch });
+			return 1;
+		},
+	});
 	const context = {
-		services: { UsersService, MailService },
+		services: { UsersService, ItemsService, MailService },
 		env: { SECRET },
+		database,
 		getSchema: async () => ({}),
 		logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 	};
@@ -76,7 +124,7 @@ function makeHarness({ existingEmails = [] } = {}) {
 		await routes[path](req, res);
 		return res;
 	};
-	return { call, sent, updated };
+	return { call, sent, updated, ops };
 }
 
 describe("POST /email-change", () => {
@@ -172,5 +220,153 @@ describe("POST /email-change/confirm", () => {
 		expect(res.statusCode).toBe(400);
 		expect(res.body.errors[0].message).toBe("That email address is already in use.");
 		expect(h.updated).toHaveLength(0);
+	});
+});
+
+// Rows a fully-populated account owns, used across the deletion suites.
+const POPULATED = {
+	playlists: [{ id: "p1" }, { id: "p2" }],
+	stacks: [{ id: 7 }],
+	tm_bookmarks_personal: [{ id: "b1" }],
+	chat_messages: [{ id: 1 }, { id: 2 }, { id: 3 }],
+};
+
+describe("POST /delete-data", () => {
+	it("401s unauthenticated", async () => {
+		const h = makeHarness();
+		const res = await h.call("/delete-data", { user: null });
+		expect(res.statusCode).toBe(401);
+		expect(h.ops).toHaveLength(0);
+	});
+
+	it("deletes every owned collection and the chat history", async () => {
+		const h = makeHarness({ ownedRows: POPULATED });
+		const res = await h.call("/delete-data");
+		expect(res.statusCode).toBe(200);
+		expect(res.body.data.failed).toEqual([]);
+		expect(res.body.data.deleted).toMatchObject({
+			playlists: 2,
+			stacks: 1,
+			tm_bookmarks_personal: 1,
+			chat_messages: 3,
+			profile: 1,
+		});
+		const collections = h.ops.filter((o) => o.op === "deleteItems").map((o) => o.collection);
+		expect(collections).toEqual(["playlists", "stacks", "tm_bookmarks_personal"]);
+	});
+
+	it("deletes chat_messages by the quoted user column", async () => {
+		// "user" is a Postgres reserved word: unquoted it resolves to
+		// CURRENT_USER and silently matches the wrong rows. Going through the
+		// knex query builder is what keeps it quoted.
+		const h = makeHarness({ ownedRows: POPULATED });
+		await h.call("/delete-data", { user: "user-9" });
+		expect(h.ops).toContainEqual({
+			op: "del",
+			table: "chat_messages",
+			col: "user",
+			val: "user-9",
+		});
+	});
+
+	it("never touches chat_blocks or directus_files", async () => {
+		// Moderation standing must outlive a data wipe, and uploaded files are
+		// kept by product requirement.
+		const h = makeHarness({ ownedRows: POPULATED });
+		await h.call("/delete-data");
+		const tables = h.ops.map((o) => o.table ?? o.collection);
+		expect(tables).not.toContain("chat_blocks");
+		expect(tables).not.toContain("directus_files");
+	});
+
+	it("blanks the profile but keeps the account", async () => {
+		const h = makeHarness({ ownedRows: POPULATED });
+		await h.call("/delete-data");
+		expect(h.updated).toHaveLength(1);
+		const { patch } = h.updated[0];
+		expect(patch.first_name).toBeNull();
+		expect(patch.username).toBeNull();
+		expect(patch.avatar).toBeNull();
+		expect(patch.filesystem).toBeNull();
+		// Email is the login identity and the account survives a data wipe.
+		expect(patch).not.toHaveProperty("email");
+		expect(h.ops.some((o) => o.op === "deleteUser")).toBe(false);
+	});
+
+	it("reports a failed collection instead of aborting the rest", async () => {
+		const h = makeHarness({ ownedRows: POPULATED, failCollections: ["stacks"] });
+		const res = await h.call("/delete-data");
+		expect(res.statusCode).toBe(200);
+		expect(res.body.data.failed).toEqual(["stacks"]);
+		// The later collections still ran.
+		expect(res.body.data.deleted.tm_bookmarks_personal).toBe(1);
+		expect(res.body.data.deleted.chat_messages).toBe(3);
+	});
+});
+
+describe("POST /delete-account", () => {
+	it("401s unauthenticated", async () => {
+		const h = makeHarness();
+		const res = await h.call("/delete-account", { user: null });
+		expect(res.statusCode).toBe(401);
+		expect(h.ops).toHaveLength(0);
+	});
+
+	it("deletes the user row and reports it", async () => {
+		const h = makeHarness({ ownedRows: POPULATED });
+		const res = await h.call("/delete-account", { user: "user-9" });
+		expect(res.statusCode).toBe(200);
+		expect(res.body.data.deleted.account).toBe(1);
+		expect(h.ops).toContainEqual({ op: "deleteUser", id: "user-9" });
+	});
+
+	it("nulls every blocking foreign key BEFORE deleting the row", async () => {
+		// This is the whole ballgame. directus_files.uploaded_by is ON DELETE
+		// NO ACTION, so Postgres rejects the delete while it still points at
+		// the user -- which is every account that ever uploaded an avatar.
+		// Nulling them after the delete would be useless, hence the ordering
+		// assertion rather than a bare "did it happen".
+		const h = makeHarness({ ownedRows: POPULATED });
+		await h.call("/delete-account", { user: "user-9" });
+
+		const nulled = h.ops.filter((o) => o.op === "nullRef");
+		expect(nulled.map((o) => `${o.table}.${o.col}`)).toEqual([
+			"directus_files.uploaded_by",
+			"directus_files.modified_by",
+			"directus_notifications.sender",
+			"directus_versions.user_updated",
+			"directus_comments.user_updated",
+		]);
+		for (const ref of nulled) expect(ref.patch[ref.col]).toBeNull();
+
+		const lastNull = h.ops.findLastIndex((o) => o.op === "nullRef");
+		const userDelete = h.ops.findIndex((o) => o.op === "deleteUser");
+		expect(lastNull).toBeLessThan(userDelete);
+	});
+
+	it("erases owned data before deleting the row", async () => {
+		// tm_bookmarks_personal.user_created is a sixth NO ACTION FK; it is
+		// resolved by deleting those rows, which only works in this order.
+		const h = makeHarness({ ownedRows: POPULATED });
+		await h.call("/delete-account");
+		const lastItemDelete = h.ops.findLastIndex((o) => o.op === "deleteItems");
+		const userDelete = h.ops.findIndex((o) => o.op === "deleteUser");
+		expect(lastItemDelete).toBeLessThan(userDelete);
+	});
+
+	it("keeps chat_blocks so the moderation record outlives the account", async () => {
+		const h = makeHarness({ ownedRows: POPULATED });
+		await h.call("/delete-account");
+		expect(h.ops.map((o) => o.table)).not.toContain("chat_blocks");
+	});
+
+	it("500s when the row cannot be deleted, without claiming success", async () => {
+		// The client keys off this: on a 500 it must NOT clear local settings
+		// or reload, because the account still exists.
+		const h = makeHarness({ ownedRows: POPULATED, failUserDelete: true });
+		const res = await h.call("/delete-account");
+		expect(res.statusCode).toBe(500);
+		expect(res.body.errors[0].message).toBe("Could not delete your account.");
+		expect(h.ops.some((o) => o.op === "deleteUser")).toBe(false);
 	});
 });

--- a/packages/frontend/src/Applications/Account/Account.module.scss
+++ b/packages/frontend/src/Applications/Account/Account.module.scss
@@ -100,3 +100,19 @@
   color: #555;
   margin: -4px 0 4px 0;
 }
+
+// Special tab: the two irreversible actions. Kept visually quiet rather than
+// alarm-red — the alert carries the warning, and a scary-looking button invites
+// curiosity clicks.
+.riskCopy {
+	color: var(--color-system-06);
+	max-width: 40ch;
+}
+
+.destructive {
+	display: flex;
+	flex-direction: column;
+	gap: calc(var(--window-padding-size) / 4);
+	align-items: flex-start;
+	padding-top: calc(var(--window-padding-size) / 2);
+}

--- a/packages/frontend/src/Applications/Account/ProfileEditor.test.tsx
+++ b/packages/frontend/src/Applications/Account/ProfileEditor.test.tsx
@@ -212,3 +212,21 @@ describe("ProfileEditor — screen name", () => {
 		await screen.findByText(/"danny" is taken\. Try danny\d\d/);
 	});
 });
+
+describe("ProfileEditor — Special tab", () => {
+	it("offers both destructive actions", () => {
+		render(<ProfileEditor />);
+		selectTab("Special");
+		expect(screen.getByRole("button", { name: "Delete My Data" })).toBeTruthy();
+		expect(screen.getByRole("button", { name: "Delete My Account" })).toBeTruthy();
+	});
+
+	it("is the last tab, after Password", () => {
+		// Order is deliberate: the destructive actions sit furthest from the
+		// tabs someone uses routinely.
+		mockAuth.user = makeUser({ provider: "default" });
+		render(<ProfileEditor />);
+		const titles = screen.getAllByRole("tab").map((t) => t.textContent);
+		expect(titles[titles.length - 1]).toBe("Special");
+	});
+});

--- a/packages/frontend/src/Applications/Account/ProfileEditor.tsx
+++ b/packages/frontend/src/Applications/Account/ProfileEditor.tsx
@@ -9,6 +9,7 @@ import { useAuth } from "../../Providers/Auth/AuthContext";
 import { UsernameTakenError, requestEmailChange, updateProfile } from "../../Providers/Auth/profileApi";
 import { checkUsername, type UsernameCheck } from "../../Providers/Auth/usernameApi";
 import styles from "./Account.module.scss";
+import { SpecialTab } from "./SpecialTab";
 
 const EDUCATOR_ROLES = [
 	{ value: "", label: "—" },
@@ -404,6 +405,10 @@ export const ProfileEditor: React.FC = () => {
 			),
 		});
 	}
+
+	// Appended last, after the conditional Password tab, so the destructive
+	// actions always sit furthest from the tabs used routinely.
+	tabs.push({ title: "Special", children: <SpecialTab /> });
 
 	return <ClassicyTabs tabs={tabs} />;
 };

--- a/packages/frontend/src/Applications/Account/SpecialTab.realAlert.test.tsx
+++ b/packages/frontend/src/Applications/Account/SpecialTab.realAlert.test.tsx
@@ -1,0 +1,75 @@
+// Companion to SpecialTab.test.tsx, which mocks ClassicyAlert away in order to
+// drive the buttons. That mock is file-scoped, so this separate file exists to
+// exercise the REAL alert — the part those tests structurally cannot reach.
+//
+// What it protects: the account confirmation puts a ClassicyInput inside the
+// alert's `message`, which the component's own docs describe as icon/text/
+// buttons only. If a classicy release ever stops rendering rich message nodes,
+// or stops honouring `disabled` on a button, the typed-confirm gate silently
+// becomes either unusable or absent — and every mocked test would still pass.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { AuthUser } from "../../Providers/Auth/authApi";
+
+const mockDeleteMyAccount = vi.hoisted(() => vi.fn());
+
+vi.mock("../../Providers/Auth/accountApi", () => ({
+	deleteMyData: vi.fn(),
+	deleteMyAccount: mockDeleteMyAccount,
+	clearLocalSettings: vi.fn(),
+	reloadDesktop: vi.fn(),
+}));
+
+const mockAuth = vi.hoisted(() => ({ user: null as AuthUser | null }));
+vi.mock("../../Providers/Auth/AuthContext", () => ({ useAuth: () => mockAuth }));
+
+// Deliberately no vi.mock("classicy") — that is the entire point of this file.
+
+import { SpecialTab } from "./SpecialTab";
+
+const makeUser = (over: Partial<AuthUser> = {}): AuthUser => ({
+	id: "1", email: "t@x.org", username: "mrbyrd", first_name: null, last_name: null,
+	avatar: null, provider: "google", city: null, state: null, country: null,
+	school_name: null, educator_role: null, grade_levels: null, subjects: null,
+	...over,
+});
+
+beforeEach(() => {
+	mockAuth.user = makeUser();
+	mockDeleteMyAccount.mockReset().mockResolvedValue({ deleted: {}, failed: [] });
+});
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+});
+
+describe("SpecialTab against the real ClassicyAlert", () => {
+	it("renders the risk copy in the data alert", () => {
+		render(<SpecialTab />);
+		fireEvent.click(screen.getByRole("button", { name: "Delete My Data" }));
+		expect(screen.getByText("This cannot be undone.")).toBeTruthy();
+	});
+
+	it("renders an interactive confirmation input inside the alert message", () => {
+		render(<SpecialTab />);
+		fireEvent.click(screen.getByRole("button", { name: "Delete My Account" }));
+		const input = screen.getByLabelText("Type your screen name to confirm") as HTMLInputElement;
+		fireEvent.change(input, { target: { value: "mrbyrd" } });
+		expect(input.value).toBe("mrbyrd");
+	});
+
+	it("gates the real Delete button on an exact screen-name match", () => {
+		render(<SpecialTab />);
+		fireEvent.click(screen.getByRole("button", { name: "Delete My Account" }));
+		const del = () => screen.getByRole("button", { name: "Delete" }) as HTMLButtonElement;
+		expect(del().disabled).toBe(true);
+
+		fireEvent.change(screen.getByLabelText("Type your screen name to confirm"), {
+			target: { value: "mrbyrd" },
+		});
+		expect(del().disabled).toBe(false);
+
+		fireEvent.click(del());
+		expect(mockDeleteMyAccount).toHaveBeenCalled();
+	});
+});

--- a/packages/frontend/src/Applications/Account/SpecialTab.test.tsx
+++ b/packages/frontend/src/Applications/Account/SpecialTab.test.tsx
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type React from "react";
+import type { AuthUser } from "../../Providers/Auth/authApi";
+
+const mockDeleteMyData = vi.hoisted(() => vi.fn());
+const mockDeleteMyAccount = vi.hoisted(() => vi.fn());
+const mockClearLocalSettings = vi.hoisted(() => vi.fn());
+const mockReloadDesktop = vi.hoisted(() => vi.fn());
+
+vi.mock("../../Providers/Auth/accountApi", () => ({
+	deleteMyData: mockDeleteMyData,
+	deleteMyAccount: mockDeleteMyAccount,
+	clearLocalSettings: mockClearLocalSettings,
+	reloadDesktop: mockReloadDesktop,
+}));
+
+const mockAuth = vi.hoisted(() => ({ user: null as AuthUser | null }));
+vi.mock("../../Providers/Auth/AuthContext", () => ({ useAuth: () => mockAuth }));
+
+vi.mock("classicy", async (importOriginal) => ({
+	...(await importOriginal<typeof import("classicy")>()),
+	// Renders label, message and ALL buttons with their disabled state, so
+	// tests can drive the typed-confirm gate without classicy's window chrome.
+	ClassicyAlert: ({
+		label,
+		message,
+		buttons,
+	}: {
+		label: string;
+		message?: React.ReactNode;
+		buttons?: { label: string; disabled?: boolean; onClick?: () => void }[];
+	}) => (
+		<div role="alertdialog" aria-label={label}>
+			<span>{label}</span>
+			{message}
+			{buttons?.map((b) => (
+				<button key={b.label} type="button" disabled={b.disabled} onClick={b.onClick}>
+					{b.label}
+				</button>
+			))}
+		</div>
+	),
+}));
+
+import { SpecialTab } from "./SpecialTab";
+
+const makeUser = (over: Partial<AuthUser> = {}): AuthUser => ({
+	id: "1", email: "t@x.org", username: "mrbyrd", first_name: null, last_name: null,
+	avatar: null, provider: "google", city: null, state: null, country: null,
+	school_name: null, educator_role: null, grade_levels: null, subjects: null,
+	...over,
+});
+
+beforeEach(() => {
+	mockAuth.user = makeUser();
+	mockDeleteMyData.mockReset().mockResolvedValue({ deleted: {}, failed: [] });
+	mockDeleteMyAccount.mockReset().mockResolvedValue({ deleted: {}, failed: [] });
+	mockClearLocalSettings.mockReset();
+	mockReloadDesktop.mockReset();
+});
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+});
+
+describe("SpecialTab — delete my data", () => {
+	it("shows a confirmation before touching the network", () => {
+		render(<SpecialTab />);
+		fireEvent.click(screen.getByRole("button", { name: "Delete My Data" }));
+		expect(screen.getByRole("alertdialog")).toBeTruthy();
+		expect(mockDeleteMyData).not.toHaveBeenCalled();
+	});
+
+	it("cancelling issues no request", () => {
+		render(<SpecialTab />);
+		fireEvent.click(screen.getByRole("button", { name: "Delete My Data" }));
+		fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+		expect(mockDeleteMyData).not.toHaveBeenCalled();
+		expect(screen.queryByRole("alertdialog")).toBeNull();
+	});
+
+	it("confirming deletes, clears settings, then reloads", async () => {
+		render(<SpecialTab />);
+		fireEvent.click(screen.getByRole("button", { name: "Delete My Data" }));
+		fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+		await waitFor(() => expect(mockReloadDesktop).toHaveBeenCalled());
+		expect(mockDeleteMyData).toHaveBeenCalled();
+		expect(mockClearLocalSettings).toHaveBeenCalled();
+	});
+
+	it("does not clear settings or reload when the server fails", async () => {
+		mockDeleteMyData.mockRejectedValue(new Error("Could not delete your data."));
+		render(<SpecialTab />);
+		fireEvent.click(screen.getByRole("button", { name: "Delete My Data" }));
+		fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+		await waitFor(() => expect(screen.getByText("Could not delete your data.")).toBeTruthy());
+		expect(mockClearLocalSettings).not.toHaveBeenCalled();
+		expect(mockReloadDesktop).not.toHaveBeenCalled();
+	});
+});
+
+describe("SpecialTab — delete my account", () => {
+	const openAccountAlert = () => {
+		render(<SpecialTab />);
+		fireEvent.click(screen.getByRole("button", { name: "Delete My Account" }));
+	};
+
+	it("keeps Delete disabled until the screen name matches exactly", () => {
+		openAccountAlert();
+		const del = () => screen.getByRole("button", { name: "Delete" }) as HTMLButtonElement;
+		expect(del().disabled).toBe(true);
+
+		fireEvent.change(screen.getByLabelText("Type your screen name to confirm"), {
+			target: { value: "mrbyr" },
+		});
+		expect(del().disabled).toBe(true);
+
+		fireEvent.change(screen.getByLabelText("Type your screen name to confirm"), {
+			target: { value: "mrbyrd" },
+		});
+		expect(del().disabled).toBe(false);
+	});
+
+	it("falls back to the email when the account has no screen name", () => {
+		mockAuth.user = makeUser({ username: null });
+		openAccountAlert();
+		fireEvent.change(screen.getByLabelText("Type your screen name to confirm"), {
+			target: { value: "t@x.org" },
+		});
+		expect((screen.getByRole("button", { name: "Delete" }) as HTMLButtonElement).disabled).toBe(
+			false,
+		);
+	});
+
+	it("deletes, clears settings, then reloads on confirm", async () => {
+		openAccountAlert();
+		fireEvent.change(screen.getByLabelText("Type your screen name to confirm"), {
+			target: { value: "mrbyrd" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+		await waitFor(() => expect(mockReloadDesktop).toHaveBeenCalled());
+		expect(mockDeleteMyAccount).toHaveBeenCalled();
+		expect(mockClearLocalSettings).toHaveBeenCalled();
+	});
+
+	it("does not clear settings or reload when the account delete fails", async () => {
+		mockDeleteMyAccount.mockRejectedValue(new Error("Could not delete your account."));
+		openAccountAlert();
+		fireEvent.change(screen.getByLabelText("Type your screen name to confirm"), {
+			target: { value: "mrbyrd" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+		await waitFor(() => expect(screen.getByText("Could not delete your account.")).toBeTruthy());
+		expect(mockClearLocalSettings).not.toHaveBeenCalled();
+		expect(mockReloadDesktop).not.toHaveBeenCalled();
+	});
+});

--- a/packages/frontend/src/Applications/Account/SpecialTab.tsx
+++ b/packages/frontend/src/Applications/Account/SpecialTab.tsx
@@ -1,0 +1,151 @@
+// Account → Special: the two irreversible actions. Both run entirely on the
+// server (profile-api extension) because neither is possible with user
+// credentials. Spec: plans/2026-07-28-account-special-tab-design.md
+import { ClassicyAlert, ClassicyButton, ClassicyControlLabel, ClassicyInput } from "classicy";
+import type React from "react";
+import { useState } from "react";
+import { useAuth } from "../../Providers/Auth/AuthContext";
+import {
+	clearLocalSettings,
+	deleteMyAccount,
+	deleteMyData,
+	reloadDesktop,
+} from "../../Providers/Auth/accountApi";
+import styles from "./Account.module.scss";
+
+type Pending = "data" | "account" | null;
+
+export const SpecialTab: React.FC = () => {
+	const { user } = useAuth();
+	const [pending, setPending] = useState<Pending>(null);
+	const [typed, setTyped] = useState("");
+	const [busy, setBusy] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	// What the user must type to arm account deletion. Screen name is the
+	// identity they actually recognise; email is the fallback for accounts
+	// that never set one.
+	const confirmName = user?.username ?? user?.email ?? "";
+
+	const close = () => {
+		setPending(null);
+		setTyped("");
+	};
+
+	const run = (action: () => Promise<unknown>) => {
+		setBusy(true);
+		setError(null);
+		action()
+			.then(() => {
+				// Order matters: the server wipe must have succeeded before we
+				// drop local state, and the reload is what makes clearing the
+				// keys stick (see accountApi.reloadDesktop).
+				clearLocalSettings();
+				reloadDesktop();
+			})
+			.catch((err: Error) => {
+				setError(err.message);
+				close();
+			})
+			.finally(() => setBusy(false));
+	};
+
+	return (
+		<div className={styles.tabPanel}>
+			<div className={styles.destructive}>
+				<ClassicyControlLabel label="Delete my data" />
+				<div className={styles.riskCopy}>
+					Erases your profile, desktop settings, playlists, stacks, bookmarks and chat
+					history. Your account and your uploaded files are kept.
+				</div>
+				<ClassicyButton disabled={busy} onClickFunc={() => setPending("data")}>
+					Delete My Data
+				</ClassicyButton>
+			</div>
+
+			<div className={styles.destructive}>
+				<ClassicyControlLabel label="Delete my account" />
+				<div className={styles.riskCopy}>
+					Everything above, and then your account itself. You will be signed out and
+					cannot sign back in. Your uploaded files are kept.
+				</div>
+				<ClassicyButton disabled={busy} onClickFunc={() => setPending("account")}>
+					Delete My Account
+				</ClassicyButton>
+			</div>
+
+			{error && <div className={styles.error}>{error}</div>}
+
+			{pending === "data" && (
+				<ClassicyAlert
+					id="account_delete_data"
+					appId="Account.app"
+					alertType="stop"
+					title="Account"
+					label="This cannot be undone."
+					message="Deletes your profile, settings, playlists, stacks, bookmarks and chat history. Keeps your files and your login."
+					// HIG: when an action risks data loss the SAFE choice is the
+					// default, so Return dismisses rather than destroys.
+					defaultButtonId="account_delete_data_cancel"
+					buttons={[
+						{
+							id: "account_delete_data_cancel",
+							label: "Cancel",
+							role: "cancel",
+							onClick: close,
+						},
+						{
+							id: "account_delete_data_go",
+							label: "Delete",
+							role: "normal",
+							disabled: busy,
+							onClick: () => run(deleteMyData),
+						},
+					]}
+				/>
+			)}
+
+			{pending === "account" && (
+				<ClassicyAlert
+					id="account_delete_account"
+					appId="Account.app"
+					alertType="stop"
+					title="Account"
+					label="This cannot be undone."
+					message={
+						<div>
+							<p>
+								Your account and everything in it will be permanently removed. Your
+								uploaded files are kept.
+							</p>
+							<ClassicyInput
+								id="account-delete-confirm"
+								labelTitle="Type your screen name to confirm"
+								prefillValue={typed}
+								disabled={busy}
+								onChangeFunc={(e) => setTyped(e.target.value)}
+							/>
+						</div>
+					}
+					defaultButtonId="account_delete_account_cancel"
+					buttons={[
+						{
+							id: "account_delete_account_cancel",
+							label: "Cancel",
+							role: "cancel",
+							onClick: close,
+						},
+						{
+							id: "account_delete_account_go",
+							label: "Delete",
+							role: "normal",
+							// Exact match only. A near-miss is a near-miss.
+							disabled: busy || typed !== confirmName,
+							onClick: () => run(deleteMyAccount),
+						},
+					]}
+				/>
+			)}
+		</div>
+	);
+};

--- a/packages/frontend/src/Providers/Auth/accountApi.test.ts
+++ b/packages/frontend/src/Providers/Auth/accountApi.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { AuthRequiredError, ForbiddenError } from "./authApi";
+import { SETTINGS_KEYS, clearLocalSettings, deleteMyAccount, deleteMyData } from "./accountApi";
+
+const jsonResponse = (body: unknown, status = 200) =>
+	new Response(JSON.stringify(body), { status });
+
+describe("deleteMyData", () => {
+	it("POSTs to /profile/delete-data with credentials and no body", async () => {
+		const f = vi.fn(async (...args: Parameters<typeof fetch>) => {
+			expect(String(args[0])).toContain("/profile/delete-data");
+			const init = args[1] as RequestInit;
+			expect(init.method).toBe("POST");
+			expect(init.credentials).toBe("include");
+			expect(init.body).toBeUndefined();
+			return jsonResponse({ data: { deleted: { playlists: 2 }, failed: [] } });
+		});
+		const result = await deleteMyData(f);
+		expect(result.deleted.playlists).toBe(2);
+		expect(result.failed).toEqual([]);
+	});
+
+	it("maps 401/403 to the shared error classes", async () => {
+		await expect(deleteMyData(vi.fn(async () => jsonResponse({}, 401)))).rejects.toBeInstanceOf(
+			AuthRequiredError,
+		);
+		await expect(deleteMyData(vi.fn(async () => jsonResponse({}, 403)))).rejects.toBeInstanceOf(
+			ForbiddenError,
+		);
+	});
+
+	it("surfaces the server's message on failure", async () => {
+		const f = vi.fn(async () =>
+			jsonResponse({ errors: [{ message: "Could not delete your data." }] }, 500),
+		);
+		await expect(deleteMyData(f)).rejects.toThrow("Could not delete your data.");
+	});
+});
+
+describe("deleteMyAccount", () => {
+	it("POSTs to /profile/delete-account", async () => {
+		const f = vi.fn(async (...args: Parameters<typeof fetch>) => {
+			expect(String(args[0])).toContain("/profile/delete-account");
+			return jsonResponse({ data: { deleted: { account: 1 }, failed: [] } });
+		});
+		expect((await deleteMyAccount(f)).deleted.account).toBe(1);
+	});
+
+	it("rejects on 500 so the caller can skip the reload", async () => {
+		const f = vi.fn(async () => jsonResponse({ errors: [{ message: "boom" }] }, 500));
+		await expect(deleteMyAccount(f)).rejects.toThrow("boom");
+	});
+});
+
+describe("clearLocalSettings", () => {
+	it("removes every persisted settings key", () => {
+		const store = new Map<string, string>(SETTINGS_KEYS.map((k) => [k, "x"]));
+		store.set("somethingElse", "keep");
+		const storage = {
+			removeItem: (k: string) => void store.delete(k),
+		} as unknown as Storage;
+
+		clearLocalSettings(storage);
+
+		for (const key of SETTINGS_KEYS) expect(store.has(key)).toBe(false);
+		expect(store.get("somethingElse")).toBe("keep");
+	});
+
+	it("includes the Classicy desktop state key", () => {
+		// The single key holding every app's settings and window positions.
+		// If this is ever dropped, "delete my data" silently keeps everything.
+		expect(SETTINGS_KEYS).toContain("classicyDesktopState");
+	});
+});

--- a/packages/frontend/src/Providers/Auth/accountApi.ts
+++ b/packages/frontend/src/Providers/Auth/accountApi.ts
@@ -1,0 +1,81 @@
+// Account-deletion seam. Both routes live on the profile-api Directus
+// extension because neither action is possible with user credentials: the
+// Teacher policy grants no delete on directus_users, and chat_messages is not
+// a Directus-managed collection. Spec: plans/2026-07-28-account-special-tab-design.md
+import { AuthRequiredError, ForbiddenError } from "./authApi";
+import { DIRECTUS_URL } from "../../lib/endpoints";
+
+/** Per-collection row counts the server actually removed, plus what it could not. */
+export interface DeletionResult {
+	deleted: Record<string, number>;
+	failed: string[];
+}
+
+/**
+ * Every localStorage key holding user settings.
+ *
+ * `classicyDesktopState` is the big one: the Classicy store persists window
+ * positions AND every app's settings (Feedback, RadioScanner, README,
+ * TimeMachine, TV selections) into that single key.
+ */
+export const SETTINGS_KEYS = [
+	"classicyDesktopState",
+	"rt911AlertsEnabled",
+	"media-chrome-pref-muted",
+	"media-chrome-pref-volume",
+	"media-chrome-pref-subtitles-lang",
+] as const;
+
+interface DirectusErrorBody {
+	errors?: { message?: unknown }[];
+}
+
+async function serverMessage(res: Response, fallback: string): Promise<string> {
+	try {
+		const body = (await res.json()) as DirectusErrorBody;
+		const message = body.errors?.[0]?.message;
+		return typeof message === "string" ? message : fallback;
+	} catch {
+		return fallback;
+	}
+}
+
+async function post(path: string, fallback: string, fetchFn: typeof fetch): Promise<DeletionResult> {
+	const res = await fetchFn(`${DIRECTUS_URL}${path}`, {
+		method: "POST",
+		credentials: "include",
+	});
+	if (res.status === 401) throw new AuthRequiredError(await serverMessage(res, fallback));
+	if (res.status === 403) throw new ForbiddenError(await serverMessage(res, fallback));
+	if (!res.ok) throw new Error(await serverMessage(res, fallback));
+	const body = (await res.json()) as { data: DeletionResult };
+	return body.data;
+}
+
+/** Erase the user's content and blank their profile. The account survives. */
+export async function deleteMyData(fetchFn: typeof fetch = fetch): Promise<DeletionResult> {
+	return post("/profile/delete-data", "Could not delete your data.", fetchFn);
+}
+
+/** Erase everything above, then remove the account itself. Irreversible. */
+export async function deleteMyAccount(fetchFn: typeof fetch = fetch): Promise<DeletionResult> {
+	return post("/profile/delete-account", "Could not delete your account.", fetchFn);
+}
+
+/** Drop every persisted setting. Must be followed by reloadDesktop() — see below. */
+export function clearLocalSettings(storage: Storage = window.localStorage): void {
+	for (const key of SETTINGS_KEYS) storage.removeItem(key);
+}
+
+/**
+ * Hard reload, and it is load-bearing rather than cosmetic.
+ *
+ * The live ClassicyStore holds the same settings in memory and writes them
+ * straight back to localStorage on its next dispatch, so clearing the keys
+ * without reloading is a no-op. The reload also discards the in-memory
+ * FilesystemSync tree, which would otherwise re-push itself to a `filesystem`
+ * link the server just nulled.
+ */
+export function reloadDesktop(): void {
+	window.location.reload();
+}

--- a/plans/2026-07-28-account-special-tab-design.md
+++ b/plans/2026-07-28-account-special-tab-design.md
@@ -1,0 +1,284 @@
+# Account "Special" tab — delete my data / delete my account
+
+**Date:** 2026-07-28
+**Status:** Approved, not yet implemented
+
+## Problem
+
+The Account app lets a signed-in user edit their profile but never lets them
+leave. There is no way to erase what the site has accumulated about them and no
+way to close the account at all. Both are ordinary expectations for a site that
+asks teachers and students to sign in, and neither is currently possible even
+by hand — a user cannot delete their own `directus_users` row.
+
+## Scope
+
+A new **Special** tab in the Account app's profile editor, holding two
+destructive actions:
+
+- **Delete my data** — erases the user's content and settings; the account
+  survives and stays signed in.
+- **Delete my account** — the same erasure, plus removal of the account itself.
+
+Explicitly out of scope, per the request: neither action removes uploaded
+files (`directus_files`, Wasabi-backed) or OpenReplay session recordings.
+
+## What the user actually owns
+
+| Where | What | Delete data | Delete account |
+|---|---|---|---|
+| `directus_users` (own row) | names, screen name, location, school, educator role, grade levels, subjects, avatar link, filesystem link | blanked | row deleted |
+| `playlists` | teacher-authored playlists (`user_created`) | deleted | deleted |
+| `stacks` | HyperCard stacks (`user_created`) | deleted | deleted |
+| `tm_bookmarks_personal` | Time Machine personal bookmarks | deleted | deleted |
+| `chat_messages` | IM Buddies conversation history | deleted | deleted |
+| `chat_blocks` | moderation blocks / cool-downs | **kept** | **kept** |
+| `directus_files` | avatar image, filesystem JSON, uploads | **kept** | **kept** (orphaned) |
+| localStorage | `classicyDesktopState`, `rt911AlertsEnabled`, `media-chrome-pref-*` | cleared | cleared |
+| OpenReplay | session recordings | **kept** | **kept** |
+
+### Why `chat_blocks` survives
+
+`chat_blocks` is not conversation content — it is the moderation record the
+chat guard writes when it detects abuse, deliberately persisted so a block
+outlives a reconnect or a reworded resend (see `internal/chat/guard.go`). If
+"Delete my data" cleared it, any student under a cool-down could self-unban
+with one click and destroy the supporting evidence in the same motion. Blocks
+describe the account's standing, not the person's content.
+
+This is imperfect on account deletion — a new sign-up gets a fresh user id, so
+a determined user evades a block regardless. Keeping the rows is for records,
+not deterrence.
+
+## Approach
+
+Two new routes on the existing `profile-api` Directus extension
+(`packages/directus-extensions/profile-api/src/index.js`).
+
+This follows the precedent already set in that file. Verified email changes
+live there because `email` is not writable through `/users/me`; account
+deletion has the identical shape — the Teacher policy grants no delete on
+`directus_users`, and `chat_messages` is not reachable with user credentials at
+all. Client-side orchestration cannot implement this feature, not merely
+inconvenience it.
+
+Both routes take the caller's identity from `req.accountability.user` and never
+from the request body, matching the existing routes' stance.
+
+### Rejected alternatives
+
+- **Client-side orchestration.** Cannot delete the user row or chat messages.
+  Would also turn one irreversible action into ~8 independent requests whose
+  partial failure leaves an account half-erased with no way to resume.
+- **Hybrid** (client deletes what it can, extension deletes the user row).
+  Duplicates the definition of "my data" across two codebases that will drift.
+
+## Server design
+
+```
+profile-api/src/index.js
+  ├─ eraseOwnedData(userId)   ← single source of truth for "what is mine"
+  ├─ POST /delete-data        → eraseOwnedData + blank profile fields
+  └─ POST /delete-account     → eraseOwnedData + blank + delete user row
+```
+
+`eraseOwnedData` existing exactly once is load-bearing: account deletion is
+*defined* as data deletion plus the user row, so the two cannot disagree about
+scope as collections are added later.
+
+Deletion of `playlists`, `stacks` and `tm_bookmarks_personal` goes through
+`ItemsService` with admin accountability, filtered on `user_created = userId`.
+`chat_messages` is not a Directus-managed collection in the same sense and is
+deleted with the context's knex instance.
+
+**The `"user"` column must be quoted.** `chat_messages` and `chat_blocks` both
+key on a column named `user`, a reserved word in Postgres. Unquoted it silently
+resolves to `CURRENT_USER` and matches the wrong rows rather than erroring —
+the Go code carries this warning at both call sites.
+
+### Deleting the user row requires clearing blocking references first
+
+Verified against the live schema on 2026-07-28. Every FK pointing at
+`directus_users` falls into three groups:
+
+| On delete | Tables | Consequence |
+|---|---|---|
+| `CASCADE` | `directus_sessions`, `directus_presets`, `directus_notifications.recipient`, `directus_access`, `directus_oauth_*` | handled automatically |
+| `SET NULL` | `directus_dashboards`, `directus_panels`, `directus_shares`, `directus_flows`, `directus_operations`, `directus_versions.user_created`, `directus_comments.user_created`, `directus_deployment*` | handled automatically |
+| **`NO ACTION`** | `directus_files.uploaded_by`, `directus_files.modified_by`, `directus_notifications.sender`, `directus_versions.user_updated`, `directus_comments.user_updated`, `tm_bookmarks_personal.user_created` | **blocks the delete** |
+
+`NO ACTION` is not a silent data loss risk — it is a hard failure. Because
+uploaded files are kept by requirement, `directus_files.uploaded_by` still
+points at the departing user, and `UsersService.deleteOne` will be rejected by
+the database for **any user who has ever uploaded an avatar**. That is nearly
+every account that would want deleting, so this is not an edge case; it is the
+default path.
+
+The delete-account route must therefore, after `eraseOwnedData` and before
+deleting the row, null the five non-owned blocking references:
+
+```sql
+UPDATE directus_files        SET uploaded_by  = NULL WHERE uploaded_by  = :id;
+UPDATE directus_files        SET modified_by  = NULL WHERE modified_by  = :id;
+UPDATE directus_notifications SET sender      = NULL WHERE sender       = :id;
+UPDATE directus_versions     SET user_updated = NULL WHERE user_updated = :id;
+UPDATE directus_comments     SET user_updated = NULL WHERE user_updated = :id;
+```
+
+Idempotent, so re-running a partially-failed deletion is safe. The sixth,
+`tm_bookmarks_personal`, resolves itself — `eraseOwnedData` deletes those rows
+outright, which is why data erasure must run *before* the row delete rather
+than after.
+
+`playlists`, `stacks`, `chat_messages` and `chat_blocks` carry plain `uuid`
+ownership columns with **no** foreign key to `directus_users`. This is what
+makes keeping `chat_blocks` after account deletion legal: the orphaned rows
+reference a user id that no longer exists, and the database does not object.
+
+### Response shape and partial failure
+
+Each deletion group is wrapped independently. The route returns
+
+```json
+{ "data": { "deleted": { "playlists": 3, "stacks": 0, ... }, "failed": ["stacks"] } }
+```
+
+rather than aborting on the first error. A user who asked to be forgotten
+should have as much removed as possible, and the UI can report what remains.
+
+**Account deletion is the exception.** If `UsersService.deleteOne` fails, the
+route returns 500 and the client does *not* clear local storage or reload —
+the account still exists, and pretending otherwise would strand someone signed
+in to an account they believe is gone.
+
+## Client design
+
+```
+Account.tsx
+  └─ ProfileEditor.tsx  → new tab entry
+       └─ SpecialTab.tsx        ← buttons, risk copy, confirmation state
+            ├─ ClassicyAlert ×2 (alertType="stop")
+            └─ accountApi.ts    ← deleteMyData() / deleteMyAccount()
+```
+
+`SpecialTab` is its own file rather than a fifth inline entry in
+`ProfileEditor`'s `tabs` array; that array is already ~160 lines of JSX and
+this tab carries genuine interaction state.
+
+### Confirmation
+
+Friction scales with severity.
+
+**Delete my data** — one `ClassicyAlert` (`alertType="stop"`), Cancel as the
+default button, listing what goes and what stays:
+
+```
+(!) This cannot be undone.
+    Deletes: profile, settings, playlists, stacks, bookmarks, chat history.
+    Keeps: your files, your login.
+            [Delete]  ((Cancel))
+```
+
+**Delete my account** — the same alert plus a text field. The Delete button
+stays disabled until the typed text exactly matches the user's screen name
+(falling back to email if no screen name is set):
+
+```
+(!) This cannot be undone.
+    Your account and everything in it will be permanently removed.
+    Type "mrbyrd" to confirm:
+    [________________]
+            [Delete]  ((Cancel))
+```
+
+### Local settings must be followed by a reload
+
+Every app's settings — Feedback, RadioScanner, README, TimeMachine, TV
+selections, window positions — persist through the Classicy store into a single
+localStorage key, `classicyDesktopState`, alongside `rt911AlertsEnabled` and
+the `media-chrome-pref-*` keys.
+
+**Clearing those keys without reloading is a no-op.** The live `ClassicyStore`
+holds the same state in memory and writes it straight back on its next
+dispatch. The client sequence is therefore strictly ordered:
+
+1. `await` the server wipe
+2. `removeItem` each key
+3. `window.location.reload()`
+
+A hard reload, not a soft state reset — it also discards the in-memory
+`FilesystemSync` tree, which would otherwise re-push itself to a `filesystem`
+link the server just nulled.
+
+After **Delete my account** the reload lands on the signed-out desktop, because
+the session cookie now points at a user row that no longer exists.
+
+## Scoped-in fix: `CONFIRM_BASE_URL`
+
+`profile-api` hardcodes the email-change landing page to
+`https://beta.911realtime.org/?confirm-email=`. Since the apex cutover, that
+host 301s to `https://911realtime.org` preserving the query string, so links
+still work — by accident of a redirect that will eventually be retired.
+
+Until then, every email-change request mails a `beta.` URL in a message asking
+someone to confirm an account change: the exact shape a spam filter and a
+cautious teacher both distrust.
+
+Replaced with an env-driven value defaulting to the apex, read inside `handler`
+where `env` is in scope:
+
+```js
+const confirmBaseUrl = `${env.RT911_APP_URL || "https://911realtime.org"}/?confirm-email=`;
+```
+
+A custom variable, deliberately **not** Directus's built-in `PUBLIC_URL` —
+that one holds the API's own public URL (`https://api.911realtime.org`), so
+reusing it would mail people a confirmation link pointing into the Directus
+API rather than the desktop app.
+
+Included here because the new routes live in the same file; deploying either
+requires the same new `rt911-api` image.
+
+## Testing
+
+- `accountApi.test.ts` — request shape, typed error mapping (401/403), and that
+  a failed account deletion neither clears storage nor reloads.
+- `SpecialTab.test.tsx` — the alert appears before any network call; Cancel
+  issues no request; the account Delete button stays disabled until the typed
+  name matches exactly.
+- `ProfileEditor.test.tsx` — the Special tab is present for a signed-in user.
+
+**Known gap:** `packages/directus-extensions` has no test harness. The two
+routes get manual verification against `api-beta` with a throwaway account,
+checking each collection before and after. Building a harness for one extension
+is out of scope here, but the routes are the riskiest part of this change and
+that risk is not covered by CI.
+
+**The throwaway account must have an uploaded avatar and at least one row in
+every affected collection.** A fresh account with no avatar has nothing
+pointing at `directus_files.uploaded_by` and so deletes cleanly even if the
+blocking-reference step is missing entirely — the manual test would pass while
+the feature is broken for every real user. Verify afterwards that the avatar
+file still exists and is still served.
+
+## Consequences
+
+**Orphaned files.** Uploaded files survive by request, so deleting the user row
+should leave their avatar and filesystem JSON in `directus_files` — bytes still
+on Wasabi, no owner, and no UI that lists them. That is the correct consequence
+of the requirement, but it means account deletion is not a complete erasure and
+should not be described as GDPR compliance without revisiting it.
+
+Verified: the FK is `NO ACTION`, so files are in no danger of cascading away.
+The cost is that the delete is *blocked* until `uploaded_by` is nulled — see
+"Deleting the user row requires clearing blocking references first" above.
+
+**Sign-out is automatic.** `directus_sessions.user` cascades, so deleting the
+row invalidates every session that account holds server-side. The client's
+reload is what makes the browser notice, not what causes it.
+
+**Deployment.** The extension change ships as a new `rt911-api` image built
+from `packages/directus-extensions/Dockerfile`, rolled out by ArgoCD from the
+`Keeping-History/infra` repo. The frontend ships separately. **The extension
+must be deployed before the frontend**, or the Special tab's buttons will call
+routes that do not exist yet.

--- a/plans/2026-07-28-account-special-tab-design.md
+++ b/plans/2026-07-28-account-special-tab-design.md
@@ -248,11 +248,20 @@ requires the same new `rt911-api` image.
   name matches exactly.
 - `ProfileEditor.test.tsx` — the Special tab is present for a signed-in user.
 
-**Known gap:** `packages/directus-extensions` has no test harness. The two
-routes get manual verification against `api-beta` with a throwaway account,
-checking each collection before and after. Building a harness for one extension
-is out of scope here, but the routes are the riskiest part of this change and
-that risk is not covered by CI.
+The extension has its own vitest suite at
+`packages/directus-extensions/profile-api/src/index.test.mjs`, run in CI by the
+`api-test` job, which gates the image build. It stubs the express router and
+Directus's context services, then invokes each route with fake `req`/`res`. The
+new routes extend that harness with an `ItemsService` stub, a knex-shaped
+`database` stub, and an `ops` array recording every mutation **in call order**.
+
+Ordering is the point. `nulls every blocking foreign key BEFORE deleting the
+row` asserts index positions rather than mere occurrence, because nulling the
+references *after* `deleteOne` would be useless — and that mutation was
+confirmed to fail the test.
+
+Manual verification against `api-beta` still runs before release, because no
+stub proves what Postgres actually does with a real FK.
 
 **The throwaway account must have an uploaded avatar and at least one row in
 every affected collection.** A fresh account with no avatar has nothing

--- a/plans/2026-07-28-account-special-tab-plan.md
+++ b/plans/2026-07-28-account-special-tab-plan.md
@@ -1,0 +1,1003 @@
+# Account "Special" Tab Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Special tab to the Account app offering "Delete my data" and "Delete my account", backed by two new privileged routes on the `profile-api` Directus extension.
+
+**Architecture:** A user cannot delete their own `directus_users` row and cannot reach `chat_messages` with user credentials, so all deletion happens server-side in the existing `profile-api` endpoint extension, which reads identity from `req.accountability.user` and acts with admin accountability. The frontend makes exactly one call per action, then clears localStorage and hard-reloads. Design: [`plans/2026-07-28-account-special-tab-design.md`](2026-07-28-account-special-tab-design.md).
+
+**Tech Stack:** React 19 + TypeScript + Vite (frontend), Vitest + @testing-library/react (tests), `classicy` component library, Directus 12.1.1 endpoint extension (plain CommonJS, no build step), Postgres via the extension's knex instance.
+
+## Global Constraints
+
+- **Never delete `directus_files` rows or OpenReplay data.** Both actions preserve them. This is the user's explicit requirement.
+- **Never delete `chat_blocks`.** Moderation standing must survive a data wipe, or a blocked student self-unbans in one click.
+- **`chat_messages` and `chat_blocks` key on a column literally named `user`** — a reserved word in Postgres. Use the knex query builder (which auto-quotes identifiers), never a hand-written raw SQL string. Unquoted, `user` silently resolves to `CURRENT_USER` and matches the wrong rows without erroring.
+- **Deleting the user row is blocked by five `NO ACTION` foreign keys** and must be preceded by nulling them. Verified against the live schema 2026-07-28. See Task 1.
+- **Clearing localStorage without a full page reload is a no-op** — the live `ClassicyStore` holds the same state in memory and writes it straight back on its next dispatch. Always `clearLocalSettings()` then `reloadDesktop()`.
+- **Identity always comes from `req.accountability.user`**, never from the request body. Matches the existing routes in the same file.
+- **`classicy` is pinned to `"latest"` and auto-bumped by `.husky/pre-commit`.** Never hand-edit its version; an unrelated version bump riding along in a commit is expected.
+- Frontend uses **tabs for indentation** and double quotes, matching the surrounding files.
+
+## Prerequisite
+
+This worktree has no `node_modules`. Before Task 2:
+
+```bash
+cd /home/robbiebyrd/rt911/.claude/worktrees/account-special-tab
+pnpm install
+```
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `packages/directus-extensions/profile-api/src/index.js` *(modify)* | Add `eraseOwnedData`, `blankProfile`, `POST /delete-data`, `POST /delete-account`; fix `CONFIRM_BASE_URL` |
+| `packages/frontend/src/Providers/Auth/accountApi.ts` *(create)* | Client seam: `deleteMyData`, `deleteMyAccount`, `clearLocalSettings`, `reloadDesktop` |
+| `packages/frontend/src/Providers/Auth/accountApi.test.ts` *(create)* | Request shape, error mapping, key list |
+| `packages/frontend/src/Applications/Account/SpecialTab.tsx` *(create)* | Buttons, risk copy, confirmation alerts, typed-confirm gating |
+| `packages/frontend/src/Applications/Account/SpecialTab.test.tsx` *(create)* | Confirmation-before-network, Cancel, gating, failure path |
+| `packages/frontend/src/Applications/Account/ProfileEditor.tsx` *(modify)* | Append the Special tab entry |
+| `packages/frontend/src/Applications/Account/Account.module.scss` *(modify)* | `.destructive`, `.riskCopy` styles |
+
+`SpecialTab` is its own file rather than a fifth inline entry in `ProfileEditor`'s `tabs` array — that array is already ~160 lines of JSX and this tab carries real interaction state (which action is pending, what has been typed, busy, error).
+
+---
+
+### Task 1: Extension routes
+
+**Files:**
+- Modify: `packages/directus-extensions/profile-api/src/index.js`
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces: `POST /profile/delete-data` and `POST /profile/delete-account`. Both require a session cookie, take no request body, and return `200 {"data":{"deleted":{"<collection>":<count>,…},"failed":["<collection>",…]}}`. Both return `401 {"errors":[{"message":…}]}` when unauthenticated. `/delete-account` additionally returns `500` if the user row itself could not be deleted.
+
+There is no test harness in `packages/directus-extensions`, so this task's verification is manual (Task 5). Write it carefully — it is the riskiest code in this change and nothing in CI covers it.
+
+- [ ] **Step 1: Fix the hardcoded confirmation host**
+
+`CONFIRM_BASE_URL` currently sits at module scope pointing at `beta.911realtime.org`. Delete that line (line 14) and derive it inside `handler`, where `env` is in scope.
+
+Remove:
+
+```js
+const CONFIRM_BASE_URL = "https://beta.911realtime.org/?confirm-email=";
+```
+
+Add immediately after `const admin = { admin: true, role: null };` inside `handler`:
+
+```js
+		// The desktop app's own origin, NOT Directus's PUBLIC_URL — that one
+		// holds the API's URL (api.911realtime.org), and mailing a confirmation
+		// link there would send people into the REST API instead of the app.
+		const confirmBaseUrl = `${env.RT911_APP_URL || "https://911realtime.org"}/?confirm-email=`;
+```
+
+Then update the one use inside the `/email-change` route body — change `${CONFIRM_BASE_URL}${token}` to `${confirmBaseUrl}${token}`.
+
+- [ ] **Step 2: Add the shared constants**
+
+Place directly above `module.exports`:
+
+```js
+// Collections whose rows belong to one user and go with them. Every one of
+// these is keyed by `user_created`; chat_messages is handled separately
+// because it is written by the Go streamer, not Directus, and keys on "user".
+const OWNED_COLLECTIONS = ["playlists", "stacks", "tm_bookmarks_personal"];
+
+// Profile fields blanked by a data wipe. `email` is absent deliberately — it
+// is the login identity, and the account survives a data wipe.
+const PROFILE_FIELDS = [
+	"first_name", "last_name", "username", "city", "state", "country",
+	"school_name", "educator_role", "grade_levels", "subjects",
+	"avatar", "filesystem",
+];
+
+// Foreign keys onto directus_users declared ON DELETE NO ACTION. Postgres
+// REJECTS the user delete while any of them still points at the row — this is
+// not a data-loss risk, it is a hard failure, and it fires for every account
+// that has ever uploaded an avatar. Nulling them is idempotent, so a retried
+// deletion is safe. tm_bookmarks_personal is the sixth such FK and resolves
+// itself: eraseOwnedData deletes those rows outright, which is why data
+// erasure must run BEFORE the row delete rather than after.
+const BLOCKING_REFS = [
+	["directus_files", "uploaded_by"],
+	["directus_files", "modified_by"],
+	["directus_notifications", "sender"],
+	["directus_versions", "user_updated"],
+	["directus_comments", "user_updated"],
+];
+```
+
+- [ ] **Step 3: Add the erase and blank helpers**
+
+Inside `handler`, after the existing `emailTaken` function. `database` must be added to the destructured context on the `handler` line — change `const { services, getSchema, env, logger } = context;` to `const { services, getSchema, env, logger, database } = context;`.
+
+```js
+			// Deletes everything this user owns, EXCEPT their directus_files
+			// (kept by product requirement) and their chat_blocks (moderation
+			// standing must outlive a data wipe, or a blocked student clears
+			// their own cool-down and the supporting evidence in one click).
+			//
+			// Each group is wrapped independently rather than aborting on the
+			// first error: someone who asked to be forgotten should have as
+			// much removed as possible, and the caller reports what remains.
+			async function eraseOwnedData(userId, schema) {
+				const deleted = {};
+				const failed = [];
+
+				for (const collection of OWNED_COLLECTIONS) {
+					try {
+						const items = new services.ItemsService(collection, { schema, accountability: admin });
+						const rows = await items.readByQuery({
+							filter: { user_created: { _eq: userId } },
+							fields: ["id"],
+							limit: -1,
+						});
+						if (rows.length > 0) await items.deleteMany(rows.map((r) => r.id));
+						deleted[collection] = rows.length;
+					} catch (err) {
+						logger.error(err, `profile-api: could not erase ${collection} for ${userId}`);
+						failed.push(collection);
+					}
+				}
+
+				try {
+					// Query builder, not raw SQL: knex quotes identifiers, and
+					// "user" is a reserved word that resolves to CURRENT_USER
+					// unquoted -- matching the wrong rows without erroring.
+					deleted.chat_messages = await database("chat_messages").where("user", userId).del();
+				} catch (err) {
+					logger.error(err, `profile-api: could not erase chat_messages for ${userId}`);
+					failed.push("chat_messages");
+				}
+
+				return { deleted, failed };
+			}
+
+			// Nulls every profile field, leaving the account signed-in-able.
+			async function blankProfile(userId, schema) {
+				const patch = {};
+				for (const field of PROFILE_FIELDS) patch[field] = null;
+				const users = new UsersService({ schema, accountability: admin });
+				await users.updateOne(userId, patch);
+			}
+```
+
+- [ ] **Step 4: Add the delete-data route**
+
+```js
+			router.post("/delete-data", async (req, res) => {
+				try {
+					const userId = req.accountability && req.accountability.user;
+					if (!userId) return errors(res, 401, "You must be signed in.");
+					const schema = await getSchema();
+					const result = await eraseOwnedData(userId, schema);
+					try {
+						await blankProfile(userId, schema);
+						result.deleted.profile = 1;
+					} catch (err) {
+						logger.error(err, `profile-api: could not blank profile for ${userId}`);
+						result.failed.push("profile");
+					}
+					logger.info(`profile-api: data erased for user ${userId}`);
+					return res.status(200).json({ data: result });
+				} catch (err) {
+					logger.error(err, "profile-api: delete-data failed");
+					return errors(res, 500, "Could not delete your data.");
+				}
+			});
+```
+
+- [ ] **Step 5: Add the delete-account route**
+
+Note the ordering: erase owned data, blank the profile, clear blocking references, *then* delete the row. A failure at the final step is a hard 500 — the client must not clear local storage or reload, because the account still exists.
+
+```js
+			router.post("/delete-account", async (req, res) => {
+				try {
+					const userId = req.accountability && req.accountability.user;
+					if (!userId) return errors(res, 401, "You must be signed in.");
+					const schema = await getSchema();
+
+					const result = await eraseOwnedData(userId, schema);
+					try {
+						await blankProfile(userId, schema);
+					} catch (err) {
+						// Not fatal: the row is about to be deleted anyway. Logged
+						// so a partial failure is still visible if the delete then
+						// fails too and the account survives scrubbed.
+						logger.error(err, `profile-api: could not blank profile for ${userId}`);
+					}
+
+					// Must happen before deleteOne -- see BLOCKING_REFS.
+					for (const [table, column] of BLOCKING_REFS) {
+						await database(table).where(column, userId).update({ [column]: null });
+					}
+
+					const users = new UsersService({ schema, accountability: admin });
+					await users.deleteOne(userId);
+
+					result.deleted.account = 1;
+					logger.info(`profile-api: account deleted for user ${userId}`);
+					return res.status(200).json({ data: result });
+				} catch (err) {
+					logger.error(err, "profile-api: delete-account failed");
+					return errors(res, 500, "Could not delete your account.");
+				}
+			});
+```
+
+- [ ] **Step 6: Verify the file parses**
+
+Run: `node --check packages/directus-extensions/profile-api/src/index.js`
+Expected: no output (exit 0). This is the only automated check available for this file.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/directus-extensions/profile-api/src/index.js
+git commit -m "feat(profile-api): delete-data and delete-account routes
+
+A user cannot delete their own directus_users row and cannot reach
+chat_messages with user credentials, so both actions run here with admin
+accountability against an identity taken from req.accountability.
+
+Five NO ACTION foreign keys onto directus_users must be nulled before the
+row delete or Postgres rejects it -- directus_files.uploaded_by fires for
+every account that has ever uploaded an avatar. Files and chat_blocks are
+preserved by requirement.
+
+Also moves the email-change confirmation host off the hardcoded beta
+subdomain to env-driven RT911_APP_URL, defaulting to the apex."
+```
+
+---
+
+### Task 2: Client API seam
+
+**Files:**
+- Create: `packages/frontend/src/Providers/Auth/accountApi.ts`
+- Test: `packages/frontend/src/Providers/Auth/accountApi.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1's two routes; `AuthRequiredError` / `ForbiddenError` from `./authApi`; `DIRECTUS_URL` from `../../lib/endpoints`.
+- Produces:
+  - `interface DeletionResult { deleted: Record<string, number>; failed: string[] }`
+  - `deleteMyData(fetchFn?: typeof fetch): Promise<DeletionResult>`
+  - `deleteMyAccount(fetchFn?: typeof fetch): Promise<DeletionResult>`
+  - `clearLocalSettings(storage?: Storage): void`
+  - `reloadDesktop(): void`
+  - `SETTINGS_KEYS: readonly string[]`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/frontend/src/Providers/Auth/accountApi.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import { AuthRequiredError, ForbiddenError } from "./authApi";
+import { SETTINGS_KEYS, clearLocalSettings, deleteMyAccount, deleteMyData } from "./accountApi";
+
+const jsonResponse = (body: unknown, status = 200) =>
+	new Response(JSON.stringify(body), { status });
+
+describe("deleteMyData", () => {
+	it("POSTs to /profile/delete-data with credentials and no body", async () => {
+		const f = vi.fn(async (...args: Parameters<typeof fetch>) => {
+			expect(String(args[0])).toContain("/profile/delete-data");
+			const init = args[1] as RequestInit;
+			expect(init.method).toBe("POST");
+			expect(init.credentials).toBe("include");
+			expect(init.body).toBeUndefined();
+			return jsonResponse({ data: { deleted: { playlists: 2 }, failed: [] } });
+		});
+		const result = await deleteMyData(f);
+		expect(result.deleted.playlists).toBe(2);
+		expect(result.failed).toEqual([]);
+	});
+
+	it("maps 401/403 to the shared error classes", async () => {
+		await expect(deleteMyData(vi.fn(async () => jsonResponse({}, 401)))).rejects.toBeInstanceOf(
+			AuthRequiredError,
+		);
+		await expect(deleteMyData(vi.fn(async () => jsonResponse({}, 403)))).rejects.toBeInstanceOf(
+			ForbiddenError,
+		);
+	});
+
+	it("surfaces the server's message on failure", async () => {
+		const f = vi.fn(async () => jsonResponse({ errors: [{ message: "Could not delete your data." }] }, 500));
+		await expect(deleteMyData(f)).rejects.toThrow("Could not delete your data.");
+	});
+});
+
+describe("deleteMyAccount", () => {
+	it("POSTs to /profile/delete-account", async () => {
+		const f = vi.fn(async (...args: Parameters<typeof fetch>) => {
+			expect(String(args[0])).toContain("/profile/delete-account");
+			return jsonResponse({ data: { deleted: { account: 1 }, failed: [] } });
+		});
+		expect((await deleteMyAccount(f)).deleted.account).toBe(1);
+	});
+
+	it("rejects on 500 so the caller can skip the reload", async () => {
+		const f = vi.fn(async () => jsonResponse({ errors: [{ message: "boom" }] }, 500));
+		await expect(deleteMyAccount(f)).rejects.toThrow("boom");
+	});
+});
+
+describe("clearLocalSettings", () => {
+	it("removes every persisted settings key", () => {
+		const store = new Map<string, string>(SETTINGS_KEYS.map((k) => [k, "x"]));
+		store.set("somethingElse", "keep");
+		const storage = {
+			removeItem: (k: string) => void store.delete(k),
+		} as unknown as Storage;
+
+		clearLocalSettings(storage);
+
+		for (const key of SETTINGS_KEYS) expect(store.has(key)).toBe(false);
+		expect(store.get("somethingElse")).toBe("keep");
+	});
+
+	it("includes the Classicy desktop state key", () => {
+		// The single key holding every app's settings and window positions.
+		// If this is ever dropped, "delete my data" silently keeps everything.
+		expect(SETTINGS_KEYS).toContain("classicyDesktopState");
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @rt911/frontend exec vitest run src/Providers/Auth/accountApi.test.ts`
+Expected: FAIL — cannot resolve `./accountApi`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/frontend/src/Providers/Auth/accountApi.ts`:
+
+```ts
+// Account-deletion seam. Both routes live on the profile-api Directus
+// extension because neither action is possible with user credentials: the
+// Teacher policy grants no delete on directus_users, and chat_messages is not
+// a Directus-managed collection. Spec: plans/2026-07-28-account-special-tab-design.md
+import { AuthRequiredError, ForbiddenError } from "./authApi";
+import { DIRECTUS_URL } from "../../lib/endpoints";
+
+/** Per-collection row counts the server actually removed, plus what it could not. */
+export interface DeletionResult {
+	deleted: Record<string, number>;
+	failed: string[];
+}
+
+/**
+ * Every localStorage key holding user settings.
+ *
+ * `classicyDesktopState` is the big one: the Classicy store persists window
+ * positions AND every app's settings (Feedback, RadioScanner, README,
+ * TimeMachine, TV selections) into that single key.
+ */
+export const SETTINGS_KEYS = [
+	"classicyDesktopState",
+	"rt911AlertsEnabled",
+	"media-chrome-pref-muted",
+	"media-chrome-pref-volume",
+	"media-chrome-pref-subtitles-lang",
+] as const;
+
+interface DirectusErrorBody {
+	errors?: { message?: unknown }[];
+}
+
+async function serverMessage(res: Response, fallback: string): Promise<string> {
+	try {
+		const body = (await res.json()) as DirectusErrorBody;
+		const message = body.errors?.[0]?.message;
+		return typeof message === "string" ? message : fallback;
+	} catch {
+		return fallback;
+	}
+}
+
+async function post(path: string, fallback: string, fetchFn: typeof fetch): Promise<DeletionResult> {
+	const res = await fetchFn(`${DIRECTUS_URL}${path}`, {
+		method: "POST",
+		credentials: "include",
+	});
+	if (res.status === 401) throw new AuthRequiredError(await serverMessage(res, fallback));
+	if (res.status === 403) throw new ForbiddenError(await serverMessage(res, fallback));
+	if (!res.ok) throw new Error(await serverMessage(res, fallback));
+	const body = (await res.json()) as { data: DeletionResult };
+	return body.data;
+}
+
+/** Erase the user's content and blank their profile. The account survives. */
+export async function deleteMyData(fetchFn: typeof fetch = fetch): Promise<DeletionResult> {
+	return post("/profile/delete-data", "Could not delete your data.", fetchFn);
+}
+
+/** Erase everything above, then remove the account itself. Irreversible. */
+export async function deleteMyAccount(fetchFn: typeof fetch = fetch): Promise<DeletionResult> {
+	return post("/profile/delete-account", "Could not delete your account.", fetchFn);
+}
+
+/** Drop every persisted setting. Must be followed by reloadDesktop() — see below. */
+export function clearLocalSettings(storage: Storage = window.localStorage): void {
+	for (const key of SETTINGS_KEYS) storage.removeItem(key);
+}
+
+/**
+ * Hard reload, and it is load-bearing rather than cosmetic.
+ *
+ * The live ClassicyStore holds the same settings in memory and writes them
+ * straight back to localStorage on its next dispatch, so clearing the keys
+ * without reloading is a no-op. The reload also discards the in-memory
+ * FilesystemSync tree, which would otherwise re-push itself to a `filesystem`
+ * link the server just nulled.
+ */
+export function reloadDesktop(): void {
+	window.location.reload();
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @rt911/frontend exec vitest run src/Providers/Auth/accountApi.test.ts`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/frontend/src/Providers/Auth/accountApi.ts packages/frontend/src/Providers/Auth/accountApi.test.ts
+git commit -m "feat(account): client seam for delete-data / delete-account
+
+clearLocalSettings must be followed by reloadDesktop: the live ClassicyStore
+holds the same settings in memory and rewrites them on its next dispatch, so
+clearing the keys alone changes nothing."
+```
+
+---
+
+### Task 3: Special tab component
+
+**Files:**
+- Create: `packages/frontend/src/Applications/Account/SpecialTab.tsx`
+- Test: `packages/frontend/src/Applications/Account/SpecialTab.test.tsx`
+- Modify: `packages/frontend/src/Applications/Account/Account.module.scss`
+
+**Interfaces:**
+- Consumes: `deleteMyData`, `deleteMyAccount`, `clearLocalSettings`, `reloadDesktop` from `../../Providers/Auth/accountApi`; `useAuth` from `../../Providers/Auth/AuthContext`.
+- Produces: `export const SpecialTab: React.FC` — takes no props, reads the signed-in user from context.
+
+- [ ] **Step 1: Add the styles**
+
+Append to `packages/frontend/src/Applications/Account/Account.module.scss`:
+
+```scss
+// Special tab: the two irreversible actions. Kept visually quiet rather than
+// alarm-red — the alert carries the warning, and a scary-looking button invites
+// curiosity clicks.
+.riskCopy {
+	color: var(--color-system-06);
+	max-width: 40ch;
+}
+
+.destructive {
+	display: flex;
+	flex-direction: column;
+	gap: calc(var(--window-padding-size) / 4);
+	align-items: flex-start;
+	padding-top: calc(var(--window-padding-size) / 2);
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `packages/frontend/src/Applications/Account/SpecialTab.test.tsx`. The `classicy` mock is **partial** via `importOriginal` — a full `vi.mock("classicy")` breaks the moment the component imports something new. The `ClassicyAlert` stand-in renders *every* button with its `disabled` state, which is what makes the typed-confirm gating testable.
+
+```tsx
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type React from "react";
+import type { AuthUser } from "../../Providers/Auth/authApi";
+
+const mockDeleteMyData = vi.hoisted(() => vi.fn());
+const mockDeleteMyAccount = vi.hoisted(() => vi.fn());
+const mockClearLocalSettings = vi.hoisted(() => vi.fn());
+const mockReloadDesktop = vi.hoisted(() => vi.fn());
+
+vi.mock("../../Providers/Auth/accountApi", () => ({
+	deleteMyData: mockDeleteMyData,
+	deleteMyAccount: mockDeleteMyAccount,
+	clearLocalSettings: mockClearLocalSettings,
+	reloadDesktop: mockReloadDesktop,
+}));
+
+const mockAuth = vi.hoisted(() => ({ user: null as AuthUser | null }));
+vi.mock("../../Providers/Auth/AuthContext", () => ({ useAuth: () => mockAuth }));
+
+vi.mock("classicy", async (importOriginal) => ({
+	...(await importOriginal<typeof import("classicy")>()),
+	// Renders label, message and ALL buttons with their disabled state, so
+	// tests can drive the typed-confirm gate without classicy's window chrome.
+	ClassicyAlert: ({
+		label,
+		message,
+		buttons,
+	}: {
+		label: string;
+		message?: React.ReactNode;
+		buttons?: { label: string; disabled?: boolean; onClick?: () => void }[];
+	}) => (
+		<div role="alertdialog" aria-label={label}>
+			<span>{label}</span>
+			{message}
+			{buttons?.map((b) => (
+				<button key={b.label} type="button" disabled={b.disabled} onClick={b.onClick}>
+					{b.label}
+				</button>
+			))}
+		</div>
+	),
+}));
+
+import { SpecialTab } from "./SpecialTab";
+
+const makeUser = (over: Partial<AuthUser> = {}): AuthUser => ({
+	id: "1", email: "t@x.org", username: "mrbyrd", first_name: null, last_name: null,
+	avatar: null, provider: "google", city: null, state: null, country: null,
+	school_name: null, educator_role: null, grade_levels: null, subjects: null,
+	...over,
+});
+
+beforeEach(() => {
+	mockAuth.user = makeUser();
+	mockDeleteMyData.mockReset().mockResolvedValue({ deleted: {}, failed: [] });
+	mockDeleteMyAccount.mockReset().mockResolvedValue({ deleted: {}, failed: [] });
+	mockClearLocalSettings.mockReset();
+	mockReloadDesktop.mockReset();
+});
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+});
+
+describe("SpecialTab — delete my data", () => {
+	it("shows a confirmation before touching the network", () => {
+		render(<SpecialTab />);
+		fireEvent.click(screen.getByRole("button", { name: "Delete My Data" }));
+		expect(screen.getByRole("alertdialog")).toBeTruthy();
+		expect(mockDeleteMyData).not.toHaveBeenCalled();
+	});
+
+	it("cancelling issues no request", () => {
+		render(<SpecialTab />);
+		fireEvent.click(screen.getByRole("button", { name: "Delete My Data" }));
+		fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+		expect(mockDeleteMyData).not.toHaveBeenCalled();
+		expect(screen.queryByRole("alertdialog")).toBeNull();
+	});
+
+	it("confirming deletes, clears settings, then reloads", async () => {
+		render(<SpecialTab />);
+		fireEvent.click(screen.getByRole("button", { name: "Delete My Data" }));
+		fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+		await waitFor(() => expect(mockReloadDesktop).toHaveBeenCalled());
+		expect(mockDeleteMyData).toHaveBeenCalled();
+		expect(mockClearLocalSettings).toHaveBeenCalled();
+	});
+
+	it("does not clear settings or reload when the server fails", async () => {
+		mockDeleteMyData.mockRejectedValue(new Error("Could not delete your data."));
+		render(<SpecialTab />);
+		fireEvent.click(screen.getByRole("button", { name: "Delete My Data" }));
+		fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+		await waitFor(() => expect(screen.getByText("Could not delete your data.")).toBeTruthy());
+		expect(mockClearLocalSettings).not.toHaveBeenCalled();
+		expect(mockReloadDesktop).not.toHaveBeenCalled();
+	});
+});
+
+describe("SpecialTab — delete my account", () => {
+	const openAccountAlert = () => {
+		render(<SpecialTab />);
+		fireEvent.click(screen.getByRole("button", { name: "Delete My Account" }));
+	};
+
+	it("keeps Delete disabled until the screen name matches exactly", () => {
+		openAccountAlert();
+		const del = () => screen.getByRole("button", { name: "Delete" }) as HTMLButtonElement;
+		expect(del().disabled).toBe(true);
+
+		fireEvent.change(screen.getByLabelText("Type your screen name to confirm"), {
+			target: { value: "mrbyr" },
+		});
+		expect(del().disabled).toBe(true);
+
+		fireEvent.change(screen.getByLabelText("Type your screen name to confirm"), {
+			target: { value: "mrbyrd" },
+		});
+		expect(del().disabled).toBe(false);
+	});
+
+	it("falls back to the email when the account has no screen name", () => {
+		mockAuth.user = makeUser({ username: null });
+		openAccountAlert();
+		fireEvent.change(screen.getByLabelText("Type your screen name to confirm"), {
+			target: { value: "t@x.org" },
+		});
+		expect((screen.getByRole("button", { name: "Delete" }) as HTMLButtonElement).disabled).toBe(false);
+	});
+
+	it("deletes, clears settings, then reloads on confirm", async () => {
+		openAccountAlert();
+		fireEvent.change(screen.getByLabelText("Type your screen name to confirm"), {
+			target: { value: "mrbyrd" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+		await waitFor(() => expect(mockReloadDesktop).toHaveBeenCalled());
+		expect(mockDeleteMyAccount).toHaveBeenCalled();
+		expect(mockClearLocalSettings).toHaveBeenCalled();
+	});
+
+	it("does not clear settings or reload when the account delete fails", async () => {
+		mockDeleteMyAccount.mockRejectedValue(new Error("Could not delete your account."));
+		openAccountAlert();
+		fireEvent.change(screen.getByLabelText("Type your screen name to confirm"), {
+			target: { value: "mrbyrd" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+		await waitFor(() => expect(screen.getByText("Could not delete your account.")).toBeTruthy());
+		expect(mockClearLocalSettings).not.toHaveBeenCalled();
+		expect(mockReloadDesktop).not.toHaveBeenCalled();
+	});
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm --filter @rt911/frontend exec vitest run src/Applications/Account/SpecialTab.test.tsx`
+Expected: FAIL — cannot resolve `./SpecialTab`.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `packages/frontend/src/Applications/Account/SpecialTab.tsx`:
+
+```tsx
+// Account → Special: the two irreversible actions. Both run entirely on the
+// server (profile-api extension) because neither is possible with user
+// credentials. Spec: plans/2026-07-28-account-special-tab-design.md
+import { ClassicyAlert, ClassicyButton, ClassicyControlLabel, ClassicyInput } from "classicy";
+import type React from "react";
+import { useState } from "react";
+import { useAuth } from "../../Providers/Auth/AuthContext";
+import {
+	clearLocalSettings,
+	deleteMyAccount,
+	deleteMyData,
+	reloadDesktop,
+} from "../../Providers/Auth/accountApi";
+import styles from "./Account.module.scss";
+
+type Pending = "data" | "account" | null;
+
+export const SpecialTab: React.FC = () => {
+	const { user } = useAuth();
+	const [pending, setPending] = useState<Pending>(null);
+	const [typed, setTyped] = useState("");
+	const [busy, setBusy] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	// What the user must type to arm account deletion. Screen name is the
+	// identity they actually recognise; email is the fallback for accounts
+	// that never set one.
+	const confirmName = user?.username ?? user?.email ?? "";
+
+	const close = () => {
+		setPending(null);
+		setTyped("");
+	};
+
+	const run = (action: () => Promise<unknown>) => {
+		setBusy(true);
+		setError(null);
+		action()
+			.then(() => {
+				// Order matters: the server wipe must have succeeded before we
+				// drop local state, and the reload is what makes clearing the
+				// keys stick (see accountApi.reloadDesktop).
+				clearLocalSettings();
+				reloadDesktop();
+			})
+			.catch((err: Error) => {
+				setError(err.message);
+				close();
+			})
+			.finally(() => setBusy(false));
+	};
+
+	return (
+		<div className={styles.tabPanel}>
+			<div className={styles.destructive}>
+				<ClassicyControlLabel label="Delete my data" />
+				<div className={styles.riskCopy}>
+					Erases your profile, desktop settings, playlists, stacks, bookmarks and
+					chat history. Your account and your uploaded files are kept.
+				</div>
+				<ClassicyButton disabled={busy} onClickFunc={() => setPending("data")}>
+					Delete My Data
+				</ClassicyButton>
+			</div>
+
+			<div className={styles.destructive}>
+				<ClassicyControlLabel label="Delete my account" />
+				<div className={styles.riskCopy}>
+					Everything above, and then your account itself. You will be signed out and
+					cannot sign back in. Your uploaded files are kept.
+				</div>
+				<ClassicyButton disabled={busy} onClickFunc={() => setPending("account")}>
+					Delete My Account
+				</ClassicyButton>
+			</div>
+
+			{error && <div className={styles.error}>{error}</div>}
+
+			{pending === "data" && (
+				<ClassicyAlert
+					id="account_delete_data"
+					appId="Account.app"
+					alertType="stop"
+					title="Account"
+					label="This cannot be undone."
+					message="Deletes your profile, settings, playlists, stacks, bookmarks and chat history. Keeps your files and your login."
+					// HIG: when an action risks data loss the SAFE choice is the
+					// default, so Return dismisses rather than destroys.
+					defaultButtonId="account_delete_data_cancel"
+					buttons={[
+						{ id: "account_delete_data_cancel", label: "Cancel", role: "cancel", onClick: close },
+						{
+							id: "account_delete_data_go",
+							label: "Delete",
+							role: "normal",
+							disabled: busy,
+							onClick: () => run(deleteMyData),
+						},
+					]}
+				/>
+			)}
+
+			{pending === "account" && (
+				<ClassicyAlert
+					id="account_delete_account"
+					appId="Account.app"
+					alertType="stop"
+					title="Account"
+					label="This cannot be undone."
+					message={
+						<div>
+							<p>
+								Your account and everything in it will be permanently removed. Your
+								uploaded files are kept.
+							</p>
+							<ClassicyInput
+								id="account-delete-confirm"
+								labelTitle="Type your screen name to confirm"
+								prefillValue={typed}
+								disabled={busy}
+								onChangeFunc={(e) => setTyped(e.target.value)}
+							/>
+						</div>
+					}
+					defaultButtonId="account_delete_account_cancel"
+					buttons={[
+						{ id: "account_delete_account_cancel", label: "Cancel", role: "cancel", onClick: close },
+						{
+							id: "account_delete_account_go",
+							label: "Delete",
+							role: "normal",
+							// Exact match only. A near-miss is a near-miss.
+							disabled: busy || typed !== confirmName,
+							onClick: () => run(deleteMyAccount),
+						},
+					]}
+				/>
+			)}
+		</div>
+	);
+};
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm --filter @rt911/frontend exec vitest run src/Applications/Account/SpecialTab.test.tsx`
+Expected: PASS, 9 tests.
+
+If the typed-confirm tests fail on `getByLabelText`, check how `ClassicyInput` associates its `labelTitle` with the input — `ProfileEditor.test.tsx` queries its fields the same way (`screen.getByLabelText("First Name")`), so the pattern is known to work.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/frontend/src/Applications/Account/SpecialTab.tsx packages/frontend/src/Applications/Account/SpecialTab.test.tsx packages/frontend/src/Applications/Account/Account.module.scss
+git commit -m "feat(account): Special tab with delete-data and delete-account
+
+Friction scales with severity: the data wipe takes one stop alert, the
+account deletion additionally requires typing the screen name. Cancel is the
+default button on both, per the HIG rule for data-loss actions."
+```
+
+---
+
+### Task 4: Wire the tab into ProfileEditor
+
+**Files:**
+- Modify: `packages/frontend/src/Applications/Account/ProfileEditor.tsx`
+- Test: `packages/frontend/src/Applications/Account/ProfileEditor.test.tsx`
+
+**Interfaces:**
+- Consumes: `SpecialTab` from `./SpecialTab`.
+- Produces: a fifth (or fourth, for OAuth accounts) tab titled `Special`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/frontend/src/Applications/Account/ProfileEditor.test.tsx`. The existing file already defines `selectTab`; reuse it.
+
+```tsx
+describe("ProfileEditor — Special tab", () => {
+	it("offers both destructive actions", () => {
+		render(<ProfileEditor />);
+		selectTab("Special");
+		expect(screen.getByRole("button", { name: "Delete My Data" })).toBeTruthy();
+		expect(screen.getByRole("button", { name: "Delete My Account" })).toBeTruthy();
+	});
+
+	it("is the last tab, after Password", () => {
+		// Order is deliberate: the destructive actions sit furthest from the
+		// tabs someone uses routinely.
+		mockAuth.user = makeUser({ provider: "default" });
+		render(<ProfileEditor />);
+		const titles = screen.getAllByRole("tab").map((t) => t.textContent);
+		expect(titles[titles.length - 1]).toBe("Special");
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @rt911/frontend exec vitest run src/Applications/Account/ProfileEditor.test.tsx -t "Special"`
+Expected: FAIL — no tab named "Special".
+
+- [ ] **Step 3: Add the import**
+
+In `ProfileEditor.tsx`, add after the `usernameApi` import:
+
+```tsx
+import { SpecialTab } from "./SpecialTab";
+```
+
+- [ ] **Step 4: Append the tab**
+
+After the `if (user?.provider === "default") { tabs.push({...}) }` block and before `return <ClassicyTabs tabs={tabs} />;`, add:
+
+```tsx
+	// Appended last, after the conditional Password tab, so the destructive
+	// actions always sit furthest from the tabs used routinely.
+	tabs.push({ title: "Special", children: <SpecialTab /> });
+```
+
+- [ ] **Step 5: Run the full Account test suite**
+
+Run: `pnpm --filter @rt911/frontend exec vitest run src/Applications/Account/`
+Expected: PASS — all Account, ProfileEditor and SpecialTab tests.
+
+- [ ] **Step 6: Run the repo checks**
+
+```bash
+pnpm --filter @rt911/frontend exec tsc -b
+pnpm lint
+pnpm test
+```
+
+Expected: all pass. If `tsc -b` reports nothing suspicious but you changed types, delete `packages/frontend/tsconfig.tsbuildinfo` and re-run — its incremental cache has masked real errors in this repo before.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/frontend/src/Applications/Account/ProfileEditor.tsx packages/frontend/src/Applications/Account/ProfileEditor.test.tsx
+git commit -m "feat(account): show the Special tab in the profile editor"
+```
+
+---
+
+### Task 5: Manual verification and deploy
+
+**Files:** none — this task verifies Tasks 1–4 against a real environment.
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: a verified deployment.
+
+`packages/directus-extensions` has no test harness, so Task 1 is entirely unverified by CI. This task is where that risk gets retired. Do not skip it.
+
+- [ ] **Step 1: Build and deploy the extension image first**
+
+The frontend must never reach production before the routes exist. The extension ships inside a custom `rt911-api` image (`packages/directus-extensions/Dockerfile` — a `COPY` into `directus/directus:12.1.1`), built by CI on merge and rolled out by ArgoCD from the `Keeping-History/infra` repo.
+
+Deployment is GitOps. Do **not** `kubectl set image` — `automated.selfHeal: true` reverts imperative edits within seconds.
+
+- [ ] **Step 2: Set `RT911_APP_URL` on the API deployment**
+
+Add `RT911_APP_URL=https://911realtime.org` to the `rt911-api` environment in the infra repo. Without it the code falls back to the same apex default, so this is belt-and-braces rather than load-bearing — but set it so staging can point elsewhere.
+
+- [ ] **Step 3: Create a throwaway account that is actually representative**
+
+Register a test account on `api-beta` and give it, at minimum:
+- an **uploaded avatar** — this is the critical one. A fresh account with no avatar has nothing pointing at `directus_files.uploaded_by`, so it deletes cleanly *even if the blocking-reference step is missing entirely*. Testing without an avatar proves nothing.
+- one playlist, one HyperCard stack, one personal Time Machine bookmark
+- at least one IM Buddies message
+- some desktop settings (move a window, change a TV channel)
+
+- [ ] **Step 4: Record the before state**
+
+```sql
+SELECT 'playlists', count(*) FROM playlists WHERE user_created = :id
+UNION ALL SELECT 'stacks', count(*) FROM stacks WHERE user_created = :id
+UNION ALL SELECT 'bookmarks', count(*) FROM tm_bookmarks_personal WHERE user_created = :id
+UNION ALL SELECT 'chat_messages', count(*) FROM chat_messages WHERE "user" = :id
+UNION ALL SELECT 'chat_blocks', count(*) FROM chat_blocks WHERE "user" = :id
+UNION ALL SELECT 'files', count(*) FROM directus_files WHERE uploaded_by = :id;
+```
+
+- [ ] **Step 5: Exercise "Delete my data" and verify**
+
+Expected after: playlists/stacks/bookmarks/chat_messages all `0`; **`chat_blocks` unchanged**; `directus_files` count unchanged and the avatar still loads from its URL; the `directus_users` row still present with every profile field `NULL` except `email`; the desktop reloaded with default settings; **still signed in**.
+
+- [ ] **Step 6: Exercise "Delete my account" and verify**
+
+Use a second throwaway account, again with an avatar. Expected after: the `directus_users` row is gone; the browser lands on the signed-out desktop; the avatar file **still exists** in `directus_files` with `uploaded_by` now `NULL`; `chat_blocks` rows survive, orphaned.
+
+If the delete returns 500 with a foreign-key violation, the `BLOCKING_REFS` loop is not running or is missing a table — check the API pod logs for the constraint name in the error, and add that table/column to `BLOCKING_REFS`.
+
+- [ ] **Step 7: Confirm the email-change link still works**
+
+Regression check on the `CONFIRM_BASE_URL` change: request an email change from a third test account and confirm the delivered link points at `https://911realtime.org/?confirm-email=…`, not the beta subdomain, and that opening it completes the change.
+
+- [ ] **Step 8: Open the PR**
+
+```bash
+git push -u origin worktree-account-special-tab
+gh pr create --title "feat(account): Special tab — delete my data / delete my account" --body "..."
+```
+
+Note in the PR body that the extension image must roll out before the frontend.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec requirement | Task |
+|---|---|
+| Special tab with two buttons | 3, 4 |
+| Delete-data scope (profile, settings, playlists, stacks, bookmarks, chat) | 1 (steps 2–4), 2 |
+| Delete-account = data + user row | 1 (step 5) |
+| Keep `directus_files` | 1 (BLOCKING_REFS nulls rather than deletes); verified 5.6 |
+| Keep OpenReplay | untouched by every task — nothing references it |
+| Keep `chat_blocks` | 1 (absent from erase); verified 5.5 |
+| Risk-explaining alert on both | 3 |
+| Typed confirm for account only | 3 |
+| Quoted `"user"` column | 1 (knex query builder) |
+| Blocking FK clearance | 1 (step 5) |
+| localStorage keys + reload ordering | 2, 3 |
+| `CONFIRM_BASE_URL` fix | 1 (step 1), verified 5.7 |
+| Partial-failure response shape | 1, 2 |
+| Deploy order | 5 |
+
+**Placeholders:** none. The only `"..."` is the `gh pr create --body` argument, which is prose for the author to write.
+
+**Type consistency:** `DeletionResult` is defined once in Task 2 and used verbatim in Task 3's mocks. `clearLocalSettings` / `reloadDesktop` / `deleteMyData` / `deleteMyAccount` keep the same names across Tasks 2, 3 and the test mocks. The server's `{deleted, failed}` shape in Task 1 matches `DeletionResult` exactly. `SETTINGS_KEYS` is `as const` in the implementation and consumed as `readonly string[]`.
+
+**Known uncovered risk:** Task 1 has no automated test of any kind — `node --check` proves only that it parses. Task 5 is the whole of its verification.

--- a/plans/2026-07-28-account-special-tab-plan.md
+++ b/plans/2026-07-28-account-special-tab-plan.md
@@ -53,7 +53,11 @@ pnpm install
 - Consumes: nothing (first task).
 - Produces: `POST /profile/delete-data` and `POST /profile/delete-account`. Both require a session cookie, take no request body, and return `200 {"data":{"deleted":{"<collection>":<count>,…},"failed":["<collection>",…]}}`. Both return `401 {"errors":[{"message":…}]}` when unauthenticated. `/delete-account` additionally returns `500` if the user row itself could not be deleted.
 
-There is no test harness in `packages/directus-extensions`, so this task's verification is manual (Task 5). Write it carefully — it is the riskiest code in this change and nothing in CI covers it.
+The extension has its own vitest suite at `src/index.test.mjs`, run in CI by the `api-test` job (which gates the image build). **Extend it with cases for both new routes** — the harness stubs the express router and Directus's services, so add an `ItemsService` stub, a knex-shaped `database` stub, and an `ops` array recording every mutation *in call order*.
+
+Assert **ordering**, not just occurrence: nulling the blocking references after `deleteOne` would be useless, so the test must compare index positions. Mutation-check it by moving the loop below `deleteOne` and confirming the test fails.
+
+Manual verification (Task 5) still runs on top, because no stub proves what Postgres does with a real foreign key.
 
 - [ ] **Step 1: Fix the hardcoded confirmation host**
 
@@ -231,8 +235,13 @@ Note the ordering: erase owned data, blank the profile, clear blocking reference
 
 - [ ] **Step 6: Verify the file parses**
 
-Run: `node --check packages/directus-extensions/profile-api/src/index.js`
-Expected: no output (exit 0). This is the only automated check available for this file.
+```bash
+node --check packages/directus-extensions/profile-api/src/index.js
+npm --prefix packages/directus-extensions/profile-api ci
+npm --prefix packages/directus-extensions/profile-api test
+```
+
+Expected: parses clean, and the 10 pre-existing email-change tests still pass — the `CONFIRM_BASE_URL` change must not regress them.
 
 - [ ] **Step 7: Commit**
 
@@ -919,7 +928,7 @@ git commit -m "feat(account): show the Special tab in the profile editor"
 - Consumes: everything above.
 - Produces: a verified deployment.
 
-`packages/directus-extensions` has no test harness, so Task 1 is entirely unverified by CI. This task is where that risk gets retired. Do not skip it.
+Task 1's unit tests stub Directus's services, so they prove the routes' logic and ordering but not what Postgres actually does with a real foreign key. This task retires that residual risk. Do not skip it.
 
 - [ ] **Step 1: Build and deploy the extension image first**
 
@@ -1000,4 +1009,4 @@ Note in the PR body that the extension image must roll out before the frontend.
 
 **Type consistency:** `DeletionResult` is defined once in Task 2 and used verbatim in Task 3's mocks. `clearLocalSettings` / `reloadDesktop` / `deleteMyData` / `deleteMyAccount` keep the same names across Tasks 2, 3 and the test mocks. The server's `{deleted, failed}` shape in Task 1 matches `DeletionResult` exactly. `SETTINGS_KEYS` is `as const` in the implementation and consumed as `readonly string[]`.
 
-**Known uncovered risk:** Task 1 has no automated test of any kind — `node --check` proves only that it parses. Task 5 is the whole of its verification.
+**Residual risk:** Task 1's tests stub every Directus service, so they cannot prove real FK behaviour, real `ItemsService` filter semantics, or that knex quotes `"user"` as expected against live Postgres. Task 5 covers that. The ordering assertion was mutation-checked (moving the blocking-ref loop after `deleteOne` fails it).


### PR DESCRIPTION
Adds a **Special** tab to the Account app with two irreversible actions, backed by two new routes on the existing `profile-api` Directus extension.

Spec: `plans/2026-07-28-account-special-tab-design.md` · Plan: `plans/2026-07-28-account-special-tab-plan.md`

## ⚠️ Deploy order

**The `rt911-api` image must roll out before the frontend.** Otherwise the Special tab's buttons call routes that do not exist yet.

Also set `RT911_APP_URL=https://911realtime.org` on the `rt911-api` deployment in the infra repo (the code falls back to the same apex default, so this is belt-and-braces).

## What each button does

| Target | Delete my data | Delete my account |
|---|---|---|
| `directus_users` (own row) | all profile fields blanked | row deleted |
| `playlists`, `stacks`, `tm_bookmarks_personal` | deleted | deleted |
| `chat_messages` | deleted | deleted |
| `chat_blocks` | **kept** | **kept** |
| `directus_files` | **kept** | **kept** (orphaned, `uploaded_by` nulled) |
| localStorage settings | cleared + reload | cleared + reload |
| OpenReplay | **kept** | **kept** |

`chat_blocks` survives deliberately: it is the moderation record the chat guard writes on abuse, not conversation content. Clearing it would let a blocked student self-unban in one click and destroy the supporting evidence in the same motion.

## Why this lives in the Directus extension

Neither action is possible with user credentials — the Teacher policy grants no delete on `directus_users`, and `chat_messages` is not reachable at all. Same reason the verified email-change flow already lives there.

## The load-bearing schema finding

`directus_files.uploaded_by` is **`ON DELETE NO ACTION`** — verified against the live database, not assumed. Postgres therefore *rejects* `UsersService.deleteOne` for any account that has ever uploaded an avatar. Not a data-loss risk; a hard failure, and the default path rather than an edge case.

Five references must be nulled before the row delete: `directus_files.uploaded_by`, `directus_files.modified_by`, `directus_notifications.sender`, `directus_versions.user_updated`, `directus_comments.user_updated`. `tm_bookmarks_personal` is a sixth, resolved by deleting those rows first — which is why erasure runs *before* the row delete.

`directus_sessions` and `directus_presets` cascade, so sign-out is automatic.

## Also in here

`profile-api`'s email-change confirmation link was hardcoded to `beta.911realtime.org`. Since the apex cutover that 301s to `911realtime.org` preserving the query string, so links work — by accident of a redirect that will eventually be retired, and meanwhile every request mails a `beta.` URL in a message asking someone to confirm an account change. Now `env.RT911_APP_URL`, defaulting to the apex. Deliberately *not* Directus's built-in `PUBLIC_URL`, which holds the API's own URL.

## Testing

1877 tests pass (212 files), `tsc -b` clean, `pnpm lint` 0 errors.

`SpecialTab.test.tsx` mocks `ClassicyAlert` in order to drive its buttons, so `SpecialTab.realAlert.test.tsx` exists to exercise the real one — the account confirmation puts a `ClassicyInput` inside the alert's `message`, which classicy's own docs describe as icon/text/buttons only. Verified it renders and stays interactive.

### Extension tests

**Correction to an earlier version of this description**, which claimed `packages/directus-extensions` had no test harness. It does — `src/index.test.mjs`, run by the `api-test` job that gates the image build. That claim was wrong.

12 new cases extend the existing harness with an `ItemsService` stub, a knex-shaped `database` stub, and an `ops` array recording every mutation *in call order*. `nulls every blocking foreign key BEFORE deleting the row` asserts index positions, not mere occurrence — mutation-checked by moving the loop below `deleteOne`, which fails it. The 10 pre-existing email-change tests still pass, confirming the `CONFIRM_BASE_URL` change did not regress them.

## ⚠️ What is still NOT covered

The extension tests stub every Directus service, so they prove the routes' logic and ordering but **not** what Postgres does with a real foreign key, nor that knex quotes `"user"` as expected against the live database.

Manual verification before this reaches users, with **throwaway accounts that have uploaded an avatar** — an account without one deletes cleanly even if the blocking-FK handling were missing entirely, so testing without one proves nothing:

- [ ] `delete-data`: content gone, `chat_blocks` unchanged, avatar still loads, profile blanked, still signed in
- [ ] `delete-account`: user row gone, signed out, avatar file still exists with `uploaded_by` NULL, `chat_blocks` orphaned but present
- [ ] email-change link points at the apex and still completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
