### PR TITLE
fix(im-buddies): only send `fallbacks` to models that support it

### DIFF
--- a/packages/backend/internal/chat/provider_anthropic.go
+++ b/packages/backend/internal/chat/provider_anthropic.go
@@ -80,13 +80,22 @@ func anthropicParams(r Request) anthropic.BetaMessageNewParams {
 		MaxTokens: int64(r.MaxTokens),
 		System:    system,
 		Messages:  messages,
-		// "default" lets a false-positive decline recover server-side rather
-		// than surfacing as a dead buddy. Server-side fallbacks require the
-		// beta endpoint, hence client.Beta.Messages.New in Generate.
-		Fallbacks: anthropic.BetaFallbacksParamUnion{
+	}
+	// "default" lets a false-positive decline recover server-side rather than
+	// surfacing as a dead buddy. Server-side fallbacks require the beta
+	// endpoint, hence client.Beta.Messages.New in Generate.
+	//
+	// Gated, because fallbacks is a per-model capability and a model that does
+	// not have it rejects the WHOLE request with a 400. Sent unconditionally,
+	// it meant a curator changing chat_settings.model in Directus — an ordinary
+	// config edit, no deploy — took every buddy down at once, each one answering
+	// with the canned stall line. That is what happened on 2026-07-30 when the
+	// model was switched to claude-sonnet-5.
+	if supportsServerSideFallback(r.Model) {
+		params.Fallbacks = anthropic.BetaFallbacksParamUnion{
 			OfDefault: constant.ValueOf[constant.Default](),
-		},
-		Betas: []anthropic.AnthropicBeta{anthropic.AnthropicBetaServerSideFallback2026_07_01},
+		}
+		params.Betas = []anthropic.AnthropicBeta{anthropic.AnthropicBetaServerSideFallback2026_07_01}
 	}
 	// r.Effort is empty whenever chat_settings.effort is NULL and no profile
 	// override applies; only set output_config.effort when there is an actual
@@ -98,6 +107,29 @@ func anthropicParams(r Request) anthropic.BetaMessageNewParams {
 		}
 	}
 	return params
+}
+
+// supportsServerSideFallback reports whether a model accepts the server-side
+// `fallbacks` parameter.
+//
+// An allow-list rather than a deny-list, deliberately. The failure modes are not
+// symmetric: omitting fallbacks from a model that supports them costs only
+// server-side recovery from a false-positive safety decline, which the caller
+// already handles as an ordinary error; sending them to a model that does not
+// support them costs every single message. So an unrecognised model — including
+// any released after this was written — gets no fallbacks and keeps working.
+//
+// Kept as an explicit list rather than read from /v1/models' allowed_fallback_models
+// because that lookup would put a network call, and a new startup failure mode,
+// in front of a feature whose entire purpose is resilience. Add a model here when
+// it is verified to accept the parameter.
+func supportsServerSideFallback(model string) bool {
+	switch model {
+	case "claude-opus-5", "claude-fable-5", "claude-mythos-5":
+		return true
+	default:
+		return false
+	}
 }
 
 // textOf concatenates every text block in the response. Non-text blocks

--- a/packages/backend/internal/chat/provider_anthropic_test.go
+++ b/packages/backend/internal/chat/provider_anthropic_test.go
@@ -1,6 +1,10 @@
 package chat
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+)
 
 func TestAnthropicParamsOmitsEffortWhenUnset(t *testing.T) {
 	// chat_settings.effort is NULL and no profile override applies whenever
@@ -17,5 +21,58 @@ func TestAnthropicParamsSendsConfiguredEffort(t *testing.T) {
 	params := anthropicParams(Request{Model: "claude-opus-5", MaxTokens: 100, Effort: "high"})
 	if got := string(params.OutputConfig.Effort); got != "high" {
 		t.Errorf("OutputConfig.Effort = %q, want \"high\"", got)
+	}
+}
+
+func TestAnthropicParamsOmitsFallbacksOnModelsThatRejectThem(t *testing.T) {
+	// Prod outage 2026-07-30: chat_settings.model was changed to
+	// claude-sonnet-5 and every generation began failing with
+	// 400 "'claude-sonnet-5' does not support the `fallbacks` parameter",
+	// which the student sees as the canned stall line from every buddy.
+	//
+	// fallbacks is a per-model capability, so sending it unconditionally turns
+	// an ordinary Directus config change into a total chat outage. Unknown and
+	// unsupporting models must simply go without it.
+	params := anthropicParams(Request{Model: "claude-sonnet-5", MaxTokens: 100})
+
+	if params.Fallbacks.OfDefault != "" {
+		t.Error("Fallbacks must be omitted for a model that rejects the parameter")
+	}
+	for _, b := range params.Betas {
+		if b == anthropic.AnthropicBetaServerSideFallback2026_07_01 {
+			t.Error("the server-side-fallback beta must not be sent to a model that rejects fallbacks")
+		}
+	}
+}
+
+func TestAnthropicParamsSendsFallbacksOnModelsThatSupportThem(t *testing.T) {
+	// The resilience this buys is real -- a false-positive safety decline
+	// recovers server-side instead of surfacing as a dead buddy -- so the guard
+	// must not throw it away on the models that do support it.
+	params := anthropicParams(Request{Model: "claude-opus-5", MaxTokens: 100})
+
+	if params.Fallbacks.OfDefault == "" {
+		t.Error("Fallbacks must be sent for claude-opus-5, which supports them")
+	}
+	var found bool
+	for _, b := range params.Betas {
+		if b == anthropic.AnthropicBetaServerSideFallback2026_07_01 {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("the server-side-fallback beta must accompany the fallbacks parameter")
+	}
+}
+
+func TestUnknownModelsDoNotGetFallbacks(t *testing.T) {
+	// Fail safe on the "we have not heard of this model" path: a model that
+	// gains fallback support later merely misses out on server-side recovery
+	// until it is listed, which is a degradation. Guessing the other way is an
+	// outage, which is exactly what happened.
+	for _, model := range []string{"claude-haiku-4-5", "claude-sonnet-4-6", "some-future-model"} {
+		if anthropicParams(Request{Model: model, MaxTokens: 100}).Fallbacks.OfDefault != "" {
+			t.Errorf("%s: unknown/unsupporting models must default to no fallbacks", model)
+		}
 	}
 }


### PR DESCRIPTION
## Incident

`chat_settings.model` was changed to `claude-sonnet-5`; every buddy immediately began answering with the canned stall line. Every generation was failing:

```
400 'claude-sonnet-5' does not support the `fallbacks` parameter.
```

`anthropicParams` set `Fallbacks` + the server-side-fallback beta **unconditionally**. `fallbacks` is a per-model capability and a model without it rejects the *entire* request — so an ordinary Directus config edit, with no deploy and no code change, took down every buddy at once.

Not introduced by #336: that block predates it, and all 141 previously-working replies used `claude-opus-5`.

## Fix

Gate it on the model, as an **allow-list**. The failure modes aren't symmetric:

- Omitting fallbacks from a model that supports them → loses only server-side recovery from a false-positive safety decline, which the caller already handles as an ordinary error.
- Sending them to a model that doesn't → **every message fails**.

So an unrecognised model — including any released after this was written — gets no fallbacks and keeps working. Deliberately *not* read from `/v1/models`' `allowed_fallback_models`: that would put a network call, and a new startup failure mode, in front of a feature whose whole purpose is resilience.

## Verified against the live API

| request | result |
|---|---|
| sonnet-5 **with** fallbacks (what prod sent) | 400 — reproduces the outage |
| sonnet-5 **without** fallbacks | 200 |
| opus-5 with fallbacks | 200 |
| post-fix path: beta endpoint, no fallbacks beta, sonnet-5 | 200 |

Three unit tests, written failing first, covering the rejecting model, the supporting model, and the unknown-model default.

## Mitigation already applied

`chat_settings.model` reverted to `claude-opus-5` to restore service immediately (60s settings TTL, no restart). Zero `fallbacks` errors since; successful generations confirmed. **Once this ships, `claude-sonnet-5` becomes a safe choice again** if that switch was intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)