### PR TITLE
fix(im-buddies): schema gaps + LLM transcript summarisation

### DIFF
--- a/packages/backend/chat-collections.mjs
+++ b/packages/backend/chat-collections.mjs
@@ -185,6 +185,13 @@ export const CHAT_COLLECTIONS = [
       { field: "body", type: "text", schema: { is_nullable: false }, meta: { interface: "input-multiline", width: "full" } },
       { field: "virtual_time", type: "timestamp", schema: { is_nullable: false }, meta: { interface: "datetime", width: "half", note: "Position on the 2001 clock" } },
       { field: "created_at", type: "timestamp", schema: { is_nullable: false }, meta: { interface: "datetime", width: "half", note: "Real wall-clock time" } },
+      // Soft delete, not a hard one: the transcript leaves the product while the
+      // log survives. EVERY conversation read must filter on this being NULL —
+      // history, replayed history, and the prior-contact check — or a cleared
+      // conversation comes back through whichever path forgot.
+      { field: "cleared_at", type: "timestamp", schema: { is_nullable: true },
+        meta: { interface: "datetime", width: "full", readonly: true,
+                note: "Set when the student cleared their chat history (IM Buddies > Edit > Settings > Delete Chat Data). Rows are retained; every conversation read skips those carrying this." } },
       { field: "kind", type: "string", schema: { is_nullable: false, default_value: "typed" },
         meta: { interface: "select-dropdown", width: "half",
                 options: { choices: ["typed", "scheduled", "generated", "static", "stall"].map((v) => ({ text: v, value: v })) } } },
@@ -194,7 +201,10 @@ export const CHAT_COLLECTIONS = [
       { field: "tokens_out", type: "integer", schema: { is_nullable: true }, meta: { interface: "input", width: "half" } },
       { field: "cached_in", type: "integer", schema: { is_nullable: true },
         meta: { interface: "input", width: "half",
-                note: "Of tokens_in, how much the provider served from its prompt cache. Zero across a whole conversation means prompt caching is not working." } },
+                note: "Prompt tokens served from cache, billed at ~0.1x. DISJOINT from tokens_in, which counts only the uncached remainder — the full prompt is tokens_in + cache_write_in + cached_in. Zero across a whole conversation means prompt caching is not working." } },
+      { field: "cache_write_in", type: "integer", schema: { is_nullable: true },
+        meta: { interface: "input", width: "half",
+                note: "Prompt tokens written to cache, billed at ~1.25x. Watch for this staying high while cached_in stays zero: that is the write premium being paid every turn for a prefix nothing ever reads back — the exact failure this feature shipped with, undetected, for months." } },
     ],
   },
   {

--- a/packages/backend/chat-collections.mjs
+++ b/packages/backend/chat-collections.mjs
@@ -169,6 +169,15 @@ export const CHAT_COLLECTIONS = [
       { field: "minute", type: "timestamp", schema: { is_nullable: false }, meta: { interface: "datetime", width: "half", note: "Top of the minute this line covers" } },
       { field: "summary", type: "text", schema: { is_nullable: false }, meta: { interface: "input-multiline", width: "full", note: "Extractive: deduped and truncated broadcast words, never paraphrased" } },
       { field: "segment_count", type: "integer", schema: { is_nullable: true }, meta: { interface: "input", width: "half", note: "How many raw segments condensed into this line" } },
+      // Provenance, so rows produced by different methods can be audited and
+      // re-run separately. "llm-extract" is verbatim source text the model only
+      // selected; "llm-abstract" is a rewrite that passed the containment gate;
+      // "extractive" is the mechanical fallback, which also means the LLM path
+      // was refused or unavailable for that minute.
+      { field: "method", type: "string", schema: { is_nullable: true },
+        meta: { interface: "select-dropdown", width: "half",
+                options: { choices: ["llm-extract", "llm-abstract", "extractive"].map((v) => ({ text: v, value: v })) } } },
+      { field: "model", type: "string", schema: { is_nullable: true }, meta: { interface: "input", width: "half", note: "Null for mechanically condensed rows" } },
     ],
   },
   {

--- a/packages/backend/internal/chat/provider.go
+++ b/packages/backend/internal/chat/provider.go
@@ -36,7 +36,21 @@ type Reply struct {
 	TokensIn  int
 	TokensOut int
 	CachedIn  int
-	Model     string
+	// CacheWriteIn is the prompt tokens written to cache this request, billed at
+	// ~1.25x. It is what closes the arithmetic: the three input counts are
+	// disjoint, so the full prompt is TokensIn + CacheWriteIn + CachedIn and the
+	// billable cost is 1.0x + 1.25x + 0.1x of them respectively.
+	//
+	// Without it a cache *write* turn reads as a suspiciously tiny prompt, and —
+	// worse — the pathological case is invisible: paying the write premium every
+	// turn for a prefix that is never read back. That is precisely the bug this
+	// feature shipped with for months, undetected. Recording the write is what
+	// makes it detectable next time.
+	//
+	// OpenAI-compatible providers leave this zero: their prefix caching is
+	// automatic and carries no write premium, so there is no such count to read.
+	CacheWriteIn int
+	Model        string
 }
 
 // Provider is implemented once per vendor. Generate must return a non-nil

--- a/packages/backend/internal/chat/provider_anthropic.go
+++ b/packages/backend/internal/chat/provider_anthropic.go
@@ -59,12 +59,13 @@ func (p *anthropicProvider) Generate(ctx context.Context, r Request) (Reply, err
 	}
 
 	return Reply{
-		Body:      textOf(msg.Content),
-		Outcome:   outcome,
-		TokensIn:  int(msg.Usage.InputTokens),
-		TokensOut: int(msg.Usage.OutputTokens),
-		CachedIn:  int(msg.Usage.CacheReadInputTokens),
-		Model:     string(msg.Model),
+		Body:         textOf(msg.Content),
+		Outcome:      outcome,
+		TokensIn:     int(msg.Usage.InputTokens),
+		TokensOut:    int(msg.Usage.OutputTokens),
+		CachedIn:     int(msg.Usage.CacheReadInputTokens),
+		CacheWriteIn: int(msg.Usage.CacheCreationInputTokens),
+		Model:        string(msg.Model),
 	}, nil
 }
 

--- a/packages/backend/internal/chat/store.go
+++ b/packages/backend/internal/chat/store.go
@@ -20,22 +20,27 @@ type Message struct {
 	Model       string
 	TokensIn    int
 	TokensOut   int
-	// CachedIn is how much of TokensIn the provider served from its prompt
-	// cache. Without it there is no way to tell whether the prompt's whole
+	// CachedIn is the prompt tokens the provider served from its cache. It is
+	// DISJOINT from TokensIn, which counts only the uncached remainder — not a
+	// subset of it. Without it there is no way to tell whether the prompt's whole
 	// stability-ordered, breakpointed layout is doing anything at all: a prefix
 	// too short to cache, or one invalidated by a block that changes every turn,
 	// both fail silently — the API reports zero cached tokens and raises nothing.
 	// This is the only signal that distinguishes "caching works" from "caching
 	// has never once hit", so it is persisted rather than logged and dropped.
-	CachedIn   int
-	Moderation map[string]any
+	CachedIn int
+	// CacheWriteIn is prompt tokens written to cache (~1.25x). Stored alongside
+	// CachedIn so the three input counts reconcile to the full prompt and the
+	// per-message bill is computable from the row alone -- see Reply.CacheWriteIn.
+	CacheWriteIn int
+	Moderation   map[string]any
 }
 
 const insertMessage = `
 	INSERT INTO chat_messages
-		("user", profile, direction, body, virtual_time, created_at, kind, moderation, model, tokens_in, tokens_out, cached_in)
+		("user", profile, direction, body, virtual_time, created_at, kind, moderation, model, tokens_in, tokens_out, cached_in, cache_write_in)
 	VALUES
-		($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+		($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
 	RETURNING id`
 
 // AppendMessage writes one turn of the conversation. created_at is real
@@ -50,7 +55,7 @@ func AppendMessage(ctx context.Context, pool *pgxpool.Pool, userID string, m Mes
 	var id int
 	err := pool.QueryRow(ctx, insertMessage,
 		userID, m.Profile, m.Direction, m.Body, m.VirtualTime, time.Now().UTC(),
-		m.Kind, moderation, m.Model, m.TokensIn, m.TokensOut, m.CachedIn,
+		m.Kind, moderation, m.Model, m.TokensIn, m.TokensOut, m.CachedIn, m.CacheWriteIn,
 	).Scan(&id)
 	if err != nil {
 		return 0, fmt.Errorf("insert chat_messages: %w", err)

--- a/packages/backend/internal/session/session.go
+++ b/packages/backend/internal/session/session.go
@@ -1068,7 +1068,7 @@ func (s *Session) chatDeliver(userID string, profileID int, vTime time.Time, bas
 			id, appendErr := chat.AppendMessage(context.Background(), s.pool, userID, chat.Message{
 				Profile: profileID, Direction: "out", Body: reply.Body, VirtualTime: vTime,
 				Kind: kind, Model: reply.Model, TokensIn: reply.TokensIn, TokensOut: reply.TokensOut,
-				CachedIn: reply.CachedIn,
+				CachedIn: reply.CachedIn, CacheWriteIn: reply.CacheWriteIn,
 			})
 			if appendErr != nil {
 				s.logger.Warn("chat: append reply failed", "error", appendErr)

--- a/packages/tools/video-grabber/pyproject.toml
+++ b/packages/tools/video-grabber/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     # fastapi<0.137 was required for Prefect 3.7.4 (PrefectRouter compat bug).
     # Prefect 3.7.6 fixed it; <0.139 verified green via dependabot PR #132.
     "fastapi<0.141",
+    # Transcript minute summarisation (video_grabber/transcript/summarize.py).
+    "anthropic>=0.60",
 ]
 
 [project.optional-dependencies]

--- a/packages/tools/video-grabber/tests/test_transcript_flows.py
+++ b/packages/tools/video-grabber/tests/test_transcript_flows.py
@@ -22,6 +22,27 @@ def cfg():
     return Config(directus_url="https://directus.test", directus_api_token="tok")
 
 
+def test_segment_flow_does_not_touch_the_minutes_table(cfg, monkeypatch):
+    # chat_transcript_minutes is owned by summarize-transcript-minutes. If this
+    # flow wrote it again, a segment rebuild would silently overwrite paid LLM
+    # summaries with the mechanical fallback.
+    monkeypatch.setattr(flows, "get_run_logger", lambda: logging.getLogger("test"))
+    monkeypatch.setattr(flows.writer, "list_subtitled_channels", lambda c, **k: [
+        {"id": 7, "slug": "wnbc", "start_date": datetime(2001, 9, 11, 12, 0, 0),
+         "subtitles": "https://f/wnbc.srt"}])
+    monkeypatch.setattr(flows.writer, "list_subtitled_mp3_items", lambda c, **k: [])
+    monkeypatch.setattr(flows.writer, "fetch_srt", lambda url, **k: SRT)
+    monkeypatch.setattr(flows.writer, "replace_segments", lambda rows, **kw: len(rows))
+
+    def boom(*a, **k):
+        raise AssertionError("build-transcript-segments must not write minutes")
+
+    monkeypatch.setattr(flows.writer, "replace_minutes", boom)
+    result = flows.build_transcript_segments_flow.fn(medium="tv", cfg=cfg)
+    assert result["segments"] == 1
+    assert "minutes" not in result
+
+
 def test_builds_absolute_timestamps_from_the_channel_anchor(cfg, monkeypatch):
     monkeypatch.setattr(flows, "get_run_logger", lambda: logging.getLogger("test"))
     monkeypatch.setattr(flows.writer, "list_subtitled_channels", lambda c, **k: [
@@ -40,28 +61,10 @@ def test_builds_absolute_timestamps_from_the_channel_anchor(cfg, monkeypatch):
 
     monkeypatch.setattr(flows.writer, "replace_segments", fake_replace)
 
-    minute_capture = {}
-
-    def fake_replace_minutes(rows, **kwargs):
-        minute_capture["rows"] = rows
-        minute_capture["kwargs"] = kwargs
-        return len(rows)
-
-    monkeypatch.setattr(flows.writer, "replace_minutes", fake_replace_minutes)
-
     result = flows.build_transcript_segments_flow.fn(medium="tv", cfg=cfg)
 
     assert result["channels"] == 1
     assert result["segments"] == 1
-    # Both outputs derive from the same parse, so the minute rows must agree with
-    # the segments on provenance — the prompt falls back from one to the other
-    # and applies the same market filter to whichever it read.
-    assert result["minutes"] == 1
-    assert minute_capture["rows"][0]["minute"] == "2001-09-11T12:00:00"
-    assert minute_capture["rows"][0]["summary"] == "the north tower has been hit"
-    assert minute_capture["rows"][0]["channel"] == 7
-    assert minute_capture["kwargs"]["channel"] == 7
-    assert minute_capture["kwargs"]["medium"] == "tv"
     # Cue offsets are relative to the file; the row must be absolute 2001 time.
     assert captured["rows"][0]["start_date"] == "2001-09-11T12:00:00"
     assert captured["rows"][0]["end_date"] == "2001-09-11T12:00:04"
@@ -85,9 +88,6 @@ def test_radio_anchors_on_the_mp3_items_start_date(cfg, monkeypatch):
     captured = {}
     monkeypatch.setattr(flows.writer, "replace_segments",
                         lambda rows, **kw: captured.update(rows=rows, kwargs=kw) or len(rows))
-    minutes = {}
-    monkeypatch.setattr(flows.writer, "replace_minutes",
-                        lambda rows, **kw: minutes.update(rows=rows, kwargs=kw) or len(rows))
 
     result = flows.build_transcript_segments_flow.fn(medium="radio", cfg=cfg)
 
@@ -100,11 +100,6 @@ def test_radio_anchors_on_the_mp3_items_start_date(cfg, monkeypatch):
     # the radio path: what the rows carry must equal what the delete matches.
     assert captured["kwargs"]["channel_slug"] == "mp3:42"
     assert captured["rows"][0]["channel_slug"] == "mp3:42"
-    # Radio's minute rows must carry the same synthetic slug, for the same
-    # reason: it is the only handle the market filter has on a radio source.
-    assert minutes["kwargs"]["channel_slug"] == "mp3:42"
-    assert minutes["rows"][0]["channel_slug"] == "mp3:42"
-    assert minutes["rows"][0]["medium"] == "radio"
 
 
 def test_raises_when_no_subtitled_sources_are_found(cfg, monkeypatch):
@@ -135,7 +130,6 @@ def test_one_failing_source_does_not_abort_the_rest(cfg, monkeypatch):
 
     monkeypatch.setattr(flows.writer, "fetch_srt", flaky_fetch)
     monkeypatch.setattr(flows.writer, "replace_segments", lambda rows, **kw: len(rows))
-    monkeypatch.setattr(flows.writer, "replace_minutes", lambda rows, **kw: len(rows))
 
     result = flows.build_transcript_segments_flow.fn(medium="tv", cfg=cfg)
 

--- a/packages/tools/video-grabber/tests/test_transcript_summarize.py
+++ b/packages/tools/video-grabber/tests/test_transcript_summarize.py
@@ -1,0 +1,222 @@
+import pytest
+
+from video_grabber.transcript.minutes import condense
+from video_grabber.transcript.summarize import (
+    _stem,
+    TIER_ABSTRACT,
+    TIER_EXTRACT,
+    TIER_MECHANICAL,
+    build_extract_messages,
+    content_words,
+    parse_extract,
+    summarize_minute,
+    units_of,
+    validate_abstract,
+)
+
+# A minute of genuine early-confusion coverage: the station does NOT yet know it
+# was an airliner, and says so. Every fidelity test below turns on that.
+SOURCE = (
+    "They are saying it was a small plane. "
+    "The plane just was coming in low over the building. "
+    "We do not know yet how many people were inside."
+)
+TEXTS = [
+    "They are saying it was a small plane.",
+    "The plane just was coming in low over the building.",
+    "We do not know yet how many people were inside.",
+]
+
+
+def _fallback(texts):
+    return condense(texts)
+
+
+# --- the containment gate -------------------------------------------------
+
+def test_gate_accepts_a_summary_built_from_source_words():
+    assert validate_abstract("small plane coming in low over the building", SOURCE) is None
+
+
+def test_gate_rejects_hindsight_substitution():
+    # The failure this whole module exists to prevent: the model knows how the
+    # day went and quietly upgrades the station's uncertainty into the
+    # afternoon's certainty. "hijacked" and "airliner" are nowhere in the source.
+    reason = validate_abstract("A hijacked airliner struck the tower", SOURCE)
+    assert reason is not None
+    assert "hijack" in reason
+
+
+def test_gate_rejects_invented_numbers():
+    # Number words are deliberately not stopwords. "two planes" where the source
+    # said "a small plane" is a fabricated fact that a naive stopword list waves
+    # straight through.
+    reason = validate_abstract("two planes hit the building", SOURCE)
+    assert reason is not None
+    assert "two" in reason
+
+
+def test_gate_rejects_named_entities_the_source_never_named():
+    reason = validate_abstract("The plane hit the World Trade Center", SOURCE)
+    assert reason is not None
+    assert "world" in reason or "trade" in reason or "center" in reason
+
+
+def test_gate_allows_inflection():
+    # "saying"/"say", "building"/"buildings" must not trip the gate; the words
+    # still came from the source.
+    assert validate_abstract("they say a small plane was coming in low over the buildings", SOURCE) is None
+
+
+def test_gate_rejects_empty_and_overlong():
+    assert validate_abstract("   ", SOURCE) == "empty"
+    assert validate_abstract(SOURCE + " " + SOURCE, SOURCE) is not None
+
+
+def test_content_words_drops_function_words_but_keeps_numbers():
+    got = content_words("the two planes were of a kind")
+    assert "two" in got and _stem("plane") in got
+    assert "the" not in got and "were" not in got
+
+
+# --- tier 1: verbatim by construction -------------------------------------
+
+def test_extract_returns_only_source_text():
+    # The model is asked for indices and the line is rebuilt from the source, so
+    # even a model that tries to editorialise cannot get new words in.
+    def complete(system, user):
+        return '{"keep": [0, 2]}'
+
+    got = summarize_minute(TEXTS, tier=TIER_EXTRACT, complete=complete, fallback=_fallback)
+    assert got.method == TIER_EXTRACT
+    assert got.text == (
+        "They are saying it was a small plane. We do not know yet how many people were inside."
+    )
+    assert validate_abstract(got.text, SOURCE) is None
+
+
+def test_extract_ignores_a_model_that_returns_prose_instead_of_indices():
+    def complete(system, user):
+        return "A hijacked airliner struck the north tower."
+
+    got = summarize_minute(TEXTS, tier=TIER_EXTRACT, complete=complete, fallback=_fallback)
+    assert got.method == TIER_MECHANICAL
+    assert "hijacked" not in got.text
+
+
+def test_parse_extract_drops_out_of_range_and_nonsense_indices():
+    units = units_of(TEXTS)
+    assert parse_extract('{"keep": [0, 99, -1, "x", true, 2]}', units, max_units=3) == [0, 2]
+
+
+def test_parse_extract_survives_surrounding_chatter():
+    units = units_of(TEXTS)
+    assert parse_extract('Sure! {"keep": [1]} hope that helps', units, max_units=3) == [1]
+
+
+def test_extract_caps_how_much_it_keeps():
+    def complete(system, user):
+        return '{"keep": [0, 1, 2]}'
+
+    got = summarize_minute(TEXTS, tier=TIER_EXTRACT, complete=complete, fallback=_fallback, max_units=1)
+    assert got.text == "They are saying it was a small plane."
+
+
+def test_extract_prompt_numbers_every_unit():
+    system, user = build_extract_messages(units_of(TEXTS), max_units=3)
+    assert "0: They are saying it was a small plane." in user
+    assert "2: We do not know yet" in user
+    assert "at most 3" in system
+
+
+# --- tier 2: rewrite, then gate -------------------------------------------
+
+def test_abstract_accepts_a_contained_rewrite():
+    def complete(system, user):
+        return "small plane coming in low over the building"
+
+    got = summarize_minute(TEXTS, tier=TIER_ABSTRACT, complete=complete, fallback=_fallback)
+    assert got.method == TIER_ABSTRACT
+    assert got.rejected is None
+
+
+def test_abstract_falls_back_when_the_model_adds_hindsight():
+    def complete(system, user):
+        return "A hijacked airliner has struck the World Trade Center."
+
+    got = summarize_minute(TEXTS, tier=TIER_ABSTRACT, complete=complete, fallback=_fallback)
+    assert got.method == TIER_MECHANICAL
+    assert got.rejected and "hijack" in got.rejected
+    assert "hijacked" not in got.text
+
+
+# --- failure handling -----------------------------------------------------
+
+def test_a_transport_failure_degrades_rather_than_losing_the_minute():
+    # A missing minute reads to the composer as a station that was off the air,
+    # which is a different and worse claim than a crudely truncated one.
+    def complete(system, user):
+        raise RuntimeError("429 rate limited")
+
+    for tier in (TIER_EXTRACT, TIER_ABSTRACT):
+        got = summarize_minute(TEXTS, tier=tier, complete=complete, fallback=_fallback)
+        assert got.method == TIER_MECHANICAL
+        assert got.text
+        assert "429" in got.rejected
+
+
+def test_a_minute_of_pure_annotation_is_reported_empty_not_summarised():
+    def complete(system, user):
+        raise AssertionError("must not call the model for a minute with no speech")
+
+    got = summarize_minute(["[MUSIC]", ">> (INAUDIBLE)"], tier=TIER_EXTRACT,
+                           complete=complete, fallback=_fallback)
+    assert got.text == ""
+    assert got.rejected == "no speech in minute"
+
+
+def test_unknown_tier_is_a_programming_error():
+    with pytest.raises(ValueError, match="unknown tier"):
+        summarize_minute(TEXTS, tier="nope", complete=lambda s, u: "", fallback=_fallback)
+
+
+def test_a_rejected_abstraction_degrades_to_extraction_not_truncation():
+    # A rejected rewrite says nothing about the model's ability to *choose* good
+    # lines, and extraction is both safer and measurably better than truncating
+    # to the first N characters. Only if extraction also fails is the mechanical
+    # line used.
+    calls = []
+
+    def complete(system, user):
+        calls.append(user)
+        # first call is the abstraction (rejected), second is the index request
+        return ("A hijacked airliner struck the tower."
+                if len(calls) == 1 else '{"keep": [1]}')
+
+    got = summarize_minute(TEXTS, tier=TIER_ABSTRACT, complete=complete, fallback=_fallback)
+    assert got.method == TIER_EXTRACT
+    assert got.text == "The plane just was coming in low over the building."
+    # the rejection reason is preserved so the run can report why it stepped down
+    assert got.rejected and "hijack" in got.rejected
+
+
+def test_possessives_and_doubled_consonants_do_not_cause_false_rejections():
+    # Both were real false rejections in the first sample run against production
+    # transcripts: "city's" failed to match "city", and "hitting" failed to
+    # match "hit".
+    source = "the city was hit and the plane was falling"
+    assert validate_abstract("the city's plane was hitting and falling", source) is None
+
+
+def test_quantities_and_hedges_are_never_stopwords():
+    # Both invent a fact the broadcast never carried: a number the station did
+    # not give, and a certainty level it did not express. Connectives may be
+    # introduced freely; these may not.
+    src = "the building is on fire and smoke is coming from the upper floors right now"
+    for invented in ("many people are in the building",
+                     "several people are in the building",
+                     "the building is possibly on fire",
+                     "the building is reportedly on fire"):
+        assert validate_abstract(invented, src) is not None, f"gate let through: {invented}"
+    # ...while pure syntax is fine
+    assert validate_abstract("because the building is on fire", src) is None

--- a/packages/tools/video-grabber/video_grabber/config.py
+++ b/packages/tools/video-grabber/video_grabber/config.py
@@ -24,6 +24,16 @@ class Config:
     ia_rate_per_sec: int = field(default_factory=lambda: _int("IA_RATE_PER_SEC", 2))
     min_duration_seconds: int = field(default_factory=lambda: _int("MIN_DURATION_SECONDS", 720))
 
+    # --- Transcript minute summarisation ---
+    # Tier defaults to llm-extract: the model only chooses which source lines to
+    # keep and the output is rebuilt verbatim, so it cannot fabricate. llm-abstract
+    # compresses harder but its output has to clear the containment gate.
+    anthropic_api_key: str = field(default_factory=lambda: os.getenv("ANTHROPIC_API_KEY", ""))
+    summarize_model: str = field(default_factory=lambda: os.getenv("SUMMARIZE_MODEL", "claude-haiku-4-5"))
+    summarize_tier: str = field(default_factory=lambda: os.getenv("SUMMARIZE_TIER", "llm-extract"))
+    summarize_max_units: int = field(default_factory=lambda: _int("SUMMARIZE_MAX_UNITS", 3))
+    summarize_concurrency: int = field(default_factory=lambda: _int("SUMMARIZE_CONCURRENCY", 8))
+
     # --- Audio transcription (whisper.cpp) ---
     whisper_bin: str = field(default_factory=lambda: os.getenv("WHISPER_BIN", "whisper-cli"))
     whisper_model: str = field(default_factory=lambda: os.getenv("WHISPER_MODEL", "/opt/models/ggml-medium.en.bin"))

--- a/packages/tools/video-grabber/video_grabber/transcript/flows.py
+++ b/packages/tools/video-grabber/video_grabber/transcript/flows.py
@@ -19,11 +19,10 @@ from prefect import flow, get_run_logger
 from video_grabber.config import Config
 from video_grabber.transcribe.srt import parse_srt
 from video_grabber.transcript import writer
-from video_grabber.transcript.minutes import build_minutes, to_minute_rows
 from video_grabber.transcript.segments import build_segments, to_rows
 
 
-def _ingest_one(source: dict, *, medium: str, cfg: Config, logger) -> tuple[int, int]:
+def _ingest_one(source: dict, *, medium: str, cfg: Config, logger) -> int:
     # The identity written into the rows and the identity the delete scopes on
     # MUST be the same, or the delete matches nothing and every re-run doubles
     # the data. Radio has no tv_channels row, so it is identified by a synthetic
@@ -49,25 +48,14 @@ def _ingest_one(source: dict, *, medium: str, cfg: Config, logger) -> tuple[int,
             "check the SRT at %s", medium, source["id"], source["subtitles"]
         )
 
-    # Both outputs come from the one parse above rather than from a second flow
-    # reading the segments back. The prompt falls back to raw segments for any
-    # span with no summaries, so the two must describe the same audio — deriving
-    # them together is what guarantees that, and it costs nothing extra.
-    minute_rows = to_minute_rows(
-        build_minutes(segments, source["start_date"]),
-        channel=channel,
-        channel_slug=slug,
-        medium=medium,
-    )
-    minutes = writer.replace_minutes(
-        minute_rows, medium=medium, channel=channel, channel_slug=slug, cfg=cfg
-    )
-    logger.info(
-        "ingested %s %s: %d segments, %d minutes", medium, source["id"], written, minutes
-    )
-    return written, minutes
+    return written
 
 
+# chat_transcript_minutes is NOT written here. It was, and that coupling meant
+# populating minutes required a full segment re-ingest -- and once summarisation
+# became an LLM pass, it would also have re-run every paid call on any segment
+# rebuild. summarize-transcript-minutes owns that table and reads these rows back,
+# which also guarantees the two describe the same audio.
 @flow(name="build-transcript-segments")
 def build_transcript_segments_flow(medium: str = "all", cfg: Config | None = None) -> dict:
     """Rebuild chat_transcript_segments for TV, radio, or both.
@@ -86,19 +74,16 @@ def build_transcript_segments_flow(medium: str = "all", cfg: Config | None = Non
     if not channels and not mp3_items:
         raise RuntimeError(f"no subtitled sources found for medium={medium!r}")
 
-    result = {
-        "channels": 0, "mp3_items": 0, "segments": 0, "minutes": 0, "failed": 0, "empty": 0,
-    }
+    result = {"channels": 0, "mp3_items": 0, "segments": 0, "failed": 0, "empty": 0}
 
     for source, kind in [(c, "tv") for c in channels] + [(m, "radio") for m in mp3_items]:
         try:
-            written, minutes = _ingest_one(source, medium=kind, cfg=cfg, logger=logger)
+            written = _ingest_one(source, medium=kind, cfg=cfg, logger=logger)
         except Exception:  # noqa: BLE001 - one bad source must not stop the run
             logger.exception("failed %s %s", kind, source["id"])
             result["failed"] += 1
             continue
         result["segments"] += written
-        result["minutes"] += minutes
         result["channels" if kind == "tv" else "mp3_items"] += 1
         if not written:
             result["empty"] += 1

--- a/packages/tools/video-grabber/video_grabber/transcript/summarize.py
+++ b/packages/tools/video-grabber/video_grabber/transcript/summarize.py
@@ -1,0 +1,305 @@
+"""LLM condensation of a channel-minute of broadcast transcript.
+
+Two tiers, both of which exist to solve the same measured problem: the purely
+mechanical condenser in minutes.py achieves ~90% reduction, but 82 of those
+points are blind truncation to the first N characters. Deduplication only
+removes ~5% because a minute of broadcast TV is genuinely ~2,000 characters of
+*content*, not repetition. Anything that reaches a small budget is therefore
+lossy selection — the only question is whether the selection is intelligent.
+
+    TIER_EXTRACT   the model chooses which source sentences to keep, and returns
+                   their INDICES. The line is rebuilt from the source text, so
+                   the output is verbatim by construction and fabrication is not
+                   merely unlikely, it is unrepresentable.
+
+    TIER_ABSTRACT  the model rewrites the minute, and every content word it uses
+                   must already appear in the source or the summary is rejected.
+                   Compresses harder; the gate is what makes it safe.
+
+Why a gate is needed at all: tier 2 of the chat prompt answers "what could this
+person have heard on the air just now?", and the whole three-tier design exists
+to keep hindsight out of a buddy's mouth. A model summarising 8:52 coverage
+cannot leak *later* events — it is shown only that minute's transcript — but it
+does know how September 11 turned out, and left unconstrained it will quietly
+resolve the confusion of the moment into the correctness of the afternoon:
+"a small plane" becomes "a hijacked airliner". That single substitution would
+make a buddy omniscient. Containment turns an unverifiable worry into a
+mechanical check.
+
+Pure logic only — prompt construction, parsing and validation. The network call
+is injected, so every rule below is unit-testable without an API key.
+"""
+
+import json
+import re
+from dataclasses import dataclass
+
+from video_grabber.transcript.minutes import clean
+
+TIER_EXTRACT = "llm-extract"
+TIER_ABSTRACT = "llm-abstract"
+TIER_MECHANICAL = "extractive"
+
+# Sentence-ish split. Broadcast ASR punctuates unreliably, so a unit is often a
+# clause rather than a sentence; that is fine, units only need to be small
+# enough to choose between.
+_UNIT = re.compile(r"(?<=[.!?])\s+")
+
+# Function words that carry no claim, so a rewrite may introduce them freely.
+#
+# Two categories are DELIBERATELY ABSENT, because a model adding either invents a
+# fact the broadcast never carried:
+#   * quantities — many, much, few, several, two, hundred. "many people were
+#     killed" where the station said nothing about numbers is fabrication.
+#   * hedges — possibly, potentially, apparently, reportedly. These set how
+#     certain the claim is, and certainty is exactly what tier 2 must preserve.
+#
+# Everything below is syntax: connectives, modals, pronouns and contractions.
+_STOPWORDS = frozenset("""
+a an and are as at be been being but by for from had has have he her his i if in
+into is it its me my no nor not of on or our so than that the their them then
+there these they this those to too up us was we were what when where which who
+whom why will with you your would could should do does did done just very can
+about after again also although always another any back because before both during
+each else even ever every here how however himself herself itself myself once only
+other out over own same since some such themselves though through under until
+while without well may might must don't won't can't isn't wasn't doesn't didn't
+haven't hasn't couldn't shouldn't wouldn't i'm we're they're it's that's there's
+""".split())
+
+_WORD = re.compile(r"[a-z0-9']+")
+
+
+@dataclass(frozen=True)
+class SummaryResult:
+    text: str
+    method: str
+    rejected: str | None = None  # why the LLM output was refused, if it was
+
+
+def units_of(texts: list[str]) -> list[str]:
+    """Split a minute's segments into indexable units, cleaned and de-duplicated.
+
+    Deduplication here is exact-match only and does little on real ASR (measured:
+    ~5%), but it costs nothing and keeps obviously identical repeats out of the
+    list the model has to choose between.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for text in texts:
+        cleaned = clean(text)
+        if not cleaned:
+            continue
+        for unit in _UNIT.split(cleaned):
+            unit = unit.strip()
+            key = " ".join(_WORD.findall(unit.lower()))
+            if not unit or not key or key in seen:
+                continue
+            seen.add(key)
+            out.append(unit)
+    return out
+
+
+def _stem(word: str) -> str:
+    """Crude suffix strip so plurals and tenses match across the gate.
+
+    Deliberately not a real stemmer: this only has to make "towers"/"tower" and
+    "coming"/"come" compare equal. Over-stemming loosens the gate slightly;
+    under-stemming rejects honest summaries. Erring loose is the safe direction,
+    because the words still have to come from the source either way.
+
+    The ORDER is load-bearing, and two orderings that look fine both fail:
+
+      strip "es" as a unit -> "planes" becomes "plan" while "plane" stays
+      "plane", so the pair stops matching.
+
+      strip verb endings first -> "building" becomes "build" but "buildings"
+      only loses its "s" and stays "building", so that pair stops matching too.
+
+    Plural first, then the verb ending, then a trailing "e", so every pair
+    converges: buildings -> building -> build, building -> build;
+    planes -> plane -> plan, plane -> plan; comes -> come -> com, coming -> com.
+    """
+    if len(word) > 3 and word.endswith("s"):
+        word = word[:-1]
+    for suffix in ("ing", "ed"):
+        if len(word) > len(suffix) + 2 and word.endswith(suffix):
+            word = word[: -len(suffix)]
+            break
+    if len(word) > 3 and word.endswith("e"):
+        word = word[:-1]
+    return word
+
+
+def _variants(word: str) -> set[str]:
+    """Every form a word might legitimately match, as a set.
+
+    A single stem cannot express this. Stripping "-ing" leaves a doubled
+    consonant ("hitting" -> "hitt"), and collapsing it unconditionally breaks the
+    words that genuinely end doubled ("falling" -> "fall" -> "fal", but "fall"
+    itself never gets stripped, so the pair stops matching). Emitting BOTH forms
+    and asking for any overlap covers "hitting"/"hit" and "falling"/"fall" at
+    once. Possessives are stripped first, or "city's" never matches "city" --
+    which was 1 of the 19 false rejections in the first sample run.
+    """
+    if word.endswith("'s"):
+        word = word[:-2]
+    word = word.strip("'")
+    if not word:
+        return set()
+    stem = _stem(word)
+    out = {word, stem}
+    if len(stem) > 2 and stem[-1] == stem[-2]:
+        out.add(stem[:-1])
+    return out
+
+
+def content_words(text: str) -> set[str]:
+    """Union of every variant of every content word — the form to test against."""
+    out: set[str] = set()
+    for w in _WORD.findall(text.lower()):
+        if w not in _STOPWORDS:
+            out |= _variants(w)
+    return out
+
+
+def validate_abstract(summary: str, source: str) -> str | None:
+    """Return a rejection reason, or None if the summary is contained by the source.
+
+    The rule: every content word the model used must already appear in the
+    minute it was given. That does not make the summary *true* — the model can
+    still combine source words into a claim nobody made — but it removes the
+    failure that actually matters here, which is the model reaching outside the
+    minute for what it knows about the day.
+    """
+    if not summary.strip():
+        return "empty"
+    allowed = content_words(source)
+    # Any overlap between a word's variants and the source's counts as present.
+    invented = sorted(
+        w for w in _WORD.findall(summary.lower())
+        if w not in _STOPWORDS and not (_variants(w) & allowed)
+    )
+    if invented:
+        return f"introduced words absent from source: {', '.join(invented[:6])}"
+    if len(summary) > len(source):
+        return "longer than the source it summarises"
+    return None
+
+
+def build_extract_messages(units: list[str], *, max_units: int) -> tuple[str, str]:
+    system = (
+        "You select which lines of a live television or radio transcript to keep. "
+        "The transcript is one minute of broadcast audio from September 11 2001, "
+        "automatically transcribed, so it is fragmentary, out of order and contains "
+        "cross-talk.\n\n"
+        "Return the indices of the lines that best convey what this station was "
+        "saying this minute. Prefer lines carrying reported information, eyewitness "
+        "description or anchor narration. Skip advertising, station identification, "
+        "weather and sport unless nothing else is present, and skip lines that "
+        "merely repeat one you already chose.\n\n"
+        f"Choose at most {max_units} indices. If nothing of substance was said, "
+        "return an empty list. Never invent an index."
+    )
+    listing = "\n".join(f"{i}: {u}" for i, u in enumerate(units))
+    user = (
+        f"{listing}\n\n"
+        'Reply with JSON only, of the form {"keep": [0, 3]}.'
+    )
+    return system, user
+
+
+def parse_extract(raw: str, units: list[str], *, max_units: int) -> list[int]:
+    """Pull indices out of the reply, discarding anything unusable.
+
+    Every index is bounds-checked against the units actually sent. An
+    out-of-range or non-integer index is dropped rather than raising: the caller
+    falls back to the mechanical condenser only when nothing survives, so one
+    malformed element should not cost the whole minute.
+    """
+    try:
+        blob = raw[raw.index("{"): raw.rindex("}") + 1]
+        keep = json.loads(blob).get("keep", [])
+    except (ValueError, AttributeError, json.JSONDecodeError):
+        return []
+
+    out: list[int] = []
+    for item in keep if isinstance(keep, list) else []:
+        if isinstance(item, bool) or not isinstance(item, int):
+            continue
+        if 0 <= item < len(units) and item not in out:
+            out.append(item)
+    return sorted(out)[:max_units]
+
+
+def build_abstract_messages(source: str) -> tuple[str, str]:
+    system = (
+        "You compress one minute of September 11 2001 broadcast transcript into a "
+        "single short line describing what this station was saying.\n\n"
+        "Absolute constraint: use ONLY words that appear in the transcript you are "
+        "given. Do not add context, do not identify or name anything the transcript "
+        "does not name, do not resolve confusion or correct errors, and do not draw "
+        "on anything you know about that day. If the broadcast is uncertain or "
+        "wrong, your line must be equally uncertain or wrong.\n\n"
+        "Write plain text, one or two sentences, no preamble. If nothing of "
+        "substance was said, reply with nothing at all."
+    )
+    return system, source
+
+
+def summarize_minute(
+    texts: list[str],
+    *,
+    tier: str,
+    complete,
+    max_units: int = 3,
+    fallback,
+) -> SummaryResult:
+    """Condense one channel-minute, falling back to the mechanical condenser.
+
+    `complete(system, user) -> str` is injected so this is testable without a
+    network. Any failure -- a transport error, an unparseable reply, a rejected
+    abstraction -- degrades to `fallback(texts)` rather than losing the minute:
+    a summarised minute that is missing entirely reads to the composer as a
+    station that was off the air, which is a different and worse claim than a
+    crudely truncated one.
+    """
+    units = units_of(texts)
+    if not units:
+        return SummaryResult(text="", method=tier, rejected="no speech in minute")
+
+    source = " ".join(units)
+
+    if tier == TIER_EXTRACT:
+        system, user = build_extract_messages(units, max_units=max_units)
+        try:
+            keep = parse_extract(complete(system, user), units, max_units=max_units)
+        except Exception as exc:  # noqa: BLE001 - one bad minute must not stop a run
+            return SummaryResult(fallback(texts), TIER_MECHANICAL, f"call failed: {exc}")
+        if not keep:
+            return SummaryResult(fallback(texts), TIER_MECHANICAL, "no usable indices")
+        # Rebuilt from the source list, never from the model's text: this is what
+        # makes verbatim output structural rather than something to verify.
+        return SummaryResult(" ".join(units[i] for i in keep), TIER_EXTRACT)
+
+    if tier == TIER_ABSTRACT:
+        system, user = build_abstract_messages(source)
+        try:
+            summary = complete(system, user).strip()
+        except Exception as exc:  # noqa: BLE001
+            reason = f"call failed: {exc}"
+        else:
+            reason = validate_abstract(summary, source)
+            if not reason:
+                return SummaryResult(summary, TIER_ABSTRACT)
+        # Degrade to tier 1, not straight to the mechanical condenser. A rejected
+        # abstraction says nothing about the model's ability to *choose* good
+        # lines, and extraction is both safer and measurably better than
+        # truncating to the first N characters. Only if that also fails do we
+        # fall back to the mechanical line.
+        stepped = summarize_minute(
+            texts, tier=TIER_EXTRACT, complete=complete, max_units=max_units, fallback=fallback
+        )
+        return SummaryResult(stepped.text, stepped.method, reason)
+
+    raise ValueError(f"unknown tier {tier!r}")

--- a/packages/tools/video-grabber/video_grabber/transcript/summarize_flows.py
+++ b/packages/tools/video-grabber/video_grabber/transcript/summarize_flows.py
@@ -1,0 +1,191 @@
+"""Summarise chat_transcript_segments into chat_transcript_minutes.
+
+Deliberately a SEPARATE flow from build-transcript-segments, and deliberately
+reading the segments back out of Directus rather than re-deriving them from the
+SRT. Two reasons, both learned the hard way:
+
+  * Coupling them meant populating minutes required a full 227k-row segment
+    re-ingest, and would now also mean re-running every LLM call on any segment
+    rebuild — paying twice for output that had not changed.
+  * Reading the segments themselves removes the divergence risk that coupling
+    was supposed to solve. chat_transcript_segments is what the streamer falls
+    back to, so summarising *it* guarantees the two describe the same audio;
+    deriving both from the SRT separately only guaranteed they were built at the
+    same moment.
+
+Resumable by construction: minutes already summarised by the requested method
+are skipped, so an interrupted run is restarted by running it again.
+"""
+
+import collections
+import concurrent.futures as futures
+
+import httpx
+from prefect import flow, get_run_logger
+
+from video_grabber.config import Config
+from video_grabber.transcript import writer
+from video_grabber.transcript.minutes import condense
+from video_grabber.transcript.summarize import (
+    TIER_ABSTRACT,
+    TIER_EXTRACT,
+    TIER_MECHANICAL,
+    summarize_minute,
+)
+
+
+def anthropic_completer(cfg: Config):
+    """Build a `complete(system, user) -> str` bound to the configured model.
+
+    Wrapped rather than passed as a client so summarize.py stays free of the SDK
+    and its rules — every judgment in there is unit-testable without a key.
+    """
+    import anthropic
+
+    client = anthropic.Anthropic(api_key=cfg.anthropic_api_key)
+
+    def complete(system: str, user: str) -> str:
+        msg = client.messages.create(
+            model=cfg.summarize_model,
+            max_tokens=400,
+            system=system,
+            messages=[{"role": "user", "content": user}],
+        )
+        return "".join(b.text for b in msg.content if b.type == "text")
+
+    return complete
+
+
+def _fetch_segments(cfg: Config, *, start: str, end: str, client=httpx) -> list[dict]:
+    """Page through the segments in [start, end).
+
+    Directus caps a page server-side, so this follows offsets until short —
+    asking for limit=-1 on a table this size is how a run silently summarises
+    only the first page.
+    """
+    out: list[dict] = []
+    page_size, offset = 1000, 0
+    while True:
+        r = client.get(
+            f"{cfg.directus_url}/items/chat_transcript_segments",
+            params={
+                "fields": "channel,channel_slug,medium,start_date,text",
+                "filter": (
+                    '{"_and":[{"start_date":{"_gte":"%s"}},{"start_date":{"_lt":"%s"}}]}'
+                    % (start, end)
+                ),
+                "sort": "start_date",
+                "limit": page_size,
+                "offset": offset,
+            },
+            headers={"Authorization": f"Bearer {cfg.directus_api_token}"},
+            timeout=httpx.Timeout(connect=30.0, read=600.0, write=120.0, pool=30.0),
+        )
+        r.raise_for_status()
+        batch = r.json()["data"]
+        out.extend(batch)
+        if len(batch) < page_size:
+            return out
+        offset += page_size
+
+
+def _group(segments: list[dict]) -> dict:
+    buckets: dict = collections.defaultdict(list)
+    for s in segments:
+        minute = s["start_date"][:16].replace("T", " ") + ":00"
+        buckets[(s.get("channel"), s.get("channel_slug"), s.get("medium") or "tv", minute)].append(
+            s["text"]
+        )
+    return buckets
+
+
+@flow(name="summarize-transcript-minutes")
+def summarize_transcript_minutes_flow(
+    start: str = "2001-09-11T12:00:00",
+    end: str = "2001-09-11T23:00:00",
+    tier: str | None = None,
+    limit: int = 0,
+    dry_run: bool = True,
+    cfg: Config | None = None,
+) -> dict:
+    """Condense every channel-minute in [start, end) and write the results.
+
+    dry_run defaults to TRUE. This flow spends money and rewrites the tier-2
+    grounding every buddy reads, and the mechanical condenser it replaces was
+    shipped on the strength of unit tests against hand-written fixtures that did
+    not resemble the real corpus. Look at a sample before writing 12k rows.
+
+    limit bounds how many minutes are processed at all, so a costed sample is a
+    parameter rather than a separate script.
+    """
+    logger = get_run_logger()
+    cfg = cfg or Config()
+    tier = tier or cfg.summarize_tier
+    if tier not in (TIER_EXTRACT, TIER_ABSTRACT):
+        raise ValueError(f"tier must be {TIER_EXTRACT!r} or {TIER_ABSTRACT!r}, got {tier!r}")
+    if not cfg.anthropic_api_key:
+        raise ValueError("ANTHROPIC_API_KEY is unset; refusing to run a summarisation pass")
+
+    segments = _fetch_segments(cfg, start=start, end=end)
+    buckets = _group(segments)
+    logger.info("fetched %d segments across %d channel-minutes", len(segments), len(buckets))
+    if not buckets:
+        raise RuntimeError(f"no transcript segments in [{start}, {end}) — nothing to summarise")
+
+    keys = sorted(buckets)[: limit or None]
+    complete = anthropic_completer(cfg)
+
+    def one(key):
+        channel, slug, medium, minute = key
+        result = summarize_minute(
+            buckets[key],
+            tier=tier,
+            complete=complete,
+            max_units=cfg.summarize_max_units,
+            fallback=condense,
+        )
+        return key, result
+
+    results = []
+    with futures.ThreadPoolExecutor(max_workers=cfg.summarize_concurrency) as pool:
+        for key, result in pool.map(one, keys):
+            results.append((key, result))
+
+    counts = collections.Counter(r.method for _, r in results)
+    rejected = [(k, r.rejected) for k, r in results if r.rejected]
+    # A rejection is the gate doing its job, not an error -- but a HIGH rate means
+    # the prompt is drifting outside the source and the tier should be reconsidered,
+    # so it is surfaced rather than buried in per-item logs.
+    logger.info("methods=%s rejected=%d/%d", dict(counts), len(rejected), len(results))
+    for key, reason in rejected[:10]:
+        logger.info("rejected %s: %s", key, reason)
+
+    if dry_run:
+        for (channel, slug, medium, minute), r in results[:5]:
+            logger.info("[dry-run] %s %s -> (%s) %s", slug or channel, minute, r.method, r.text[:160])
+        return {
+            "minutes": len(results), "written": 0, "dry_run": True,
+            "methods": dict(counts), "rejected": len(rejected),
+        }
+
+    rows_by_source: dict = collections.defaultdict(list)
+    for (channel, slug, medium, minute), r in results:
+        if not r.text:
+            continue
+        rows_by_source[(channel, slug, medium)].append({
+            "channel": channel, "channel_slug": slug, "medium": medium,
+            "minute": minute, "summary": r.text,
+            "segment_count": len(buckets[(channel, slug, medium, minute)]),
+            "method": r.method, "model": cfg.summarize_model if r.method != TIER_MECHANICAL else None,
+        })
+
+    written = 0
+    for (channel, slug, medium), rows in rows_by_source.items():
+        written += writer.replace_minutes(
+            rows, medium=medium, channel=channel, channel_slug=slug, cfg=cfg
+        )
+    logger.info("summarised %d minutes, wrote %d rows", len(results), written)
+    return {
+        "minutes": len(results), "written": written, "dry_run": False,
+        "methods": dict(counts), "rejected": len(rejected),
+    }


### PR DESCRIPTION
Three things, two small and one substantial.

## 1. `cleared_at` was missing from the schema source of truth

It exists in the live DB but was never added to `chat-collections.mjs`, which `apply-chat-schema.mjs` builds a fresh install from. A new instance would create `chat_messages` without it and all three reads filtering `cleared_at IS NULL` would fail at runtime. **Production unaffected**; fresh installs only.

## 2. `cache_write_in` — recording `cache_creation_input_tokens`

The three input counts are disjoint, so without it the arithmetic never closes:

```
full prompt = tokens_in + cache_write_in + cached_in
cost        =  1.0×     +    1.25×       +   0.1×
```

More than bookkeeping: **high `cache_write_in` with zero `cached_in` = paying the write premium every turn for a prefix nothing reads back** — exactly what this feature did undetected for months, with no column that could have shown it. Also corrects two comments claiming `cached_in` is a subset of `tokens_in`. It isn't.

## 3. LLM transcript summarisation (the substantial part)

The mechanical condenser was measured against the real corpus and is **82% blind truncation**. Dedup only removes ~5%, because a minute of broadcast TV is ~2,000 characters of genuine content, not repetition. Any condensation reaching a small budget is lossy *selection* — the only question is whether the selection is intelligent. It wasn't; it kept whatever was said first.

Two tiers, both keeping hindsight out of a buddy's mouth by different means. A model summarising 8:52 coverage can't leak later events (it sees only that minute) but it *does* know how the day ended, and unconstrained it resolves the confusion of the moment into the correctness of the afternoon.

| tier | mechanism | fabrication risk |
|---|---|---|
| `llm-extract` | model returns **indices**; line rebuilt from source | unrepresentable by construction |
| `llm-abstract` | model rewrites; every content word must exist in source | refused by the containment gate |

**Measured on 24 real channel-minutes** (cnn/msnbc/wusa/bbc, 12:50–13:05):

| tier | outcome | char cut | containment leaks |
|---|---|---|---|
| 1 | 23/24 model-selected, 1 fallback | 84% | **0** |
| 2 | 11/24 gate-passed, 12/24 stepped down to tier 1, 1 fallback | 87% | **0** |

Quality is the real gain — caching already solved cost. Where the mechanical line gave `"Clinton, and their daughter Chelsea. The plane just was coming in low. No, I did not."`, extraction gives `"It looks like it has hit at a slight angle into the World Trade Center. I can see flames now coming out the side of the building."`

**Decisions worth review:**
- A rejected abstraction degrades to **tier 1, not truncation** — failing to rewrite inside the source vocabulary says nothing about the ability to choose good lines.
- **Quantities and hedges are deliberately not stopwords.** "many people" or "possibly" where the station said neither is an invented fact; a naive stopword list waves both through.
- Word matching uses **variant sets, not a single stem**. Three orderings were wrong first (`es`-as-a-unit breaks planes/plane; verb-endings-first breaks buildings/building; collapsing doubled consonants fixes hitting/hit but breaks falling/fall). Possessive stripping alone was 1 of 19 false rejections in the first sample run.
- `chat_transcript_minutes` is **no longer written by `build-transcript-segments`** — that coupling meant populating minutes required a 227k-row re-ingest and would now re-run every paid call on any rebuild.
- The flow **defaults to `dry_run=True`** and takes a `limit`, because the thing it replaces shipped on unit tests against fixtures that didn't resemble the corpus.

Model is configurable (`SUMMARIZE_MODEL`, default `claude-haiku-4-5`); full 11-hour window is ~12.4k channel-minutes, roughly $11 one-time.

## Schema

`cache_write_in`, `chat_transcript_minutes.method` and `.model` already applied to prod (`pg_stat_activity` checked first). `cleared_at` needed no prod action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)