### PR TITLE
fix(ui): opt in to classicy's split-out fonts.css

### DIFF
--- a/packages/frontend/e2e/tests/platinum-fonts.spec.ts
+++ b/packages/frontend/e2e/tests/platinum-fonts.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+
+// classicy 0.70.0 split every base64 @font-face rule out of classicy.css into
+// an opt-in dist/fonts.css. Forgetting that second import doesn't throw and
+// doesn't warn: the stylesheets still ask for "Charcoal, ChicagoFLF, Geneva",
+// the browser finds no such faces, silently falls back to sans-serif, and the
+// entire Platinum look is gone behind a green build and a clean console. That
+// shipped to production once. This is the tripwire.
+//
+// Deliberately NOT document.fonts.check(): it returns TRUE when no matching
+// @font-face exists at all, because the fallback family satisfies it. It
+// therefore passes in exactly the broken case — verified against production
+// while it was still degraded.
+test("the Platinum @font-face rules are registered", async ({ page }) => {
+	await page.goto("/");
+	await expect(page.locator(".classicyDesktop")).toBeVisible();
+
+	const families = await page.evaluate(async () => {
+		await document.fonts.ready;
+		return [...new Set([...document.fonts].map((f) => f.family))].sort();
+	});
+
+	expect(families).toEqual(
+		expect.arrayContaining(["Charcoal", "ChicagoFLF", "Geneva", "Monaco"]),
+	);
+});

--- a/packages/frontend/src/app.tsx
+++ b/packages/frontend/src/app.tsx
@@ -2,6 +2,13 @@ import { Component, lazy, StrictMode, Suspense, type ReactNode } from "react";
 import { createRoot } from "react-dom/client";
 import "./app.css";
 import "classicy/dist/classicy.css";
+// Opt-in since classicy 0.70.0, which split every base64 @font-face rule out
+// of classicy.css into this sibling stylesheet so consumers aren't forced to
+// download ~900 kB of fonts they may not use. We DO use them — Chicago,
+// Geneva, Monaco and Charcoal are the whole Platinum look — so we opt in.
+// Dropping this import doesn't error, it just silently falls back to system
+// fonts everywhere.
+import "classicy/dist/fonts.css";
 import { ClassicyAppManagerProvider, registerClassicyFileSystemAdapter } from "classicy";
 import { directusFilesystemAdapter } from "./Providers/FilesystemSync/directusFilesystemAdapter";
 import { FilesystemSyncProvider } from "./Providers/FilesystemSync/FilesystemSyncProvider";


### PR DESCRIPTION
## Symptom

The whole Platinum desktop renders in the browser's default sans-serif on production.

## Cause

classicy 0.70.0 split every base64 `@font-face` rule out of `classicy.css` into an **opt-in** `dist/fonts.css`, so consumers aren't forced to download ~900 kB of fonts they may not use. `app.tsx` only ever imported `classicy.css`, so we never opted in.

It fails silently by design — nothing throws, nothing warns, the build is green and the console is clean. The stylesheets still ask for `Charcoal, ChicagoFLF, Geneva`; those families just no longer exist, so the browser falls through to the last entry in each stack.

## Evidence

Measured on production while degraded vs. this branch built locally:

| | production (degraded) | this branch |
|---|---|---|
| `document.fonts.size` | **0** | **13** |
| loaded faces | none | `ChicagoFLF`, `Charcoal`, `Geneva` |
| computed font of "About This Computer" | sans-serif fallback | Charcoal |

## Tripwire

Adds `e2e/tests/platinum-fonts.spec.ts`. It asserts on the **registered `@font-face` family set**, deliberately *not* `document.fonts.check()` — that returns `TRUE` when no matching face exists at all, because the fallback family satisfies it, so it passes in exactly the broken case (confirmed against production while degraded).

Mutation-checked: removing the import fails the test on the `arrayContaining` assertion itself, not on a crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)