### PR TITLE
fix(build): declare the "node" types dependency explicitly

### DIFF
--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -4,7 +4,14 @@
 		"useDefineForClassFields": true,
 		"lib": ["ES2022", "DOM", "DOM.Iterable"],
 		"module": "ESNext",
-		"types": ["vite/client", "geojson"],
+		// "node" is required by co-located tests that read fixtures off disk
+		// (node:fs, node:path, __dirname) and stub globals. It used to arrive
+		// by accident: `types` is an allow-list, but a `/// <reference
+		// types="node" />` inside a *transitive* dependency's .d.ts is honoured
+		// regardless of it. Dropping two classicy peer deps removed that
+		// reference and 15 pre-existing type errors appeared at once, in files
+		// nobody had touched. Declare it explicitly so it can't vanish again.
+		"types": ["vite/client", "geojson", "node"],
 		"skipLibCheck": true,
 		"resolveJsonModule": true,
 		/* Bundler mode */


### PR DESCRIPTION
## Why now

`tsc -b` fails on the classicy 0.70.3 bump (#355) with 15 errors across three files nobody touched:

```
useFeedback.test.ts(28,3):   error TS2304: Cannot find name 'global'.
appWiring.test.tsx(1,30):    error TS2591: Cannot find name 'node:fs'.
DefaultFileSystem.test.ts(14,3): error TS2304: Cannot find name '__dirname'.
```

## Cause

`types` in `packages/frontend/tsconfig.json` is an **allow-list** (`["vite/client", "geojson"]`) and never included `"node"` — even though co-located tests read fixtures off disk and stub globals.

It type-checked anyway because a `/// <reference types="node" />` inside a **transitive** dependency's `.d.ts` is honoured regardless of the allow-list. classicy 0.70.3 stopped externalizing `@mdxeditor/editor` and `pdfjs-dist`, so pnpm no longer installs them as peers, and that reference disappeared with them.

So this is a pre-existing latent fault that the bump merely exposed — not a regression introduced by it.

## Fix

Add `"node"`. `@types/node` is already a declared devDependency; this just stops the compiler from finding it by accident.

Verified with classicy 0.70.3 installed: `tsc -b --force` clean, `vitest run` 220 files / 2017 tests pass, `eslint` 0 errors, production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)