### PR TITLE
fix(frontend): label AF1's climb/cruise phases in the track legend

### DIFF
--- a/packages/frontend/src/Applications/FlightTracker/flightPhases.test.ts
+++ b/packages/frontend/src/Applications/FlightTracker/flightPhases.test.ts
@@ -39,6 +39,13 @@ describe("phaseLabel", () => {
 		expect(PHASE_COLORS.ground).not.toBe(DEFAULT_PHASE_COLOR);
 		expect(phaseLabel("ground")).toBe("On Ground");
 	});
+
+	it("labels the altitude-derived phases AF1's legend surfaces", () => {
+		// AF1 has no curated phase ramp, so its legend renders climb/cruise
+		// alongside ground/descent — unlabeled they showed as raw slugs.
+		expect(phaseLabel("climb")).toBe("Climb");
+		expect(phaseLabel("cruise")).toBe("Cruise");
+	});
 });
 
 describe("orderedTrackPhases", () => {

--- a/packages/frontend/src/Applications/FlightTracker/flightPhases.ts
+++ b/packages/frontend/src/Applications/FlightTracker/flightPhases.ts
@@ -58,6 +58,11 @@ export const PHASE_LABELS: Record<string, string> = {
 	descent: "Descent",
 	down: "Down",
 	ground: "On Ground",
+	// Altitude-derived phases (resample._assign_phases). Only flights whose
+	// legend is enabled — the notables and AF1 — ever surface these, but without
+	// entries here they render as raw lowercase slugs next to the labeled ones.
+	climb: "Climb",
+	cruise: "Cruise",
 };
 
 export function phaseLabel(phase: string): string {


### PR DESCRIPTION
Follow-up to #369, found during production verification.

AF1 has no curated phase ramp (it's not a hijacked flight), so its phase legend renders the altitude-derived `climb`/`cruise` slugs alongside `ground`/`descent`. `PHASE_LABELS` had no entries for them, so they displayed as raw lowercase text next to the properly-labeled ones.

Verified live on 911realtime.org before the fix: legend read `On Ground · climb · cruise · Descent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)