### PR TITLE
fix(frontend): give AF1's normal-ops phases their own palette

### DIFF
--- a/packages/frontend/src/Applications/FlightTracker/FlightDetailPanel.tsx
+++ b/packages/frontend/src/Applications/FlightTracker/FlightDetailPanel.tsx
@@ -12,7 +12,7 @@ import { isNotable, isObserver, isPresidential } from "./notableFlights";
 import { PROVENANCE_NOTE, isEstimated, sourceLabel } from "./flightProvenance";
 import { formatCoords, formatDurationMs, type LegEstimates } from "./flightEta";
 import { type MapPoi, POI_DETAIL_FIELDS, detailTitleFor } from "./mapPois";
-import { PHASE_COLORS, DEFAULT_PHASE_COLOR, phaseLabel } from "./flightPhases";
+import { DEFAULT_PHASE_COLOR, phaseColorHex, phaseLabel, phasePaletteFor } from "./flightPhases";
 import { groundStopAt } from "./groundStops";
 
 interface FlightDetailPanelProps {
@@ -233,7 +233,9 @@ export const FlightDetailPanel: FC<FlightDetailPanelProps> = ({
 							<dt>
 								<span
 									className={styles.phaseSwatch}
-									style={{ backgroundColor: PHASE_COLORS[ph] ?? DEFAULT_PHASE_COLOR }}
+									style={{
+									backgroundColor: phaseColorHex(ph, phasePaletteFor(selected.flight)),
+								}}
 								/>
 							</dt>
 							<dd>{phaseLabel(ph)}</dd>

--- a/packages/frontend/src/Applications/FlightTracker/FlightMap.tsx
+++ b/packages/frontend/src/Applications/FlightTracker/FlightMap.tsx
@@ -18,7 +18,7 @@ import {
 	trailColor,
 	trailGradient,
 } from "./flightMapStyle";
-import { phaseLineColorExpression } from "./flightPhases";
+import { type PhasePalette, phaseLineColorExpression } from "./flightPhases";
 import { sourceDashExpression, sourceOpacityExpression } from "./flightProvenance";
 import planeSvg from "./plane.svg?raw";
 import pinSvg from "./pin.svg?raw";
@@ -313,6 +313,10 @@ interface FlightMapProps {
 	// Raw altitude profile of the selected flight: the smooth 3D track tube
 	// splines it in all three axes (see trackTube.ts).
 	trackProfile?: AltitudeSample[] | null;
+	// Which phase vocabulary the profile's phases belong to. The 2D segments
+	// arrive pre-colored in trackGeoJSON, but the 3D tube colors its own
+	// vertices, so it needs the selected flight's palette (flightPhases.ts).
+	trackPalette?: PhasePalette;
 	nowMs: number;
 	playing: boolean;
 	mapStyle: BasemapStyleId;
@@ -562,7 +566,7 @@ const REPLAY_TRAIL_STROKE_COLOR = "#ffffff";
 export const FlightMap: FC<FlightMapProps> = ({
 	ref: handleRef,
 	positions, seedPositions, basemapUrls, trackGeoJSON,
-	trackProfile = null, nowMs, playing,
+	trackProfile = null, trackPalette, nowMs, playing,
 	mapStyle, darkMap, pinColor, notablePinColor, observerPinColor, anonPinColor, radarSweep, trailMultiplier,
 	// Warm-stone defaults mirror flightMapSettings.ts's DEFAULT_FLIGHT_MAP_SETTINGS
 	// so call sites that predate hero landmarks (or omit the setting) still get a
@@ -725,6 +729,9 @@ export const FlightMap: FC<FlightMapProps> = ({
 	const buildings3DRef = useRef<Buildings3DLayer | null>(null);
 	const trackProfileRef = useRef<AltitudeSample[] | null>(trackProfile);
 	trackProfileRef.current = trackProfile;
+	// Read inside the map-load callback, which captures values once.
+	const trackPaletteRef = useRef<PhasePalette | undefined>(trackPalette);
+	trackPaletteRef.current = trackPalette;
 	// Apply the layer-visibility matrix AND the custom layers' draw gates from
 	// one place, so the three flags can never drift apart across call sites.
 	const syncPlaneVisibility = (map: maplibregl.Map) => {
@@ -1070,7 +1077,9 @@ export const FlightMap: FC<FlightMapProps> = ({
 			// elevation (the curtain staircases; it stays as the globe fallback).
 			const trackTube = new TrackTube3DLayer();
 			trackTube.setColor(TRACK_LINE_COLOR);
-			trackTube.setGeometry(buildTrackTube(trackProfileRef.current));
+			trackTube.setGeometry(
+				buildTrackTube(trackProfileRef.current, undefined, trackPaletteRef.current),
+			);
 			trackTubeRef.current = trackTube;
 			map.addLayer(trackTube);
 			// Smooth live-trail ribbons: splined breadcrumbs with per-vertex
@@ -1363,9 +1372,9 @@ export const FlightMap: FC<FlightMapProps> = ({
 	// empty/null profile clears it. Radius comes per-frame from the rAF loop.
 	useEffect(() => {
 		if (!mapRef.current || !loadedRef.current) return;
-		trackTubeRef.current?.setGeometry(buildTrackTube(trackProfile));
+		trackTubeRef.current?.setGeometry(buildTrackTube(trackProfile, undefined, trackPalette));
 		dirtyRef.current = true;
-	}, [trackProfile]);
+	}, [trackProfile, trackPalette]);
 
 	// Re-theme / recolor live. setPaintProperty only — setStyle() would tear
 	// down the flights/trails/track sources and layers. Before "load" fires,

--- a/packages/frontend/src/Applications/FlightTracker/FlightTracker.tsx
+++ b/packages/frontend/src/Applications/FlightTracker/FlightTracker.tsx
@@ -92,7 +92,7 @@ import {
 import styles from "./FlightTracker.module.scss";
 import type { FeatureCollection } from "geojson";
 import { buildTrackSegments } from "./flightTrackSegments";
-import { orderedTrackPhases } from "./flightPhases";
+import { orderedTrackPhases, phasePaletteFor } from "./flightPhases";
 import {
 	BASEMAP_URLS,
 	type BasemapStyleId,
@@ -859,7 +859,7 @@ export const FlightTracker: FC = () => {
 			selection && profile && profile.length >= 2
 			&& (isNotable(selection.flight) || hasEstimated)
 		) {
-			const features = buildTrackSegments(profile);
+			const features = buildTrackSegments(profile, phasePaletteFor(selection.flight));
 			if (features.length) return { type: "FeatureCollection", features };
 		}
 		// non-notable (or no profile yet): the decimated track as one plain feature.
@@ -1244,6 +1244,7 @@ export const FlightTracker: FC = () => {
 								basemapUrls={BASEMAP_URLS}
 								trackGeoJSON={trackGeoJSON}
 								trackProfile={profile}
+								trackPalette={phasePaletteFor(selection?.flight)}
 								nowMs={nowMs}
 								playing={!paused}
 								mapStyle={settings.mapStyle}

--- a/packages/frontend/src/Applications/FlightTracker/flightPhases.test.ts
+++ b/packages/frontend/src/Applications/FlightTracker/flightPhases.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { DEFAULT_PHASE_COLOR, PHASE_COLORS, phaseColorHex, phaseColorRgb01, phaseLineColorExpression, orderedTrackPhases, phaseLabel } from "./flightPhases";
+import { DEFAULT_PHASE_COLOR, PHASE_COLORS, phaseColorHex, phaseColorRgb01, phaseLineColorExpression, orderedTrackPhases, phaseLabel, phasePaletteFor } from "./flightPhases";
 
 describe("flightPhases", () => {
 	it("maps known phases and falls back to the track red", () => {
@@ -18,12 +18,16 @@ describe("flightPhases", () => {
 	});
 
 	it("builds a match expression covering all 8 phases with a default", () => {
+		// Outer node prefers a stamped per-feature color; the slug match is the
+		// fallback for features that carry only a phase.
 		const expr = phaseLineColorExpression() as unknown[];
-		expect(expr[0]).toBe("match");
+		expect(expr[0]).toBe("coalesce");
+		const match = expr[2] as unknown[];
+		expect(match[0]).toBe("match");
 		for (const slug of Object.keys(PHASE_COLORS)) {
-			expect(expr).toContain(slug);
+			expect(match).toContain(slug);
 		}
-		expect(expr[expr.length - 1]).toBe("#b22222"); // default is last
+		expect(match[match.length - 1]).toBe("#b22222"); // default is last
 	});
 });
 
@@ -45,6 +49,56 @@ describe("phaseLabel", () => {
 		// alongside ground/descent — unlabeled they showed as raw slugs.
 		expect(phaseLabel("climb")).toBe("Climb");
 		expect(phaseLabel("cruise")).toBe("Cruise");
+	});
+});
+
+describe("phasePaletteFor / per-flight palettes", () => {
+	it("gives the hijacked four the escalation ramp and everyone else normal ops", () => {
+		expect(phasePaletteFor("AA11")).toBe("escalation");
+		expect(phasePaletteFor("UA93")).toBe("escalation");
+		expect(phasePaletteFor("AF1")).toBe("normal");
+		expect(phasePaletteFor("GOFER06")).toBe("normal");
+		expect(phasePaletteFor(undefined)).toBe("normal");
+	});
+
+	it("colors AF1's altitude-derived phases distinctly instead of all-red", () => {
+		const p = phasePaletteFor("AF1");
+		const climb = phaseColorHex("climb", p);
+		const cruise = phaseColorHex("cruise", p);
+		const descent = phaseColorHex("descent", p);
+		const ground = phaseColorHex("ground", p);
+		// The reported bug: all three fell through to the flat red.
+		for (const c of [climb, cruise, descent]) {
+			expect(c).not.toBe(DEFAULT_PHASE_COLOR);
+		}
+		expect(new Set([climb, cruise, descent, ground]).size).toBe(4);
+	});
+
+	it("reuses the escalation ramp's calm colors for the matching regimes", () => {
+		const p = phasePaletteFor("AF1");
+		expect(phaseColorHex("climb", p)).toBe(PHASE_COLORS.takeoff);
+		expect(phaseColorHex("cruise", p)).toBe(PHASE_COLORS.artcc);
+		expect(phaseColorHex("descent", p)).toBe(PHASE_COLORS.tracon);
+		expect(phaseColorHex("ground", p)).toBe(PHASE_COLORS.ground);
+	});
+
+	it("keeps the crisis red for a hijacked flight's final dive", () => {
+		// `descent` is the one slug both vocabularies use — it must stay the
+		// escalation ramp's red for the notables while AF1's reads as approach.
+		expect(phaseColorHex("descent", phasePaletteFor("AA11"))).toBe(PHASE_COLORS.descent);
+		expect(phaseColorHex("descent", phasePaletteFor("AF1")))
+			.not.toBe(PHASE_COLORS.descent);
+	});
+
+	it("defaults to the escalation ramp when no palette is given", () => {
+		expect(phaseColorHex("descent")).toBe(PHASE_COLORS.descent);
+		expect(phaseColorHex("hijack")).toBe(PHASE_COLORS.hijack);
+	});
+
+	it("prefers a stamped feature color in the 2D line expression", () => {
+		const expr = phaseLineColorExpression() as unknown as unknown[];
+		expect(expr[0]).toBe("coalesce");
+		expect(expr[1]).toEqual(["get", "color"]);
 	});
 });
 

--- a/packages/frontend/src/Applications/FlightTracker/flightPhases.ts
+++ b/packages/frontend/src/Applications/FlightTracker/flightPhases.ts
@@ -1,4 +1,5 @@
 import type { ExpressionSpecification } from "maplibre-gl";
+import { isNotable } from "./notableFlights";
 
 // Escalation-ramp palette for the 4 hijacked flights (issue #229): calm
 // green→teal→blue for normal ops, warming to red/maroon as the crisis
@@ -16,33 +17,73 @@ export const PHASE_COLORS: Record<string, string> = {
 	ground: "#8a8a8a",
 };
 
-// Coarse altitude phases (climb/cruise/descent) and unknowns fall back to the
-// existing flat track red, so non-notable flights render exactly as before.
+// Normal-operations palette for the altitude-derived phases the resampler
+// writes (resample._assign_phases) — what a curated flight that was never
+// hijacked carries, e.g. AF1. It deliberately reuses the escalation ramp's
+// CALM colors for the equivalent flight regimes, so both kinds of track read
+// as one system: departure green, en-route blue, terminal-area teal.
+//
+// `descent` is the one slug both vocabularies use, and it means opposite
+// things: the hijacked four's curated `descent` is the final dive (crisis
+// red), while an altitude-derived `descent` is a routine approach. That
+// collision is why the palette is chosen per flight instead of globally —
+// recoloring `descent` for everyone would drain the escalation ramp.
+export const NORMAL_PHASE_COLORS: Record<string, string> = {
+	climb: "#2e7d32", // as takeoff — departure
+	cruise: "#1565c0", // as artcc — en route
+	descent: "#0097a7", // as tracon — terminal area / approach
+	ground: "#8a8a8a", // the same neutral both palettes use
+};
+
+// Unknown phases (and any flight with no phase profile at all) fall back to
+// the flat track red, so ordinary BTS flights render exactly as before.
 export const DEFAULT_PHASE_COLOR = "#b22222";
 
-export function phaseColorHex(phase?: string): string {
-	// `phase ? …` (not `phase && …`) so an empty string also falls through to
-	// the default instead of returning "" (which would parse to a NaN color).
-	return (phase ? PHASE_COLORS[phase] : undefined) ?? DEFAULT_PHASE_COLOR;
+/** Which vocabulary a flight's `phase` values belong to. */
+export type PhasePalette = "escalation" | "normal";
+
+/**
+ * The hijacked four carry the curated escalation ramp; every other curated
+ * flight (AF1 today) carries altitude-derived phases. Keyed off `isNotable`
+ * because that is exactly the set the notable loader writes curated phases for.
+ */
+export function phasePaletteFor(flight?: string): PhasePalette {
+	return flight && isNotable(flight) ? "escalation" : "normal";
 }
 
-export function phaseColorRgb01(phase?: string): [number, number, number] {
-	const n = Number.parseInt(phaseColorHex(phase).slice(1), 16);
+function colorsFor(palette: PhasePalette = "escalation"): Record<string, string> {
+	return palette === "normal" ? NORMAL_PHASE_COLORS : PHASE_COLORS;
+}
+
+export function phaseColorHex(phase?: string, palette?: PhasePalette): string {
+	// `phase ? …` (not `phase && …`) so an empty string also falls through to
+	// the default instead of returning "" (which would parse to a NaN color).
+	return (phase ? colorsFor(palette)[phase] : undefined) ?? DEFAULT_PHASE_COLOR;
+}
+
+export function phaseColorRgb01(
+	phase?: string,
+	palette?: PhasePalette,
+): [number, number, number] {
+	const n = Number.parseInt(phaseColorHex(phase, palette).slice(1), 16);
 	return [((n >> 16) & 255) / 255, ((n >> 8) & 255) / 255, (n & 255) / 255];
 }
 
-// Data-driven line-color for the 2D track: each per-phase segment feature
-// carries properties.phase; unknown/absent phases hit the default red.
+// Data-driven line-color for the 2D track. The layer's paint is fixed when the
+// layer is added, but the palette depends on which flight is selected — so
+// buildTrackSegments resolves each segment's color up front and stamps it as
+// properties.color, and this expression simply prefers it. Features without one
+// (a plain undecorated track geometry) still match the escalation ramp by slug,
+// then fall through to the flat red.
 export function phaseLineColorExpression(): ExpressionSpecification {
 	const cases: (string)[] = [];
 	for (const [slug, hex] of Object.entries(PHASE_COLORS)) {
 		cases.push(slug, hex);
 	}
 	return [
-		"match",
-		["get", "phase"],
-		...cases,
-		DEFAULT_PHASE_COLOR,
+		"coalesce",
+		["get", "color"],
+		["match", ["get", "phase"], ...cases, DEFAULT_PHASE_COLOR],
 	] as unknown as ExpressionSpecification;
 }
 

--- a/packages/frontend/src/Applications/FlightTracker/flightTrackSegments.ts
+++ b/packages/frontend/src/Applications/FlightTracker/flightTrackSegments.ts
@@ -1,3 +1,5 @@
+import { type PhasePalette, phaseColorHex } from "./flightPhases";
+
 interface PhasePoint {
 	lat: number;
 	lon: number;
@@ -13,8 +15,15 @@ interface PhasePoint {
  * last point is repeated as the next run's first) so the colored line has no
  * gap at the phase change. Each Feature carries properties.phase. Fewer than
  * two points cannot form a line → [].
+ *
+ * `palette` selects which phase vocabulary the colors come from (see
+ * flightPhases.phasePaletteFor); the resolved color is stamped on each feature
+ * so the map layer's fixed paint expression doesn't have to know the flight.
  */
-export function buildTrackSegments(points: PhasePoint[]): GeoJSON.Feature[] {
+export function buildTrackSegments(
+	points: PhasePoint[],
+	palette?: PhasePalette,
+): GeoJSON.Feature[] {
 	if (points.length < 2) return [];
 	const features: GeoJSON.Feature[] = [];
 	let start = 0;
@@ -30,6 +39,7 @@ export function buildTrackSegments(points: PhasePoint[]): GeoJSON.Feature[] {
 			properties: {
 				phase: points[start].phase ?? null,
 				source: points[start].source ?? null,
+				color: phaseColorHex(points[start].phase, palette),
 			},
 			geometry: {
 				type: "LineString",

--- a/packages/frontend/src/Applications/FlightTracker/trackTube.ts
+++ b/packages/frontend/src/Applications/FlightTracker/trackTube.ts
@@ -3,7 +3,7 @@ import { altitudeFtAt, exaggeratedHeightM } from "./flightAltitude";
 import type { LandingClock, MotionBuffer } from "./flightMotion";
 import { extrapolate, motionNow } from "./flightMotion";
 import { TRAIL_3D_MAX_POINTS } from "./flightAltitude";
-import { phaseColorRgb01 } from "./flightPhases";
+import { type PhasePalette, phaseColorRgb01 } from "./flightPhases";
 import { lngLatToMercator, mercatorPerMeter } from "./plane3dMesh";
 
 // Smooth 3D flight track. The fill-extrusion curtain can only staircase —
@@ -102,11 +102,12 @@ const EMPTY_TUBE: TrackTube = {
 export function buildTrackTube(
 	profile: AltitudeSample[] | null,
 	steps = DEFAULT_STEPS,
+	palette?: PhasePalette,
 ): TrackTube {
 	if (!profile || profile.length < 2) return EMPTY_TUBE;
 	const pts = splineTrack(profile, steps);
 	const n = pts.length;
-	const pointColor = pts.map((p) => phaseColorRgb01(p.phase));
+	const pointColor = pts.map((p) => phaseColorRgb01(p.phase, palette));
 
 	// Per-point center data and ring frames.
 	const cx = new Float64Array(n); // mercator x


### PR DESCRIPTION
AF1's phase legend rendered **Climb, Cruise and Descent all in the same red**: `climb`/`cruise` had no `PHASE_COLORS` entries so they fell to `DEFAULT_PHASE_COLOR`, and `descent` resolved to the hijack ramp's crisis red.

## Why per-flight and not a global recolor

The two phase vocabularies collide on exactly one slug. For the hijacked four, curated `descent` is the final dive into the target (deliberately crisis red, #229); for an altitude-derived profile it's a routine approach. Recoloring `descent` globally would drain the escalation ramp.

So the palette is chosen per flight (`phasePaletteFor`, keyed off `isNotable`). `NORMAL_PHASE_COLORS` reuses the escalation ramp's own **calm** colors for the equivalent flight regimes, so both kinds of track read as one system:

| Phase | Color | Borrowed from |
|---|---|---|
| Climb | `#2e7d32` green | `takeoff` — departure |
| Cruise | `#1565c0` blue | `artcc` — en route |
| Descent | `#0097a7` teal | `tracon` — terminal area |
| On Ground | `#8a8a8a` gray | shared neutral |

## Plumbing

The track layer's paint is fixed when the layer is added, so it can't consult the selection. `buildTrackSegments` now resolves each segment's color and stamps it as `properties.color`; `phaseLineColorExpression()` coalesces to that before falling back to the by-slug match (undecorated features are unaffected). The 3D tube colors its own vertices, so it takes the palette through a new `trackPalette` prop.

## Verification
2,100 tests pass (7 new, incl. a regression pinning that the notables' `descent` stays crisis red while AF1's does not); `tsc -b`, eslint, `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)