### PR TITLE
Audio pipeline: transcript linkage, chunked/VAD re-transcription, party identification, enhancement toggle

### DIFF
--- a/packages/frontend/src/Applications/RadioScanner/FocusedItemPlayer.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/FocusedItemPlayer.tsx
@@ -15,6 +15,7 @@ import styles from "./RadioScanner.module.scss";
 import { WaveformVisualizer } from "./WaveformVisualizer";
 import { RadioProgressBar } from "./RadioProgressBar";
 import { setAudioLevel } from "./audioCapture";
+import { resolveAudioUrl } from "./audioSource";
 
 interface FocusedItemPlayerProps {
 	item: MediaItem;
@@ -26,6 +27,8 @@ interface FocusedItemPlayerProps {
 	onCycleVizMode: () => void;
 	waveColors: { bright: string; dim: string } | null;
 	maxVolume: number;
+	/** true = play the source recording rather than the enhanced render. */
+	playOriginalAudio?: boolean;
 }
 
 export const FocusedItemPlayer: React.FC<FocusedItemPlayerProps> = ({
@@ -38,6 +41,7 @@ export const FocusedItemPlayer: React.FC<FocusedItemPlayerProps> = ({
 	onCycleVizMode,
 	waveColors,
 	maxVolume,
+	playOriginalAudio = false,
 }) => {
 	const audioRef = useRef<HTMLAudioElement>(null);
 	const [playing, setPlaying] = useState(false);
@@ -95,7 +99,7 @@ export const FocusedItemPlayer: React.FC<FocusedItemPlayerProps> = ({
 			{/* eslint-disable-next-line jsx-a11y/media-has-caption -- captions are rendered by the CaptionOverlay sibling, not a native <track> (audio has no display surface for one) */}
 			<audio
 				ref={audioRef}
-				src={item.url}
+				src={resolveAudioUrl(item, playOriginalAudio)}
 				crossOrigin="anonymous"
 				style={{ display: "none" }}
 				onLoadedMetadata={() => {

--- a/packages/frontend/src/Applications/RadioScanner/RadioScanner.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/RadioScanner.tsx
@@ -493,6 +493,19 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
                                 }
                             />
                         </ClassicyControlGroup>
+                        <ClassicyControlGroup label="Audio">
+                            <ClassicyCheckbox
+                                id="radioscanner_settings_play_original"
+                                label="Play original recording (more noise)"
+                                checked={settingsForm.playOriginalAudio}
+                                onClickFunc={(checked: boolean) =>
+                                    setSettingsForm((f) => ({
+                                        ...f,
+                                        playOriginalAudio: checked,
+                                    }))
+                                }
+                            />
+                        </ClassicyControlGroup>
                         <ClassicyControlGroup label="Waveform Colors">
                             <ClassicyCheckbox
                                 id="radioscanner_settings_use_theme"
@@ -731,6 +744,7 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
                                 onCycleVizMode={onCycleVizMode}
                                 waveColors={waveColors}
                                 maxVolume={maxVolume}
+                                playOriginalAudio={settings.playOriginalAudio}
                             />
                         ) : (
                             activeStationObj && (
@@ -913,6 +927,7 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
                                         onCycleVizMode={onCycleVizMode}
                                         waveColors={waveColors}
                                         maxVolume={maxVolume}
+                                        playOriginalAudio={settings.playOriginalAudio}
                                     />
                                 </>
                             )

--- a/packages/frontend/src/Applications/RadioScanner/StationPlayer.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/StationPlayer.tsx
@@ -9,6 +9,7 @@ import {
 	DEFAULT_CAPTION_STYLE,
 	type VizMode,
 } from "./radioScannerSettings";
+import { resolveAudioUrl } from "./audioSource";
 import {
 	activeSegments,
 	calcSeekSeconds,
@@ -31,6 +32,8 @@ interface StationPlayerProps {
 	onCycleVizMode: () => void;
 	waveColors: { bright: string; dim: string } | null;
 	maxVolume: number;
+	/** true = play the source recording rather than the enhanced render. */
+	playOriginalAudio?: boolean;
 }
 
 /**
@@ -53,6 +56,7 @@ export const StationPlayer: React.FC<StationPlayerProps> = ({
 	onCycleVizMode,
 	waveColors,
 	maxVolume,
+	playOriginalAudio = false,
 }) => {
 	const segments = activeSegments(station, nowMs);
 	const audioRefs = useRef<Map<number, HTMLAudioElement>>(new Map());
@@ -236,7 +240,7 @@ export const StationPlayer: React.FC<StationPlayerProps> = ({
 				<audio
 					key={item.id}
 					ref={audioRef(item.id)}
-					src={item.url}
+					src={resolveAudioUrl(item, playOriginalAudio)}
 					crossOrigin="anonymous"
 					style={{ display: "none" }}
 					onLoadedMetadata={(e) => {

--- a/packages/frontend/src/Applications/RadioScanner/audioSource.test.ts
+++ b/packages/frontend/src/Applications/RadioScanner/audioSource.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { resolveAudioUrl } from "./audioSource";
+
+describe("resolveAudioUrl", () => {
+	it("plays the enhanced render by default", () => {
+		expect(
+			resolveAudioUrl({ url: "/o.mp3", enhanced_url: "/e.mp3" }, false),
+		).toBe("/e.mp3");
+	});
+
+	it("plays the original when the listener asks for it", () => {
+		expect(
+			resolveAudioUrl({ url: "/o.mp3", enhanced_url: "/e.mp3" }, true),
+		).toBe("/o.mp3");
+	});
+
+	it("falls back to url when no enhanced render exists yet", () => {
+		// enhanced_url is null until the enhancement pass has processed that
+		// file. The default path must not produce an undefined src, which would
+		// fail silently as a broken audio element.
+		expect(resolveAudioUrl({ url: "/o.mp3", enhanced_url: null }, false)).toBe(
+			"/o.mp3",
+		);
+	});
+
+	it("falls back to url when the field is absent entirely", () => {
+		expect(resolveAudioUrl({ url: "/o.mp3" }, false)).toBe("/o.mp3");
+	});
+
+	it("never returns undefined for either preference", () => {
+		for (const preferOriginal of [true, false]) {
+			expect(
+				resolveAudioUrl({ url: "/o.mp3" }, preferOriginal),
+			).toBeTypeOf("string");
+		}
+	});
+});

--- a/packages/frontend/src/Applications/RadioScanner/audioSource.ts
+++ b/packages/frontend/src/Applications/RadioScanner/audioSource.ts
@@ -1,0 +1,28 @@
+/**
+ * Which copy of a recording to play.
+ *
+ * Every item has a canonical `url` pointing at the source recording. Some also
+ * have an `enhanced_url` — a noise-reduced render produced for listening. The
+ * enhanced copy is the default; the Settings toggle switches back to the
+ * original for anyone who would rather hear the tape as it was.
+ */
+export interface AudioSourceItem {
+	url: string;
+	enhanced_url?: string | null;
+}
+
+/**
+ * Resolve the URL to play.
+ *
+ * `url` is always populated and always points at the source recording, so it is
+ * the safe fallback: a file the enhancement pass has not reached yet simply
+ * plays unenhanced rather than producing an undefined `src`, which would fail
+ * silently as a broken audio element.
+ */
+export const resolveAudioUrl = (
+	item: AudioSourceItem,
+	preferOriginal: boolean,
+): string => {
+	if (preferOriginal) return item.url;
+	return item.enhanced_url ?? item.url;
+};

--- a/packages/frontend/src/Applications/RadioScanner/radioScannerSettings.test.ts
+++ b/packages/frontend/src/Applications/RadioScanner/radioScannerSettings.test.ts
@@ -29,8 +29,21 @@ describe("readRadioScannerSettings", () => {
 			colorDim: 0x330000,
 			maxVolume: 40,
 			captionStyle: DEFAULT_CAPTION_STYLE,
+			playOriginalAudio: true,
 		};
 		expect(readRadioScannerSettings({ settings: stored })).toEqual(stored);
+	});
+
+	it("defaults playOriginalAudio to false so the enhanced render is heard first", () => {
+		const out = readRadioScannerSettings({ settings: {} });
+		expect(out.playOriginalAudio).toBe(false);
+	});
+
+	it("falls back playOriginalAudio when the stored value is not a boolean", () => {
+		const out = readRadioScannerSettings({
+			settings: { playOriginalAudio: "yes" },
+		});
+		expect(out.playOriginalAudio).toBe(false);
 	});
 
 	it("falls back per field on invalid values", () => {

--- a/packages/frontend/src/Applications/RadioScanner/radioScannerSettings.ts
+++ b/packages/frontend/src/Applications/RadioScanner/radioScannerSettings.ts
@@ -79,6 +79,12 @@ export interface RadioScannerSettings {
 	maxVolume: number;
 	/** Closed-caption appearance (the CC on/off toggle is separate, live state). */
 	captionStyle: CaptionStyle;
+	/**
+	 * true = play the source recording instead of the noise-reduced render.
+	 * Defaults false: the enhanced copy is easier to listen to, but the original
+	 * stays one click away because this is a primary-source archive.
+	 */
+	playOriginalAudio: boolean;
 }
 
 export const DEFAULT_RADIO_SCANNER_SETTINGS: RadioScannerSettings = {
@@ -88,6 +94,7 @@ export const DEFAULT_RADIO_SCANNER_SETTINGS: RadioScannerSettings = {
 	colorDim: 0x00b446, // the pre-theme hardcoded dim green
 	maxVolume: 100, // no attenuation
 	captionStyle: DEFAULT_CAPTION_STYLE,
+	playOriginalAudio: false,
 };
 
 /** Persist the whole settings object in one dispatch. */
@@ -157,6 +164,10 @@ export const readRadioScannerSettings = (
 			? stored.maxVolume
 			: DEFAULT_RADIO_SCANNER_SETTINGS.maxVolume,
 		captionStyle: readCaptionStyle(stored.captionStyle),
+		playOriginalAudio:
+			typeof stored.playOriginalAudio === "boolean"
+				? stored.playOriginalAudio
+				: DEFAULT_RADIO_SCANNER_SETTINGS.playOriginalAudio,
 	};
 };
 

--- a/packages/frontend/src/Providers/MediaStream/MediaStreamContext.ts
+++ b/packages/frontend/src/Providers/MediaStream/MediaStreamContext.ts
@@ -44,6 +44,14 @@ export interface MediaItem {
 	image_caption?: string;
 	/** Public URL to the .srt subtitle file; the .vtt sibling is derived for <track>. */
 	subtitles?: string;
+	/**
+	 * Public URL to the noise-reduced render, when one exists.
+	 *
+	 * `url` stays canonical and always points at the source recording — it is the
+	 * join key for the whole audio pipeline. This is the listening copy, and it is
+	 * null until the enhancement pass has processed that file.
+	 */
+	enhanced_url?: string | null;
 	content?: string;
 	sort?: number;
 }

--- a/packages/tools/video-grabber/Dockerfile
+++ b/packages/tools/video-grabber/Dockerfile
@@ -57,6 +57,16 @@ RUN mkdir -p /build/whisper-libs && \
     find /build/whisper.cpp/build -name '*.so*' -type f -exec cp -av {} /build/whisper-libs/ \;
 RUN cd whisper.cpp && bash ./models/download-ggml-model.sh medium.en && \
     mkdir -p /opt/models && cp models/ggml-medium.en.bin /opt/models/
+# Silero VAD. whisper-cli --vad requires an explicit --vad-model and fails at
+# runtime without it. Fetched here so the runtime image needs no network.
+# Falls back to a direct download if the helper script is absent from the pinned
+# whisper.cpp checkout; a missing model must break the build, not the pipeline.
+RUN cd whisper.cpp && \
+    (bash ./models/download-vad-model.sh silero-v5.1.2 || \
+     curl -fsSL -o models/ggml-silero-v5.1.2.bin \
+       https://huggingface.co/ggml-org/whisper-vad/resolve/main/ggml-silero-v5.1.2.bin) && \
+    cp models/ggml-silero-v5.1.2.bin /opt/models/ && \
+    test -s /opt/models/ggml-silero-v5.1.2.bin
 
 # ---- runtime image ---------------------------------------------------------
 FROM python:3.14-slim

--- a/packages/tools/video-grabber/tests/test_catalogue_filenames.py
+++ b/packages/tools/video-grabber/tests/test_catalogue_filenames.py
@@ -1,0 +1,38 @@
+from datetime import datetime, timezone
+
+from video_grabber.catalogue.filenames import parse_key
+
+
+def test_clip_hhmmss_is_local_et_converted_to_utc():
+    p = parse_key("audio/AA77/083950 aa77 approach indy .mp3")
+    assert p.start_utc == datetime(2001, 9, 11, 12, 39, 50, tzinfo=timezone.utc)
+    assert p.title == "approach indy"
+
+
+def test_clip_hhmm_is_accepted():
+    p = parse_key("audio/AA77/0812 aa77 taxi to runway t.mp3")
+    assert p.start_utc == datetime(2001, 9, 11, 12, 12, 0, tzinfo=timezone.utc)
+
+
+def test_faa_atc_tape_window_is_already_utc():
+    p = parse_key("audio/faa_atc/zny/tmu/4 ZNY 132 TMU DC 1245-1316 UTC AP.mp3")
+    assert p.start_utc == datetime(2001, 9, 11, 12, 45, tzinfo=timezone.utc)
+
+
+def test_unparseable_name_yields_no_timestamp_rather_than_a_guess():
+    p = parse_key("audio/norad/neads/DRM1_DAT2_Channel_3_MCC_TK.mp3")
+    assert p.start_utc is None
+    assert p.title == "DRM1_DAT2_Channel_3_MCC_TK"
+
+
+def test_an_hour_of_100_is_not_read_as_midnight():
+    # The transcript-contamination bug: '\d{2}' matched '10' out of '100225'
+    # and a re-anchored search read hour 100 as 0.
+    p = parse_key("audio/AA77/100225 aa77 line 4530 repo.mp3")
+    assert p.start_utc == datetime(2001, 9, 11, 14, 2, 25, tzinfo=timezone.utc)
+
+
+def test_impossible_clock_time_is_refused():
+    # '995959' is not a time. Better to store nothing than a wrong instant.
+    p = parse_key("audio/AA77/995959 something.mp3")
+    assert p.start_utc is None

--- a/packages/tools/video-grabber/tests/test_enhance_chains.py
+++ b/packages/tools/video-grabber/tests/test_enhance_chains.py
@@ -1,0 +1,53 @@
+import pytest
+
+from video_grabber.enhance.chains import CHAINS, audition_key, enhanced_key
+
+
+def test_enhanced_key_mirrors_the_audio_path_under_the_new_prefix():
+    assert enhanced_key("audio/AA77/0812 aa77 taxi.mp3") == \
+        "audio-enhanced/AA77/0812 aa77 taxi.mp3"
+
+
+def test_enhanced_key_refuses_anything_outside_audio():
+    # Guards against ever writing an "enhanced" file over a source recording.
+    with pytest.raises(ValueError):
+        enhanced_key("subtitles/audio/x.srt")
+
+
+def test_enhanced_key_refuses_an_already_enhanced_key():
+    # Re-running must not produce audio-enhanced/audio-enhanced/...
+    with pytest.raises(ValueError):
+        enhanced_key("audio-enhanced/AA77/x.mp3")
+
+
+def test_enhanced_key_is_never_the_input_key():
+    k = "audio/norad/neads/DRM1_DAT2_Channel_3_MCC_TK.mp3"
+    assert enhanced_key(k) != k
+
+
+def test_audition_keys_are_namespaced_per_chain():
+    a = audition_key("audio/AA77/x.mp3", "dfn_moderate")
+    b = audition_key("audio/AA77/x.mp3", "dfn_full")
+    assert a != b
+    assert a.startswith("audio-enhanced/_audition/")
+
+
+def test_audition_key_rejects_an_unknown_chain():
+    with pytest.raises(ValueError, match="unknown chain"):
+        audition_key("audio/AA77/x.mp3", "magic_restore")
+
+
+def test_every_chain_declares_whether_it_uses_a_model():
+    for name, chain in CHAINS.items():
+        assert isinstance(chain.uses_model, bool), name
+
+
+def test_no_chain_is_generative():
+    # Hard constraint: generative enhancement can emit speech nobody said, and
+    # its failure mode is invisible to every quality signal we would use.
+    for name, chain in CHAINS.items():
+        assert not chain.generative, f"{name} is generative and must not exist here"
+
+
+def test_at_least_one_chain_is_model_free_so_the_audition_has_a_control():
+    assert any(not c.uses_model for c in CHAINS.values())

--- a/packages/tools/video-grabber/tests/test_parties_flows.py
+++ b/packages/tools/video-grabber/tests/test_parties_flows.py
@@ -1,0 +1,32 @@
+from video_grabber.parties.flows import sample_windows, srt_text_to_plain
+
+SRT = (
+    "1\n00:00:01,000 --> 00:00:02,000\nIndy Center.\n\n"
+    "2\n00:00:03,000 --> 00:00:04,000\nAmerican 77.\n"
+)
+
+
+def test_srt_to_plain_drops_indices_and_timestamps():
+    assert srt_text_to_plain(SRT) == "Indy Center. American 77."
+
+
+def test_sample_windows_returns_whole_text_when_short():
+    assert sample_windows("short", n=6, size=2000) == ["short"]
+
+
+def test_sample_windows_spreads_across_a_long_transcript():
+    # Position-varying content: a repeating pattern whose period divides the
+    # step would make distinct windows compare equal and hide a real bug.
+    text = "".join(f"{i:04d}" for i in range(5000))
+    got = sample_windows(text, n=6, size=2000)
+    assert len(got) == 6
+    assert all(len(w) == 2000 for w in got)
+    assert len(set(got)) == 6
+
+
+def test_sample_windows_reaches_the_end_of_the_transcript():
+    # The last minutes of a NEADS tape are as interesting as the first; a
+    # sampler that only ever reads the opening would miss them.
+    text = "a" * 19000 + "TAIL" + "b" * 1000
+    got = sample_windows(text, n=6, size=2000)
+    assert any("TAIL" in w for w in got)

--- a/packages/tools/video-grabber/tests/test_parties_identify.py
+++ b/packages/tools/video-grabber/tests/test_parties_identify.py
@@ -1,0 +1,164 @@
+import pytest
+
+from video_grabber.parties.identify import (
+    BROADCAST,
+    CONVERSATION,
+    TIER_CLIP,
+    TIER_TAPE,
+    media_kind,
+    parse_parties,
+    should_identify,
+    tier_for,
+    validate_parties,
+)
+
+TRANSCRIPT = (
+    "American dispatch, Jim McDonald. This is Indianapolis Center, "
+    "trying to get a hold of American 77."
+)
+
+
+# --- the allow-list -------------------------------------------------------
+
+def test_wins_is_broadcast_and_never_identified():
+    assert media_kind("audio/wins1010/2001-09-11_1010_WINS_NEWS_10_AM.mp3") == BROADCAST
+    assert should_identify("audio/wins1010/2001-09-11_1010_WINS_NEWS_10_AM.mp3") is False
+
+
+def test_wcbs_is_broadcast_and_never_identified():
+    assert media_kind("audio/wcbs/2001-09-11-08-48-00-wcbs.mp3") == BROADCAST
+    assert should_identify("audio/wcbs/2001-09-11-08-48-00-wcbs.mp3") is False
+
+
+def test_atc_folders_are_conversation():
+    assert media_kind("audio/AA77/0812 aa77 taxi.mp3") == CONVERSATION
+    assert should_identify("audio/AA77/0812 aa77 taxi.mp3") is True
+
+
+def test_unknown_folder_is_skipped_not_identified():
+    # Fail-closed: a folder nobody classified must not be identified by default.
+    assert media_kind("audio/brand_new_collection/x.mp3") is None
+    assert should_identify("audio/brand_new_collection/x.mp3") is False
+
+
+def test_allow_list_is_not_a_deny_list():
+    # Mutation guard. If someone rewrites should_identify as
+    # `media_kind(key) != BROADCAST`, this turns red.
+    assert should_identify("audio/unclassified/x.mp3") is False
+
+
+def test_key_outside_audio_is_not_identified():
+    assert media_kind("subtitles/audio/AA77/x.srt") is None
+
+
+# --- tiering --------------------------------------------------------------
+
+def test_short_clip_is_a_clip():
+    assert tier_for(43) == TIER_CLIP
+
+
+def test_long_tape_is_a_tape():
+    assert tier_for(24300) == TIER_TAPE
+
+
+def test_missing_duration_raises_rather_than_defaulting():
+    # Defaulting to clip would push a 6.75h transcript through the clip prompt.
+    with pytest.raises(ValueError, match="duration"):
+        tier_for(None)
+
+
+# --- the containment gate -------------------------------------------------
+
+GOOD = {
+    "tier": "clip",
+    "side_a": {"facility": "Indianapolis Center", "position": None, "person": None,
+               "role": "atc"},
+    "side_b": {"facility": "American", "position": "dispatch", "person": "Jim McDonald",
+               "role": "airline"},
+    "link": "landline", "aircraft": ["AAL77"], "confidence": "high",
+    "evidence": "This is Indianapolis Center, trying to get a hold of American 77",
+}
+
+
+def test_gate_accepts_names_the_transcript_contains():
+    cleaned, reasons = validate_parties(GOOD, TRANSCRIPT)
+    assert reasons == []
+    assert cleaned["confidence"] == "high"
+    assert cleaned["side_b"]["person"] == "Jim McDonald"
+
+
+def test_gate_drops_a_facility_the_transcript_never_names():
+    # The failure this exists to prevent: the model knows 9/11 and supplies
+    # NEADS from memory rather than from the audio.
+    bad = {**GOOD, "side_a": {"facility": "NEADS", "position": None, "person": None,
+                              "role": "military"}}
+    cleaned, reasons = validate_parties(bad, TRANSCRIPT)
+    assert cleaned["side_a"]["facility"] is None
+    assert cleaned["confidence"] == "low"
+    assert any("neads" in r.lower() for r in reasons)
+
+
+def test_gate_drops_an_invented_person():
+    bad = {**GOOD, "side_b": {"facility": "American", "position": "dispatch",
+                              "person": "Colin Scoggins", "role": "airline"}}
+    cleaned, reasons = validate_parties(bad, TRANSCRIPT)
+    assert cleaned["side_b"]["person"] is None
+    assert cleaned["confidence"] == "low"
+
+
+def test_gate_rejects_evidence_that_is_not_verbatim():
+    bad = {**GOOD, "evidence": "Indianapolis Center said they lost the aircraft"}
+    cleaned, reasons = validate_parties(bad, TRANSCRIPT)
+    assert cleaned["confidence"] == "low"
+    assert any("verbatim" in r for r in reasons)
+
+
+def test_gate_tolerates_whitespace_and_case_in_evidence():
+    ok = {**GOOD, "evidence": "  this IS indianapolis   center  "}
+    _, reasons = validate_parties(ok, TRANSCRIPT)
+    assert reasons == []
+
+
+def test_gate_accepts_a_callsign_whose_number_is_in_the_transcript():
+    # 'AAL77' is a normalisation of 'American 77', not a quotation, so the gate
+    # checks the numeric part rather than the literal token.
+    cleaned, reasons = validate_parties(GOOD, TRANSCRIPT)
+    assert cleaned["aircraft"] == ["AAL77"]
+    assert reasons == []
+
+
+def test_gate_drops_a_callsign_the_transcript_never_mentions():
+    bad = {**GOOD, "aircraft": ["AAL77", "UAL93"]}
+    cleaned, reasons = validate_parties(bad, TRANSCRIPT)
+    assert cleaned["aircraft"] == ["AAL77"]
+    assert any("93" in r for r in reasons)
+
+
+def test_gate_leaves_various_alone_on_tape_tier():
+    tape = {**GOOD, "tier": "tape",
+            "side_b": {"facility": "various", "position": None, "person": None,
+                       "role": None}}
+    cleaned, reasons = validate_parties(tape, TRANSCRIPT)
+    assert cleaned["side_b"]["facility"] == "various"
+    assert reasons == []
+
+
+# --- parsing --------------------------------------------------------------
+
+def test_parse_accepts_a_fenced_json_block():
+    raw = '```json\n{"tier":"clip","confidence":"high"}\n```'
+    assert parse_parties(raw)["tier"] == "clip"
+
+
+def test_parse_accepts_bare_json():
+    assert parse_parties('{"tier":"clip"}')["tier"] == "clip"
+
+
+def test_parse_rejects_non_json():
+    with pytest.raises(ValueError):
+        parse_parties("I could not determine the parties.")
+
+
+def test_parse_rejects_a_json_array():
+    with pytest.raises(ValueError, match="not an object"):
+        parse_parties("[1, 2, 3]")

--- a/packages/tools/video-grabber/tests/test_srt.py
+++ b/packages/tools/video-grabber/tests/test_srt.py
@@ -138,3 +138,24 @@ def test_a_cue_never_parses_to_an_end_before_its_start():
     # digits. An end before a start is impossible and must never parse silently.
     cues = parse_srt("1\n99:59:45,000 --> 100:00:04,000\nspans the boundary\n")
     assert cues[0].end > cues[0].start
+
+
+def test_strips_music_and_blank_audio_markers():
+    from video_grabber.transcribe.srt import strip_nonspeech_cues
+    cues = [Cue(0, 1, "[Music]"), Cue(1, 2, "Bravo 112"),
+            Cue(2, 3, "[BLANK_AUDIO]"), Cue(3, 4, "♪♪")]
+    assert [c.text for c in strip_nonspeech_cues(cues)] == ["Bravo 112"]
+
+
+def test_keeps_inaudible_markers_because_they_mark_real_speech():
+    # '[unintelligible]' means someone spoke and whisper could not resolve it.
+    # That is information; '[Music]' over an open mic is not.
+    from video_grabber.transcribe.srt import strip_nonspeech_cues
+    cues = [Cue(0, 1, "[unintelligible]"), Cue(1, 2, "Bravo 112")]
+    assert len(strip_nonspeech_cues(cues)) == 2
+
+
+def test_leaves_ordinary_speech_untouched():
+    from video_grabber.transcribe.srt import strip_nonspeech_cues
+    cues = [Cue(0, 1, "American 77, Indy Center")]
+    assert strip_nonspeech_cues(cues) == cues

--- a/packages/tools/video-grabber/tests/test_transcribe_chunking.py
+++ b/packages/tools/video-grabber/tests/test_transcribe_chunking.py
@@ -1,0 +1,49 @@
+import pytest
+
+from video_grabber.transcribe.chunking import windows
+
+
+def test_short_recording_is_one_window():
+    assert windows(120.0, chunk_s=600, overlap_s=5) == [(0, 120000)]
+
+
+def test_exact_multiple_produces_no_trailing_sliver():
+    assert windows(1200.0, chunk_s=600, overlap_s=0) == [(0, 600000), (600000, 600000)]
+
+
+def test_windows_overlap_so_speech_on_a_boundary_is_not_lost():
+    got = windows(1200.0, chunk_s=600, overlap_s=5)
+    assert got[1][0] == 595000
+
+
+def test_final_window_is_clipped_to_the_real_end():
+    got = windows(1300.0, chunk_s=600, overlap_s=0)
+    assert got[-1][0] + got[-1][1] == 1300000
+
+
+def test_a_six_hour_tape_is_split_into_bounded_windows():
+    got = windows(24299.0, chunk_s=600, overlap_s=5)
+    assert all(d <= 600000 for _, d in got)
+    assert got[0][0] == 0
+    assert got[-1][0] + got[-1][1] == 24299000
+
+
+def test_every_second_of_audio_is_covered():
+    # A gap between windows silently drops speech; this is the invariant that
+    # matters more than the exact window count.
+    got = windows(24299.0, chunk_s=600, overlap_s=5)
+    reach = 0
+    for start, length in got:
+        assert start <= reach, f"gap before {start}"
+        reach = max(reach, start + length)
+    assert reach == 24299000
+
+
+def test_zero_duration_raises_rather_than_returning_nothing():
+    with pytest.raises(ValueError):
+        windows(0, chunk_s=600, overlap_s=5)
+
+
+def test_overlap_larger_than_chunk_raises():
+    with pytest.raises(ValueError):
+        windows(1200.0, chunk_s=600, overlap_s=600)

--- a/packages/tools/video-grabber/tests/test_transcribe_flows.py
+++ b/packages/tools/video-grabber/tests/test_transcribe_flows.py
@@ -175,6 +175,41 @@ def test_build_channel_subtitles_raises_when_channel_lookup_misses():
             flows.build_channel_subtitles_flow("cctv4")
 
 
+def test_existing_srt_key_prefers_the_mirrored_path():
+    stems = {"0812 aa77 taxi"}
+    paths = {"subtitles/audio/AA77/0812 aa77 taxi.srt"}
+    assert flows.existing_srt_key("audio/AA77/0812 aa77 taxi.mp3", stems, paths) == \
+        "subtitles/audio/AA77/0812 aa77 taxi.srt"
+
+
+def test_existing_srt_key_falls_back_to_the_flat_stem():
+    stems = {"0812 aa77 taxi"}
+    assert flows.existing_srt_key("audio/AA77/0812 aa77 taxi.mp3", stems, set()) == \
+        "subtitles/audio/0812 aa77 taxi.srt"
+
+
+def test_existing_srt_key_returns_none_when_untranscribed():
+    assert flows.existing_srt_key("audio/AA77/never.mp3", set(), set()) is None
+
+
+def test_subtitle_base_key_mirrors_the_audio_path():
+    cfg = SimpleNamespace(subtitles_prefix="subtitles")
+    assert flows.subtitle_base_key("mp3", "audio/AA77/0812 aa77 taxi.mp3", cfg) == \
+        "subtitles/audio/AA77/0812 aa77 taxi"
+
+
+def test_subtitle_base_key_disambiguates_colliding_basenames():
+    cfg = SimpleNamespace(subtitles_prefix="subtitles")
+    a = flows.subtitle_base_key("mp3", "audio/AA11/081015 aa11 fl290.mp3", cfg)
+    b = flows.subtitle_base_key("mp3", "audio/faa_atc/clips/aa11/081015 aa11 fl290.mp3", cfg)
+    assert a != b
+
+
+def test_subtitle_base_key_leaves_tv_alone():
+    cfg = SimpleNamespace(subtitles_prefix="subtitles")
+    assert flows.subtitle_base_key("tv", "TCN_test", cfg) == "subtitles/programs/TCN_test"
+
+
 def _mp3_job(job_id):
     return SimpleNamespace(
         id=job_id, kind="mp3",

--- a/packages/tools/video-grabber/tests/test_transcribe_flows.py
+++ b/packages/tools/video-grabber/tests/test_transcribe_flows.py
@@ -100,13 +100,16 @@ def flow_env(monkeypatch, tmp_path):
         ),
     )
     monkeypatch.setattr(flows, "extract_audio", lambda url, dst: dst)
+    # The wav is never written, so ffprobe cannot read it; the chunking maths is
+    # covered by test_transcribe_chunking.py and test_transcribe_windows_*.
+    monkeypatch.setattr(flows, "probe_duration_seconds", lambda p: 12.0)
     monkeypatch.setattr(
         flows, "wasabi",
         SimpleNamespace(upload_text=lambda text, key, cfg: None, list_keys=lambda *a: []),
     )
 
     def make_transcriber(fail=None):
-        def fake_transcribe(wav, out_base, cfg):
+        def fake_transcribe(wav, out_base, cfg, **kw):
             # idle_session_timeout fires mid-transcription: every connection
             # opened before this point is now dead.
             for c in conns:
@@ -173,6 +176,26 @@ def test_build_channel_subtitles_raises_when_channel_lookup_misses():
          patch.object(flows, "get_tv_channel_start_date", return_value=None):
         with pytest.raises(ValueError, match="no tv_channels row"):
             flows.build_channel_subtitles_flow("cctv4")
+
+
+def test_transcribe_windows_shifts_each_window_onto_the_file_timeline(monkeypatch, tmp_path):
+    calls = []
+
+    def fake(wav, out_base, cfg, *, offset_ms=0, duration_ms=0, vad=False, runner=None):
+        calls.append((offset_ms, vad))
+        out_base.parent.mkdir(parents=True, exist_ok=True)
+        srt = out_base.with_suffix(".srt")
+        srt.write_text("1\n00:00:01,000 --> 00:00:02,000\nword\n")
+        return srt
+
+    monkeypatch.setattr(flows, "transcribe_wav", fake)
+    cfg = SimpleNamespace(chunk_seconds=600, chunk_overlap_seconds=0)
+    cues = flows.transcribe_windows(tmp_path / "a.wav", tmp_path, cfg, duration_s=1200.0)
+    assert [c[0] for c in calls] == [0, 600000]
+    # VAD must be on for every window -- it is the whole point of the change.
+    assert all(vad for _, vad in calls)
+    # the second window's 1s cue lands at 601s on the file timeline
+    assert any(abs(c.start - 601.0) < 0.01 for c in cues)
 
 
 def test_existing_srt_key_prefers_the_mirrored_path():

--- a/packages/tools/video-grabber/tests/test_transcribe_flows.py
+++ b/packages/tools/video-grabber/tests/test_transcribe_flows.py
@@ -178,6 +178,46 @@ def test_build_channel_subtitles_raises_when_channel_lookup_misses():
             flows.build_channel_subtitles_flow("cctv4")
 
 
+class _ScanConn:
+    """Minimal Connection stub: scan-transcribe calls .mappings().all()."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, stmt, params=None):
+        return SimpleNamespace(
+            mappings=lambda: SimpleNamespace(all=lambda: []),
+            rowcount=0,
+        )
+
+    def commit(self):
+        pass
+
+
+def test_scan_transcribe_never_enqueues_enhanced_audio(monkeypatch):
+    """Transcripts must come from the source recording, never from a render.
+
+    Enhanced audio lives at audio-enhanced/ and mp3_items gains an enhanced_url
+    field, so anything deriving transcribe work from Directus rows rather than
+    from the audio/ prefix would silently start transcribing processed audio.
+    """
+    seen = []
+
+    def list_keys(prefix, cfg):
+        seen.append(prefix)
+        return []
+
+    monkeypatch.setattr(flows, "wasabi", SimpleNamespace(list_keys=list_keys))
+    monkeypatch.setattr(flows, "get_db", _ScanConn)
+    monkeypatch.setattr(flows, "get_run_logger", lambda: logging.getLogger("test"))
+    flows.scan_transcribe_flow.fn()
+    assert "audio/" in seen
+    assert not any(p.startswith("audio-enhanced") for p in seen)
+
+
 def test_transcribe_windows_shifts_each_window_onto_the_file_timeline(monkeypatch, tmp_path):
     calls = []
 

--- a/packages/tools/video-grabber/tests/test_transcribe_flows.py
+++ b/packages/tools/video-grabber/tests/test_transcribe_flows.py
@@ -173,3 +173,32 @@ def test_build_channel_subtitles_raises_when_channel_lookup_misses():
          patch.object(flows, "get_tv_channel_start_date", return_value=None):
         with pytest.raises(ValueError, match="no tv_channels row"):
             flows.build_channel_subtitles_flow("cctv4")
+
+
+def _mp3_job(job_id):
+    return SimpleNamespace(
+        id=job_id, kind="mp3",
+        source_key="audio/AA77/x.mp3",
+        source_url="https://files.911realtime.org/audio/AA77/x.mp3",
+    )
+
+
+def test_transcribe_item_fails_when_no_mp3_items_row_matches(flow_env):
+    """A miss means the SRT is in the bucket with nothing pointing at it.
+
+    This warned-and-continued for 575 jobs while every run reported success.
+    """
+    flow_env.monkeypatch.setattr(flows, "transcribe_wav", flow_env.make_transcriber())
+    flow_env.monkeypatch.setattr(flows, "get_transcribe_job", _mp3_job)
+    flow_env.monkeypatch.setattr(flows, "patch_mp3_subtitles", lambda *a, **k: False)
+    with pytest.raises(RuntimeError, match="matched no mp3_items row"):
+        flows.transcribe_item_flow.fn("job-1")
+    assert _stages(flow_env.conns)[-1] == "failed"
+
+
+def test_transcribe_item_succeeds_when_the_row_matches(flow_env):
+    flow_env.monkeypatch.setattr(flows, "transcribe_wav", flow_env.make_transcriber())
+    flow_env.monkeypatch.setattr(flows, "get_transcribe_job", _mp3_job)
+    flow_env.monkeypatch.setattr(flows, "patch_mp3_subtitles", lambda *a, **k: True)
+    flows.transcribe_item_flow.fn("job-1")
+    assert _stages(flow_env.conns) == ["transcribing", "done"]

--- a/packages/tools/video-grabber/tests/test_transcribe_whisper.py
+++ b/packages/tools/video-grabber/tests/test_transcribe_whisper.py
@@ -35,3 +35,41 @@ def test_transcribe_wav_raises_on_failure(tmp_path):
         assert "vulkan" in str(e)
     else:
         raise AssertionError("expected RuntimeError")
+
+
+def _cfg():
+    return SimpleNamespace(whisper_bin="whisper-cli", whisper_model="/m.bin",
+                           whisper_threads=4, vad_model="/vad.bin")
+
+
+def _capture(tmp_path, **kw):
+    seen = {}
+
+    def runner(cmd, **_):
+        seen["cmd"] = cmd
+        return SimpleNamespace(returncode=0, stderr="")
+
+    transcribe_wav(tmp_path / "a.wav", tmp_path / "out", _cfg(), runner=runner, **kw)
+    return seen["cmd"]
+
+
+def test_vad_flags_are_passed_when_enabled(tmp_path):
+    cmd = _capture(tmp_path, vad=True)
+    assert "--vad" in cmd
+    assert cmd[cmd.index("--vad-model") + 1] == "/vad.bin"
+
+
+def test_window_flags_are_passed(tmp_path):
+    cmd = _capture(tmp_path, offset_ms=600000, duration_ms=600000)
+    assert cmd[cmd.index("-ot") + 1] == "600000"
+    assert cmd[cmd.index("-d") + 1] == "600000"
+
+
+def test_no_window_flags_when_transcribing_whole_file(tmp_path):
+    cmd = _capture(tmp_path)
+    assert "-ot" not in cmd and "--vad" not in cmd
+
+
+def test_wav_path_stays_last_so_flags_are_never_swallowed(tmp_path):
+    cmd = _capture(tmp_path, vad=True, offset_ms=1000, duration_ms=2000)
+    assert cmd[-1].endswith("a.wav")

--- a/packages/tools/video-grabber/tests/test_wasabi_public_url.py
+++ b/packages/tools/video-grabber/tests/test_wasabi_public_url.py
@@ -1,0 +1,26 @@
+from video_grabber.directus.writer import wasabi_public_url
+
+
+def test_encodes_spaces():
+    assert wasabi_public_url("audio/AA77/0812 aa77 taxi.mp3") == (
+        "https://files.911realtime.org/audio/AA77/0812%20aa77%20taxi.mp3"
+    )
+
+
+def test_keeps_path_separators_unencoded():
+    assert "/audio/AA77/" in wasabi_public_url("audio/AA77/x.mp3")
+
+
+def test_matches_the_form_directus_actually_stores():
+    # The exact row that never linked for 18 months.
+    assert wasabi_public_url("audio/AA77/0812 aa77 taxi to runway t.mp3") == (
+        "https://files.911realtime.org/audio/AA77/"
+        "0812%20aa77%20taxi%20to%20runway%20t.mp3"
+    )
+
+
+def test_space_free_keys_are_unchanged():
+    # The three folders that DID link must keep linking.
+    assert wasabi_public_url("audio/norad/neads/DRM1_DAT2_Channel_3_MCC_TK.mp3") == (
+        "https://files.911realtime.org/audio/norad/neads/DRM1_DAT2_Channel_3_MCC_TK.mp3"
+    )

--- a/packages/tools/video-grabber/video_grabber/catalogue/filenames.py
+++ b/packages/tools/video-grabber/video_grabber/catalogue/filenames.py
@@ -1,0 +1,68 @@
+"""Derive mp3_items metadata from a bucket key.
+
+Every rule here refuses rather than guesses. A filename this parser cannot read
+yields start_utc=None and the row is created without a timestamp — a wrong
+timestamp puts 2001-09-11 audio on the wrong day of the replay, which is exactly
+the failure mode of the transcript-timeline contamination incident.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+DAY = datetime(2001, 9, 11, tzinfo=timezone.utc)
+ET_OFFSET = timedelta(hours=4)  # EDT on 2001-09-11; UTC = ET + 4
+
+# Anchored at the start and bounded by a lookahead, so '100225' reads as
+# 10:02:25 and never as hour '10' followed by a re-anchored search.
+_CLIP_TIME = re.compile(r"^(\d{2})(\d{2})(\d{2})?(?=\D|$)")
+# faa_atc tape windows: '… 1245-1316 UTC …'
+_UTC_WINDOW = re.compile(r"\b(\d{2})(\d{2})-(\d{2})(\d{2})\s+UTC\b")
+# A leading callsign token left over after the timestamp is stripped.
+_CALLSIGN = re.compile(r"^(aa|ua|d|dal|ual)?\s*\d{1,4}\s*", re.I)
+
+
+@dataclass(frozen=True)
+class ParsedName:
+    title: str
+    start_utc: datetime | None
+
+
+def _at(hh: int, mm: int, ss: int = 0, *, offset: timedelta = timedelta()) -> datetime | None:
+    if hh > 23 or mm > 59 or ss > 59:
+        return None
+    return DAY + timedelta(hours=hh, minutes=mm, seconds=ss) + offset
+
+
+def _clip_start(stem: str) -> datetime | None:
+    m = _CLIP_TIME.match(stem)
+    if not m:
+        return None
+    return _at(int(m.group(1)), int(m.group(2)), int(m.group(3) or 0), offset=ET_OFFSET)
+
+
+def _utc_window_start(stem: str) -> datetime | None:
+    m = _UTC_WINDOW.search(stem)
+    if not m:
+        return None
+    return _at(int(m.group(1)), int(m.group(2)))
+
+
+def _title(stem: str) -> str:
+    rest = _CLIP_TIME.sub("", stem).strip()
+    rest = _CALLSIGN.sub("", rest).strip()
+    return rest or stem
+
+
+def parse_key(key: str) -> ParsedName:
+    """Return the title and UTC start instant implied by a bucket key."""
+    stem = Path(key).stem
+    start = _utc_window_start(stem)
+    if start is not None:
+        return ParsedName(title=stem, start_utc=start)
+    start = _clip_start(stem)
+    if start is not None:
+        return ParsedName(title=_title(stem), start_utc=start)
+    return ParsedName(title=stem, start_utc=None)

--- a/packages/tools/video-grabber/video_grabber/catalogue/flows.py
+++ b/packages/tools/video-grabber/video_grabber/catalogue/flows.py
@@ -1,0 +1,134 @@
+"""Reconcile mp3_items against the audio/ prefix.
+
+Two flows, both idempotent and both defaulting to dry_run=True: these write to
+the live catalogue, and a wrong start_date puts historical audio on the wrong
+day of the replay.
+"""
+import subprocess as _sp
+from pathlib import Path
+from urllib.parse import unquote
+
+import httpx
+from prefect import flow, get_run_logger
+
+from video_grabber.catalogue.filenames import parse_key
+from video_grabber.config import Config
+from video_grabber.directus.writer import _WASABI_BASE, _auth_headers, wasabi_public_url
+from video_grabber.storage import wasabi
+
+_PAGE = 500
+# Cloudflare in front of files.911realtime.org blocks some default tool
+# User-Agents outright; ffprobe's own is fine, but pin a browser UA so an
+# in-cluster probe never 403s and gets mistaken for an unreadable file.
+_UA = ("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+       "Chrome/120.0 Safari/537.36")
+
+
+def probe_duration(url: str) -> int | None:
+    """Duration in whole seconds, or None if ffprobe cannot read the file."""
+    r = _sp.run(
+        ["ffprobe", "-v", "error", "-user_agent", _UA,
+         "-show_entries", "format=duration", "-of", "default=nw=1:nk=1", url],
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0 or not r.stdout.strip():
+        return None
+    try:
+        return int(float(r.stdout.strip()))
+    except ValueError:
+        return None
+
+
+def _page_mp3_items(cfg: Config, fields: str, *, client=httpx):
+    """Yield every mp3_items row, following offsets until a short page."""
+    offset = 0
+    while True:
+        r = client.get(
+            f"{cfg.directus_url}/items/mp3_items",
+            params={"fields": fields, "limit": _PAGE, "offset": offset},
+            headers=_auth_headers(cfg),
+        )
+        r.raise_for_status()
+        page = r.json().get("data") or []
+        yield from page
+        if len(page) < _PAGE:
+            return
+        offset += _PAGE
+
+
+def key_from_url(url: str) -> str:
+    """Bucket key for a stored mp3_items.url (which is percent-encoded)."""
+    return unquote(url.replace(f"{_WASABI_BASE}/", ""))
+
+
+@flow(name="backfill-mp3-catalogue")
+def backfill_mp3_catalogue_flow(dry_run: bool = True) -> None:
+    """Create an mp3_items row for every audio/ object that has none."""
+    logger = get_run_logger()
+    cfg = Config()
+    have = {row["url"] for row in _page_mp3_items(cfg, "url") if row.get("url")}
+    keys = [k for k in wasabi.list_keys("audio/", cfg) if k.lower().endswith(".mp3")]
+
+    created = unreadable = 0
+    for key in keys:
+        url = wasabi_public_url(key)
+        if url in have:
+            continue
+        parsed = parse_key(key)
+        duration = probe_duration(url)
+        if duration is None:
+            # calc_duration gates clip/tape tiering downstream; a row without it
+            # would make identification refuse. Skip loudly instead.
+            logger.warning("backfill: could not probe %s; skipping", key)
+            unreadable += 1
+            continue
+        body = {
+            "title": parsed.title,
+            "full_title": parsed.title,
+            "url": url,
+            "format": "mp3",
+            "calc_duration": duration,
+            "timezone": "EDT",
+            "approved": 0,
+        }
+        if parsed.start_utc is not None:
+            body["start_date"] = parsed.start_utc.strftime("%Y-%m-%d %H:%M:%S")
+        if dry_run:
+            logger.info("DRY RUN would create: %s", body)
+        else:
+            r = httpx.post(f"{cfg.directus_url}/items/mp3_items",
+                           json=body, headers=_auth_headers(cfg))
+            r.raise_for_status()
+        created += 1
+    logger.info("backfill-mp3-catalogue: %d rows %s, %d unreadable",
+                created, "would be created" if dry_run else "created", unreadable)
+
+
+@flow(name="link-mp3-subtitles")
+def link_mp3_subtitles_flow(dry_run: bool = True) -> None:
+    """Point every mp3_items.subtitles at its SRT. Idempotent."""
+    from video_grabber.transcribe.flows import existing_srt_key
+
+    logger = get_run_logger()
+    cfg = Config()
+    srt_keys = [k for k in wasabi.list_keys(f"{cfg.subtitles_prefix}/", cfg)
+                if k.endswith(".srt")]
+    srt_paths, srt_stems = set(srt_keys), {Path(k).stem for k in srt_keys}
+
+    linked = missing = unchanged = 0
+    for row in _page_mp3_items(cfg, "id,url,subtitles"):
+        srt_key = existing_srt_key(key_from_url(row["url"]), srt_stems, srt_paths)
+        if srt_key is None:
+            missing += 1
+            continue
+        target = wasabi_public_url(srt_key)
+        if row.get("subtitles") == target:
+            unchanged += 1
+            continue
+        if not dry_run:
+            pr = httpx.patch(f"{cfg.directus_url}/items/mp3_items/{row['id']}",
+                             json={"subtitles": target}, headers=_auth_headers(cfg))
+            pr.raise_for_status()
+        linked += 1
+    logger.info("link-mp3-subtitles: %d %s, %d already correct, %d without an SRT",
+                linked, "would be linked" if dry_run else "linked", unchanged, missing)

--- a/packages/tools/video-grabber/video_grabber/config.py
+++ b/packages/tools/video-grabber/video_grabber/config.py
@@ -31,6 +31,13 @@ class Config:
     anthropic_api_key: str = field(default_factory=lambda: os.getenv("ANTHROPIC_API_KEY", ""))
     summarize_model: str = field(default_factory=lambda: os.getenv("SUMMARIZE_MODEL", "claude-haiku-4-5"))
     summarize_tier: str = field(default_factory=lambda: os.getenv("SUMMARIZE_TIER", "llm-extract"))
+    # Party identification is judgment-heavy; the summarizer's haiku default is
+    # too light for deciding who is speaking on a garbled tape.
+    parties_model: str = field(default_factory=lambda: os.getenv("PARTIES_MODEL", "claude-sonnet-5"))
+    enhance_chain: str = field(default_factory=lambda: os.getenv("ENHANCE_CHAIN", ""))
+    deep_filter_bin: str = field(
+        default_factory=lambda: os.getenv("DEEP_FILTER_BIN", "/usr/local/bin/deep-filter")
+    )
     summarize_max_units: int = field(default_factory=lambda: _int("SUMMARIZE_MAX_UNITS", 3))
     summarize_concurrency: int = field(default_factory=lambda: _int("SUMMARIZE_CONCURRENCY", 8))
 

--- a/packages/tools/video-grabber/video_grabber/config.py
+++ b/packages/tools/video-grabber/video_grabber/config.py
@@ -37,6 +37,9 @@ class Config:
     # --- Audio transcription (whisper.cpp) ---
     whisper_bin: str = field(default_factory=lambda: os.getenv("WHISPER_BIN", "whisper-cli"))
     whisper_model: str = field(default_factory=lambda: os.getenv("WHISPER_MODEL", "/opt/models/ggml-medium.en.bin"))
+    vad_model: str = field(default_factory=lambda: os.getenv("VAD_MODEL", "/opt/models/ggml-silero-v5.1.2.bin"))
+    chunk_seconds: int = field(default_factory=lambda: _int("TRANSCRIBE_CHUNK_SECONDS", 600))
+    chunk_overlap_seconds: int = field(default_factory=lambda: _int("TRANSCRIBE_CHUNK_OVERLAP_SECONDS", 5))
     whisper_threads: int = field(default_factory=lambda: _int("WHISPER_THREADS", 4))
     subtitles_prefix: str = field(default_factory=lambda: os.getenv("SUBTITLES_PREFIX", "subtitles"))
 

--- a/packages/tools/video-grabber/video_grabber/directus/writer.py
+++ b/packages/tools/video-grabber/video_grabber/directus/writer.py
@@ -8,12 +8,26 @@ Directus media_items writer.
 """
 import json
 from datetime import timedelta
+from urllib.parse import quote
 
 import httpx
 
 from video_grabber.config import Config
 
 _WASABI_BASE = "https://files.911realtime.org"
+
+
+def wasabi_public_url(key: str) -> str:
+    """Public URL for a bucket key, encoded the way mp3_items.url stores it.
+
+    Load-bearing: patch_mp3_subtitles matches mp3_items.url with an exact _eq
+    filter. Directus stores '…/0812%20aa77….mp3'; passing the raw key matched
+    only the three folders whose filenames contain no spaces, silently leaving
+    575 of 621 rows unlinked while the pipeline reported success.
+
+    quote() leaves '/' alone by default, so path structure survives.
+    """
+    return f"{_WASABI_BASE}/{quote(key)}"
 
 
 def get_directus_token(cfg: Config) -> str:

--- a/packages/tools/video-grabber/video_grabber/enhance/chains.py
+++ b/packages/tools/video-grabber/video_grabber/enhance/chains.py
@@ -1,0 +1,72 @@
+"""Named audio-enhancement chains for the listening experience.
+
+Every chain here is *discriminative*: it estimates a mask over the real recording
+and can only remove energy. Generative restoration is deliberately absent. A model
+that resynthesizes speech from a learned prior will produce fluent, confident audio
+for a passage that was six seconds of static, and nothing downstream can tell --
+it sounds better, ASR confidence rises, and containment checks pass because the
+transcript really does contain the words. On a primary-source archive that is a
+provenance failure, not a tuning choice.
+
+Enhancement output is for listening only. Transcription always reads audio/.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+AUDIO_PREFIX = "audio/"
+ENHANCED_PREFIX = "audio-enhanced/"
+
+
+@dataclass(frozen=True)
+class Chain:
+    """One enhancement recipe.
+
+    ffmpeg_pre  filter string applied before the model, or None
+    dfn_atten   DeepFilterNet attenuation limit in dB, or None to skip the model
+    ffmpeg_post filter string applied after the model, or None
+    """
+    ffmpeg_pre: str | None
+    dfn_atten: int | None
+    ffmpeg_post: str | None
+    generative: bool = False
+
+    @property
+    def uses_model(self) -> bool:
+        return self.dfn_atten is not None
+
+
+BAND = "highpass=f=200,lowpass=f=3400"
+SPEECH = "speechnorm=e=12.5:r=0.0001:l=1"
+
+CHAINS: dict[str, Chain] = {
+    # DSP only -- the control. Measured best for ASR; included so the audition can
+    # tell whether the model earns its place for listening.
+    "dsp_only": Chain(ffmpeg_pre=f"{BAND},{SPEECH}", dfn_atten=None, ffmpeg_post=None),
+    # Conservative model: mixes enhanced with original, limiting artifacts.
+    "dfn_moderate": Chain(ffmpeg_pre=None, dfn_atten=20, ffmpeg_post=SPEECH),
+    # Full attenuation. Sounds cleanest, measured worst for ASR -- which does not
+    # disqualify it here, because nothing transcribes this output.
+    "dfn_full": Chain(ffmpeg_pre=None, dfn_atten=100, ffmpeg_post=SPEECH),
+    # Model plus band-limiting and gain staging.
+    "dfn_full_band": Chain(ffmpeg_pre=None, dfn_atten=100, ffmpeg_post=f"{BAND},{SPEECH}"),
+}
+
+
+def enhanced_key(audio_key: str) -> str:
+    """Destination key for an enhanced render."""
+    if not audio_key.startswith(AUDIO_PREFIX):
+        raise ValueError(
+            f"refusing to derive an enhanced key from {audio_key!r}: "
+            f"only keys under {AUDIO_PREFIX!r} can be enhanced"
+        )
+    return ENHANCED_PREFIX + audio_key[len(AUDIO_PREFIX):]
+
+
+def audition_key(audio_key: str, chain_name: str) -> str:
+    """Destination key for one audition render, namespaced by chain."""
+    if chain_name not in CHAINS:
+        raise ValueError(f"unknown chain {chain_name!r}")
+    stem = Path(audio_key).name
+    return f"{ENHANCED_PREFIX}_audition/{chain_name}/{stem}"

--- a/packages/tools/video-grabber/video_grabber/enhance/flows.py
+++ b/packages/tools/video-grabber/video_grabber/enhance/flows.py
@@ -1,0 +1,152 @@
+"""Render enhanced audio. Audition first, corpus second.
+
+Writes only to audio-enhanced/ and only to mp3_items.enhanced_url. `url` is never
+touched: it is the join key for patch_mp3_subtitles, link_mp3_subtitles_flow and
+backfill_mp3_catalogue_flow, and repointing it would break all three -- the last
+of them by silently creating a duplicate row for every file in the bucket.
+"""
+import subprocess
+import tempfile
+from pathlib import Path
+
+import httpx
+from prefect import flow, get_run_logger
+
+from video_grabber.catalogue.flows import _page_mp3_items
+from video_grabber.config import Config
+from video_grabber.directus.writer import _auth_headers, wasabi_public_url
+from video_grabber.enhance.chains import CHAINS, audition_key, enhanced_key
+from video_grabber.storage import wasabi
+
+# Eight clips spanning the failure modes: three that transcribed badly, three
+# mid-quality, two clean controls. The same set used in the findings experiment,
+# so the audition is comparable to the measurements already recorded.
+AUDITION_CLIPS = [
+    "audio/AA77/093535 aa77 he's descendin.mp3",
+    "audio/AA77/093657 aa77 looks like wen.mp3",
+    "audio/AA77/100225 aa77 line 4530 repo.mp3",
+    "audio/AA77/083955 aa77 bobcat or hend.mp3",
+    "audio/AA77/093222 aa77 danielle heard.mp3",
+    "audio/AA77/093728 aa77 track b032 los.mp3",
+    "audio/AA77/084013 aa77 zid checkin mo.mp3",
+    "audio/AA77/091836 aa77 summersall to .mp3",
+]
+
+
+def _run(cmd: list[str]) -> None:
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode != 0:
+        raise RuntimeError(f"{cmd[0]} failed ({r.returncode}): {r.stderr[-600:]}")
+
+
+def render_one(audio_key: str, chain_name: str, cfg: Config, dest_key: str) -> str:
+    """Render one file through one chain and upload it to dest_key."""
+    chain = CHAINS[chain_name]
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        src = d / "src.mp3"
+        wasabi.download_file(audio_key, src, cfg)
+
+        # DeepFilterNet operates at 48 kHz; stage there even for the DSP-only
+        # chain so every variant differs by filtering alone, not resampling.
+        stage = d / "stage.wav"
+        cmd = ["ffmpeg", "-nostdin", "-v", "error", "-y", "-i", str(src)]
+        if chain.ffmpeg_pre:
+            cmd += ["-af", chain.ffmpeg_pre]
+        cmd += ["-ar", "48000", "-ac", "1", "-c:a", "pcm_s16le", str(stage)]
+        _run(cmd)
+
+        current = stage
+        if chain.dfn_atten is not None:
+            outdir = d / "dfn"
+            outdir.mkdir()
+            dfn = [cfg.deep_filter_bin, "-D", "-o", str(outdir), str(stage)]
+            if chain.dfn_atten < 100:
+                dfn += ["-a", str(chain.dfn_atten)]
+            _run(dfn)
+            produced = sorted(outdir.glob("*.wav"))
+            if not produced:
+                raise RuntimeError(f"deep-filter produced nothing for {audio_key!r}")
+            current = produced[0]
+
+        final = d / "final.mp3"
+        cmd = ["ffmpeg", "-nostdin", "-v", "error", "-y", "-i", str(current)]
+        if chain.ffmpeg_post:
+            cmd += ["-af", chain.ffmpeg_post]
+        cmd += ["-c:a", "libmp3lame", "-b:a", "128k", str(final)]
+        _run(cmd)
+
+        wasabi.upload_mp3(final, dest_key, cfg, cache_control="max-age=31536000")
+    return dest_key
+
+
+@flow(name="render-audition")
+def render_audition_flow(keys: list[str] | None = None) -> None:
+    """Render the audition set through every chain, for a human to listen to.
+
+    ASR metrics cannot answer whether enhanced audio *sounds* better, so the
+    chain is chosen by ear. This flow only produces the candidates.
+    """
+    logger = get_run_logger()
+    cfg = Config()
+    clips = keys or AUDITION_CLIPS
+    for key in clips:
+        logger.info("original: %s", wasabi_public_url(key))
+        for chain_name in CHAINS:
+            dest = audition_key(key, chain_name)
+            try:
+                render_one(key, chain_name, cfg, dest)
+            except Exception as exc:  # noqa: BLE001 - one bad chain must not stop the set
+                logger.warning("audition %s/%s failed: %s", chain_name, key, exc)
+                continue
+            logger.info("  %-14s %s", chain_name, wasabi_public_url(dest))
+
+
+@flow(name="render-enhanced-corpus")
+def render_enhanced_corpus_flow(dry_run: bool = True, limit: int | None = None) -> None:
+    """Render every audio/ mp3 through the chosen chain and record the render.
+
+    Writes only mp3_items.enhanced_url. Idempotent: re-running overwrites it
+    with the same value.
+    """
+    logger = get_run_logger()
+    cfg = Config()
+    if not cfg.enhance_chain:
+        raise RuntimeError(
+            "ENHANCE_CHAIN is unset. Choose a chain by listening to the audition "
+            "output (render-audition) before running the corpus render."
+        )
+    if cfg.enhance_chain not in CHAINS:
+        raise RuntimeError(
+            f"unknown ENHANCE_CHAIN {cfg.enhance_chain!r}; known: {sorted(CHAINS)}"
+        )
+
+    by_url = {row["url"]: row["id"] for row in _page_mp3_items(cfg, "id,url")
+              if row.get("url")}
+    keys = [k for k in wasabi.list_keys("audio/", cfg) if k.lower().endswith(".mp3")]
+
+    done = unlinked = 0
+    for key in keys:
+        if limit is not None and done >= limit:
+            break
+        dest = enhanced_key(key)
+        if dry_run:
+            logger.info("DRY RUN would render %s -> %s", key, dest)
+            done += 1
+            continue
+
+        render_one(key, cfg.enhance_chain, cfg, dest)
+
+        item_id = by_url.get(wasabi_public_url(key))
+        if item_id is None:
+            logger.warning("no mp3_items row for %s; rendered but not linked", key)
+            unlinked += 1
+            done += 1
+            continue
+        pr = httpx.patch(f"{cfg.directus_url}/items/mp3_items/{item_id}",
+                         json={"enhanced_url": wasabi_public_url(dest)},
+                         headers=_auth_headers(cfg))
+        pr.raise_for_status()
+        done += 1
+    logger.info("render-enhanced-corpus: %d files (%s), %d unlinked",
+                done, "dry run" if dry_run else cfg.enhance_chain, unlinked)

--- a/packages/tools/video-grabber/video_grabber/parties/flows.py
+++ b/packages/tools/video-grabber/video_grabber/parties/flows.py
@@ -1,0 +1,110 @@
+"""Identify who each recording's traffic is between and write mp3_items.parties."""
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+from prefect import flow, get_run_logger
+
+from video_grabber.catalogue.flows import _page_mp3_items, key_from_url
+from video_grabber.config import Config
+from video_grabber.directus.writer import _auth_headers
+from video_grabber.parties.identify import (
+    TIER_TAPE,
+    build_clip_messages,
+    build_tape_messages,
+    parse_parties,
+    should_identify,
+    tier_for,
+    validate_parties,
+)
+from video_grabber.storage import wasabi
+from video_grabber.transcript.summarize_flows import anthropic_completer
+
+SAMPLE_WINDOWS = 6
+SAMPLE_CHARS = 2000
+
+
+def srt_text_to_plain(srt: str) -> str:
+    return " ".join(
+        line.strip() for line in srt.splitlines()
+        if line.strip() and not line.strip().isdigit() and "-->" not in line
+    )
+
+
+def sample_windows(text: str, n: int = SAMPLE_WINDOWS, size: int = SAMPLE_CHARS) -> list[str]:
+    """Evenly spaced excerpts. A 6.75h transcript does not fit in one prompt."""
+    if len(text) <= size:
+        return [text]
+    step = max(1, (len(text) - size) // max(1, n - 1))
+    return [text[i:i + size] for i in range(0, len(text) - size + 1, step)][:n]
+
+
+@flow(name="identify-parties")
+def identify_parties_flow(limit: int | None = None, force: bool = False,
+                          dry_run: bool = True) -> None:
+    """Identify communication parties for every eligible mp3_items row.
+
+    Idempotency marker is `parties IS NOT NULL`, so the flow is resumable
+    without a jobs table; pass force=True to re-identify.
+    """
+    logger = get_run_logger()
+    cfg = Config()
+    if not cfg.anthropic_api_key:
+        raise RuntimeError("ANTHROPIC_API_KEY is not set")
+    complete = anthropic_completer(cfg, model=cfg.parties_model, max_tokens=1200)
+
+    done = skipped = failed = broadcast = 0
+    for row in _page_mp3_items(cfg, "id,url,subtitles,calc_duration,parties"):
+        if limit is not None and done >= limit:
+            break
+        key = key_from_url(row["url"])
+
+        if not should_identify(key):
+            broadcast += 1
+            continue
+        if row.get("parties") and not force:
+            skipped += 1
+            continue
+        if not row.get("subtitles"):
+            logger.warning("identify-parties: %s has no subtitles; skipping", key)
+            skipped += 1
+            continue
+
+        transcript = srt_text_to_plain(wasabi.read_text(key_from_url(row["subtitles"]), cfg))
+        if not transcript.strip():
+            skipped += 1
+            continue
+
+        tier = tier_for(row.get("calc_duration"))
+        if tier == TIER_TAPE:
+            system, user = build_tape_messages(Path(key).name, sample_windows(transcript))
+        else:
+            system, user = build_clip_messages(transcript)
+
+        try:
+            parsed = parse_parties(complete(system, user))
+        except ValueError as exc:
+            logger.warning("identify-parties: %s unparseable: %s", key, exc)
+            failed += 1
+            continue
+
+        cleaned, reasons = validate_parties(parsed, transcript)
+        cleaned["tier"] = tier
+        cleaned["model"] = cfg.parties_model
+        cleaned["generated_at"] = datetime.now(timezone.utc).isoformat()
+        if reasons:
+            cleaned["gate_reasons"] = reasons
+            logger.info("identify-parties: %s downgraded: %s", key, reasons)
+
+        if dry_run:
+            logger.info("DRY RUN %s -> %s", key, cleaned)
+        else:
+            pr = httpx.patch(f"{cfg.directus_url}/items/mp3_items/{row['id']}",
+                             json={"parties": cleaned}, headers=_auth_headers(cfg))
+            pr.raise_for_status()
+        done += 1
+
+    logger.info(
+        "identify-parties: %d identified, %d skipped, %d broadcast (excluded), %d failed",
+        done, skipped, broadcast, failed,
+    )

--- a/packages/tools/video-grabber/video_grabber/parties/identify.py
+++ b/packages/tools/video-grabber/video_grabber/parties/identify.py
@@ -1,0 +1,195 @@
+"""Decide who a recording's traffic is between. Pure logic only.
+
+The network call is injected, so every rule here is unit-testable without a key —
+same split as transcript/summarize.py, and for the same reason: the judgments that
+matter must be testable in isolation.
+
+The containment gate is the point of this module. The model knows how September 11
+turned out. Asked who is speaking on a garbled tape it will confidently supply
+"NEADS" or "Colin Scoggins" from background knowledge rather than from the audio.
+Identification has to be a reading task, not a recall task, so every name the model
+returns must already be in the transcript and its evidence quote must be verbatim.
+"""
+from __future__ import annotations
+
+import json
+import re
+
+from video_grabber.transcript.summarize import unsupported_words
+
+CONVERSATION = "conversation"
+BROADCAST = "broadcast"
+
+TIER_CLIP = "clip"
+TIER_TAPE = "tape"
+CLIP_MAX_SECONDS = 300
+
+# Keyed on the first path segment under audio/. A module constant rather than an
+# env var: this is a property of the corpus, not the deployment, and an env var is
+# one more thing that can arrive empty.
+MEDIA_KIND: dict[str, str] = {
+    "AA11": CONVERSATION, "AA77": CONVERSATION, "UA93": CONVERSATION,
+    "UA175": CONVERSATION, "DL1989": CONVERSATION, "NEADS": CONVERSATION,
+    "norad": CONVERSATION, "Langley": CONVERSATION, "QUIT": CONVERSATION,
+    "GOFER06": CONVERSATION, "ATCSCC": CONVERSATION, "FAA": CONVERSATION,
+    "ZBW": CONVERSATION, "ZDC": CONVERSATION, "ZNY": CONVERSATION,
+    "ZOB": CONVERSATION, "faa_atc": CONVERSATION, "fdny_dispatch": CONVERSATION,
+    "rutgers_audiograph": CONVERSATION,
+    # News radio: a broadcast has no counterparty. Excluded by decision.
+    "wins1010": BROADCAST, "wcbs": BROADCAST,
+}
+
+
+def media_kind(key: str) -> str | None:
+    """'conversation', 'broadcast', or None for a folder nobody has classified."""
+    parts = key.split("/")
+    if len(parts) < 3 or parts[0] != "audio":
+        return None
+    return MEDIA_KIND.get(parts[1])
+
+
+def should_identify(key: str) -> bool:
+    """Affirmative allow-list.
+
+    Deliberately not `!= BROADCAST`. A deny-list that fails to load, or a typo in a
+    folder name, silently re-admits WINS and WCBS and produces confident nonsense;
+    an allow-list that fails to load identifies nothing, which is immediately
+    obvious. An unclassified folder is skipped, not identified.
+    """
+    return media_kind(key) == CONVERSATION
+
+
+def tier_for(duration_seconds: int | None) -> str:
+    if duration_seconds is None:
+        raise ValueError(
+            "duration is required to tier a recording; refusing to guess "
+            "(defaulting to clip would send a 6.75h transcript through the clip prompt)"
+        )
+    return TIER_CLIP if duration_seconds < CLIP_MAX_SECONDS else TIER_TAPE
+
+
+_SYSTEM = """\
+You identify who is speaking in a transcript of September 11, 2001 air traffic \
+control, military, and emergency audio.
+
+Rules you must follow:
+- Use ONLY what the transcript says. Do not use anything you know about the events \
+of September 11 from any other source.
+- If the transcript does not name a facility, position, or person, return null for \
+that field. Do not infer it.
+- The `evidence` field must be an exact quote copied character-for-character from \
+the transcript.
+- If you cannot tell who is speaking, say so with confidence "low" and null sides. \
+That is a correct answer, not a failure.
+
+Return ONLY a JSON object:
+{"tier":"clip",
+ "side_a":{"facility":str|null,"position":str|null,"person":str|null,"role":str|null},
+ "side_b":{"facility":str|null,"position":str|null,"person":str|null,"role":str|null},
+ "link":"air-ground"|"landline"|"internal"|"unknown",
+ "aircraft":[str],
+ "confidence":"high"|"medium"|"low",
+ "evidence":str}
+
+`role` is one of: atc, military, airline, emergency, aircraft, unknown."""
+
+
+def build_clip_messages(transcript: str) -> tuple[str, str]:
+    return _SYSTEM, f"Transcript:\n\n{transcript}"
+
+
+def build_tape_messages(filename: str, samples: list[str]) -> tuple[str, str]:
+    system = _SYSTEM.replace('"tier":"clip"', '"tier":"tape"') + (
+        "\n\nThis is a long continuous recording of ONE position. side_a is that "
+        "position. side_b represents the many counterparties, so set its facility "
+        'to "various". Identify the position from the filename and the samples.'
+    )
+    joined = "\n\n---\n\n".join(samples)
+    return system, f"Filename: {filename}\n\nSampled excerpts:\n\n{joined}"
+
+
+_FENCE = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.S)
+_DIGITS = re.compile(r"\d+")
+
+
+def parse_parties(raw: str) -> dict:
+    """Parse the model's reply, tolerating a markdown fence."""
+    text = (raw or "").strip()
+    m = _FENCE.search(text)
+    if m:
+        text = m.group(1)
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"model did not return JSON: {raw[:200]!r}") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError(f"model returned {type(parsed).__name__}, not an object")
+    return parsed
+
+
+def _normalise(s: str) -> str:
+    return re.sub(r"\s+", " ", s or "").strip().lower()
+
+
+def evidence_is_verbatim(evidence: str, transcript: str) -> bool:
+    if not (evidence or "").strip():
+        return False
+    return _normalise(evidence) in _normalise(transcript)
+
+
+def _callsign_supported(callsign: str, transcript: str) -> bool:
+    """A callsign is supported when its flight number appears in the transcript.
+
+    'AAL77' is a normalisation of the spoken 'American 77', not a quotation, so
+    requiring the literal token would reject every correct answer. The flight
+    number is the part that cannot be invented without inventing an aircraft.
+    """
+    digits = _DIGITS.findall(callsign or "")
+    if not digits:
+        return False
+    return all(d in transcript for d in digits)
+
+
+def validate_parties(parsed: dict, transcript: str) -> tuple[dict, list[str]]:
+    """Drop every name the transcript does not support; return (cleaned, reasons).
+
+    Any rejection forces confidence to 'low' rather than discarding the whole
+    answer: a partly-supported identification is still worth keeping, but it must
+    not claim to be certain.
+    """
+    cleaned = json.loads(json.dumps(parsed))
+    reasons: list[str] = []
+
+    if not evidence_is_verbatim(cleaned.get("evidence", ""), transcript):
+        reasons.append("evidence is not a verbatim quote from the transcript")
+        cleaned["evidence"] = None
+
+    for side in ("side_a", "side_b"):
+        block = cleaned.get(side) or {}
+        for field in ("facility", "position", "person"):
+            value = block.get(field)
+            # 'various' is the tape tier's deliberate placeholder for "many
+            # counterparties", not a claim about the transcript.
+            if not value or value == "various":
+                continue
+            missing = unsupported_words(value, transcript)
+            if missing:
+                reasons.append(
+                    f"{side}.{field}={value!r} names {missing} which the transcript "
+                    f"never contains"
+                )
+                block[field] = None
+        cleaned[side] = block
+
+    aircraft = cleaned.get("aircraft") or []
+    kept = []
+    for name in aircraft:
+        if _callsign_supported(str(name), transcript):
+            kept.append(name)
+        else:
+            reasons.append(f"aircraft {name!r} not present in transcript")
+    cleaned["aircraft"] = kept
+
+    if reasons:
+        cleaned["confidence"] = "low"
+    return cleaned, reasons

--- a/packages/tools/video-grabber/video_grabber/serve.py
+++ b/packages/tools/video-grabber/video_grabber/serve.py
@@ -52,6 +52,15 @@ from video_grabber.normalize.flows import (
     normalize_item_flow,
     scan_normalize_flow,
 )
+from video_grabber.catalogue.flows import (
+    backfill_mp3_catalogue_flow,
+    link_mp3_subtitles_flow,
+)
+from video_grabber.parties.flows import identify_parties_flow
+from video_grabber.enhance.flows import (
+    render_audition_flow,
+    render_enhanced_corpus_flow,
+)
 
 # Four concurrent download+encode pipelines. These jobs are largely
 # download-bound (pulling the ~200 MB .ogv derivative from IA) with VAAPI doing
@@ -287,6 +296,14 @@ def main() -> None:
             name="normalize-item",
             concurrency_limit=_NORMALIZE_ITEM_LIMIT,
         ),
+        # Catalogue / parties / enhancement — all MANUAL ONLY. Each writes to the
+        # live Directus catalogue or the bucket and every one defaults to a dry
+        # run; none of them should ever acquire a schedule.
+        backfill_mp3_catalogue_flow.to_deployment(name="backfill-mp3-catalogue"),
+        link_mp3_subtitles_flow.to_deployment(name="link-mp3-subtitles"),
+        identify_parties_flow.to_deployment(name="identify-parties"),
+        render_audition_flow.to_deployment(name="render-audition"),
+        render_enhanced_corpus_flow.to_deployment(name="render-enhanced-corpus"),
     )
 
 

--- a/packages/tools/video-grabber/video_grabber/serve.py
+++ b/packages/tools/video-grabber/video_grabber/serve.py
@@ -34,6 +34,7 @@ from video_grabber.pipeline.flows import (
 from video_grabber.transcribe.flows import (
     build_channel_subtitles_flow,
     dispatch_transcribe_flow,
+    reconcile_transcribe_jobs_flow,
     scan_transcribe_flow,
     transcribe_item_flow,
 )
@@ -240,6 +241,12 @@ def main() -> None:
         scan_transcribe_flow.to_deployment(
             name="scan-transcribe",
             concurrency_limit=_TRANSCRIBE_SCAN_LIMIT,
+        ),
+        # MANUAL ONLY — never give this a schedule. It seeds transcribe_jobs from
+        # the SRTs already in the bucket so scan-transcribe stops re-enqueueing
+        # ~296h of already-captioned audio.
+        reconcile_transcribe_jobs_flow.to_deployment(
+            name="reconcile-transcribe-jobs",
         ),
         dispatch_transcribe_flow.to_deployment(
             name="dispatch-transcribe",

--- a/packages/tools/video-grabber/video_grabber/transcribe/chunking.py
+++ b/packages/tools/video-grabber/video_grabber/transcribe/chunking.py
@@ -1,0 +1,37 @@
+"""Split a recording into bounded transcription windows.
+
+Whole-file transcription of the long position tapes fails badly: a single
+5-minute window of the NEADS MCC tape yields 150 words while the entire 6.67-hour
+file yields 84. Bounding the window bounds the decoder state.
+
+Windows overlap slightly so a sentence straddling a boundary is seen whole by at
+least one window; the merge step de-duplicates the repeated cues.
+"""
+from __future__ import annotations
+
+
+def windows(duration_s: float, chunk_s: int, overlap_s: int) -> list[tuple[int, int]]:
+    """Return [(offset_ms, duration_ms), …] covering the whole recording."""
+    if duration_s <= 0:
+        raise ValueError(f"duration must be positive, got {duration_s!r}")
+    if overlap_s >= chunk_s:
+        raise ValueError(
+            f"overlap_s ({overlap_s}) must be smaller than chunk_s ({chunk_s})"
+        )
+
+    total_ms = int(round(duration_s * 1000))
+    chunk_ms = chunk_s * 1000
+    step = chunk_ms - overlap_s * 1000
+
+    if total_ms <= chunk_ms:
+        return [(0, total_ms)]
+
+    out: list[tuple[int, int]] = []
+    start = 0
+    while start < total_ms:
+        length = min(chunk_ms, total_ms - start)
+        out.append((start, length))
+        if start + length >= total_ms:
+            break
+        start += step
+    return out

--- a/packages/tools/video-grabber/video_grabber/transcribe/flows.py
+++ b/packages/tools/video-grabber/video_grabber/transcribe/flows.py
@@ -25,10 +25,10 @@ from prefect.deployments import run_deployment
 
 from video_grabber.config import Config
 from video_grabber.directus.writer import (
-    _WASABI_BASE,
     get_tv_channel_start_date,
     patch_mp3_subtitles,
     patch_tv_channel_subtitles,
+    wasabi_public_url,
 )
 from video_grabber.storage import wasabi
 from video_grabber.transcribe.audio import extract_audio
@@ -132,7 +132,7 @@ def scan_transcribe_flow() -> None:
         """)).mappings().all()
         tv_n = 0
         for r in tv_rows:
-            src_url = f"{_WASABI_BASE}/{r['wasabi_key']}"
+            src_url = wasabi_public_url(r["wasabi_key"])
             res = db.execute(sa.text("""
                 INSERT INTO transcribe_jobs (kind, source_key, channel_slug, source_url, stage)
                 VALUES ('tv', :sk, :slug, :url, 'pending')
@@ -145,7 +145,7 @@ def scan_transcribe_flow() -> None:
         mp3_keys = [k for k in wasabi.list_keys("audio/", cfg) if k.lower().endswith(".mp3")]
         mp3_n = 0
         for key in mp3_keys:
-            src_url = f"{_WASABI_BASE}/{key}"
+            src_url = wasabi_public_url(key)
             res = db.execute(sa.text("""
                 INSERT INTO transcribe_jobs (kind, source_key, source_url, stage)
                 VALUES ('mp3', :sk, :url, 'pending')
@@ -188,7 +188,7 @@ def transcribe_item_flow(job_id: str) -> None:
         wasabi.upload_text(vtt_path.read_text(), f"{base_key}.vtt", cfg)
 
         if job.kind == "mp3":
-            matched = patch_mp3_subtitles(job.source_url, f"{_WASABI_BASE}/{srt_key}", cfg)
+            matched = patch_mp3_subtitles(job.source_url, wasabi_public_url(srt_key), cfg)
             if not matched:
                 logger.warning(
                     "transcribe-item: patch_mp3_subtitles found no mp3_items row for "
@@ -253,7 +253,7 @@ def build_channel_subtitles_flow(channel_slug: str) -> None:
     srt_key = f"{base_key}.srt"
     wasabi.upload_text(render_srt(cues), srt_key, cfg)
     wasabi.upload_text(render_vtt(cues), f"{base_key}.vtt", cfg)
-    patch_tv_channel_subtitles(channel_slug, f"{_WASABI_BASE}/{srt_key}", cfg)
+    patch_tv_channel_subtitles(channel_slug, wasabi_public_url(srt_key), cfg)
     logger.info("build-channel-subtitles: %s merged %d programs → %s",
                 channel_slug, len(rows), srt_key)
 

--- a/packages/tools/video-grabber/video_grabber/transcribe/flows.py
+++ b/packages/tools/video-grabber/video_grabber/transcribe/flows.py
@@ -190,11 +190,14 @@ def transcribe_item_flow(job_id: str) -> None:
         if job.kind == "mp3":
             matched = patch_mp3_subtitles(job.source_url, wasabi_public_url(srt_key), cfg)
             if not matched:
-                logger.warning(
-                    "transcribe-item: patch_mp3_subtitles found no mp3_items row for "
-                    "source_url=%s source_key=%s — SRT/VTT uploaded but Directus not updated",
-                    job.source_url,
-                    job.source_key,
+                # A miss means the SRT is in the bucket but nothing points at it.
+                # This warned-and-continued for 575 jobs while every run reported
+                # success — which is how the URL-encoding bug survived 18 months.
+                # It is a failure, not a note.
+                raise RuntimeError(
+                    f"patch_mp3_subtitles matched no mp3_items row for "
+                    f"source_url={job.source_url!r} (source_key={job.source_key!r}). "
+                    f"SRT/VTT uploaded to {srt_key!r} but the row is unlinked."
                 )
 
         transition_transcribe_job(job_id, "done", srt_key=srt_key)

--- a/packages/tools/video-grabber/video_grabber/transcribe/flows.py
+++ b/packages/tools/video-grabber/video_grabber/transcribe/flows.py
@@ -15,6 +15,7 @@ airing at air_date sits at (air_date − tv_channels.start_date) seconds in the
 stream (see ../epg/assembler.py and docs/transcription.md)."""
 import os
 import shutil
+import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -32,7 +33,17 @@ from video_grabber.directus.writer import (
 )
 from video_grabber.storage import wasabi
 from video_grabber.transcribe.audio import extract_audio
-from video_grabber.transcribe.srt import Cue, dedupe_consecutive, merge, parse_srt, render_srt, render_vtt, shift
+from video_grabber.transcribe.chunking import windows
+from video_grabber.transcribe.srt import (
+    Cue,
+    dedupe_consecutive,
+    merge,
+    parse_srt,
+    render_srt,
+    render_vtt,
+    shift,
+    strip_nonspeech_cues,
+)
 from video_grabber.transcribe.whisper import transcribe_wav
 
 _SCRATCH = Path(os.getenv("SCRATCH_DIR", "/tmp/vg-scratch"))
@@ -111,6 +122,40 @@ def build_channel_cues(window_start: datetime, programs: list[tuple[datetime, st
     for air_date, srt_text in programs:
         offset = (_as_utc(air_date) - ws_utc).total_seconds()
         blocks.append(shift(parse_srt(srt_text), offset))
+    return merge(blocks)
+
+
+def probe_duration_seconds(path: Path) -> float:
+    r = subprocess.run(
+        ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+         "-of", "default=nw=1:nk=1", str(path)],
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0 or not r.stdout.strip():
+        raise RuntimeError(f"ffprobe could not read a duration from {path}")
+    return float(r.stdout.strip())
+
+
+def transcribe_windows(wav: Path, scratch: Path, cfg, duration_s: float) -> list[Cue]:
+    """Transcribe a recording as a sequence of bounded windows, merged onto one
+    timeline.
+
+    Whole-file transcription collapses on the long position tapes: a single
+    5-minute window of the NEADS MCC tape yields 150 words while the entire
+    6.67-hour file yields 84. See
+    plans/2026-08-13-audio-enhancement-findings.md.
+
+    VAD is enabled for every window. On the short clips it costs nothing; on the
+    tapes it is what stops hours of open-mic silence swamping the decoder.
+    """
+    blocks: list[list[Cue]] = []
+    for i, (offset_ms, length_ms) in enumerate(
+        windows(duration_s, cfg.chunk_seconds, cfg.chunk_overlap_seconds)
+    ):
+        base = scratch / f"w{i:04d}"
+        srt_path = transcribe_wav(wav, base, cfg, offset_ms=offset_ms,
+                                  duration_ms=length_ms, vad=True)
+        blocks.append(shift(parse_srt(srt_path.read_text()), offset_ms / 1000.0))
     return merge(blocks)
 
 
@@ -231,14 +276,18 @@ def transcribe_item_flow(job_id: str) -> None:
     try:
         transition_transcribe_job(job_id, "transcribing")
         wav = extract_audio(job.source_url, scratch / "audio.wav")
-        out_base = scratch / "out"
-        srt_path = transcribe_wav(wav, out_base, cfg)
-        vtt_path = out_base.with_suffix(".vtt")
+        cues = transcribe_windows(wav, scratch, cfg, probe_duration_seconds(wav))
 
-        # Overwrite both files with hallucination-loop-cleaned cues. Whisper
-        # sometimes repeats a phrase over silence at the end of a file; keeping
-        # only the first occurrence of each consecutive identical cue removes it.
-        clean_cues = dedupe_consecutive(parse_srt(srt_path.read_text()))
+        # strip_nonspeech_cues runs BEFORE dedupe_consecutive so [Music] and
+        # [BLANK_AUDIO] are removed outright rather than collapsed to one cue —
+        # collapsing is what made six hours of open-mic NEADS audio look like a
+        # clean 84-word transcript. dedupe then removes genuine hallucination
+        # loops, where whisper repeats a phrase over silence.
+        clean_cues = dedupe_consecutive(strip_nonspeech_cues(cues))
+        out_base = scratch / "out"
+        out_base.parent.mkdir(parents=True, exist_ok=True)
+        srt_path = out_base.with_suffix(".srt")
+        vtt_path = out_base.with_suffix(".vtt")
         srt_path.write_text(render_srt(clean_cues))
         vtt_path.write_text(render_vtt(clean_cues))
 

--- a/packages/tools/video-grabber/video_grabber/transcribe/flows.py
+++ b/packages/tools/video-grabber/video_grabber/transcribe/flows.py
@@ -114,6 +114,35 @@ def build_channel_cues(window_start: datetime, programs: list[tuple[datetime, st
     return merge(blocks)
 
 
+def existing_srt_key(mp3_key: str, srt_stems: set[str], srt_paths: set[str]) -> str | None:
+    """Return the SRT key already in the bucket for *mp3_key*, or None.
+
+    Checks the mirrored layout first and falls back to the historical flat-stem
+    layout, so this stays correct whichever layout the bucket is currently in.
+    """
+    mirrored = f"subtitles/{Path(mp3_key).with_suffix('.srt')}"
+    if mirrored in srt_paths:
+        return mirrored
+    stem = Path(mp3_key).stem
+    if stem in srt_stems:
+        return f"subtitles/audio/{stem}.srt"
+    return None
+
+
+def subtitle_base_key(job_kind: str, source_key: str, cfg) -> str:
+    """Extension-less subtitle key for a source.
+
+    mp3 keys mirror their full audio/ path rather than collapsing to a bare
+    stem: 93 basenames repeat across folders, and a flat namespace makes the
+    second transcription silently overwrite the first. Those 93 are currently
+    genuine duplicates of the same clip, so nothing is corrupt today — this is
+    hardening against the first real collision.
+    """
+    if job_kind == "tv":
+        return f"{cfg.subtitles_prefix}/programs/{source_key}"
+    return f"{cfg.subtitles_prefix}/{Path(source_key).with_suffix('')}"
+
+
 # ---- flows ----------------------------------------------------------------
 
 @flow(name="scan-transcribe")
@@ -156,6 +185,41 @@ def scan_transcribe_flow() -> None:
         logger.info("scan-transcribe: +%d tv, +%d mp3 new jobs", tv_n, mp3_n)
 
 
+@flow(name="reconcile-transcribe-jobs")
+def reconcile_transcribe_jobs_flow() -> None:
+    """Seed transcribe_jobs as 'done' for every mp3 whose SRT already exists.
+
+    Load-bearing guard. transcribe_jobs is empty, and scan-transcribe only
+    de-duplicates against rows that are already there — so without this, the next
+    scan re-enqueues all 789 mp3s and re-transcribes ~296 hours of audio that is
+    already captioned. Idempotent: ON CONFLICT DO NOTHING.
+    """
+    logger = get_run_logger()
+    cfg = Config()
+    srt_keys = [k for k in wasabi.list_keys(f"{cfg.subtitles_prefix}/", cfg)
+                if k.endswith(".srt")]
+    srt_paths = set(srt_keys)
+    srt_stems = {Path(k).stem for k in srt_keys}
+    mp3_keys = [k for k in wasabi.list_keys("audio/", cfg) if k.lower().endswith(".mp3")]
+
+    seeded = skipped = 0
+    with get_db() as db:
+        for key in mp3_keys:
+            srt_key = existing_srt_key(key, srt_stems, srt_paths)
+            if srt_key is None:
+                skipped += 1
+                continue
+            res = db.execute(sa.text("""
+                INSERT INTO transcribe_jobs (kind, source_key, source_url, stage, srt_key)
+                VALUES ('mp3', :sk, :url, 'done', :srt)
+                ON CONFLICT (source_key) DO NOTHING
+            """), {"sk": key, "url": wasabi_public_url(key), "srt": srt_key})
+            seeded += res.rowcount or 0
+        db.commit()
+    logger.info("reconcile-transcribe-jobs: seeded %d done, %d still untranscribed",
+                seeded, skipped)
+
+
 @flow(name="transcribe-item", retries=1, retry_delay_seconds=60)
 def transcribe_item_flow(job_id: str) -> None:
     """Transcribe one unit. Produces per-unit SRT/VTT in Wasabi; mp3 also PATCHes
@@ -178,11 +242,7 @@ def transcribe_item_flow(job_id: str) -> None:
         srt_path.write_text(render_srt(clean_cues))
         vtt_path.write_text(render_vtt(clean_cues))
 
-        if job.kind == "tv":
-            base_key = f"{cfg.subtitles_prefix}/programs/{job.source_key}"
-        else:  # mp3 → mirror the audio/ basename
-            stem = Path(job.source_key).stem
-            base_key = f"{cfg.subtitles_prefix}/audio/{stem}"
+        base_key = subtitle_base_key(job.kind, job.source_key, cfg)
         srt_key = f"{base_key}.srt"
         wasabi.upload_text(srt_path.read_text(), srt_key, cfg)
         wasabi.upload_text(vtt_path.read_text(), f"{base_key}.vtt", cfg)

--- a/packages/tools/video-grabber/video_grabber/transcribe/srt.py
+++ b/packages/tools/video-grabber/video_grabber/transcribe/srt.py
@@ -109,3 +109,24 @@ def render_vtt(cues: list[Cue]) -> str:
         out.append(c.text)
         out.append("")
     return "\n".join(out)
+
+
+# Markers whisper emits for non-speech audio. Deliberately excludes
+# [unintelligible] / [inaudible]: those mark speech that could not be resolved,
+# which is information worth keeping.
+_NONSPEECH = re.compile(
+    r"^\s*[\[\(]?\s*(music|blank_audio|silence|sound|noise|applause)\s*[\]\)]?\s*$",
+    re.I,
+)
+_MUSIC_GLYPHS = re.compile(r"^[\s♪♫♩♬]+$")
+
+
+def strip_nonspeech_cues(cues: list[Cue]) -> list[Cue]:
+    """Drop cues that carry no speech at all.
+
+    dedupe_consecutive() collapses runs of identical cues, which turned six hours
+    of open-mic [Music] into a single cue and made an empty transcript look like a
+    clean one. Removing them outright is the honest representation.
+    """
+    return [c for c in cues
+            if not _NONSPEECH.match(c.text) and not _MUSIC_GLYPHS.match(c.text)]

--- a/packages/tools/video-grabber/video_grabber/transcribe/whisper.py
+++ b/packages/tools/video-grabber/video_grabber/transcribe/whisper.py
@@ -12,7 +12,9 @@ from pathlib import Path
 from video_grabber.config import Config
 
 
-def transcribe_wav(wav: Path, out_base: Path, cfg: Config, *, runner=subprocess.run) -> Path:
+def transcribe_wav(wav: Path, out_base: Path, cfg: Config, *,
+                   offset_ms: int = 0, duration_ms: int = 0, vad: bool = False,
+                   runner=subprocess.run) -> Path:
     out_base.parent.mkdir(parents=True, exist_ok=True)
     cmd = [
         cfg.whisper_bin,
@@ -22,8 +24,16 @@ def transcribe_wav(wav: Path, out_base: Path, cfg: Config, *, runner=subprocess.
         "--output-srt",
         "--output-vtt",
         "--output-file", str(out_base),
-        str(wav),
     ]
+    if vad:
+        # VAD skips the long silences on open-mic position tapes: both a large
+        # compute saving and the reason the decoder stops collapsing on them.
+        cmd += ["--vad", "--vad-model", cfg.vad_model]
+    if offset_ms:
+        cmd += ["-ot", str(offset_ms)]
+    if duration_ms:
+        cmd += ["-d", str(duration_ms)]
+    cmd.append(str(wav))
     result = runner(cmd, capture_output=True, text=True)
     if result.returncode != 0:
         raise RuntimeError(f"whisper-cli failed ({result.returncode}): {result.stderr[-2000:]}")

--- a/packages/tools/video-grabber/video_grabber/transcript/summarize.py
+++ b/packages/tools/video-grabber/video_grabber/transcript/summarize.py
@@ -174,6 +174,21 @@ def content_words(text: str) -> set[str]:
     return out
 
 
+def unsupported_words(text: str, source: str) -> list[str]:
+    """Content words in *text* that no variant of appears in *source*.
+
+    Shared by the summary gate and the party-identification gate: both need to
+    ask "did the model reach outside what it was shown?", and both answer it the
+    same way. Any overlap between a word's variants and the source's counts as
+    present.
+    """
+    allowed = content_words(source)
+    return sorted({
+        w for w in _WORD.findall(text.lower())
+        if w not in _STOPWORDS and not (_variants(w) & allowed)
+    })
+
+
 def validate_abstract(summary: str, source: str) -> str | None:
     """Return a rejection reason, or None if the summary is contained by the source.
 
@@ -185,12 +200,7 @@ def validate_abstract(summary: str, source: str) -> str | None:
     """
     if not summary.strip():
         return "empty"
-    allowed = content_words(source)
-    # Any overlap between a word's variants and the source's counts as present.
-    invented = sorted(
-        w for w in _WORD.findall(summary.lower())
-        if w not in _STOPWORDS and not (_variants(w) & allowed)
-    )
+    invented = unsupported_words(summary, source)
     if invented:
         return f"introduced words absent from source: {', '.join(invented[:6])}"
     if len(summary) > len(source):

--- a/packages/tools/video-grabber/video_grabber/transcript/summarize_flows.py
+++ b/packages/tools/video-grabber/video_grabber/transcript/summarize_flows.py
@@ -34,20 +34,24 @@ from video_grabber.transcript.summarize import (
 )
 
 
-def anthropic_completer(cfg: Config):
-    """Build a `complete(system, user) -> str` bound to the configured model.
+def anthropic_completer(cfg: Config, *, model: str | None = None, max_tokens: int = 400):
+    """Build a `complete(system, user) -> str` bound to a model.
 
     Wrapped rather than passed as a client so summarize.py stays free of the SDK
     and its rules — every judgment in there is unit-testable without a key.
+
+    Defaults to the summarizer's model and budget; party identification passes
+    its own, since it needs more reasoning and a larger JSON reply.
     """
     import anthropic
 
     client = anthropic.Anthropic(api_key=cfg.anthropic_api_key)
+    chosen = model or cfg.summarize_model
 
     def complete(system: str, user: str) -> str:
         msg = client.messages.create(
-            model=cfg.summarize_model,
-            max_tokens=400,
+            model=chosen,
+            max_tokens=max_tokens,
             system=system,
             messages=[{"role": "user", "content": user}],
         )


### PR DESCRIPTION
Implements the code portions of three plans landed on `main`:

- `plans/2026-08-13-audio-party-identification-plan.md`
- `plans/2026-08-13-chunked-vad-transcription-plan.md`
- `plans/2026-08-13-audio-enhancement-toggle-plan.md`

## The bug this started from

`patch_mp3_subtitles` matched `mp3_items.url` with an exact `_eq` filter, but callers
passed a **raw** bucket key while the column stores it **percent-encoded**. Only the
three folders whose filenames contain no spaces ever matched — 46 of 621 rows. The
function returned `False`, the flow logged a warning and still marked the job `done`,
so the pipeline reported success 575 times while writing 7% of its intended output.

## What's here

**Linkage** — `wasabi_public_url()` encodes at the point of construction; an unmatched
patch now fails the job instead of warning; SRT keys mirror the full `audio/` path
rather than collapsing to a bare stem (93 basenames repeat across folders).

**Guard** — `reconcile-transcribe-jobs` seeds the currently-empty `transcribe_jobs`
table as `done` for every mp3 whose SRT already exists. Without it the next
`scan-transcribe` re-enqueues all 789 mp3s and re-transcribes ~296 hours.

**Chunked/VAD transcription** — whole-file transcription collapses on the long
position tapes: a single 5-minute window of the NEADS MCC tape yields 150 words while
the entire 6.67-hour file yields 84. `transcribe-item` now walks bounded windows with
`--vad`, merging cues back onto one timeline. `strip_nonspeech_cues` runs *before*
`dedupe_consecutive` — collapsing thousands of `[Music]` cues to one is what made an
empty transcript look clean.

**Party identification** — an affirmative allow-list (WINS/WCBS excluded,
unclassified folders skipped, mutation-checked) plus a containment gate that drops any
facility, position, person or aircraft the transcript does not support. The model
knows how September 11 went; identification has to be a reading task, not a recall one.

**Enhancement** — renders to a new `audio-enhanced/` prefix and writes only
`enhanced_url`. `mp3_items.url` is deliberately left alone: it is the join key for
three flows, and repointing it would break all three — one of them by silently
creating a duplicate row for every file in the bucket.

## Verification

- video-grabber: 497 passed, 8 skipped, 12 errors (all `test_migrations.py`, the
  documented Postgres environment gap). `ruff check` clean.
- frontend: 2137 passed, `tsc -b` clean, lint 0 errors.

## Not in this PR

Operational steps that need the built image: the S3 SRT migration, the two Directus
schema fields, the catalogue backfill, the corpus re-transcription and the party
identification run. The enhancement corpus render is additionally gated on a human
listening to the `render-audition` output — `ENHANCE_CHAIN` defaults to empty and the
flow refuses to start until a chain is chosen by ear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)