### PR TITLE
fix(transcribe): collapse alternating hallucination loops; keep orphan supervision

### DIFF
--- a/packages/tools/video-grabber/tests/test_srt.py
+++ b/packages/tools/video-grabber/tests/test_srt.py
@@ -1,4 +1,5 @@
 from video_grabber.transcribe.srt import (
+    collapse_repetition_loops,
     Cue,
     dedupe_consecutive,
     parse_srt,
@@ -155,7 +156,63 @@ def test_keeps_inaudible_markers_because_they_mark_real_speech():
     assert len(strip_nonspeech_cues(cues)) == 2
 
 
-def test_leaves_ordinary_speech_untouched():
+def test_strip_leaves_ordinary_speech_untouched():
     from video_grabber.transcribe.srt import strip_nonspeech_cues
     cues = [Cue(0, 1, "American 77, Indy Center")]
     assert strip_nonspeech_cues(cues) == cues
+
+
+# ---- alternating hallucination loops ----------------------------------------
+#
+# dedupe_consecutive only collapses runs of IDENTICAL neighbours. The NEADS MCC
+# tape produced an A/B/A/B loop 447 cues long — every cue differed from the one
+# before it, so every one survived and inflated the transcript from ~2,177 real
+# words to 4,738.
+
+def _cues(texts):
+    return [Cue(float(i), float(i) + 1, t) for i, t in enumerate(texts)]
+
+
+def test_collapses_an_alternating_two_phrase_loop():
+    cues = _cues(["start"] + ["A", "B"] * 8 + ["end"])
+    got = [c.text for c in collapse_repetition_loops(cues)]
+    assert got == ["start", "A", "B", "end"]
+
+
+def test_collapses_a_single_phrase_loop():
+    cues = _cues(["start"] + ["A"] * 10 + ["end"])
+    assert [c.text for c in collapse_repetition_loops(cues)] == ["start", "A", "end"]
+
+
+def test_collapses_a_three_phrase_cycle():
+    cues = _cues(["A", "B", "C"] * 5)
+    assert [c.text for c in collapse_repetition_loops(cues)] == ["A", "B", "C"]
+
+
+def test_keeps_scattered_repeats_that_are_not_a_loop():
+    # "Okay" recurs all over real ATC audio between genuine content. Only
+    # cycles are artifacts; scattered repetition is speech.
+    texts = ["Okay", "turn left", "Okay", "descend", "Okay", "contact center"]
+    assert [c.text for c in collapse_repetition_loops(_cues(texts))] == texts
+
+
+def test_keeps_a_short_repeat_that_is_not_yet_a_loop():
+    # A readback repeats a phrase twice. Two is not a hallucination loop.
+    texts = ["3743", "3743", "American 77"]
+    assert [c.text for c in collapse_repetition_loops(_cues(texts))] == texts
+
+
+def test_preserves_timing_of_the_surviving_cycle():
+    cues = _cues(["A", "B"] * 6)
+    got = collapse_repetition_loops(cues)
+    assert (got[0].start, got[0].text) == (0.0, "A")
+    assert (got[1].start, got[1].text) == (1.0, "B")
+
+
+def test_empty_input():
+    assert collapse_repetition_loops([]) == []
+
+
+def test_loops_leave_ordinary_speech_untouched():
+    texts = ["American 77, Indy Center", "Roger, 3743", "Contact departure"]
+    assert [c.text for c in collapse_repetition_loops(_cues(texts))] == texts

--- a/packages/tools/video-grabber/video_grabber/serve.py
+++ b/packages/tools/video-grabber/video_grabber/serve.py
@@ -175,31 +175,37 @@ def _start_transcribe_workers() -> None:
     thread (a) respawns any worker that dies — a native whisper/Vulkan crash would
     otherwise permanently lose a slot — and (b) periodically re-queues jobs orphaned
     in 'transcribing' by such a crash. Workers write to /tmp/transcribe-worker-N.log."""
-    if _TRANSCRIBE_DISPATCH_LIMIT == 0:
-        # Return BEFORE the startup orphan recovery below. That recovery re-queues
-        # every 'transcribing' row outright, ignoring heartbeats, on the assumption
-        # that no worker can be alive across a restart of this process. That is
-        # false when another host claims from the same table: it would yank jobs
-        # the Mac Studio is actively transcribing, every time this pod rolls.
-        print("[serve] TRANSCRIBE_DISPATCH_LIMIT=0 — not claiming transcribe jobs "
-              "on this host; leaving them to remote workers", flush=True)
-        return
-
     from video_grabber.config import Config
     from video_grabber.transcribe.flows import _sync_db_url
 
     cfg = Config()
     engine = sa.create_engine(_sync_db_url(cfg.database_url))
 
-    # On boot no worker is running, so every 'transcribing' row is an orphan.
-    n = _recover_orphaned_transcribing(engine, 0)
-    if n:
-        print(f"[serve] recovered {n} orphaned transcribing job(s) at startup", flush=True)
-
+    claims_locally = _TRANSCRIBE_DISPATCH_LIMIT > 0
     procs = {}
-    for i in range(_TRANSCRIBE_DISPATCH_LIMIT):
-        procs[i] = _spawn_transcribe_worker(i)
-        print(f"[serve] started transcribe-worker-{i} pid={procs[i].pid}", flush=True)
+
+    if claims_locally:
+        # On boot no LOCAL worker is running, so every 'transcribing' row is an
+        # orphan. This deliberately ignores heartbeats, which is only sound while
+        # this host is the sole claimer.
+        n = _recover_orphaned_transcribing(engine, 0)
+        if n:
+            print(f"[serve] recovered {n} orphaned transcribing job(s) at startup", flush=True)
+
+        for i in range(_TRANSCRIBE_DISPATCH_LIMIT):
+            procs[i] = _spawn_transcribe_worker(i)
+            print(f"[serve] started transcribe-worker-{i} pid={procs[i].pid}", flush=True)
+    else:
+        # No local claiming, but the supervisor below still runs. Remote workers
+        # (the Mac Studio) have no supervisor of their own, so without this a
+        # worker that dies mid-job leaves its row stuck in 'transcribing' forever.
+        #
+        # The boot recovery above is skipped precisely because it ignores
+        # heartbeats: a remote worker CAN be alive across a restart of this
+        # process, and re-queueing its row would yank a job it is still running.
+        # The periodic pass is heartbeat-aware and therefore safe.
+        print("[serve] TRANSCRIBE_DISPATCH_LIMIT=0 — not claiming transcribe jobs "
+              "on this host; supervising remote workers' orphans only", flush=True)
 
     def supervise() -> None:
         while True:

--- a/packages/tools/video-grabber/video_grabber/transcribe/flows.py
+++ b/packages/tools/video-grabber/video_grabber/transcribe/flows.py
@@ -35,6 +35,7 @@ from video_grabber.storage import wasabi
 from video_grabber.transcribe.audio import extract_audio
 from video_grabber.transcribe.chunking import windows
 from video_grabber.transcribe.srt import (
+    collapse_repetition_loops,
     Cue,
     dedupe_consecutive,
     merge,
@@ -283,7 +284,13 @@ def transcribe_item_flow(job_id: str) -> None:
         # collapsing is what made six hours of open-mic NEADS audio look like a
         # clean 84-word transcript. dedupe then removes genuine hallucination
         # loops, where whisper repeats a phrase over silence.
-        clean_cues = dedupe_consecutive(strip_nonspeech_cues(cues))
+        # Order matters. strip first so markers are removed outright rather than
+        # collapsed to one; then collapse cycles, which catches the alternating
+        # A/B/A/B loops dedupe_consecutive cannot see; then dedupe the leftover
+        # identical pairs a cycle of two repeats leaves behind.
+        clean_cues = dedupe_consecutive(
+            collapse_repetition_loops(strip_nonspeech_cues(cues))
+        )
         out_base = scratch / "out"
         out_base.parent.mkdir(parents=True, exist_ok=True)
         srt_path = out_base.with_suffix(".srt")

--- a/packages/tools/video-grabber/video_grabber/transcribe/srt.py
+++ b/packages/tools/video-grabber/video_grabber/transcribe/srt.py
@@ -130,3 +130,56 @@ def strip_nonspeech_cues(cues: list[Cue]) -> list[Cue]:
     """
     return [c for c in cues
             if not _NONSPEECH.match(c.text) and not _MUSIC_GLYPHS.match(c.text)]
+
+
+# A hallucination loop repeats a short cycle of phrases. Period 1 is the classic
+# "same line over and over"; the NEADS MCC tape produced a period-2 A/B/A/B loop
+# 447 cues long. Cap the period so a genuinely repetitive exchange (a readback,
+# a roll call) is not mistaken for an artifact, and require several repeats so
+# ordinary speech that happens to echo survives.
+_LOOP_MAX_PERIOD = 4
+_LOOP_MIN_REPEATS = 3
+
+
+def collapse_repetition_loops(cues: list[Cue],
+                              max_period: int = _LOOP_MAX_PERIOD,
+                              min_repeats: int = _LOOP_MIN_REPEATS) -> list[Cue]:
+    """Collapse whisper hallucination loops to a single cycle.
+
+    dedupe_consecutive only removes runs of IDENTICAL neighbours, so an
+    alternating A/B/A/B loop passes through it untouched — every cue differs
+    from the one before it. On the NEADS MCC tape that inflated a ~2,177-word
+    transcript to 4,738 words of fabricated dialogue, which then becomes input
+    to party identification.
+
+    Only *cycles* are collapsed. A phrase that recurs scattered between genuine
+    content ("Okay", a callsign) is speech, not an artifact, and is preserved.
+
+    Loops with a period longer than ``max_period`` are not detected; that is a
+    deliberate floor on how much repetition counts as real dialogue.
+    """
+    if not cues:
+        return cues
+    texts = [c.text.strip() for c in cues]
+    n = len(cues)
+    out: list[Cue] = []
+    i = 0
+    while i < n:
+        collapsed = False
+        # Smallest period first: an A/A/A/A run is a period-1 loop, not period-2.
+        for period in range(1, max_period + 1):
+            if i + period * min_repeats > n:
+                continue
+            block = texts[i:i + period]
+            repeats = 1
+            while texts[i + repeats * period:i + (repeats + 1) * period] == block:
+                repeats += 1
+            if repeats >= min_repeats:
+                out.extend(cues[i:i + period])
+                i += period * repeats
+                collapsed = True
+                break
+        if not collapsed:
+            out.append(cues[i])
+            i += 1
+    return out


### PR DESCRIPTION
Two defects found while validating the chunked/VAD change against the NEADS MCC tape.

## 1. Alternating hallucination loops survive dedup

`dedupe_consecutive` only removes runs of **identical neighbours**. An alternating
A/B/A/B loop passes straight through, because every cue differs from the one before it.

That tape produced a 447-cue loop:

```
224x  "Do you need a call sign on?"
223x  "Yeah, I don't know."
```

which inflated the transcript from 2,307 real words to **4,738** — the majority of it
fabricated dialogue. This is not cosmetic: party identification reads these transcripts,
so loop text becomes model input, and a word count over the result reads as a huge
improvement when most of it is an artifact. (It briefly fooled me into reporting a 56×
gain that was really 26×.)

`collapse_repetition_loops` detects a repeating cycle of period 1–4 recurring 3+ times
and collapses it to a single cycle. Only *cycles* are collapsed — a phrase scattered
between genuine content is speech, not an artifact.

**Verified on the real file:** 703 cues → 261, 4,738 words → 2,307, with `Okay.` (6×),
`(unintelligible)` (15×) and `[INTERPOSING VOICES]` (6×) all correctly preserved.

Applied as `strip_nonspeech_cues` → `collapse_repetition_loops` → `dedupe_consecutive`;
the last still earns its place, catching the identical pairs a two-repeat cycle leaves.

## 2. Setting the dispatch limit to 0 silently disabled orphan recovery

#381 made the cluster stop claiming transcribe jobs, but it returned *before* the
supervisor thread was started — and the supervisor is what re-queues jobs orphaned by a
worker crash. Remote workers have no supervisor of their own, so a Mac worker dying
mid-job would have left its row stuck in `transcribing` forever, with nothing to notice.

The supervisor now always runs. Only the **boot-time** recovery is skipped when not
claiming locally, and that distinction is the whole point: boot recovery deliberately
ignores heartbeats (sound when this host is the only claimer, wrong when it isn't), so
leaving it in would yank jobs the Mac is actively transcribing on every pod roll — and
ArgoCD rolls the pod on every image bump.

505 passed / ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)