### PR TITLE
perf(transcribe): pre-split windows instead of -ot/-d on the whole file

### DIFF
--- a/packages/tools/video-grabber/tests/test_transcribe_flows.py
+++ b/packages/tools/video-grabber/tests/test_transcribe_flows.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
@@ -103,6 +104,13 @@ def flow_env(monkeypatch, tmp_path):
     # The wav is never written, so ffprobe cannot read it; the chunking maths is
     # covered by test_transcribe_chunking.py and test_transcribe_windows_*.
     monkeypatch.setattr(flows, "probe_duration_seconds", lambda p: 12.0)
+    # Same reason: there is no real wav on disk for ffmpeg to cut a window from.
+    def _fake_slice(src, dest, off, length):
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(b"")
+        return dest
+
+    monkeypatch.setattr(flows, "slice_wav", _fake_slice)
     monkeypatch.setattr(
         flows, "wasabi",
         SimpleNamespace(upload_text=lambda text, key, cfg: None, list_keys=lambda *a: []),
@@ -219,23 +227,57 @@ def test_scan_transcribe_never_enqueues_enhanced_audio(monkeypatch):
 
 
 def test_transcribe_windows_shifts_each_window_onto_the_file_timeline(monkeypatch, tmp_path):
-    calls = []
+    slices, calls = [], []
+
+    def fake_slice(src, dest, offset_ms, length_ms):
+        slices.append((offset_ms, length_ms))
+        dest.write_bytes(b"")
+        return dest
 
     def fake(wav, out_base, cfg, *, offset_ms=0, duration_ms=0, vad=False, runner=None):
-        calls.append((offset_ms, vad))
+        # Whisper must see the SEGMENT, never the full recording with -ot/-d:
+        # --vad rescans the whole input regardless of the duration flag.
+        calls.append((Path(wav).name, offset_ms, duration_ms, vad))
         out_base.parent.mkdir(parents=True, exist_ok=True)
         srt = out_base.with_suffix(".srt")
         srt.write_text("1\n00:00:01,000 --> 00:00:02,000\nword\n")
         return srt
 
+    monkeypatch.setattr(flows, "slice_wav", fake_slice)
     monkeypatch.setattr(flows, "transcribe_wav", fake)
     cfg = SimpleNamespace(chunk_seconds=600, chunk_overlap_seconds=0)
     cues = flows.transcribe_windows(tmp_path / "a.wav", tmp_path, cfg, duration_s=1200.0)
-    assert [c[0] for c in calls] == [0, 600000]
+
+    assert slices == [(0, 600000), (600000, 600000)]
+    assert [c[0] for c in calls] == ["w0000.wav", "w0001.wav"]
+    # No offset/duration flags: the segment IS the window.
+    assert all(off == 0 and dur == 0 for _, off, dur, _ in calls)
     # VAD must be on for every window -- it is the whole point of the change.
-    assert all(vad for _, vad in calls)
+    assert all(vad for *_, vad in calls)
     # the second window's 1s cue lands at 601s on the file timeline
     assert any(abs(c.start - 601.0) < 0.01 for c in cues)
+
+
+def test_transcribe_windows_deletes_each_segment_after_use(monkeypatch, tmp_path):
+    """A 6.75h tape is ~41 windows; keeping them would add ~780 MB of scratch."""
+    seen = []
+
+    def fake_slice(src, dest, offset_ms, length_ms):
+        dest.write_bytes(b"x")
+        seen.append(dest)
+        return dest
+
+    def fake(wav, out_base, cfg, **kw):
+        out_base.parent.mkdir(parents=True, exist_ok=True)
+        srt = out_base.with_suffix(".srt")
+        srt.write_text("1\n00:00:01,000 --> 00:00:02,000\nword\n")
+        return srt
+
+    monkeypatch.setattr(flows, "slice_wav", fake_slice)
+    monkeypatch.setattr(flows, "transcribe_wav", fake)
+    cfg = SimpleNamespace(chunk_seconds=600, chunk_overlap_seconds=0)
+    flows.transcribe_windows(tmp_path / "a.wav", tmp_path, cfg, duration_s=1200.0)
+    assert seen and not any(p.exists() for p in seen)
 
 
 def test_existing_srt_key_prefers_the_mirrored_path():

--- a/packages/tools/video-grabber/video_grabber/transcribe/flows.py
+++ b/packages/tools/video-grabber/video_grabber/transcribe/flows.py
@@ -137,6 +137,29 @@ def probe_duration_seconds(path: Path) -> float:
     return float(r.stdout.strip())
 
 
+def slice_wav(src: Path, dest: Path, offset_ms: int, length_ms: int) -> Path:
+    """Cut one window out of a WAV as its own file.
+
+    Whisper is given the segment rather than the whole recording with -ot/-d,
+    because --vad scans the ENTIRE input regardless of the duration flag. On a
+    1-hour file that is ~11 s of wasted VAD per window; on the 6.75-hour NORAD
+    tapes it is ~74 s per window across ~41 windows, which is most of the
+    runtime. Measured on a 1-hour file: 49.8 s via -d, 38 s pre-split including
+    the cut.
+
+    -c copy on PCM is a byte-range cut, so this costs almost nothing.
+    """
+    r = subprocess.run(
+        ["ffmpeg", "-nostdin", "-v", "error", "-y",
+         "-ss", f"{offset_ms / 1000:.3f}", "-t", f"{length_ms / 1000:.3f}",
+         "-i", str(src), "-c", "copy", str(dest)],
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        raise RuntimeError(f"ffmpeg could not slice {src} at {offset_ms}ms: {r.stderr[-400:]}")
+    return dest
+
+
 def transcribe_windows(wav: Path, scratch: Path, cfg, duration_s: float) -> list[Cue]:
     """Transcribe a recording as a sequence of bounded windows, merged onto one
     timeline.
@@ -154,9 +177,13 @@ def transcribe_windows(wav: Path, scratch: Path, cfg, duration_s: float) -> list
         windows(duration_s, cfg.chunk_seconds, cfg.chunk_overlap_seconds)
     ):
         base = scratch / f"w{i:04d}"
-        srt_path = transcribe_wav(wav, base, cfg, offset_ms=offset_ms,
-                                  duration_ms=length_ms, vad=True)
-        blocks.append(shift(parse_srt(srt_path.read_text()), offset_ms / 1000.0))
+        segment = scratch / f"w{i:04d}.wav"
+        slice_wav(wav, segment, offset_ms, length_ms)
+        try:
+            srt_path = transcribe_wav(segment, base, cfg, vad=True)
+            blocks.append(shift(parse_srt(srt_path.read_text()), offset_ms / 1000.0))
+        finally:
+            segment.unlink(missing_ok=True)
     return merge(blocks)
 
 


### PR DESCRIPTION
The corpus re-transcription was running at ~1 file/hour with five workers — ~250 hours to
completion. Two separate problems; this PR fixes the larger one.

## `--vad` ignores `-d`

`--vad` scans the **entire input** regardless of the duration flag, so every window paid a
full-file VAD pass. Measured on a 1-hour file with `-d 60000` (transcribe 1 minute):

| | time |
|---|---|
| no VAD | 4.83 s |
| with VAD | 15.99 s |

~11 s of fixed cost per invocation on a 1-hour file. On the 6.75-hour NORAD tapes that is
~74 s per window × ~41 windows. Across the corpus, roughly **18 hours of pure waste**,
concentrated in the 30 largest tapes.

Cutting the window out first with `ffmpeg -c copy` — a byte-range cut on PCM, essentially
free — means whisper only ever sees 10 minutes. Measured on a 1-hour file: **49.8 s via
`-d` vs 38 s pre-split**, including the cut, and the gap widens with file length.

Segments are deleted immediately after use; a 6.75 h tape is ~41 windows, which would
otherwise leave ~780 MB of scratch per job.

## The other problem (not fixed here)

Whisper concurrency on the Mac collapses:

| concurrent | wall (1 window each) |
|---|---|
| 1 | 50 s |
| 2 | 81 s |
| 3 | 118 s |
| 5 | **>600 s, never finished** |

Five was the configured worker count, which is why jobs sat for 3+ hours having produced
no window output at all. Pre-splitting should ease this — each process now holds a 19 MB
segment rather than a 112 MB–770 MB WAV — but the worker count needs re-measuring against
the new code before the corpus run resumes.

506 passed / ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)