### PR TITLE
fix(transcribe): one job per worker process

### DIFF
--- a/packages/tools/video-grabber/video_grabber/transcribe/dispatch_worker.py
+++ b/packages/tools/video-grabber/video_grabber/transcribe/dispatch_worker.py
@@ -107,6 +107,27 @@ def main() -> None:
             _current["id"] = None
         processed += 1
 
+        # Exit after ONE job and let the supervisor respawn us.
+        #
+        # A worker that keeps running flows in the same interpreter wedges: the
+        # process stops making progress with no whisper or ffmpeg child alive,
+        # its main thread parked in kevent inside Prefect's event loop, on jobs
+        # of under three minutes of audio. Measured against the same job in a
+        # fresh interpreter, which completes in ~14s, a wedged worker sat for
+        # 25+ minutes. Every component was timed and none is slow: extract 0.7s,
+        # probe 0.04s, slice 0.03s, whisper 4.6s, uploads 0.6s, Directus 0.3s,
+        # DB transitions 0.9s, empty Prefect flow 4.3s. Neither the heartbeat
+        # thread nor repeated flow runs reproduce it in isolation.
+        #
+        # This module already exists because "a fully isolated Python
+        # interpreter: its own event loop, connection pool, and signal
+        # handlers" was needed per slot (see the module docstring). Extending
+        # that isolation from per-slot to per-job costs one interpreter start
+        # (~3s against a ~14s job) and removes the failure mode rather than
+        # betting on having found it.
+        _log(f"exiting after {processed} job(s); supervisor will respawn")
+        return
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The corpus re-transcription kept stalling. This is the third and final cause.

## Symptom

A dispatch worker claims a job, marks it `transcribing`, and then stops making progress:

- no `whisper-cli` or `ffmpeg` child alive
- main thread parked in `kevent` inside Prefect's event loop
- 25+ minutes elapsed on jobs of **0.9 and 2.9 minutes of audio**
- the same job in a fresh interpreter completes in **~14 s**

## What was measured and ruled out

Every component was timed on the Mac and none is slow:

| step | time |
|---|---|
| `extract_audio` | 0.72 s |
| `probe_duration_seconds` | 0.04 s |
| `slice_wav` | 0.03 s |
| `transcribe_wav` | 4.64 s |
| `wasabi.upload_text` | 0.31 s |
| `patch_mp3_subtitles` | 0.31 s |
| DB transition | 0.89 s |
| empty Prefect flow | 4.31 s |
| **whole flow, fresh process** | **13.99 s** |

Also ruled out: network (Prefect API 0.22 s, Directus 0.16 s, Wasabi 0.42 s through the
tunnel), connection leaks (5 DB connections, 6 tunnel connections), the heartbeat thread
(4.2 s flat with and without), and repeated flow runs in one interpreter (no degradation
across 5 runs).

**The precise mechanism is not identified.** I could not reproduce it outside the worker.

## The change

Exit after one job; the supervisor respawns. `dispatch_worker` already exists because "a
fully isolated Python interpreter: its own event loop, connection pool, and signal
handlers" was needed **per slot** — this extends the same isolation to **per job**.

Cost is one interpreter start, ~3 s against a ~14 s job. That trades a small, known
overhead for removing a failure mode, rather than betting on having found it. Both
supervisors already respawn on exit: launchd `KeepAlive` on the Mac, and serve.py's
supervisor thread in-cluster.

506 passed / ruff clean.

Related: #379 (executor version pinning), #386 (VAD rescanning the whole file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)