### PR TITLE
fix(transcribe): assert the worker is not throttled; version the Mac config

### DIFF
--- a/packages/tools/video-grabber/docs/transcription.md
+++ b/packages/tools/video-grabber/docs/transcription.md
@@ -368,3 +368,26 @@ blocks it and captions do not appear, even though the VTT file exists in Wasabi.
   `.srt` → `application/x-subrip`, so Wasabi object metadata will carry the
   correct content type from the first upload. nginx-s3-gateway proxies the stored
   `Content-Type` verbatim, so no further configuration is needed on that side.
+
+## Where transcription actually runs
+
+Both the cluster pod and the Mac Studio poll `transcribe_jobs` directly
+(`FOR UPDATE SKIP LOCKED`), so whichever claims a row first runs it — there is no
+scheduling by fitness. The Mac is several times faster, so the cluster is configured
+not to claim at all: `TRANSCRIBE_DISPATCH_LIMIT=0` in the worker ConfigMap. At 0 the
+pod still serves every Prefect deployment and still supervises orphaned rows; it just
+stops competing for the work.
+
+The Mac's provisioning lives in [`../mac/README.md`](../mac/README.md) — plist template,
+install and update steps. Two of its settings are load-bearing and non-obvious:
+
+- **`ProcessType` must be `Standard`.** Under `Background`, macOS throttles CPU/IO/GPU
+  and `whisper --vad` hangs outright: the worker stays alive, heartbeats its claim, and
+  never finishes, so the supervisor cannot reclaim the row either. 6 files/hour vs 108.
+  `dispatch_worker` asserts this at startup (`video_grabber/transcribe/qos.py`).
+- **Two workers, not five.** Concurrent whisper on that machine collapses — 1.87
+  windows/min at 2, and at 5 it never finishes.
+
+Because each executor resolves the flow entrypoint from its own working directory
+(`path: "."`, no work pool), the two can silently run different code. That happened:
+the Mac ran a five-week-stale copy against production. See issue #379.

--- a/packages/tools/video-grabber/mac/README.md
+++ b/packages/tools/video-grabber/mac/README.md
@@ -1,0 +1,118 @@
+# Mac Studio transcribe workers
+
+The Mac Studio (M1 Max) runs native whisper.cpp/Metal workers that claim from the same
+`transcribe_jobs` queue as the cluster, reached over a reverse SSH tunnel. It is several
+times faster than the CPU-only cluster pod, so in practice it does the transcription and
+the cluster is configured not to claim at all (`TRANSCRIBE_DISPATCH_LIMIT=0`).
+
+These files exist because the Mac's configuration used to live **only on that machine**.
+That is how it came to run five-week-stale code against production (issue #379) and to
+sit throttled for weeks (issue #389). Provision from here, not by hand.
+
+## Layout on the Mac
+
+```
+~/transcribe/
+  rt911/                  sparse git checkout (packages/tools/video-grabber only)
+  video-grabber -> rt911/packages/tools/video-grabber   symlink; the venv installs this
+  venv/                   python 3.12, `pip install -e ./video-grabber`
+  whisper.cpp/            Metal build + ggml-medium.en.bin + ggml-silero-v5.1.2.bin
+  worker.env              mode 600, production credentials — NOT in this repo
+  run-worker.sh           one worker slot
+  logs/
+```
+
+## Two settings that are not obvious and cost real time
+
+**`ProcessType` must be `Standard`.** The plists originally said `Background`, which macOS
+throttles across CPU, I/O and GPU. That was survivable until whisper gained `--vad`: VAD
+loads a second model and takes an ANE/CoreML path that stalls outright when throttled. The
+failure is not slowness but a hang — the worker stays alive, heartbeats its claimed job,
+and never finishes it, so the supervisor cannot reclaim the row either. One throttled
+worker permanently removes a job from the queue. Throughput was **6 files/hour throttled,
+108 not**.
+
+`dispatch_worker` now asserts this at startup and exits rather than run throttled
+(`ALLOW_THROTTLED_WORKER=1` overrides). To reproduce the condition deliberately:
+`taskpolicy -b python3 -c '...'` — see `video_grabber/transcribe/qos.py`.
+
+**Run 2 workers, not 5.** Concurrent whisper processes on this machine collapse. Measured
+per 10-minute window:
+
+| workers | wall | throughput |
+|---|---:|---|
+| 1 | 38 s | 1.57 win/min |
+| 2 | 64 s | **1.87 win/min** |
+| 3 | 94 s | 1.91 win/min |
+| 5 | never finished | — |
+
+The step from 3 to 5 is a hang, not gradual degradation, so 2 trades 2% of throughput for
+a real safety margin. Workers 3–5 should stay `launchctl disable`d.
+
+## Install / update
+
+```sh
+# first time
+git clone --filter=blob:none --sparse --depth 1 \
+    https://github.com/Keeping-History/rt911.git ~/transcribe/rt911
+git -C ~/transcribe/rt911 sparse-checkout set packages/tools/video-grabber
+ln -s rt911/packages/tools/video-grabber ~/transcribe/video-grabber
+~/transcribe/venv/bin/pip install -e ~/transcribe/video-grabber
+
+# run-worker.sh must sit in ~/transcribe: it does `cd "$(dirname "$0")"` and then
+# sources ./worker.env and runs ./venv, neither of which exist beside the repo copy.
+cp ~/transcribe/video-grabber/mac/run-worker.sh ~/transcribe/run-worker.sh
+
+# install the agents (N = 1..2)
+for N in 1 2; do
+  sed -e "s|__N__|$N|g" -e "s|__HOME__|$HOME|g" \
+      ~/transcribe/video-grabber/mac/com.rt911.transcribe-worker.plist.template \
+      > ~/Library/LaunchAgents/com.rt911.transcribe-worker-$N.plist
+  launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.rt911.transcribe-worker-$N.plist
+done
+```
+
+`launchctl bootstrap` over SSH registers an agent but does not always start it despite
+`RunAtLoad`; `launchctl kickstart gui/$(id -u)/<label>` forces it.
+
+To update after a merge — **stop first**, because a running worker holds claims:
+
+```sh
+for N in 1 2; do launchctl bootout gui/$(id -u)/com.rt911.transcribe-worker-$N; done
+git -C ~/transcribe/rt911 fetch --depth 1 origin main
+git -C ~/transcribe/rt911 reset --hard origin/main
+~/transcribe/venv/bin/pip install -q -e ~/transcribe/video-grabber
+for N in 1 2; do launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.rt911.transcribe-worker-$N.plist; done
+```
+
+Requeue anything left mid-flight **while the workers are stopped**, never after — resetting
+`transcribing` rows under a live claimer hands the same job to a second worker:
+
+```sql
+UPDATE transcribe_jobs SET stage = 'pending', error_message = NULL
+ WHERE stage = 'transcribing';
+```
+
+## worker.env
+
+Not committed — it holds production credentials. Required keys:
+
+```sh
+DATABASE_URL=postgresql+asyncpg://…@127.0.0.1:15432/video_grabber   # via the tunnel
+DIRECTUS_URL=http://127.0.0.1:18055
+DIRECTUS_API_TOKEN=…
+WASABI_ENDPOINT_URL=https://s3.us-central-1.wasabisys.com
+WASABI_BUCKET=files.911realtime.org
+WASABI_ACCESS_KEY_ID=…
+WASABI_SECRET_ACCESS_KEY=…
+PREFECT_API_URL=http://127.0.0.1:14200/api
+WHISPER_BIN=$HOME/transcribe/whisper.cpp/build/bin/whisper-cli
+WHISPER_MODEL=$HOME/transcribe/whisper.cpp/models/ggml-medium.en.bin
+VAD_MODEL=$HOME/transcribe/whisper.cpp/models/ggml-silero-v5.1.2.bin
+WHISPER_THREADS=8
+SCRATCH_DIR=$HOME/transcribe/scratch
+```
+
+`VAD_MODEL` is required — `transcribe_windows` always passes `--vad`, and whisper-cli
+fails without the model file. Fetch it with
+`bash ./models/download-vad-model.sh silero-v5.1.2` from `~/transcribe/whisper.cpp`.

--- a/packages/tools/video-grabber/mac/com.rt911.transcribe-worker.plist.template
+++ b/packages/tools/video-grabber/mac/com.rt911.transcribe-worker.plist.template
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>com.rt911.transcribe-worker-__N__</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__HOME__/transcribe/run-worker.sh</string>
+        <string>mac-__N__</string>
+    </array>
+    <key>RunAtLoad</key><true/>
+    <key>KeepAlive</key><true/>
+    <!-- MUST be Standard. Background throttles CPU/IO/GPU, and whisper --vad
+         then hangs indefinitely rather than merely running slow: the worker
+         stays alive, heartbeats, and never completes a job. 6 files/hour vs
+         108 on this one word. dispatch_worker asserts this at startup. -->
+    <key>ProcessType</key><string>Standard</string>
+    <key>StandardOutPath</key><string>__HOME__/transcribe/logs/worker-mac-__N__.launchd.log</string>
+    <key>StandardErrorPath</key><string>__HOME__/transcribe/logs/worker-mac-__N__.launchd.log</string>
+</dict>
+</plist>

--- a/packages/tools/video-grabber/mac/run-worker.sh
+++ b/packages/tools/video-grabber/mac/run-worker.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# One rt911 transcribe worker slot: claims transcribe_jobs from the cluster DB
+# (via the reverse SSH tunnel) and runs whisper.cpp/Metal locally.
+cd "$(dirname "$0")"
+set -a; . ./worker.env; set +a
+export PATH=/opt/homebrew/bin:/usr/local/bin:$PATH
+mkdir -p "$SCRATCH_DIR"
+exec ./venv/bin/python -m video_grabber.transcribe.dispatch_worker "${1:-mac}"

--- a/packages/tools/video-grabber/tests/test_transcribe_qos.py
+++ b/packages/tools/video-grabber/tests/test_transcribe_qos.py
@@ -1,0 +1,77 @@
+from types import SimpleNamespace
+
+import pytest
+
+from video_grabber.transcribe import dispatch_worker as dw
+from video_grabber.transcribe.qos import darwin_background_qos
+
+
+def _libc(value, errno=0):
+    """Stand in for libc, returning a fixed getpriority result."""
+    import ctypes
+
+    def getpriority(which, who):
+        ctypes.set_errno(errno)
+        return value
+
+    return SimpleNamespace(getpriority=getpriority)
+
+
+def test_reports_throttled_when_darwin_priority_is_one():
+    assert darwin_background_qos(platform="darwin", libc=_libc(1)) is True
+
+
+def test_reports_healthy_when_darwin_priority_is_zero():
+    assert darwin_background_qos(platform="darwin", libc=_libc(0)) is False
+
+
+def test_not_applicable_off_macos():
+    # The cluster runs Linux, where this policy does not exist.
+    assert darwin_background_qos(platform="linux", libc=_libc(1)) is None
+
+
+def test_unanswerable_check_is_none_not_throttled():
+    # An errno from the syscall must not read as "throttled" and take a healthy
+    # worker down on a platform quirk.
+    assert darwin_background_qos(platform="darwin", libc=_libc(0, errno=22)) is None
+
+
+def test_missing_libc_is_none_not_throttled():
+    class Boom:
+        def __getattr__(self, _):
+            raise AttributeError("no libc")
+
+    assert darwin_background_qos(platform="darwin", libc=Boom()) is None
+
+
+# ---- the startup gate -------------------------------------------------------
+
+
+def test_worker_refuses_to_start_when_throttled(monkeypatch, capsys):
+    """A throttled worker is worse than no worker: it claims jobs and holds them.
+
+    Under background QoS whisper --vad never returns, so the row sits in
+    'transcribing' with a live heartbeat — the supervisor cannot even reclaim it.
+    """
+    monkeypatch.setattr(dw, "darwin_background_qos", lambda: True)
+    monkeypatch.delenv("ALLOW_THROTTLED_WORKER", raising=False)
+    with pytest.raises(SystemExit) as exc:
+        dw.assert_not_throttled()
+    assert exc.value.code != 0
+    assert "background QoS" in capsys.readouterr().out
+
+
+def test_worker_starts_normally_when_not_throttled(monkeypatch):
+    monkeypatch.setattr(dw, "darwin_background_qos", lambda: False)
+    dw.assert_not_throttled()  # must not raise
+
+
+def test_worker_starts_when_the_check_does_not_apply(monkeypatch):
+    monkeypatch.setattr(dw, "darwin_background_qos", lambda: None)
+    dw.assert_not_throttled()  # must not raise
+
+
+def test_override_allows_a_throttled_worker(monkeypatch):
+    monkeypatch.setattr(dw, "darwin_background_qos", lambda: True)
+    monkeypatch.setenv("ALLOW_THROTTLED_WORKER", "1")
+    dw.assert_not_throttled()  # must not raise

--- a/packages/tools/video-grabber/video_grabber/transcribe/dispatch_worker.py
+++ b/packages/tools/video-grabber/video_grabber/transcribe/dispatch_worker.py
@@ -20,6 +20,7 @@ Two behaviours keep the pipeline self-healing:
     stale, and serve.py re-queues it. A live worker — even on a ~1h46m transcription —
     keeps it fresh, so a slow job is never mistaken for a dead one.
 """
+import os
 import sys
 import threading
 import time
@@ -28,6 +29,7 @@ import sqlalchemy as sa
 
 from video_grabber.config import Config
 from video_grabber.transcribe.flows import _sync_db_url, transcribe_item_flow
+from video_grabber.transcribe.qos import THROTTLED_MESSAGE, darwin_background_qos
 
 _CLAIM_SQL = sa.text("""
     UPDATE transcribe_jobs SET
@@ -79,7 +81,24 @@ def _heartbeat(url: str) -> None:
             _log(f"heartbeat error: {exc}")
 
 
+def assert_not_throttled() -> None:
+    """Exit rather than run under macOS background QoS.
+
+    Refusing is deliberately stricter than warning. A throttled worker does not
+    merely run slowly — whisper --vad never returns, so the worker claims a job,
+    heartbeats it forever and never completes or fails it. The supervisor cannot
+    reclaim a row whose heartbeat is live, so one throttled worker permanently
+    removes a job from the queue. Crash-looping under KeepAlive is noisy, which
+    is the point: the alternative is an 18x throughput loss that looks like
+    nothing at all.
+    """
+    if darwin_background_qos() and os.getenv("ALLOW_THROTTLED_WORKER") != "1":
+        _log(THROTTLED_MESSAGE)
+        raise SystemExit(1)
+
+
 def main() -> None:
+    assert_not_throttled()
     cfg = Config()
     url = _sync_db_url(cfg.database_url)
     threading.Thread(target=_heartbeat, args=(url,), daemon=True).start()

--- a/packages/tools/video-grabber/video_grabber/transcribe/qos.py
+++ b/packages/tools/video-grabber/video_grabber/transcribe/qos.py
@@ -1,0 +1,57 @@
+"""Detect whether this process is running under macOS background QoS.
+
+A launchd agent declared `<key>ProcessType</key><string>Background</string>` is
+throttled by macOS across CPU, I/O and GPU. The transcribe workers shipped that
+way, which was survivable until whisper gained `--vad` — VAD loads a second model
+and takes an ANE/CoreML path that stalls outright under throttling. The result was
+not a slowdown but a hang: worker alive, heartbeat firing, main thread parked in
+kevent, no whisper or ffmpeg child, 25+ minutes on a 30-second clip. Changing the
+one word to `Standard` took throughput from 6 files/hour to 108.
+
+Nothing in the pipeline could see this. Every component timed fast in isolation and
+the only way to find it was to run the same worker outside launchd and notice it
+finished in seconds. That is too subtle to rediscover, so the worker asserts it at
+startup instead.
+
+The signal is `getpriority(PRIO_DARWIN_PROCESS, 0)`: 0 for a normal process, 1 for
+one in background state. Note that the ordinary nice value stays 0 in both cases,
+so `os.getpriority(os.PRIO_PROCESS, …)` cannot be used for this.
+"""
+from __future__ import annotations
+
+import ctypes
+import sys
+
+# <sys/resource.h>. Not exposed by Python's os module, which only wraps
+# PRIO_PROCESS / PRIO_PGRP / PRIO_USER.
+_PRIO_DARWIN_PROCESS = 4
+
+
+def darwin_background_qos(*, platform: str | None = None, libc=None) -> bool | None:
+    """True if throttled, False if not, None if the question does not apply.
+
+    None is returned off macOS (the cluster runs Linux, where this policy does not
+    exist) and whenever libc cannot be loaded or the call fails — an unanswerable
+    check must not be read as "throttled" and take a healthy worker down.
+    """
+    if (platform or sys.platform) != "darwin":
+        return None
+    try:
+        libc = libc or ctypes.CDLL("libc.dylib", use_errno=True)
+        ctypes.set_errno(0)
+        value = libc.getpriority(_PRIO_DARWIN_PROCESS, 0)
+        if ctypes.get_errno() != 0:
+            return None
+    except (OSError, AttributeError):
+        return None
+    return value == 1
+
+
+THROTTLED_MESSAGE = (
+    "refusing to start: this process is under macOS background QoS "
+    "(getpriority(PRIO_DARWIN_PROCESS) == 1), which throttles CPU, I/O and GPU. "
+    "whisper --vad stalls indefinitely under it — the worker stays alive and "
+    "heartbeats while never finishing a job, so it holds claims instead of "
+    "failing them. Set <key>ProcessType</key><string>Standard</string> in the "
+    "LaunchAgent plist and reload it. Override with ALLOW_THROTTLED_WORKER=1."
+)


### PR DESCRIPTION
Closes #389.

## The bug this guards against

The Mac Studio's LaunchAgents shipped with `ProcessType=Background`, which macOS throttles
across CPU, I/O and GPU. That was survivable until whisper gained `--vad` (#386): VAD loads
a second model and takes an ANE/CoreML path that stalls outright when throttled.

The failure mode is a **hang, not slowness**, and it is worse than a dead worker: the
process stays alive and keeps heartbeating its claimed job, so the supervisor cannot
reclaim the row either. One throttled worker permanently removes a job from the queue.
Throughput was **6 files/hour throttled, 108 not**.

Nothing in the pipeline could see it. Every component timed fast in isolation — extract
0.7 s, whisper 4.6 s, uploads 0.6 s, Directus 0.3 s, whole flow 14 s in a fresh
interpreter. The only way to find it was to run the identical worker outside launchd and
notice it finished in seconds.

## The check

`dispatch_worker` now calls `getpriority(PRIO_DARWIN_PROCESS, 0)` at startup and exits if
it returns 1. `ALLOW_THROTTLED_WORKER=1` overrides.

Refusing rather than warning is deliberate — see above; a throttled worker is worse than no
worker. It crash-loops under `KeepAlive`, which is noisy, and that is the point: the
alternative is an 18× throughput loss that looks like nothing at all.

Detection notes worth knowing:
- The ordinary nice value is **0 in both states**, so `os.getpriority(os.PRIO_PROCESS, …)`
  cannot detect this. `PRIO_DARWIN_PROCESS` (4) is not exposed by Python's `os` module and
  is called through ctypes.
- Returns `None` — not "throttled" — off macOS, or if libc will not load or the call sets
  errno. An unanswerable check must never take a healthy worker down.
- Reproduce the condition deliberately with `taskpolicy -b`, which is how the detection was
  verified against both states.

## Versioning the config

`mac/` now holds the plist template, `run-worker.sh` and a README covering install, update
and the 2-worker concurrency limit. `worker.env` is **not** committed (production
credentials); the README lists the required keys.

This is the actual root cause of the issue: the Mac's configuration existed only on that
machine, which is how it drifted five weeks out of date against production (#379) and sat
throttled for weeks. `docs/transcription.md` gains a section on where transcription runs
and why the cluster is set to `TRANSCRIBE_DISPATCH_LIMIT=0`.

## Not deployed yet

Deliberately **not** applied to the Mac — a corpus re-transcription is running and updating
the checkout means restarting workers. The assertion takes effect on the next restart. The
live plists are already `Standard`, so it will pass.

515 passed / ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)