### PR TITLE
fix(transcribe): tolerate non-UTF-8 whisper output; correct the sparse metric

### DIFF
--- a/packages/tools/video-grabber/tests/test_transcribe_flows.py
+++ b/packages/tools/video-grabber/tests/test_transcribe_flows.py
@@ -315,6 +315,26 @@ def test_subtitle_base_key_leaves_tv_alone():
     assert flows.subtitle_base_key("tv", "TCN_test", cfg) == "subtitles/programs/TCN_test"
 
 
+def test_read_whisper_text_tolerates_non_utf8_bytes(tmp_path):
+    """whisper.cpp writes raw decoder output and does not guarantee UTF-8.
+
+    A single 0xb5 byte mid-file failed a NORAD job outright under the default
+    strict decode, losing 6+ hours of transcription. One mojibake character beats
+    no transcript.
+    """
+    p = tmp_path / "out.srt"
+    p.write_bytes(b"1\n00:00:01,000 --> 00:00:02,000\nBravo \xb5 112\n")
+    text = flows.read_whisper_text(p)
+    assert "Bravo" in text and "112" in text
+    assert len(flows.parse_srt(text)) == 1
+
+
+def test_read_whisper_text_is_unchanged_for_clean_utf8(tmp_path):
+    p = tmp_path / "out.srt"
+    p.write_text("1\n00:00:01,000 --> 00:00:02,000\nAmerican 77\n")
+    assert flows.read_whisper_text(p) == p.read_text()
+
+
 def _mp3_job(job_id):
     return SimpleNamespace(
         id=job_id, kind="mp3",

--- a/packages/tools/video-grabber/video_grabber/transcribe/flows.py
+++ b/packages/tools/video-grabber/video_grabber/transcribe/flows.py
@@ -160,6 +160,18 @@ def slice_wav(src: Path, dest: Path, offset_ms: int, length_ms: int) -> Path:
     return dest
 
 
+def read_whisper_text(path: Path) -> str:
+    """Read a whisper output file, tolerating bytes that are not valid UTF-8.
+
+    whisper.cpp writes raw decoder output and does not guarantee UTF-8. One NORAD
+    tape emitted 0xb5 mid-file, which failed the whole job on the default strict
+    decode -- losing 6+ hours of transcription over one byte. Replacing the
+    offending bytes keeps the rest, which is the right trade for an archive: one
+    mojibake character beats no transcript at all.
+    """
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
 def transcribe_windows(wav: Path, scratch: Path, cfg, duration_s: float) -> list[Cue]:
     """Transcribe a recording as a sequence of bounded windows, merged onto one
     timeline.
@@ -181,7 +193,7 @@ def transcribe_windows(wav: Path, scratch: Path, cfg, duration_s: float) -> list
         slice_wav(wav, segment, offset_ms, length_ms)
         try:
             srt_path = transcribe_wav(segment, base, cfg, vad=True)
-            blocks.append(shift(parse_srt(srt_path.read_text()), offset_ms / 1000.0))
+            blocks.append(shift(parse_srt(read_whisper_text(srt_path)), offset_ms / 1000.0))
         finally:
             segment.unlink(missing_ok=True)
     return merge(blocks)
@@ -327,8 +339,8 @@ def transcribe_item_flow(job_id: str) -> None:
 
         base_key = subtitle_base_key(job.kind, job.source_key, cfg)
         srt_key = f"{base_key}.srt"
-        wasabi.upload_text(srt_path.read_text(), srt_key, cfg)
-        wasabi.upload_text(vtt_path.read_text(), f"{base_key}.vtt", cfg)
+        wasabi.upload_text(read_whisper_text(srt_path), srt_key, cfg)
+        wasabi.upload_text(read_whisper_text(vtt_path), f"{base_key}.vtt", cfg)
 
         if job.kind == "mp3":
             matched = patch_mp3_subtitles(job.source_url, wasabi_public_url(srt_key), cfg)

--- a/plans/2026-08-13-audio-enhancement-findings.md
+++ b/plans/2026-08-13-audio-enhancement-findings.md
@@ -145,3 +145,46 @@ refuses to start while it is unset.
 Worth stating plainly, because it is easy to assume otherwise: this choice has **no
 effect on transcripts**. Transcription reads `audio/` and never `audio-enhanced/`,
 enforced by a test. Enhancement is a listening feature only.
+
+## Corpus re-transcription results, and a correction (2026-08-14)
+
+The chunked/VAD pass ran over all 782 eligible files. 787 done, 1 failed.
+
+**The "sparse" metric this document leans on is wrong, and the 125-candidate figure
+above should not be trusted.** Reading the flagged transcripts against their audio
+shows it measures *how quiet a channel is*, not whether transcription worked:
+
+| wpm | what is actually in the transcript |
+|---|---|
+| 0.4 | "This is the end of the re-recording concerning events on September 11, 2001." — a complete transcript of a mostly-silent tape |
+| 8.6 | The FAA's certification preamble, read verbatim and transcribed correctly |
+| 23.5 | 1,340 words of genuine ATC traffic over 57 minutes |
+| 24.2 | "Boston Center, TMU, we have a problem here, we have a hijacked aircraft headed towards New York… scramble some F-16s" |
+
+That last one is among the most significant recordings in the archive, transcribed
+accurately, and the metric called it a rescue candidate. An FAA TMU position where a
+controller speaks a few times an hour is *correctly* transcribed at 3 wpm.
+
+Scored on signals that actually indicate failure — an empty transcript, or one
+containing nothing but `[inaudible]`/`[Music]` markers:
+
+| | before | after |
+|---|---:|---:|
+| true failures | 13 | **9** |
+| total words | 529,263 | **615,684** (+86k, 1.2×) |
+| SRTs | 695 | 781 |
+
+So the corpus-wide gain is **1.2×, not the 26× the NEADS tape showed**. That tape was a
+genuine catastrophic failure (84 words for 6.67 hours, from `[Music]` cues collapsing to
+one) and went to ~2,307 real words; generalising from it overstated the problem. The
+chunking work was still worth doing — it fixed the real failures and added 86k words —
+but most of the corpus was never broken, only quiet.
+
+Any future evaluation should use empty/degenerate as the failure signal and ignore
+words-per-minute entirely.
+
+### Outstanding
+
+- 1 job failed on non-UTF-8 whisper output (`0xb5`); fixed by `read_whisper_text`.
+- 8 files have no SRT: the 6 uncatalogued FDNY tapes (#377), one never-transcribed ZBW
+  file, and the UTF-8 failure above.


### PR DESCRIPTION
Two things from the completed corpus re-transcription (787 done, 1 failed).

## The failure

```
audio/norad/neads/DRM1_DAT2_Channel_19_SD2_OP.mp3
'utf-8' codec can't decode byte 0xb5 in position 4689: invalid start byte
```

whisper.cpp writes raw decoder output and does not guarantee UTF-8. `srt_path.read_text()`
uses the default strict decode, so one byte failed a job that had already transcribed 6+
hours of audio. `read_whisper_text` uses `errors="replace"` — for an archive, one mojibake
character beats no transcript. Applied at all three read sites.

## The correction — the metric was wrong

The findings doc's "sparse" test (< 25 words per minute of audio) drove the
125-rescue-candidate figure that justified this whole workstream. Reading the flagged
transcripts against their audio shows it measures **how quiet a channel is**, not whether
transcription worked:

| wpm | what is actually in the transcript |
|---|---|
| 0.4 | "This is the end of the re-recording concerning events on September 11, 2001." — complete |
| 8.6 | The FAA certification preamble, verbatim and correct |
| 23.5 | 1,340 words of genuine ATC traffic over 57 minutes |
| 24.2 | "Boston Center, TMU, we have a problem here, we have a hijacked aircraft headed towards New York… scramble some F-16s" |

The last is among the most significant recordings in the archive, transcribed accurately,
and the metric called it a rescue candidate. An FAA TMU position where a controller speaks
a few times an hour is *correctly* transcribed at 3 wpm.

Rescored on signals that actually indicate failure — empty, or nothing but
`[inaudible]`/`[Music]`:

| | before | after |
|---|---:|---:|
| true failures | 13 | **9** |
| total words | 529,263 | **615,684** (+86k, 1.2×) |

**The corpus-wide gain is 1.2×, not the 26× the NEADS tape showed.** That tape was a real
catastrophic failure (84 words for 6.67 hours) and went to ~2,307 real words, but
generalising from it overstated the problem. The chunking work still fixed the genuine
failures and added 86k words — most of the corpus was never broken, only quiet.

Future evaluation should use empty/degenerate and ignore words-per-minute.

517 passed / ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
