### PR TITLE
fix(parties): size max_tokens for adaptive thinking, not just the reply

### DIFF
--- a/packages/tools/video-grabber/tests/test_parties_identify.py
+++ b/packages/tools/video-grabber/tests/test_parties_identify.py
@@ -162,3 +162,15 @@ def test_parse_rejects_non_json():
 def test_parse_rejects_a_json_array():
     with pytest.raises(ValueError, match="not an object"):
         parse_parties("[1, 2, 3]")
+
+
+@pytest.mark.parametrize("raw", ["", "   \n ", None])
+def test_parse_blames_the_token_budget_for_an_empty_reply(raw):
+    """An empty reply means max_tokens went entirely on thinking, not a bad prompt.
+
+    claude-sonnet-5 thinks by default when `thinking` is unset, and max_tokens caps
+    thinking and text together — so the response is a lone thinking block with no
+    text. Reporting that as malformed JSON sends the next reader to the prompt.
+    """
+    with pytest.raises(ValueError, match="no text"):
+        parse_parties(raw)

--- a/packages/tools/video-grabber/video_grabber/parties/flows.py
+++ b/packages/tools/video-grabber/video_grabber/parties/flows.py
@@ -23,6 +23,17 @@ from video_grabber.transcript.summarize_flows import anthropic_completer
 SAMPLE_WINDOWS = 6
 SAMPLE_CHARS = 2000
 
+# max_tokens caps thinking AND response text together, and claude-sonnet-5 runs
+# adaptive thinking whenever `thinking` is unset (unlike sonnet-4.6, where omitting
+# it meant no thinking at all). The reply itself is ~350 tokens of JSON, so 1200
+# looked generous — but a hard clip spends the whole budget reasoning and returns
+# stop_reason=max_tokens with no text block at all. Measured on
+# audio/ZOB/095654: 1200 -> 1200 output tokens, ['thinking'], text ''.
+# The same clip at 4000 -> end_turn, 2813 output tokens, ['thinking', 'text'].
+# Failure is silent and self-selecting for the ambiguous clips that most need the
+# reasoning, so leave real headroom rather than trimming to the observed maximum.
+PARTIES_MAX_TOKENS = 4000
+
 
 def srt_text_to_plain(srt: str) -> str:
     return " ".join(
@@ -51,7 +62,7 @@ def identify_parties_flow(limit: int | None = None, force: bool = False,
     cfg = Config()
     if not cfg.anthropic_api_key:
         raise RuntimeError("ANTHROPIC_API_KEY is not set")
-    complete = anthropic_completer(cfg, model=cfg.parties_model, max_tokens=1200)
+    complete = anthropic_completer(cfg, model=cfg.parties_model, max_tokens=PARTIES_MAX_TOKENS)
 
     done = skipped = failed = broadcast = 0
     for row in _page_mp3_items(cfg, "id,url,subtitles,calc_duration,parties"):

--- a/packages/tools/video-grabber/video_grabber/parties/identify.py
+++ b/packages/tools/video-grabber/video_grabber/parties/identify.py
@@ -115,6 +115,17 @@ _DIGITS = re.compile(r"\d+")
 def parse_parties(raw: str) -> dict:
     """Parse the model's reply, tolerating a markdown fence."""
     text = (raw or "").strip()
+    if not text:
+        # An empty reply is not malformed JSON, and saying "did not return JSON"
+        # sent us looking at the prompt for an hour. The cause is a max_tokens
+        # budget consumed entirely by adaptive thinking, so the response carries a
+        # thinking block and no text block. Name that, so the next reader checks
+        # the budget first. See PARTIES_MAX_TOKENS in parties/flows.py.
+        raise ValueError(
+            "model returned no text. The usual cause is max_tokens being consumed "
+            "by adaptive thinking (stop_reason=max_tokens, content=['thinking']); "
+            "raise the token budget rather than changing the prompt."
+        )
     m = _FENCE.search(text)
     if m:
         text = m.group(1)


### PR DESCRIPTION
The corpus party-identification run silently lost 9 rows out of 758 eligible. The cause was not the prompt.

## What happened

`anthropic_completer` never passes `thinking`. On **claude-sonnet-5 that means adaptive thinking is on** — unlike sonnet-4.6, where omitting it meant no thinking at all — and `max_tokens` caps thinking **and** response text *together*. The JSON reply is ~350 tokens, so `1200` looked generous. In practice the hardest clips spent the whole budget reasoning and returned no text block at all.

Measured directly on `audio/ZOB/095654 zob cleve atct disc.mp3` (2,132-char transcript):

| `max_tokens` | `stop_reason` | output tokens | content blocks | text |
|---|---|---:|---|---|
| 1200 | `max_tokens` | 1200 | `['thinking']` | `''` |
| 4000 | `end_turn` | 2813 | `['thinking', 'text']` | valid JSON |

Two things make this a bad failure shape:

- **It is silent.** No exception, no HTTP error — just an empty string, which `parse_parties` reported as `model did not return JSON: ''`. That sends the reader to inspect the prompt, which is the one thing that is not wrong.
- **It self-selects for the hardest inputs.** Easy clips answer inside the budget; ambiguous ones — exactly the clips where identification is hard and the reasoning is worth paying for — think longer and return nothing.

## The change

- `PARTIES_MAX_TOKENS = 4000`, with the measurement recorded at the constant. Deliberately headroom rather than the observed 2,813, since the failure is invisible and input-dependent.
- `parse_parties` now raises on an empty reply naming the token budget as the cause, instead of reporting malformed JSON.
- Test covers the empty-reply case (`""`, whitespace, `None`).

## Not fixed here

`summarize_flows.anthropic_completer` still defaults to `max_tokens=400`. Any other sonnet-5 caller has the same latent failure; I only fixed the parties path.

## Verification

520 passed / ruff clean. The 4 affected rows were filled out-of-band at the larger budget, so `mp3_items` is now at 755/758 identified — the 3 remaining are 2 recordings with no speech and 1 file that was never transcribed. WINS/WCBS exclusion holds at 0 leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
