### PR TITLE
feat(playlist): zoom controls on the editor timeline

### DIFF
--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.scss
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.scss
@@ -1,11 +1,41 @@
 // Layout-essential rules only for the Playlist editor's read-only timeline
 // strip (C4). Visual polish (colors, fonts, chrome) lands in a later pass.
 
+.playlistTimelineWrap {
+	position: relative;
+	width: 100%;
+}
+
+/* The zoom controls sit outside .playlistTimeline on purpose: that element is
+ * the scrolling viewport, so controls placed inside it would scroll away from
+ * the user as soon as they panned. They are laid out in flow rather than
+ * absolutely positioned — the editor window's overflow: hidden clips absolutely
+ * positioned children (the same trap the Add Settings dropdown hit). */
+.playlistTimelineZoom {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	padding: 2px 0;
+}
+
+.playlistTimelineZoomLevel {
+	min-width: 3em;
+	text-align: center;
+	font-variant-numeric: tabular-nums; // stops the row twitching as 1×→16× widens
+}
+
 .playlistTimeline {
 	position: relative;
 	width: 100%;
 	overflow-x: auto;
 	overflow-y: hidden;
+}
+
+/* Zoom widens this track inside the viewport above; every child stays
+ * positioned by percentage, so nothing else has to know about zoom. */
+.playlistTimelineTrack {
+	position: relative;
+	min-width: 100%;
 }
 
 .playlistTimelineRuler {

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistTimeline.test.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistTimeline.test.tsx
@@ -123,4 +123,60 @@ describe("PlaylistTimeline", () => {
 		render(<PlaylistTimeline entries={[]} selectedUid={null} onSelect={vi.fn()} />);
 		expect(document.querySelectorAll(".playlistTimelineHourTick")).toHaveLength(40);
 	});
+
+	it("widens the track and subdivides the ruler on zoom in, and restores it on zoom out", () => {
+		render(<PlaylistTimeline entries={[]} selectedUid={null} onSelect={vi.fn()} />);
+		const track = screen.getByTestId("timeline-track");
+		const level = screen.getByTestId("timeline-zoom-level");
+		expect(track.style.width).toBe("100%");
+		expect(level.textContent).toBe("1×");
+
+		fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+		expect(track.style.width).toBe("200%");
+		expect(level.textContent).toBe("2×");
+		expect(document.querySelectorAll(".playlistTimelineHourTick").length).toBeGreaterThan(40);
+
+		fireEvent.click(screen.getByRole("button", { name: "Zoom out" }));
+		expect(track.style.width).toBe("100%");
+		expect(document.querySelectorAll(".playlistTimelineHourTick")).toHaveLength(40);
+	});
+
+	it("disables each control at its end of the ladder", () => {
+		render(<PlaylistTimeline entries={[]} selectedUid={null} onSelect={vi.fn()} />);
+		// jest-dom is not installed here, so assert the DOM property directly
+		// rather than reaching for toBeDisabled().
+		const zoomIn = screen.getByRole("button", { name: "Zoom in" }) as HTMLButtonElement;
+		const zoomOut = screen.getByRole("button", { name: "Zoom out" }) as HTMLButtonElement;
+
+		expect(zoomOut.disabled).toBe(true);
+		expect(zoomIn.disabled).toBe(false);
+
+		// Walk past the top of the ladder; it must stop, not run past MAX_ZOOM.
+		for (let i = 0; i < 12; i += 1) fireEvent.click(zoomIn);
+		expect(screen.getByTestId("timeline-zoom-level").textContent).toBe("64×");
+		expect(zoomIn.disabled).toBe(true);
+		expect(zoomOut.disabled).toBe(false);
+	});
+
+	it("un-stacks flags that only collided because they were close as a fraction of ten days", () => {
+		// 20 minutes apart: under 1.5% of a ten-day span, so at 1x they stack into
+		// separate rows. Zooming in is the whole reason a user reaches for this
+		// control, so the stacking threshold has to scale with the track.
+		const crowded: EditorEntry[] = [
+			{ uid: "n1", entry: { kind: "media", app: "news", itemId: "1" },
+				timelineMeta: { publishedAt: "2001-09-11T12:00:00Z" } },
+			{ uid: "n2", entry: { kind: "media", app: "news", itemId: "2" },
+				timelineMeta: { publishedAt: "2001-09-11T12:20:00Z" } },
+		];
+		render(<PlaylistTimeline entries={crowded} selectedUid={null} onSelect={vi.fn()} />);
+
+		const topOf = (i: number) =>
+			(document.querySelectorAll<HTMLElement>(".playlistTimelineFlag")[i]).style.top;
+		expect(topOf(0)).not.toBe(topOf(1));
+
+		for (let i = 0; i < 5; i += 1) {
+			fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+		}
+		expect(topOf(0)).toBe(topOf(1));
+	});
 });

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistTimeline.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistTimeline.tsx
@@ -1,15 +1,22 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { EditorEntry } from "./editorState";
 import "./PlaylistEditor.scss";
 import { resolveTimelineMeta } from "./resolveTimelineMeta";
 import {
 	layoutBars,
 	layoutFlags,
-	TIMELINE_START_MS,
+	MAX_ZOOM,
+	MIN_ZOOM,
+	rulerLabels,
+	rulerTicks,
+	steppedZoom,
 } from "./timelineLayout";
 
-const DAY_MS = 24 * 3600_000;
-const HOUR_TICK_COUNT = 40; // 10 days * 4 six-hour ticks/day
+// Flags stack into rows when they fall within this fraction of each other. It is
+// a fraction of the whole span, so it has to shrink as the track widens —
+// otherwise zooming in spreads the flags apart on screen while still stacking
+// them, which defeats the main reason to zoom into a crowded stretch.
+const FLAG_MIN_GAP_FRAC = 0.015;
 
 export function barMaskImage(fadeStart: boolean, fadeEnd: boolean): string {
 	if (fadeStart && fadeEnd) {
@@ -31,6 +38,32 @@ export function PlaylistTimeline({
 }) {
 	const [resolved, setResolved] = useState<Map<string, EditorEntry["timelineMeta"]>>(new Map());
 	const attemptedRef = useRef(new Set<string>());
+	// Annotated: ZOOM_LEVELS is `as const`, so MIN_ZOOM narrows to the literal 1
+	// and an inferred state type would reject every other level.
+	const [zoom, setZoom] = useState<number>(MIN_ZOOM);
+	const viewportRef = useRef<HTMLDivElement>(null);
+	const anchorRef = useRef<number | null>(null);
+
+	// Zoom about the middle of what the user is currently looking at. Without
+	// this, widening the track keeps scrollLeft fixed and the view lurches
+	// towards 9 September every time you zoom in.
+	function changeZoom(direction: 1 | -1) {
+		const el = viewportRef.current;
+		if (el && el.scrollWidth > 0) {
+			anchorRef.current = (el.scrollLeft + el.clientWidth / 2) / el.scrollWidth;
+		}
+		setZoom((z) => steppedZoom(z, direction));
+	}
+
+	useLayoutEffect(() => {
+		const el = viewportRef.current;
+		const anchor = anchorRef.current;
+		anchorRef.current = null;
+		// scrollWidth is 0 under jsdom, so this is a no-op in tests rather than
+		// writing NaN into scrollLeft.
+		if (!el || anchor === null || el.scrollWidth === 0) return;
+		el.scrollLeft = anchor * el.scrollWidth - el.clientWidth / 2;
+	}, [zoom]);
 
 	useEffect(() => {
 		const toResolve = entries.filter(
@@ -55,83 +88,120 @@ export function PlaylistTimeline({
 		[entries, resolved],
 	);
 	const bars = useMemo(() => layoutBars(merged), [merged]);
-	const flags = useMemo(() => layoutFlags(merged), [merged]);
+	const flags = useMemo(() => layoutFlags(merged, FLAG_MIN_GAP_FRAC / zoom), [merged, zoom]);
 	const flagRows = flags.reduce((m, f) => Math.max(m, f.row), 0) + 1;
+	const ticks = useMemo(() => rulerTicks(zoom), [zoom]);
+	const labels = useMemo(() => rulerLabels(zoom), [zoom]);
 
 	return (
-		<div className="playlistTimeline" data-testid="playlist-timeline">
-			<div className="playlistTimelineRuler">
-				{Array.from({ length: 11 }, (_, day) => (
-					<span key={day} className="playlistTimelineDayTick" style={{ left: `${day * 10}%` }}>
-						{new Date(TIMELINE_START_MS + day * DAY_MS).toISOString().slice(5, 10)}
-					</span>
-				))}
-				{Array.from({ length: HOUR_TICK_COUNT }, (_, i) => (
-					<span
-						key={`hour-${i}`}
-						className="playlistTimelineHourTick"
-						style={{ left: `${i * 2.5}%` }}
-					/>
-				))}
+		<div className="playlistTimelineWrap">
+			<div className="playlistTimelineZoom">
+				<button
+					type="button"
+					onClick={() => changeZoom(-1)}
+					disabled={zoom <= MIN_ZOOM}
+					title="Zoom out"
+					aria-label="Zoom out"
+				>
+					−
+				</button>
+				<span className="playlistTimelineZoomLevel" data-testid="timeline-zoom-level">
+					{zoom}×
+				</span>
+				<button
+					type="button"
+					onClick={() => changeZoom(1)}
+					disabled={zoom >= MAX_ZOOM}
+					title="Zoom in"
+					aria-label="Zoom in"
+				>
+					+
+				</button>
 			</div>
-			<div className="playlistTimelineFlagRow" style={{ height: `${flagRows * 18}px` }}>
-				{flags.map((f) => (
-					<button
-						key={f.uid}
-						type="button"
-						className={`playlistTimelineFlag playlistTimelineFlag-${f.kindGlyph}`}
-						style={{ left: `${f.atFrac * 100}%`, top: `${f.row * 18}px` }}
-						title={f.label}
-						onClick={() => onSelect(f.uid)}
-					>
-						⚑
-					</button>
-				))}
-				{flags.filter((f) => f.extentEndFrac !== undefined).map((f) => (
-					<span
-						key={`${f.uid}-extent`}
-						className="playlistTimelineFlagExtent"
-						style={{
-							left: `${f.atFrac * 100}%`,
-							width: `${((f.extentEndFrac ?? f.atFrac) - f.atFrac) * 100}%`,
-							top: `${f.row * 18 + 14}px`,
-						}}
-					/>
-				))}
-			</div>
-			<div className="playlistTimelineLanes">
-				{bars.map((b) => (
-					<div key={b.uid} className={`playlistTimelineLane playlistTimelineLane-${b.group}`}>
-						<button
-							type="button"
-							className={
-								b.uid === selectedUid
-									? "playlistTimelineBar playlistTimelineBarSelected"
-									: "playlistTimelineBar"
-							}
-							style={{
-								left: `${b.startFrac * 100}%`,
-								width: `${(b.endFrac - b.startFrac) * 100}%`,
-								maskImage: barMaskImage(b.fadeStart, b.fadeEnd),
-							}}
-							title={b.label}
-							onClick={() => onSelect(b.uid)}
-						>
-							{b.focus === "once" && <span aria-hidden>▸</span>}
-							{b.focus === "locked" && <span aria-hidden>🔒</span>}
-							{b.label}
-							{b.actualStartFrac !== undefined && b.endFrac - b.startFrac > 0 && (
-								<span
-									className="playlistTimelineActualSpan"
-									style={{
-										left: `${((b.actualStartFrac - b.startFrac) / (b.endFrac - b.startFrac)) * 100}%`,
-										width: `${(((b.actualEndFrac ?? b.endFrac) - b.actualStartFrac) / (b.endFrac - b.startFrac)) * 100}%`,
-									}}
-								/>
-							)}
-						</button>
+			<div className="playlistTimeline" data-testid="playlist-timeline" ref={viewportRef}>
+				<div
+					className="playlistTimelineTrack"
+					data-testid="timeline-track"
+					style={{ width: `${zoom * 100}%` }}
+				>
+					<div className="playlistTimelineRuler">
+						{labels.map((l) => (
+							<span
+								key={`label-${l.leftPct}`}
+								className="playlistTimelineDayTick"
+								style={{ left: `${l.leftPct}%` }}
+							>
+								{l.text}
+							</span>
+						))}
+						{ticks.map((leftPct) => (
+							<span
+								key={`hour-${leftPct}`}
+								className="playlistTimelineHourTick"
+								style={{ left: `${leftPct}%` }}
+							/>
+						))}
 					</div>
-				))}
+					<div className="playlistTimelineFlagRow" style={{ height: `${flagRows * 18}px` }}>
+						{flags.map((f) => (
+							<button
+								key={f.uid}
+								type="button"
+								className={`playlistTimelineFlag playlistTimelineFlag-${f.kindGlyph}`}
+								style={{ left: `${f.atFrac * 100}%`, top: `${f.row * 18}px` }}
+								title={f.label}
+								onClick={() => onSelect(f.uid)}
+							>
+								⚑
+							</button>
+						))}
+						{flags.filter((f) => f.extentEndFrac !== undefined).map((f) => (
+							<span
+								key={`${f.uid}-extent`}
+								className="playlistTimelineFlagExtent"
+								style={{
+									left: `${f.atFrac * 100}%`,
+									width: `${((f.extentEndFrac ?? f.atFrac) - f.atFrac) * 100}%`,
+									top: `${f.row * 18 + 14}px`,
+								}}
+							/>
+						))}
+					</div>
+					<div className="playlistTimelineLanes">
+						{bars.map((b) => (
+							<div key={b.uid} className={`playlistTimelineLane playlistTimelineLane-${b.group}`}>
+								<button
+									type="button"
+									className={
+										b.uid === selectedUid
+											? "playlistTimelineBar playlistTimelineBarSelected"
+											: "playlistTimelineBar"
+									}
+									style={{
+										left: `${b.startFrac * 100}%`,
+										width: `${(b.endFrac - b.startFrac) * 100}%`,
+										maskImage: barMaskImage(b.fadeStart, b.fadeEnd),
+									}}
+									title={b.label}
+									onClick={() => onSelect(b.uid)}
+								>
+									{b.focus === "once" && <span aria-hidden>▸</span>}
+									{b.focus === "locked" && <span aria-hidden>🔒</span>}
+									{b.label}
+									{b.actualStartFrac !== undefined && b.endFrac - b.startFrac > 0 && (
+										<span
+											className="playlistTimelineActualSpan"
+											style={{
+												left: `${((b.actualStartFrac - b.startFrac) / (b.endFrac - b.startFrac)) * 100}%`,
+												width: `${(((b.actualEndFrac ?? b.endFrac) - b.actualStartFrac) / (b.endFrac - b.startFrac)) * 100}%`,
+											}}
+										/>
+									)}
+								</button>
+							</div>
+						))}
+					</div>
+				</div>
 			</div>
 		</div>
 	);

--- a/packages/frontend/src/Applications/PlaylistEditor/timelineLayout.test.ts
+++ b/packages/frontend/src/Applications/PlaylistEditor/timelineLayout.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { layoutBars, layoutFlags, timeToFraction } from "./timelineLayout";
+import {
+	layoutBars,
+	layoutFlags,
+	MAX_ZOOM,
+	MIN_ZOOM,
+	rulerLabels,
+	rulerTicks,
+	steppedZoom,
+	tickIntervalHours,
+	timeToFraction,
+} from "./timelineLayout";
 
 const media = (uid: string, entry: object, timelineMeta?: object) =>
 	({ uid, entry: { kind: "media", app: "tv", itemId: uid, ...entry }, timelineMeta }) as never;
@@ -70,5 +80,60 @@ describe("layoutFlags", () => {
 		]);
 		expect(flag.atFrac).toBeCloseTo(timeToFraction("2001-09-11T09:00:00Z"));
 		expect(flag.extentEndFrac).toBeCloseTo(timeToFraction("2001-09-11T10:00:00Z"));
+	});
+});
+
+describe("zoom", () => {
+	it("steps through the ladder and clamps at both ends instead of running off it", () => {
+		expect(steppedZoom(1, 1)).toBe(2);
+		expect(steppedZoom(8, 1)).toBe(16);
+		expect(steppedZoom(8, -1)).toBe(4);
+		expect(steppedZoom(MIN_ZOOM, -1)).toBe(MIN_ZOOM);
+		expect(steppedZoom(MAX_ZOOM, 1)).toBe(MAX_ZOOM);
+	});
+
+	it("snaps an off-ladder zoom to the nearest level rather than refusing to move", () => {
+		expect(steppedZoom(5, 1)).toBe(4);
+	});
+
+	it("keeps on-screen tick density roughly constant as zoom grows", () => {
+		// Ticks per viewport = (240 / interval) / zoom. It should stay in the same
+		// ballpark rather than collapsing to a handful or exploding.
+		for (const zoom of [1, 2, 4, 8, 16, 32, 64]) {
+			const perViewport = 240 / tickIntervalHours(zoom) / zoom;
+			expect(perViewport).toBeGreaterThanOrEqual(15);
+			expect(perViewport).toBeLessThanOrEqual(60);
+		}
+	});
+
+	it("floors the tick interval so deep zoom cannot emit unbounded DOM nodes", () => {
+		// The whole span is always rendered, so the total tick count — not the
+		// visible count — is what has to stay bounded.
+		expect(rulerTicks(MAX_ZOOM).length).toBeLessThanOrEqual(960);
+		expect(tickIntervalHours(MAX_ZOOM)).toBe(tickIntervalHours(MAX_ZOOM * 4));
+	});
+
+	it("reproduces the original ruler exactly at 1x", () => {
+		const ticks = rulerTicks(1);
+		expect(ticks).toHaveLength(40);
+		expect(ticks[1]).toBeCloseTo(2.5);
+
+		const labels = rulerLabels(1);
+		expect(labels).toHaveLength(11);
+		expect(labels[0]).toEqual({ leftPct: 0, text: "09-09" });
+		expect(labels[2].leftPct).toBeCloseTo(20);
+		expect(labels[10].text).toBe("09-19");
+	});
+
+	it("subdivides ticks and switches labels to clock times when zoomed in", () => {
+		expect(rulerTicks(4).length).toBeGreaterThan(rulerTicks(1).length);
+
+		const labels = rulerLabels(8);
+		// Midnight keeps its date so a zoomed viewport is never ambiguous about
+		// which day it is showing; the labels between read as clock times.
+		expect(labels[0].text).toBe("09-09");
+		const between = labels.slice(1, 12).map((l) => l.text);
+		expect(between.some((t) => /^\d\d:\d\d$/.test(t))).toBe(true);
+		expect(labels.every((l) => l.leftPct >= 0 && l.leftPct <= 100)).toBe(true);
 	});
 });

--- a/packages/frontend/src/Applications/PlaylistEditor/timelineLayout.ts
+++ b/packages/frontend/src/Applications/PlaylistEditor/timelineLayout.ts
@@ -4,6 +4,87 @@ import type { EditorEntry } from "./editorState";
 export const TIMELINE_START_MS = Date.UTC(2001, 8, 9);
 export const TIMELINE_END_MS = Date.UTC(2001, 8, 19);
 const SPAN = TIMELINE_END_MS - TIMELINE_START_MS;
+const SPAN_HOURS = SPAN / 3_600_000; // 240
+
+/* ── Zoom ──────────────────────────────────────────────────────────────────
+ * Zoom widens the track rather than re-mapping time to fractions: every
+ * position stays a fraction of the full 10-day span, and the rendered track is
+ * `zoom * 100%` wide inside a horizontally scrolling viewport. Two things fall
+ * out of that choice — every existing layout calculation is untouched, and
+ * panning is just the browser's own scrolling, with no pan control to build.
+ *
+ * The cost is that the whole span is always in the DOM, which is why the tick
+ * interval has a floor (see tickIntervalHours): without one, deep zoom would
+ * emit tens of thousands of tick nodes for a viewport showing a few dozen.
+ */
+export const ZOOM_LEVELS = [1, 2, 4, 8, 16, 32, 64] as const;
+export const MIN_ZOOM = ZOOM_LEVELS[0];
+export const MAX_ZOOM = ZOOM_LEVELS[ZOOM_LEVELS.length - 1];
+
+/** The next level in/out, clamped at the ends so callers need no bounds check. */
+export function steppedZoom(zoom: number, direction: 1 | -1): number {
+	const i = ZOOM_LEVELS.indexOf(zoom as (typeof ZOOM_LEVELS)[number]);
+	// An off-ladder value (older persisted state, say) snaps to the nearest level
+	// rather than refusing to move.
+	if (i === -1) {
+		const nearest = ZOOM_LEVELS.reduce((a, b) =>
+			Math.abs(b - zoom) < Math.abs(a - zoom) ? b : a,
+		);
+		return nearest;
+	}
+	return ZOOM_LEVELS[Math.min(ZOOM_LEVELS.length - 1, Math.max(0, i + direction))];
+}
+
+// Coarse→fine. Every value is a divisor of 24h and 4× each is still a round
+// interval, which is what lets the label ladder below stay readable.
+const NICE_TICK_HOURS = [6, 3, 1, 0.5, 0.25];
+const LABEL_EVERY_N_TICKS = 4;
+
+/**
+ * Tick spacing for a zoom level, in hours.
+ *
+ * Targets a constant *on-screen* density: at 1× a 6-hour tick sits 2.5% of the
+ * track apart, which is the density the ruler was designed around, so the aim
+ * is 6/zoom hours. The ladder floor (0.25h) caps the tick count at 960 for the
+ * full span no matter how far in you zoom — past that the marks are denser than
+ * the eye can use, and the DOM cost is real because the whole span is rendered.
+ */
+export function tickIntervalHours(zoom: number): number {
+	const target = 6 / Math.max(1, zoom);
+	return NICE_TICK_HOURS.find((h) => h <= target) ?? NICE_TICK_HOURS[NICE_TICK_HOURS.length - 1];
+}
+
+/** Unlabelled tick positions, as percentages of the track. */
+export function rulerTicks(zoom: number): number[] {
+	const interval = tickIntervalHours(zoom);
+	const count = Math.round(SPAN_HOURS / interval);
+	// End-exclusive: the closing boundary carries a label instead of a bare tick.
+	return Array.from({ length: count }, (_, i) => (i * interval * 100) / SPAN_HOURS);
+}
+
+export type RulerLabel = { leftPct: number; text: string };
+
+/**
+ * Labelled positions, as percentages of the track.
+ *
+ * At 1× this is exactly the eleven `MM-DD` day labels the ruler has always
+ * shown. Zoomed in, labels subdivide with the ticks and switch to clock times,
+ * because day boundaries alone can leave a zoomed viewport with no visible
+ * reference at all — at 64× a viewport spans under four hours.
+ */
+export function rulerLabels(zoom: number): RulerLabel[] {
+	const interval = tickIntervalHours(zoom) * LABEL_EVERY_N_TICKS;
+	const count = Math.round(SPAN_HOURS / interval);
+	return Array.from({ length: count + 1 }, (_, i) => {
+		const hours = i * interval;
+		const iso = new Date(TIMELINE_START_MS + hours * 3_600_000).toISOString();
+		// Keep the date visible at day boundaries even in clock-time mode, so a
+		// zoomed viewport is never ambiguous about which day it is showing.
+		const atMidnight = hours % 24 === 0;
+		const text = interval >= 24 || atMidnight ? iso.slice(5, 10) : iso.slice(11, 16);
+		return { leftPct: (hours * 100) / SPAN_HOURS, text };
+	});
+}
 
 export function timeToFraction(iso: string): number {
 	const frac = (playlistUtcMs(iso) - TIMELINE_START_MS) / SPAN;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 18.1.2
       classicy:
         specifier: latest
-        version: 0.72.2(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/dlv@1.1.5)(@types/react@19.2.18)(immer@11.1.16)(react-dom@19.2.8(react@19.2.8))(react-player@3.4.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zustand@5.0.14(@types/react@19.2.18)(immer@11.1.16)(react@19.2.8))
+        version: 0.72.3(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/dlv@1.1.5)(@types/react@19.2.18)(immer@11.1.16)(react-dom@19.2.8(react@19.2.8))(react-player@3.4.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zustand@5.0.14(@types/react@19.2.18)(immer@11.1.16)(react@19.2.8))
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -1035,8 +1035,8 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
-  classicy@0.72.2:
-    resolution: {integrity: sha512-Hl7zCNC+rSuwLGnmAckTFDHell4dsE1fvaI6kHPhPMbIoAzwX+h1E7hB92vpRQCilK7xdsS+WoP1Vr3L5JGMKg==}
+  classicy@0.72.3:
+    resolution: {integrity: sha512-YcZUdggXjQpjetnV1LZUI8SeXqRvCC6moGL5dULJC81aGuKgViHNhsuAU+q9ZkTcm291Vif6Y5IVWbODVpl78A==}
     peerDependencies:
       '@tanstack/react-table': ^8.21.3
       immer: ^11.1.8
@@ -3462,7 +3462,7 @@ snapshots:
       readdirp: 5.0.0
     optional: true
 
-  classicy@0.72.2(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/dlv@1.1.5)(@types/react@19.2.18)(immer@11.1.16)(react-dom@19.2.8(react@19.2.8))(react-player@3.4.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zustand@5.0.14(@types/react@19.2.18)(immer@11.1.16)(react@19.2.8)):
+  classicy@0.72.3(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/dlv@1.1.5)(@types/react@19.2.18)(immer@11.1.16)(react-dom@19.2.8(react@19.2.8))(react-player@3.4.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zustand@5.0.14(@types/react@19.2.18)(immer@11.1.16)(react@19.2.8)):
     dependencies:
       '@analytics/google-tag-manager': 0.6.0
       '@noble/hashes': 2.3.0


### PR DESCRIPTION
The playlist timeline showed a fixed ten-day span (9 Sep → 19 Sep), so anything shorter than a few hours was sub-pixel and crowded entries were unreadable.

## Approach

**Zoom widens the track rather than re-mapping time to fractions.** Every position in this timeline is already a fraction of the full span, so the rendered track becomes `zoom * 100%` wide inside the viewport that already had `overflow-x: auto`. Two things fall out of that choice:

- `timeToFraction`, `layoutBars`, and `layoutFlags` are completely untouched.
- Panning is the browser's own scrolling — there is no pan control to build.

The cost is that the whole span is always in the DOM, which is why the tick interval has a floor. Without one, 64× would emit tens of thousands of tick nodes in order to show a few dozen.

## What's in it

- `−` / `+` step a doubling ladder from **1× to 64×**, with the current level between them, disabling at each end.
- **Zoom is anchored on the centre of the current view.** Without this, widening the track leaves `scrollLeft` fixed and the view lurches back toward 9 September on every click.
- **The ruler adapts.** Ticks subdivide with zoom (6h → 3h → 1h → 30m → 15m) and labels switch from dates to clock times, keeping the date at midnight boundaries. At 64× a viewport spans under four hours, so day labels alone would leave no visible reference at all.

## One behaviour change beyond the controls

Flag stacking used a fixed `minGapFrac` of 1.5% **of the whole ten days**, so two news flags twenty minutes apart stayed stacked no matter how far you zoomed — which defeats the main reason to zoom into a crowded stretch. It now scales with the track, and there's a test for exactly that case.

## No visual change at rest

At 1× the DOM is unchanged — 40 six-hour ticks and 11 `MM-DD` labels — so nothing moves for anyone who never touches the controls. The pre-existing `renders 40 six-hour ruler ticks` test passes **unmodified**; that's the check used to confirm it.

## Placement notes

The controls sit *outside* the scrolling viewport (inside it they'd scroll away as soon as you panned) and are laid out in normal flow rather than absolutely positioned — the editor window's `overflow: hidden` clips absolutely positioned children, the same trap the Add Settings dropdown hit.

## Not included

Not wired into the `View` menu, and the zoom level is not persisted across window reopens. Both are easy follow-ups if wanted.

## Verification

`tsc -b` clean · 2,236 frontend tests pass (9 new) · `eslint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
