### PR TITLE
fix(playlist): stop the timeline scrolling sideways when fully zoomed out

### DIFF
--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.scss
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.scss
@@ -39,17 +39,31 @@
 	min-width: 100%;
 }
 
+/* Full width, so a tick at 40% lines up with a bar at 40% in the lanes below.
+ *
+ * `overflow: hidden` is the belt to the brace below: the ruler's children are
+ * absolutely positioned by percentage, and anything that renders past 100% —
+ * a long label, a future annotation — becomes scrollable overflow on
+ * .playlistTimeline and makes a fully-zoomed-out timeline scroll sideways for
+ * no visible reason. Clipping here contains that at the source. */
 .playlistTimelineRuler {
 	position: relative;
 	height: var(--window-control-size);
 	font-size: calc(var(--ui-font-size)*.85);
-	width: calc(100% - (var(--window-control-size)*2 + var(--window-padding-size)*2));
+	width: 100%;
+	overflow: hidden;
 }
 
 .playlistTimelineDayTick {
 	position: absolute;
 	top: 0;
 	white-space: nowrap;
+}
+
+/* The closing label sits at left:100%, so left-aligned it would draw its whole
+ * width beyond the track. Right-align it so it ENDS at the edge instead. */
+.playlistTimelineDayTickEnd {
+	transform: translateX(-100%);
 }
 
 .playlistTimelineHourTick {
@@ -61,9 +75,17 @@
 	opacity: 0.4;
 }
 
+/* `timeToFraction` clamps to 1, so any entry at or after 19 Sep lands at exactly
+ * left:100% and its translateX(-50%) glyph hangs half-way past the edge — enough
+ * to make the whole timeline scrollable at 1x. `clip` rather than `hidden`: it
+ * contains the horizontal overhang without creating a scroll container, and
+ * unlike `hidden` it can be paired with a visible vertical axis, which the
+ * stacked flag rows need. */
 .playlistTimelineFlagRow {
 	position: relative;
 	width: 100%;
+	overflow-x: clip;
+	overflow-y: visible;
 }
 
 .playlistTimelineFlag {

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistTimeline.test.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistTimeline.test.tsx
@@ -149,6 +149,26 @@ describe("PlaylistTimeline", () => {
 		expect(document.querySelectorAll(".playlistTimelineHourTick")).toHaveLength(40);
 	});
 
+	it("right-aligns only the closing ruler label, at every zoom level", () => {
+		// A label at left:100% that is left-aligned draws its whole width past
+		// the track. That is scrollable overflow, and it made a fully zoomed-out
+		// timeline scroll sideways — jsdom does no layout, so the guard is the
+		// class, and the CSS translateX(-100%) is what it buys.
+		render(<Controlled entries={[]} />);
+		const ends = () => document.querySelectorAll(".playlistTimelineDayTickEnd");
+		const labels = () => document.querySelectorAll(".playlistTimelineDayTick");
+
+		expect(ends()).toHaveLength(1);
+		expect(labels()[labels().length - 1].classList).toContain("playlistTimelineDayTickEnd");
+		expect(labels()[0].classList).not.toContain("playlistTimelineDayTickEnd");
+
+		// Zoomed in there are far more labels, but still exactly one at the end.
+		fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+		fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+		expect(labels().length).toBeGreaterThan(11);
+		expect(ends()).toHaveLength(1);
+	});
+
 	it("widens the track and subdivides the ruler on zoom in, and restores it on zoom out", () => {
 		render(<Controlled entries={[]} />);
 		const track = screen.getByTestId("timeline-track");

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistTimeline.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistTimeline.tsx
@@ -135,7 +135,15 @@ export function PlaylistTimeline({
 						{labels.map((l) => (
 							<span
 								key={`label-${l.leftPct}`}
-								className="playlistTimelineDayTick"
+								// The closing label is right-aligned. Left-aligned at
+								// left:100% it draws its whole width past the track,
+								// which is scrollable overflow — that is what made a
+								// fully zoomed-out timeline scroll sideways.
+								className={
+									l.leftPct >= 100
+										? "playlistTimelineDayTick playlistTimelineDayTickEnd"
+										: "playlistTimelineDayTick"
+								}
 								style={{ left: `${l.leftPct}%` }}
 							>
 								{l.text}


### PR DESCRIPTION
Removes the ruler width workaround by fixing what was actually overflowing.

## What was happening

The ruler had been narrowed to stop a horizontal scrollbar at 1×:

```scss
width: calc(100% - (var(--window-control-size)*2 + var(--window-padding-size)*2));
```

That stopped the scrollbar, but it also meant the ruler and the lanes were measured against **different widths** — so a tick at 40% no longer sat above a bar at 40%, and the drift grows with zoom.

**The lanes were never the problem.** `.playlistTimelineDayTick` is absolutely positioned with `white-space: nowrap` and no transform, so the closing `09-19` label sits at `left: 100%` and draws its **entire width past the track**. That's scrollable overflow on `.playlistTimeline`, and it was present at every zoom level — including before the zoom feature existed.

## The fix

Right-align the closing label so it *ends* at the edge instead of starting there, and restore the ruler to full width.

Two containment rules back that up, since percentage-positioned children make this easy to reintroduce:

- **the ruler clips its own overflow** — a longer label or a future annotation can't leak out again;
- **the flag row clips horizontally.** `timeToFraction` clamps to 1, so any entry at or after 19 Sep lands at exactly `left: 100%` and its `translateX(-50%)` glyph hangs half-way past the edge. `clip` rather than `hidden` so the vertical axis stays visible for the stacked flag rows.

## Verification

`tsc -b` clean · 187 Playlist Editor tests pass · `eslint` 0 errors.

jsdom does no layout, so the test asserts the class that earns the transform — exactly one closing label, at 1× and zoomed in. **The visual result is worth a quick look in the browser**, since no automated check here can measure actual overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
