### PR TITLE
feat(transcribe): stamp the executor's commit on each job; size the LLM budget

### DIFF
--- a/.github/workflows/build-video-grabber.yml
+++ b/.github/workflows/build-video-grabber.yml
@@ -86,6 +86,10 @@ jobs:
         with:
           context: packages/tools/video-grabber
           push: true
+          # Readable from inside the container, unlike the OCI label below — a
+          # worker stamps this onto the transcribe_jobs row it claims (#379).
+          build-args: |
+            CODE_VERSION=${{ github.sha }}
           tags: |
             ghcr.io/keeping-history/video-grabber:${{ github.sha }}
             ghcr.io/keeping-history/video-grabber:latest

--- a/packages/tools/video-grabber/Dockerfile
+++ b/packages/tools/video-grabber/Dockerfile
@@ -113,7 +113,13 @@ COPY alembic.ini .
 # this build context before `docker build`. Installed with its dateutil dep.
 COPY mbox_parser.py /usr/local/bin/mbox_parser.py
 RUN pip install --no-cache-dir . python-dateutil
-ENV USENETARCHIVE_BIN=/usr/local/bin \
+# The commit this image was built from. There is no git in the container, so an
+# executor running this image cannot otherwise say what code it is on — which is
+# exactly how issue #379 stayed invisible. Set by build-video-grabber.yml; the
+# default keeps a local `docker build` honest rather than claiming a version.
+ARG CODE_VERSION=unknown
+ENV CODE_VERSION=${CODE_VERSION} \
+    USENETARCHIVE_BIN=/usr/local/bin \
     MBOX_PARSER=/usr/local/bin/mbox_parser.py \
     WHISPER_BIN=/usr/local/bin/whisper-cli \
     WHISPER_MODEL=/opt/models/ggml-medium.en.bin

--- a/packages/tools/video-grabber/tests/test_anthropic_completer.py
+++ b/packages/tools/video-grabber/tests/test_anthropic_completer.py
@@ -1,0 +1,85 @@
+"""The completer must not hand back an empty string when a call was truncated.
+
+Returning "" is indistinguishable from "the model had nothing to say", and both
+callers degrade quietly on it: the summarizer falls back to mechanical
+condensation, and party identification logs "did not return JSON" and moves on.
+Neither names the real cause, which is a max_tokens budget consumed entirely by
+thinking on a model that thinks by default.
+"""
+import sys
+import types
+
+import pytest
+
+from video_grabber.config import Config
+from video_grabber.transcript.summarize_flows import DEFAULT_MAX_TOKENS, anthropic_completer
+
+
+class _Block:
+    def __init__(self, type_, text=""):
+        self.type = type_
+        self.text = text
+
+
+class _Msg:
+    def __init__(self, content, stop_reason):
+        self.content = content
+        self.stop_reason = stop_reason
+
+
+def _install_fake_anthropic(monkeypatch, msg):
+    """Stand in for the SDK so no key or network is needed."""
+    captured = {}
+
+    class _Messages:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return msg
+
+    class _Client:
+        def __init__(self, api_key=None):
+            self.messages = _Messages()
+
+    monkeypatch.setitem(
+        sys.modules, "anthropic", types.SimpleNamespace(Anthropic=_Client)
+    )
+    return captured
+
+
+def test_truncated_with_no_text_names_the_token_budget(monkeypatch):
+    msg = _Msg([_Block("thinking")], "max_tokens")
+    _install_fake_anthropic(monkeypatch, msg)
+
+    complete = anthropic_completer(Config(), model="claude-sonnet-5", max_tokens=1200)
+    with pytest.raises(ValueError) as exc:
+        complete("sys", "user")
+
+    said = str(exc.value)
+    assert "max_tokens=1200" in said
+    assert "thinking" in said
+    assert "claude-sonnet-5" in said
+
+
+def test_normal_reply_passes_through(monkeypatch):
+    msg = _Msg([_Block("thinking"), _Block("text", '{"ok":true}')], "end_turn")
+    captured = _install_fake_anthropic(monkeypatch, msg)
+
+    complete = anthropic_completer(Config(), model="claude-sonnet-5")
+    assert complete("sys", "user") == '{"ok":true}'
+    assert captured["max_tokens"] == DEFAULT_MAX_TOKENS
+
+
+def test_a_model_with_genuinely_nothing_to_say_is_not_an_error(monkeypatch):
+    # end_turn with empty text is a real (if odd) answer, not a truncation. Only
+    # stop_reason=max_tokens means the budget was the problem.
+    msg = _Msg([_Block("text", "")], "end_turn")
+    _install_fake_anthropic(monkeypatch, msg)
+
+    complete = anthropic_completer(Config(), model="claude-haiku-4-5")
+    assert complete("sys", "user") == ""
+
+
+def test_default_budget_leaves_room_for_thinking():
+    # A ceiling, not a reservation: billing follows tokens actually emitted, so
+    # this costs nothing on a non-thinking model and rescues a thinking one.
+    assert DEFAULT_MAX_TOKENS >= 4000

--- a/packages/tools/video-grabber/tests/test_version.py
+++ b/packages/tools/video-grabber/tests/test_version.py
@@ -1,0 +1,74 @@
+"""Version resolution and the optional pin (issue #379).
+
+The point of this module is that an executor can always answer "what commit am I
+running?" — so the tests care most about the cases where it cannot: no env, no
+git, a pin that does not match.
+"""
+import subprocess
+
+from video_grabber import version as V
+
+
+def test_env_wins_because_the_container_has_no_git(monkeypatch):
+    monkeypatch.setenv("CODE_VERSION", "abc123")
+    assert V.code_version() == "abc123"
+
+
+def test_falls_back_to_git_when_no_env(monkeypatch):
+    monkeypatch.delenv("CODE_VERSION", raising=False)
+    monkeypatch.setattr(V, "_from_git", lambda: "deadbeef")
+    assert V.code_version() == "deadbeef"
+
+
+def test_unknown_rather_than_raising_when_nothing_can_answer(monkeypatch):
+    # A stamping mechanism that can crash a worker is worse than the drift it
+    # reports, so every failure path lands on "unknown".
+    monkeypatch.delenv("CODE_VERSION", raising=False)
+    monkeypatch.setattr(V, "_from_git", lambda: None)
+    assert V.code_version() == V.UNKNOWN
+
+
+def test_git_failures_do_not_propagate(monkeypatch):
+    monkeypatch.delenv("CODE_VERSION", raising=False)
+
+    def boom(*a, **kw):
+        raise OSError("no git on this box")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    assert V._from_git() is None
+    assert V.code_version() == V.UNKNOWN
+
+
+def test_blank_env_is_not_a_version(monkeypatch):
+    monkeypatch.setenv("CODE_VERSION", "   ")
+    monkeypatch.setattr(V, "_from_git", lambda: "fromgit")
+    assert V.code_version() == "fromgit"
+
+
+def test_no_pin_means_no_mismatch(monkeypatch):
+    monkeypatch.delenv("EXPECTED_CODE_VERSION", raising=False)
+    monkeypatch.setenv("CODE_VERSION", "abc123")
+    assert V.version_mismatch() is None
+
+
+def test_pin_matches_on_short_sha_prefix(monkeypatch):
+    monkeypatch.setenv("CODE_VERSION", "abc123def4567890")
+    monkeypatch.setenv("EXPECTED_CODE_VERSION", "abc123d")
+    assert V.version_mismatch() is None
+
+
+def test_pin_reports_the_actual_version_on_mismatch(monkeypatch):
+    monkeypatch.setenv("CODE_VERSION", "1111111")
+    monkeypatch.setenv("EXPECTED_CODE_VERSION", "2222222")
+    said = V.version_mismatch()
+    assert said is not None
+    assert "1111111" in said and "2222222" in said
+
+
+def test_unknown_fails_a_pin(monkeypatch):
+    # "I cannot tell you what I am running" is precisely the state #379 was, so
+    # it must not satisfy a check whose purpose is to catch that state.
+    monkeypatch.delenv("CODE_VERSION", raising=False)
+    monkeypatch.setattr(V, "_from_git", lambda: None)
+    monkeypatch.setenv("EXPECTED_CODE_VERSION", "abc123")
+    assert V.version_mismatch() is not None

--- a/packages/tools/video-grabber/video_grabber/db/migrations/versions/006_transcribe_code_version.py
+++ b/packages/tools/video-grabber/video_grabber/db/migrations/versions/006_transcribe_code_version.py
@@ -1,0 +1,33 @@
+"""record which commit each transcribe job ran on
+
+Revision ID: 006
+Revises: 005
+Create Date: 2026-08-14
+
+Issue #379: the cluster pod and the Mac Studio both serve `transcribe-item` and
+silently ran different code for five weeks. Nothing recorded which executor —
+let alone which commit — produced a given transcript, so the divergence only
+surfaced when the same job, dispatched twice, wrote two different SRT keys.
+
+`code_version` is stamped at claim time, so "which commit transcribed this?"
+becomes one query instead of a hunt through per-run logs. Nullable with no
+default: existing rows genuinely predate the mechanism, and back-filling them
+with anything would be inventing evidence about the very thing this column
+exists to record.
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "006"
+down_revision: Union[str, None] = "005"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("transcribe_jobs", sa.Column("code_version", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("transcribe_jobs", "code_version")

--- a/packages/tools/video-grabber/video_grabber/transcribe/dispatch_worker.py
+++ b/packages/tools/video-grabber/video_grabber/transcribe/dispatch_worker.py
@@ -30,12 +30,14 @@ import sqlalchemy as sa
 from video_grabber.config import Config
 from video_grabber.transcribe.flows import _sync_db_url, transcribe_item_flow
 from video_grabber.transcribe.qos import THROTTLED_MESSAGE, darwin_background_qos
+from video_grabber.version import code_version, version_mismatch
 
 _CLAIM_SQL = sa.text("""
     UPDATE transcribe_jobs SET
         stage = CAST('transcribing' AS transcribe_stage),
         retry_count = retry_count + CASE WHEN stage = 'failed' THEN 1 ELSE 0 END,
-        last_transition_at = now()
+        last_transition_at = now(),
+        code_version = :code_version
     WHERE id = (
         SELECT id FROM transcribe_jobs
         WHERE stage = 'pending'
@@ -99,7 +101,16 @@ def assert_not_throttled() -> None:
 
 def main() -> None:
     assert_not_throttled()
+    # Refuse to start rather than to claim: a worker that fails the pin has
+    # nothing useful to do, and exiting makes launchd's log say so once instead
+    # of every poll. Unpinned (the default) this is a no-op. See issue #379.
+    mismatch = version_mismatch()
+    if mismatch:
+        raise RuntimeError(mismatch)
+
     cfg = Config()
+    version = code_version()
+    _log(f"running code_version={version}")
     url = _sync_db_url(cfg.database_url)
     threading.Thread(target=_heartbeat, args=(url,), daemon=True).start()
     processed = 0
@@ -107,7 +118,7 @@ def main() -> None:
     while True:
         engine = sa.create_engine(url)
         with engine.connect() as db:
-            row = db.execute(_CLAIM_SQL).first()
+            row = db.execute(_CLAIM_SQL, {"code_version": version}).first()
             db.commit()
         engine.dispose()
 

--- a/packages/tools/video-grabber/video_grabber/transcribe/flows.py
+++ b/packages/tools/video-grabber/video_grabber/transcribe/flows.py
@@ -46,6 +46,7 @@ from video_grabber.transcribe.srt import (
     strip_nonspeech_cues,
 )
 from video_grabber.transcribe.whisper import transcribe_wav
+from video_grabber.version import code_version
 
 _SCRATCH = Path(os.getenv("SCRATCH_DIR", "/tmp/vg-scratch"))
 _ASYNCPG_PREFIX = "postgresql+asyncpg://"
@@ -426,11 +427,17 @@ def dispatch_transcribe_flow(max_runs: int = 1000, max_retries: int = 3) -> None
     processed = 0
     with get_db() as db:
         while processed < max_runs:
+            # `code_version` records the commit of whoever CLAIMS. This path
+            # dispatches to `transcribe-item`, which may execute on the cluster
+            # pod or on the Mac, so the stamp is a claim-side fact, not proof of
+            # what ran. The per-worker claim in dispatch_worker.py — where claim
+            # and execution are the same process — is the authoritative one.
             row = db.execute(sa.text("""
                 UPDATE transcribe_jobs SET
                     stage = 'transcribing',
                     retry_count = retry_count + CASE WHEN stage = 'failed' THEN 1 ELSE 0 END,
-                    last_transition_at = now()
+                    last_transition_at = now(),
+                    code_version = :code_version
                 WHERE id = (
                     SELECT id FROM transcribe_jobs
                     WHERE stage = 'pending'
@@ -440,7 +447,7 @@ def dispatch_transcribe_flow(max_runs: int = 1000, max_retries: int = 3) -> None
                     LIMIT 1
                 )
                 RETURNING id
-            """), {"max_retries": max_retries}).first()
+            """), {"max_retries": max_retries, "code_version": code_version()}).first()
             db.commit()
             if row is None:
                 logger.info("dispatch-transcribe: queue empty after %d runs", processed)

--- a/packages/tools/video-grabber/video_grabber/transcript/summarize_flows.py
+++ b/packages/tools/video-grabber/video_grabber/transcript/summarize_flows.py
@@ -34,14 +34,26 @@ from video_grabber.transcript.summarize import (
 )
 
 
-def anthropic_completer(cfg: Config, *, model: str | None = None, max_tokens: int = 400):
+# max_tokens caps thinking AND reply text together, and the newer models think by
+# default when `thinking` is unset. The summarizer's own replies are a couple of
+# hundred tokens, so 400 looked right — but it is a ceiling, not a reservation:
+# you are billed for tokens actually emitted, so a generous cap costs nothing on
+# a model that does not think, and is the difference between a working call and
+# an empty string on one that does. claude-haiku-4-5 (the default) does not think;
+# SUMMARIZE_MODEL can point anywhere, which is why the default is sized for the
+# thinking case. See PARTIES_MAX_TOKENS in parties/flows.py for the measurement.
+DEFAULT_MAX_TOKENS = 4000
+
+
+def anthropic_completer(cfg: Config, *, model: str | None = None,
+                        max_tokens: int = DEFAULT_MAX_TOKENS):
     """Build a `complete(system, user) -> str` bound to a model.
 
     Wrapped rather than passed as a client so summarize.py stays free of the SDK
     and its rules — every judgment in there is unit-testable without a key.
 
-    Defaults to the summarizer's model and budget; party identification passes
-    its own, since it needs more reasoning and a larger JSON reply.
+    Defaults to the summarizer's model; party identification passes its own,
+    since it needs more reasoning and a larger JSON reply.
     """
     import anthropic
 
@@ -55,7 +67,19 @@ def anthropic_completer(cfg: Config, *, model: str | None = None, max_tokens: in
             system=system,
             messages=[{"role": "user", "content": user}],
         )
-        return "".join(b.text for b in msg.content if b.type == "text")
+        text = "".join(b.text for b in msg.content if b.type == "text")
+        if not text.strip() and msg.stop_reason == "max_tokens":
+            # Returning "" here is how this failed silently before: the caller
+            # cannot tell a truncated call from a model that had nothing to say,
+            # so the summarizer quietly degraded to mechanical condensation and
+            # party identification logged "did not return JSON". Name the cause.
+            raise ValueError(
+                f"model {chosen} returned no text: the whole max_tokens={max_tokens} "
+                f"budget went on thinking (stop_reason=max_tokens, blocks="
+                f"{[b.type for b in msg.content]}). Raise the budget rather than "
+                f"changing the prompt."
+            )
+        return text
 
     return complete
 

--- a/packages/tools/video-grabber/video_grabber/version.py
+++ b/packages/tools/video-grabber/video_grabber/version.py
@@ -1,0 +1,81 @@
+"""Which commit is this executor actually running?
+
+Issue #379: two machines serve `transcribe-item` — the cluster worker pod and the
+Mac Studio's launchd workers — and they silently ran different code for five
+weeks. Every layer inspected correctly in isolation, because the machine you
+inspect is not the machine that ran the job. Nothing recorded which commit
+produced a given transcript, so the divergence was invisible until two dispatches
+of the same job wrote two different keys.
+
+So each worker stamps its version onto the `transcribe_jobs` row it claims, and
+the question becomes one query:
+
+    SELECT code_version, count(*) FROM transcribe_jobs GROUP BY 1;
+
+Resolution order, most trustworthy first:
+
+1. `CODE_VERSION` — baked into the image at build time from the commit SHA
+   (Dockerfile ARG, set by build-video-grabber.yml). The container has no git, so
+   this is the only way it can know.
+2. `git rev-parse HEAD` against this file's own directory — covers the Mac, whose
+   tree is a real sparse checkout. Deliberately not the process's cwd: a worker
+   started from anywhere would otherwise report whatever repo it happened to sit
+   in.
+3. `"unknown"` — never raises. A stamping mechanism that can crash a worker is
+   worse than the drift it reports.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+UNKNOWN = "unknown"
+
+
+def _from_git() -> str | None:
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(Path(__file__).resolve().parent), "rev-parse", "HEAD"],
+            capture_output=True, text=True, timeout=5, check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    sha = out.stdout.strip()
+    return sha or None
+
+
+def code_version() -> str:
+    """The commit this process is running, or 'unknown'."""
+    env = (os.getenv("CODE_VERSION") or "").strip()
+    if env:
+        return env
+    return _from_git() or UNKNOWN
+
+
+def expected_version() -> str | None:
+    """Operator-pinned commit, if any (`EXPECTED_CODE_VERSION`)."""
+    want = (os.getenv("EXPECTED_CODE_VERSION") or "").strip()
+    return want or None
+
+
+def version_mismatch() -> str | None:
+    """Message describing a pin violation, or None when free to run.
+
+    Matching is by prefix so a pin can be a short SHA. An unresolvable version
+    is treated as a mismatch when a pin is set: "I could not tell you what I am
+    running" is exactly the state that caused #379, so it must not pass a check
+    whose whole purpose is to catch it.
+    """
+    want = expected_version()
+    if not want:
+        return None
+    have = code_version()
+    if have != UNKNOWN and (have.startswith(want) or want.startswith(have)):
+        return None
+    return (
+        f"EXPECTED_CODE_VERSION={want} but this executor is running {have}. "
+        f"Refusing to claim work: an executor that cannot prove its version is "
+        f"how issue #379 went unnoticed for five weeks. Update the checkout (or "
+        f"the image tag), or clear EXPECTED_CODE_VERSION to run unpinned."
+    )


### PR DESCRIPTION
Two independent silent failures.

## 1. Executor code version — closes #379 (option 2)

The cluster pod and the Mac Studio both serve `transcribe-item` and **silently ran different code for five weeks**. Every layer inspected correctly in isolation, because the machine you inspect is not the machine that ran the job.

Each worker now stamps its version onto the `transcribe_jobs` row it claims, so the question becomes one query:

```sql
SELECT code_version, count(*) FROM transcribe_jobs GROUP BY 1;
```

`video_grabber/version.py` resolves it, most trustworthy first:

1. **`CODE_VERSION`**, baked into the image from the commit SHA (Dockerfile `ARG`, set by `build-video-grabber.yml`). The container has no git, so this is the only way it can know — the existing `org.opencontainers.image.revision` label is **not readable from inside the container**.
2. **`git rev-parse HEAD` against this file's own directory** — covers the Mac's sparse checkout. Deliberately *not* the process cwd: a worker started elsewhere would report whatever repo it happened to sit in.
3. **`"unknown"`, never raising.** A stamping mechanism that can crash a worker is worse than the drift it reports.

`EXPECTED_CODE_VERSION` optionally pins a commit. A mismatched worker **refuses to start** rather than to claim, so launchd logs it once instead of every poll. An unresolvable version fails a pin deliberately — *"I cannot tell you what I am running"* is exactly the state #379 was in, so it must not satisfy the check designed to catch it.

Both claim paths stamp, but they don't mean the same thing: `dispatch-transcribe` records who **claimed**, which may not be who executes; `dispatch_worker.py` is authoritative because there claim and execution are the same process. Noted at the call site.

`code_version` is nullable with no backfill — existing rows genuinely predate the mechanism, and filling them in would invent evidence about the one thing the column exists to record.

## 2. LLM token budget

`anthropic_completer` defaulted to `max_tokens=400`, sized for the summarizer's couple-hundred-token reply. But `max_tokens` caps **thinking and text together**, and newer models think by default — so the whole budget goes on thinking and the call returns `""`. The summarizer then degrades quietly to mechanical condensation, and party identification logs "did not return JSON". Neither names the cause.

`max_tokens` is a **ceiling, not a reservation** — billing follows tokens actually emitted — so a generous default costs nothing on `claude-haiku-4-5` (the current default) and rescues any thinking model `SUMMARIZE_MODEL` is pointed at. Raised to 4000, and a truncated call with no text now raises **with the budget in the message** instead of returning an empty string.

## Deploy note

This adds migration `006`. Per `CLAUDE.md`, schema changes also need the migrate Job bumped in the infra repo — happy to do that once this lands, or leave it to you.

## Verification

533 tests pass (13 new), ruff clean. New coverage: version resolution and every fallback, pin matching by short SHA, pin failure on `unknown`, and the completer's truncation guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
