### PR TITLE
fix(frontend): allow classicy's ScreenSaver activate as the one scriptable action

### DIFF
--- a/packages/frontend/src/appManifests.test.ts
+++ b/packages/frontend/src/appManifests.test.ts
@@ -87,8 +87,19 @@ describe("app manifests", () => {
 		},
 	);
 
-	it("exposes no scriptable actions (parity with the empty pre-manifest allowlist)", () => {
-		expect(listScriptableActions()).toEqual([]);
+	// `scriptable: true` exposes an action to untrusted HyperCard stack scripts,
+	// so this is an allowlist, not a snapshot. It was `[]` until classicy 0.72.5
+	// shipped a built-in ScreenSaver whose Activate action is scriptable — this
+	// repo still marks nothing of its own scriptable.
+	//
+	// Compared as `appId:type` rather than whole objects so a wording change to
+	// classicy's description does not fail the build, while any NEW scriptable
+	// action still does. Widening this to "just assert it's an array" would throw
+	// away the only thing that makes the allowlist a control.
+	it("exposes only classicy's built-in ScreenSaver activate as scriptable", () => {
+		expect(listScriptableActions().map((a) => `${a.appId}:${a.type}`)).toEqual([
+			"ScreenSaver.app:ClassicyAppScreenSaverActivate",
+		]);
 	});
 
 	// classicy routes each action to exactly ONE handler — the first registered


### PR DESCRIPTION
**`main` is red** (`bf8a8401`), and it is failing `frontend-checks` for every open PR — including ones that touch no frontend code at all (#399 is video-grabber only). This unblocks them.

## What happened

`classicy` 0.72.5 ships a built-in `ScreenSaver.app` whose `Activate` action is marked `scriptable`. `appManifests.test.ts` pins the scriptable allowlist to `[]`, so the guard fired — correctly — on the routine classicy auto-bump.

```
AssertionError: expected [ { appId: 'ScreenSaver.app', …(3) } ] to deeply equal []
```

## The decision this forces

Per `packages/frontend/CLAUDE.md`, `scriptable: true` is *"a product/security decision, not a default — it exposes the action to untrusted HyperCard stack scripts"*, and flipping one on requires explicit sign-off. So this PR is that sign-off, not a test tweak.

`ClassicyAppScreenSaverActivate` starts the selected screensaver and is ignored while the screensaver is disabled. The worst a hostile stack gets is a blanked screen — no data access, no navigation, no clock control. Accepting it.

**If you'd rather not**, the alternative is pinning `classicy` below 0.72.5 rather than loosening the allowlist — say so and I'll swap this for that.

## The allowlist stays an allowlist

It now names that one action **exactly**, so a second scriptable action still fails the build. Compared as `appId:type` rather than whole objects, so a wording change to classicy's description doesn't break CI while a new capability still does. Nothing in this repo is marked scriptable.

## Verification

2249 tests pass, `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
