### PR TITLE
fix(tv): hide disabled channels from the EPG

### DIFF
--- a/packages/frontend/src/Applications/TV/TVEPGPanel.test.tsx
+++ b/packages/frontend/src/Applications/TV/TVEPGPanel.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * The EPG must not offer a channel the user switched off in Settings.
+ *
+ * epgVisibility.test.ts pins the rule; this pins the WIRING — that the panel
+ * reads the blacklist from the store and that the filtered list is the one the
+ * grid actually renders. The two are separate failures: filtering the wrong
+ * memo would leave this suite green and the panel wrong.
+ */
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const store = vi.hoisted(() => ({
+	current: {
+		System: {
+			Manager: {
+				DateAndTime: { dateTime: "2001-09-11T12:40:00.000Z", timeZoneOffset: "-4" },
+				Applications: { apps: { "TV.app": { data: {} as Record<string, unknown> } } },
+			},
+		},
+	},
+}));
+
+vi.mock("classicy", async (importOriginal) => ({
+	...(await importOriginal<typeof import("classicy")>()),
+	// Serve whatever selector the component passes, against our fake store.
+	useAppManager: (sel: (s: unknown) => unknown) => sel(store.current),
+	useAppManagerDispatch: () => vi.fn(),
+}));
+
+import { TVEPGPanel } from "./TVEPGPanel";
+
+const GUIDE = [
+	{ name: "CNN", number: "1", callSign: "CNN", location: "Atlanta", icon: "cnn", grid: [] },
+	{ name: "BBC", number: "2", callSign: "BBC", location: "London", icon: "bbc", grid: [] },
+	{ name: "WNYW", number: "3", callSign: "WNYW", location: "New York", icon: "wnyw", grid: [] },
+];
+
+const setDisabled = (slugs: string[] | undefined) => {
+	store.current.System.Manager.Applications.apps["TV.app"].data =
+		slugs === undefined ? {} : { disabledChannels: slugs };
+};
+
+beforeEach(() => {
+	setDisabled(undefined);
+	vi.stubGlobal("fetch", vi.fn(async () => ({
+		ok: true,
+		status: 200,
+		statusText: "OK",
+		json: async () => GUIDE,
+	})));
+});
+
+afterEach(() => {
+	cleanup();
+	vi.unstubAllGlobals();
+	vi.clearAllMocks();
+});
+
+const channelCell = (name: string) => screen.queryByTitle(`Watch ${name} on TV`);
+
+describe("TVEPGPanel channel visibility", () => {
+	it("lists every channel when none are disabled", async () => {
+		render(<TVEPGPanel onClose={vi.fn()} />);
+		await waitFor(() => expect(channelCell("CNN")).not.toBeNull());
+		expect(channelCell("BBC")).not.toBeNull();
+		expect(channelCell("WNYW")).not.toBeNull();
+	});
+
+	it("hides a channel switched off in Settings", async () => {
+		setDisabled(["BBC"]);
+		render(<TVEPGPanel onClose={vi.fn()} />);
+		await waitFor(() => expect(channelCell("CNN")).not.toBeNull());
+		expect(channelCell("BBC")).toBeNull();
+		expect(channelCell("WNYW")).not.toBeNull();
+	});
+
+	it("hides regardless of the case the slug is stored in", async () => {
+		// guide.json and the streamer's source list agree on case only by
+		// coincidence; the panel must not depend on that.
+		setDisabled(["cnn"]);
+		render(<TVEPGPanel onClose={vi.fn()} />);
+		await waitFor(() => expect(channelCell("BBC")).not.toBeNull());
+		expect(channelCell("CNN")).toBeNull();
+	});
+
+	it("keeps a guide channel that no source provides", async () => {
+		// WNYW cannot appear in Settings, so it can never be switched back on.
+		setDisabled(["CNN", "BBC", "CCTV4"]);
+		render(<TVEPGPanel onClose={vi.fn()} />);
+		await waitFor(() => expect(channelCell("WNYW")).not.toBeNull());
+		expect(channelCell("CNN")).toBeNull();
+		expect(channelCell("BBC")).toBeNull();
+	});
+});

--- a/packages/frontend/src/Applications/TV/TVEPGPanel.tsx
+++ b/packages/frontend/src/Applications/TV/TVEPGPanel.tsx
@@ -23,6 +23,7 @@ import {
 } from "react";
 import "./epgIcons"; // side effect: registers ClassicyIcons.applications.epg
 import type { EpgIconNamespace } from "./epgIcons";
+import { visibleEpgChannels } from "./epgVisibility";
 import { tvTuneChannel } from "./TVContext";
 import epgStyles from "./TVEPGPanel.module.scss";
 import styles from "./TV.module.scss";
@@ -91,6 +92,22 @@ export const TVEPGPanel: React.FC<TVEPGPanelProps> = ({ onClose }) => {
 	);
 
 	const [gridData, setGridData] = useState<EPGChannel[]>([]);
+
+	// Read straight from the store rather than taking a prop: the panel already
+	// sources the clock this way, and TV.tsx holds the same blacklist for the
+	// player grid, so a prop would be a second copy of one setting.
+	const disabledChannels = useAppManager(
+		(s) => s.System.Manager.Applications.apps["TV.app"]?.data?.disabledChannels as
+			| string[]
+			| undefined,
+	);
+
+	// The guide lists every channel that ever broadcast; Settings decides which of
+	// them this viewer wants to see.
+	const visibleChannels = useMemo(
+		() => visibleEpgChannels(gridData, disabledChannels),
+		[gridData, disabledChannels],
+	);
 
 	useEffect(() => {
 		const controller = new AbortController();
@@ -239,7 +256,7 @@ export const TVEPGPanel: React.FC<TVEPGPanelProps> = ({ onClose }) => {
 		return headers;
 	}, [gridStartTime]);
 
-	const epgData = useMemo(() => gridData.map((channel, idx) => (
+	const epgData = useMemo(() => visibleChannels.map((channel, idx) => (
 		<Fragment key={`${channel.name}_${channel.number}`}>
 			<div
 				className={epgStyles.epgChannel}
@@ -259,7 +276,7 @@ export const TVEPGPanel: React.FC<TVEPGPanelProps> = ({ onClose }) => {
 			</div>
 			{getProgramData(channel, idx)}
 		</Fragment>
-	)), [getProgramData, gridData, tuneToChannel]);
+	)), [getProgramData, visibleChannels, tuneToChannel]);
 
 	const gridTemplateColumns = `${CHANNEL_HEADER_WIDTH}fr repeat(${GRID_WIDTH / MINUTES_PER_GRID}, 1fr)`;
 

--- a/packages/frontend/src/Applications/TV/epgVisibility.test.ts
+++ b/packages/frontend/src/Applications/TV/epgVisibility.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { visibleEpgChannels } from "./epgVisibility";
+
+const ch = (name: string) => ({ name });
+const GUIDE = [ch("CNN"), ch("BBC"), ch("CCTV4"), ch("WNYW")];
+
+describe("visibleEpgChannels", () => {
+	it("drops the channels the user switched off", () => {
+		expect(visibleEpgChannels(GUIDE, ["BBC"]).map((c) => c.name))
+			.toEqual(["CNN", "CCTV4", "WNYW"]);
+	});
+
+	it("shows everything when nothing is disabled", () => {
+		expect(visibleEpgChannels(GUIDE, []).map((c) => c.name))
+			.toEqual(["CNN", "BBC", "CCTV4", "WNYW"]);
+		expect(visibleEpgChannels(GUIDE, undefined).map((c) => c.name))
+			.toEqual(["CNN", "BBC", "CCTV4", "WNYW"]);
+	});
+
+	it("matches regardless of case, as resolveChannelId does", () => {
+		// guide.json spells channels "CNN" while the slug list is free to differ;
+		// the two agree on case today only by coincidence.
+		expect(visibleEpgChannels(GUIDE, ["cnn", "cctv4"]).map((c) => c.name))
+			.toEqual(["BBC", "WNYW"]);
+		expect(visibleEpgChannels([ch("cnn")], ["CNN"])).toEqual([]);
+	});
+
+	it("keeps a channel that has no source rather than hiding it", () => {
+		// WNYW is in the guide but no source provides it, so it never appears in
+		// Settings. Hiding it would take away a channel the user has no control
+		// to restore — the list is a blacklist, not a whitelist.
+		expect(visibleEpgChannels(GUIDE, ["CNN", "BBC", "CCTV4"]).map((c) => c.name))
+			.toEqual(["WNYW"]);
+	});
+
+	it("does not mutate or alias the input", () => {
+		const input = [ch("CNN"), ch("BBC")];
+		const out = visibleEpgChannels(input, []);
+		out.push(ch("EXTRA"));
+		expect(input).toHaveLength(2);
+	});
+
+	it("leaves order untouched", () => {
+		expect(visibleEpgChannels(GUIDE, ["BBC"]).map((c) => c.name))
+			.toEqual(["CNN", "CCTV4", "WNYW"]);
+	});
+});

--- a/packages/frontend/src/Applications/TV/epgVisibility.ts
+++ b/packages/frontend/src/Applications/TV/epgVisibility.ts
@@ -1,0 +1,22 @@
+/**
+ * Hide channels the user switched off in Settings from the EPG grid.
+ *
+ * The join is `EPGChannel.name` against a source slug, and it is case-insensitive
+ * for the same reason `resolveChannelId` in TV.tsx is: the two lists come from
+ * different places (guide.json vs the streamer's `sources.video`) and only
+ * happen to agree on case today.
+ *
+ * `disabledChannels` is a BLACKLIST, so a channel that is absent from it stays
+ * visible — including one with no source at all. The guide currently carries
+ * WNYW, which no source provides; it can never appear in Settings, so it can
+ * never be switched off, and hiding it would remove a channel the user was
+ * given no way to bring back.
+ */
+export function visibleEpgChannels<T extends { name: string }>(
+	channels: readonly T[],
+	disabledChannels: readonly string[] | undefined,
+): T[] {
+	if (!disabledChannels?.length) return [...channels];
+	const off = new Set(disabledChannels.map((c) => c.toLowerCase()));
+	return channels.filter((c) => !off.has(c.name.toLowerCase()));
+}


### PR DESCRIPTION
Switching a channel off in Settings removed it from the player grid but **not from the guide** — it stayed listed, tunable, and one click away from coming back.

## Cause

`TVEPGPanel` fetches `guide.json`, which lists every channel that ever broadcast, and rendered all of it. It had no knowledge of the `disabledChannels` blacklist that `TV.tsx` already applies to the player grid.

## The fix

The panel now reads that same blacklist **straight from the store** rather than through a prop — it already sources the clock that way, and a prop would create a second copy of one setting.

**The join key is `EPGChannel.name` against a source slug**, matched case-insensitively for the same reason `resolveChannelId` does it: the two lists come from different places (`guide.json` vs the streamer's `sources.video`) and only *happen* to agree on case today.

I checked that against production rather than assuming it:

| | |
|---|---:|
| channels in `guide.json` | 23 |
| video sources in Directus | 22 |
| sources with no guide entry | 0 |

Names match exactly, **including CCTV4** — its `cctv3` alias is an HLS path, not a slug, so the aliasing recorded in the EPG-icons work doesn't bite here.

## One deliberate behaviour

Absence from the blacklist keeps a channel **visible**. That matters for `WNYW`, the one guide channel no source provides: it can never appear in Settings, so it could never be switched back on. Hiding it would remove a channel the user has no control to restore.

## Tests

Split on purpose, because they can fail independently:

- `epgVisibility.test.ts` pins the **rule** (case-insensitivity, blacklist semantics, no mutation, order preserved).
- `TVEPGPanel.test.tsx` pins the **wiring** — that the panel reads the store and that the filtered list is what the grid renders. Filtering the wrong memo would leave the helper's tests green and the panel wrong.

**Verified non-vacuous:** reverting the one-line change to `gridData.map` fails 3 of the 4 panel tests.

## Verification

2261 tests pass (10 new) · `tsc -b` clean · `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
