### PR TITLE
feat(tv): icons instead of text on the control-bar buttons

### DIFF
--- a/packages/frontend/src/Applications/TV/TV.module.scss
+++ b/packages/frontend/src/Applications/TV/TV.module.scss
@@ -168,6 +168,18 @@ $strip-height: calc(5em + 8px);
   flex-direction: row;
 }
 
+// Icon-only control buttons (MultiView / play-pause / mute / captions).
+// The height is explicit because these icons are not a uniform set: cc.png is
+// EPG badge artwork at 306x230 and would dwarf the control row at its natural
+// size, while multiview.png is a 16x16 glyph. `width: auto` keeps each one's
+// own aspect ratio instead of squashing the wide ones to a square.
+.tvControlIcon {
+  display: block;
+  height: calc(var(--ui-font-size) * 1.15);
+  width: auto;
+  object-fit: contain;
+}
+
 .tvChannelButtons {
   display: flex;
   flex-direction: row;

--- a/packages/frontend/src/Applications/TV/TV.tsx
+++ b/packages/frontend/src/Applications/TV/TV.tsx
@@ -44,6 +44,7 @@ import { moveChannel, orderChannels } from "./channelOrder";
 import { ThumbnailTile } from "./ThumbnailTile";
 import "./epgIcons"; // side effect: registers ClassicyIcons.applications.epg
 import type { EpgIconNamespace } from "./epgIcons";
+import multiviewIcon from "./multiview.png";
 import { useThumbnailReorder } from "./useThumbnailReorder";
 import { trackAppToggle, trackChannelChange } from "../../openreplay";
 import { bumpToLevel, maybeProbeUp, TV_ABR_CONFIG } from "./abr";
@@ -96,7 +97,8 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 	const appId = "TV.app";
 	// classicy no longer declares the epg namespace — epgIcons.ts registers it,
 	// so the read goes through a cast at the registered address.
-	const appIcon = (ClassicyIcons.applications as unknown as { epg: EpgIconNamespace }).epg.app;
+	const epgIconSet = (ClassicyIcons.applications as unknown as { epg: EpgIconNamespace }).epg;
+	const appIcon = epgIconSet.app;
 	const aboutWindow = useAboutApp(appId, appIcon);
 
 	const desktopEventDispatch = useAppManagerDispatch();
@@ -1132,7 +1134,9 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 									}
 								>
 									<ClassicyButton onClickFunc={toggleMultiSelect} depressed={multiSelectMode} buttonSize="small" margin="sm" padding="sm">
-										MultiView
+										{/* alt is the button's accessible name now that the label is gone —
+										    the balloon help above explains, but only on hover. */}
+										<img className={styles.tvControlIcon} src={multiviewIcon} alt="MultiView" />
 									</ClassicyButton>
 								</ClassicyBalloonHelp>
 								<ClassicyBalloonHelp
@@ -1150,7 +1154,14 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 										buttonSize="small"
 										margin="sm" padding="sm"
 									>
-										{tvPaused ? "Play" : "Pause"}
+										{/* The icon shows the ACTION, not the state: paused offers Play. */}
+										<img
+											className={styles.tvControlIcon}
+											src={(tvPaused
+												? ClassicyIcons.system.quicktime.playButton
+												: ClassicyIcons.system.quicktime.pauseButton) as string}
+											alt={tvPaused ? "Play" : "Pause"}
+										/>
 									</ClassicyButton>
 								</ClassicyBalloonHelp>
 								<ClassicyBalloonHelp
@@ -1169,7 +1180,15 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 										buttonSize="small"
 										margin="sm" padding="sm"
 									>
-										Mute
+										{/* Same speaker pair the per-grid-player mute button already uses,
+										    so one convention covers both mute controls in this app. */}
+										<img
+											className={styles.tvControlIcon}
+											src={(overallMuted
+												? ClassicyIcons.controlPanels.soundManager.soundMute
+												: ClassicyIcons.controlPanels.soundManager.soundOn) as string}
+											alt={overallMuted ? "Unmute" : "Mute"}
+										/>
 									</ClassicyButton>
 								</ClassicyBalloonHelp>
 								<ClassicyBalloonHelp
@@ -1185,7 +1204,13 @@ export const TV: React.FC<ClassicyTVProps> = () => {
 										buttonSize="small"
 										margin="sm" padding="sm"
 									>
-										{captionsOn ? "CC On" : "CC Off"}
+										{/* One artwork for both states — the pressed styling carries on/off
+										    visually, so the alt text has to carry it for everyone else. */}
+										<img
+											className={styles.tvControlIcon}
+											src={epgIconSet.cc}
+											alt={captionsOn ? "Closed captions on" : "Closed captions off"}
+										/>
 									</ClassicyButton>
 								</ClassicyBalloonHelp>
 							</div>

--- a/packages/frontend/src/Applications/TV/controlIcons.test.ts
+++ b/packages/frontend/src/Applications/TV/controlIcons.test.ts
@@ -1,0 +1,53 @@
+/**
+ * The TV control bar is now icon-only, so a missing icon is a blank button.
+ *
+ * This is not hypothetical: classicy dropped `ClassicyIcons.applications.epg` on
+ * a routine version bump, which is why the EPG artwork now lives in this repo.
+ * A key that disappears the same way resolves to `undefined`, React renders
+ * `<img src="undefined">`, and the result is a broken image with no error
+ * anywhere — the buttons carry no text to fall back on.
+ *
+ * `tsc` does not catch it either: the icon objects are typed loosely enough that
+ * a missing leaf reads as `any`/`string` at the call site.
+ */
+import { ClassicyIcons } from "classicy";
+import { describe, expect, it } from "vitest";
+import multiviewIcon from "./multiview.png";
+import "./epgIcons"; // side effect: registers ClassicyIcons.applications.epg
+import type { EpgIconNamespace } from "./epgIcons";
+
+// Read through the registry, exactly as TV.tsx does — a key that was never
+// registered (or got dropped) fails here the same way it would on screen.
+const epgIconSet = (ClassicyIcons.applications as unknown as { epg: EpgIconNamespace })
+	.epg;
+
+const icons: [string, unknown][] = [
+	["play", ClassicyIcons.system.quicktime.playButton],
+	["pause", ClassicyIcons.system.quicktime.pauseButton],
+	["unmuted (soundOn)", ClassicyIcons.controlPanels.soundManager.soundOn],
+	["muted (soundMute)", ClassicyIcons.controlPanels.soundManager.soundMute],
+	["closed captions", epgIconSet.cc],
+	["multiview", multiviewIcon],
+];
+
+describe("TV control-bar icons", () => {
+	it.each(icons)("%s resolves to a usable src", (_name, src) => {
+		expect(typeof src).toBe("string");
+		expect(src as string).not.toBe("");
+		// "undefined"/"null" as a literal string is what a vanished key looks
+		// like once React has stringified it into the src attribute.
+		expect(src as string).not.toMatch(/^(undefined|null)$/);
+	});
+
+	it("uses two distinct icons for play and pause", () => {
+		// A single shared glyph would leave the button showing the same thing in
+		// both states, which is the failure this pair exists to avoid.
+		expect(ClassicyIcons.system.quicktime.playButton)
+			.not.toBe(ClassicyIcons.system.quicktime.pauseButton);
+	});
+
+	it("uses two distinct icons for muted and unmuted", () => {
+		expect(ClassicyIcons.controlPanels.soundManager.soundOn)
+			.not.toBe(ClassicyIcons.controlPanels.soundManager.soundMute);
+	});
+});


### PR DESCRIPTION
MultiView, Play/Pause, Mute and CC On/Off were text buttons sitting in a row of an otherwise graphical player. All four are now icons.

| Button | Icon |
|---|---|
| MultiView | `multiview.png` (new, 16×16) |
| Play / Pause | `ClassicyIcons.system.quicktime.playButton` / `.pauseButton` — the quicktime SVGs classicy already ships |
| Mute | `soundManager.soundOn` / `.soundMute` |
| CC | `epgIcons/cc.png` |

The mute pair is **the same one the per-grid-player mute button in this file already uses**, so one convention now covers both mute controls rather than two speakers that disagree.

## Accessibility

Each `alt` is the button's accessible name now that the labels are gone. The balloon help was already there, but it only appears on hover, so it can't do that job.

The alt text also has to carry **state** where the icon doesn't: captions use one artwork for both on and off and rely on the pressed styling, so the alt reads "Closed captions on" / "Closed captions off" rather than just "CC". Play/pause is the opposite case — two distinct glyphs, and the icon shows the *action* (paused offers Play), matching the text it replaces.

## Sizing

Explicit, because these icons are not a uniform set: **`cc.png` is EPG badge artwork at 306×230** and would dwarf the control row at natural size, while `multiview.png` is a 16×16 glyph. `width: auto` keeps each one's own aspect ratio instead of squashing the wide ones.

## Why there's a test for something as dull as an icon path

Not hypothetical: classicy dropped `ClassicyIcons.applications.epg` on a routine version bump, which is why the EPG artwork now lives in this repo. A key that disappears the same way resolves to `undefined`, React renders `<img src="undefined">`, and an **icon-only button goes blank with no error and no text to fall back on**.

`tsc` doesn't catch it either — the icon objects are typed loosely enough that a missing leaf reads as `string` at the call site. So `controlIcons.test.ts` asserts all six sources resolve to a usable string, and pins `play !== pause` and `muted !== unmuted`, since a shared glyph would leave a toggle looking identical in both states.

## Verification

2259 tests pass (8 new) · `tsc -b` clean · `eslint` clean.

Worth a look in the browser before merging — no automated check here can tell you the icons are the right *size* next to the volume slider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
