### PR TITLE
Playlist rooms: state catch-up on join + mid-class definition push (reload)

### DIFF
--- a/packages/backend/docs/websocket-protocol.md
+++ b/packages/backend/docs/websocket-protocol.md
@@ -723,16 +723,24 @@ command addressed to that room:
 { "type": "room_command", "action": "focus", "app": "TV.app" }
 { "type": "room_command", "action": "message", "message": "Look at channel 4" }
 { "type": "room_command", "action": "lock", "target": "clock", "on": true }
+{ "type": "room_command", "action": "reload" }
 ```
 
 | Field     | Type   | Notes                                                                    |
 | --------- | ------ | ------------------------------------------------------------------------ |
-| `action`  | string | `jump` \| `focus` \| `message`. Unknown actions are rejected at the operator endpoint and never reach a client. |
+| `action`  | string | `jump` \| `focus` \| `message` \| `lock` \| `reload`. Unknown actions are rejected at the operator endpoint and never reach a client. |
 | `time`    | string | `jump` only — the virtual instant to move every student's clock to.       |
 | `app`     | string | `focus` only — the Classicy app id to bring to front (e.g. `TV.app`).     |
 | `message` | string | `message` only — the note body to display.                                |
 | `target`  | string | `lock` only — the surface to lock. `clock` is the only one implemented.   |
 | `on`      | bool   | `lock` only — the state to move to. **Always present on a lock frame**, including `false`: it rides a pointer server-side so an unlock is not dropped by `omitempty`. A client that receives a lock frame without `on` should do nothing rather than assume `false`. |
+
+`reload` carries no payload at all: it tells every student to **re-fetch the published playlist
+definition from Directus and re-evaluate it** — the definition itself never rides this wire. It is
+how a teacher's mid-class edit ("Push Update to Class") reaches students whose page loaded the
+older definition. Applying a `reload` must not touch the client's room lock state — the two are
+independent surfaces, and a definition refresh that silently unlocked the clock would free a
+classroom the teacher had locked.
 
 A **room is a playlist id**: students following `?playlist=<id>` are its members. The streamer
 never resolves the id — playlists are authored in Directus and executed client-side; the id
@@ -740,16 +748,28 @@ travels as an opaque string.
 
 Commands originate on whichever pod served the teacher's `POST /room` call and are relayed to the
 others over Redis pub/sub (`internal/fanout`), so a class spread across replicas stays in step.
-That relay is **fire-and-forget and nothing is persisted**: a client that is disconnected when a
-command is sent does not receive it on reconnect, and a `jump` is not replayed. Room membership
-lives on the session, so a client must re-send `join_room` after every reconnect (the frontend's
-`MediaStreamProvider` does this alongside its channel re-subscribes).
+The relay itself is fire-and-forget, but each pod also **remembers the last-known control state per
+room** — the latest `jump`, the latest `lock`, and whether a `reload` has been pushed — and
+**replays it as ordinary `room_command` frames when a session sends `join_room`**, in application
+order (`jump`, then `lock`, then `reload`). A student who connects late, or reconnects after a
+drop, therefore converges with the class without any new client logic: the replayed frames are the
+same commands a live student saw, and the client applies them idempotently. The transient actions
+(`focus`, `message`) are moments rather than state and are deliberately **not** replayed.
+
+Two bounds on that memory: it is **per pod and in-memory** (fed by the fanout bus, which every pod
+subscribes to — including the publisher, via Redis's self-echo), so a pod that restarts starts
+empty and catches up on the teacher's next command; and it is keyed by playlist id with one command
+per sticky action, written only by the owner-authorised `POST /room` path, so it cannot grow under
+client control. Room membership still lives on the session, so a client must re-send `join_room`
+after every reconnect (the frontend's `MediaStreamProvider` does this alongside its channel
+re-subscribes) — the replay-on-join is what turns that re-join into a full catch-up.
 
 A `jump` is ignored by the client while [forced clock mode](#forced-clock-mode-server--client-clock-heartbeat_ackmaster_time)
 is active — the operator's master clock outranks a teacher.
 
-`lock` is **absolute, never a toggle**: the streamer holds no lock state, so the teacher's client owns
-the on/off and sends the value it wants. Two consequences: reopening the teacher's playlist document
+`lock` is **absolute, never a toggle**: the teacher's client owns the on/off and sends the value it
+wants — the per-room memory above is replay state for late joiners, not an authority a toggle could
+consult (there is no read-back API). Two consequences: reopening the teacher's playlist document
 window resets its Control menu (students stay locked — only the checkmark forgets), and two teachers driving one
 playlist will not see each other's state. `content` is a deliberate non-target — it exists as a
 disabled button in the teacher UI and the server rejects it with 400, so a dead control can never

--- a/packages/backend/internal/handler/room.go
+++ b/packages/backend/internal/handler/room.go
@@ -39,6 +39,7 @@ type roomRequest struct {
 //	POST /room {"room":"42","action":"jump","time":"2001-09-11T13:03:00Z"}
 //	POST /room {"room":"42","action":"focus","app":"TV.app"}
 //	POST /room {"room":"42","action":"message","message":"Look at channel 4"}
+//	POST /room {"room":"42","action":"reload"}
 //
 // A room is a playlist id, and **only the Directus user who created that
 // playlist may drive it**. Authorisation is per playlist, not a shared
@@ -149,7 +150,8 @@ func mayDriveRoom(owner, uid string) bool {
 }
 
 // buildRoomCommand validates the per-action payload and returns the command to
-// publish. The action itself is already known valid.
+// publish. The action itself is already known valid. Reload carries no payload
+// — the definition is re-read from Directus by each client, never relayed.
 func buildRoomCommand(req roomRequest) (model.RoomCommand, error) {
 	cmd := model.RoomCommand{
 		Room: req.Room, Action: req.Action, App: req.App,

--- a/packages/backend/internal/handler/room_test.go
+++ b/packages/backend/internal/handler/room_test.go
@@ -130,6 +130,15 @@ func TestBuildRoomCommandAcceptsValidPayloads(t *testing.T) {
 	if err != nil || msg.Message != "Look at channel 4" {
 		t.Fatalf("message: %+v err=%v", msg, err)
 	}
+	// Reload deliberately has no payload to validate: the definition is
+	// re-fetched from Directus by each client, never relayed through here.
+	reload, err := buildRoomCommand(roomRequest{Room: "42", Action: "reload"})
+	if err != nil || reload.Action != "reload" {
+		t.Fatalf("reload: %+v err=%v", reload, err)
+	}
+	if !model.ValidRoomAction("reload") {
+		t.Fatal("reload must be a relayable action")
+	}
 }
 
 // The authorisation rule lives in one SQL predicate, so assert its shape here:

--- a/packages/backend/internal/model/room.go
+++ b/packages/backend/internal/model/room.go
@@ -16,9 +16,16 @@ const (
 	RoomActionMessage = "message"
 	// RoomActionLock locks or unlocks one control surface for the room: Target
 	// names the surface and On is the state to move it to. A toggle is resolved
-	// by the teacher's client, not here — the server holds no lock state, so
-	// each command carries the absolute value it wants rather than "flip it".
+	// by the teacher's client, not here — each command carries the absolute
+	// value it wants rather than "flip it". (The hub remembers the last lock
+	// command per room so a late joiner can be caught up, but that memory is
+	// replay state, not an authority a toggle could consult.)
 	RoomActionLock = "lock"
+	// RoomActionReload tells every student to re-fetch the published playlist
+	// definition and re-evaluate it. A teacher edits mid-class, saves, and
+	// pushes; the definition itself never rides the wire — clients re-read it
+	// from Directus, so the command needs no payload.
+	RoomActionReload = "reload"
 )
 
 // Lock targets. Only the clock is implemented; "content" exists in the teacher
@@ -54,7 +61,7 @@ type RoomCommand struct {
 // so a typo fails visibly instead of reaching clients that silently ignore it.
 func ValidRoomAction(action string) bool {
 	switch action {
-	case RoomActionJump, RoomActionFocus, RoomActionMessage, RoomActionLock:
+	case RoomActionJump, RoomActionFocus, RoomActionMessage, RoomActionLock, RoomActionReload:
 		return true
 	}
 	return false

--- a/packages/backend/internal/session/hub.go
+++ b/packages/backend/internal/session/hub.go
@@ -36,6 +36,30 @@ type Hub struct {
 	// and so lags admission under a burst (the exact moment the cap must hold).
 	maxSessions int64
 	active      atomic.Int64
+
+	// roomsMu guards roomStates: the last-known control state per room, fed by
+	// BroadcastRoom and replayed to a session on JoinRoom. Its own mutex, not
+	// h.mu — recording state must never contend with the tick fan-out, and
+	// keeping the two separate means no lock ordering to get wrong.
+	roomsMu    sync.Mutex
+	roomStates map[string]*roomState
+}
+
+// roomState is the last-known control state for one room — exactly what a
+// student who joins (or reconnects) late must still observe. Only the sticky
+// actions are kept: a jump and a lock describe where the class *is*, and a
+// reload marks that the published definition changed since page load. Focus
+// and message are moments, not state, and are deliberately not replayed.
+//
+// The memory is per pod, fed by the fanout bus (every pod sees every publish,
+// including its own), so all live pods converge; a pod that boots later starts
+// empty and catches up on the teacher's next command. Entries are one command
+// per action and keys are playlist ids that an authorised owner drove, so the
+// map is bounded by real use — there is no client-controlled growth to prune.
+type roomState struct {
+	jump   *model.RoomCommand
+	lock   *model.RoomCommand
+	reload *model.RoomCommand
 }
 
 func NewHub(logger *slog.Logger, maxSessions int) *Hub {
@@ -45,6 +69,7 @@ func NewHub(logger *slog.Logger, maxSessions int) *Hub {
 		unreg:       make(chan *Session, 64),
 		logger:      logger,
 		maxSessions: int64(maxSessions),
+		roomStates:  make(map[string]*roomState),
 	}
 }
 
@@ -125,11 +150,16 @@ func (h *Hub) BroadcastAlert(item model.AlertItem) {
 // A blank room matches nothing — it would otherwise address every session not
 // following a playlist, which is the opposite of what an unset field means.
 //
-// Same RLock + non-blocking send_ discipline as the tick loop.
+// Same RLock + non-blocking send_ discipline as the tick loop. The command is
+// also recorded as the room's last-known state (see roomState) so a student
+// who joins after it was sent still converges — the fanout bus delivers this
+// call on every pod, so the record happens everywhere, even on pods with no
+// member session at the time.
 func (h *Hub) BroadcastRoom(cmd model.RoomCommand) {
 	if cmd.Room == "" {
 		return
 	}
+	h.recordRoomState(cmd)
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	for _, s := range h.sessions {
@@ -137,6 +167,52 @@ func (h *Hub) BroadcastRoom(cmd model.RoomCommand) {
 			s.SendRoomCommand(cmd)
 		}
 	}
+}
+
+// recordRoomState keeps the sticky actions (jump/lock/reload) as the room's
+// last-known state. Focus and message are transient and intentionally skipped.
+func (h *Hub) recordRoomState(cmd model.RoomCommand) {
+	var slot func(*roomState) **model.RoomCommand
+	switch cmd.Action {
+	case model.RoomActionJump:
+		slot = func(st *roomState) **model.RoomCommand { return &st.jump }
+	case model.RoomActionLock:
+		slot = func(st *roomState) **model.RoomCommand { return &st.lock }
+	case model.RoomActionReload:
+		slot = func(st *roomState) **model.RoomCommand { return &st.reload }
+	default:
+		return
+	}
+	h.roomsMu.Lock()
+	defer h.roomsMu.Unlock()
+	st := h.roomStates[cmd.Room]
+	if st == nil {
+		st = &roomState{}
+		h.roomStates[cmd.Room] = st
+	}
+	c := cmd
+	*slot(st) = &c
+}
+
+// RoomState returns the commands a fresh member of room must replay to catch
+// up, in application order: jump first (put the clock where the class is),
+// then lock (pin it there), then reload (pick up a mid-class definition push).
+// The order also means a replayed reload cannot be undone by a stale clock
+// move landing after it. Empty when the room has no recorded state.
+func (h *Hub) RoomState(room string) []model.RoomCommand {
+	h.roomsMu.Lock()
+	defer h.roomsMu.Unlock()
+	st := h.roomStates[room]
+	if st == nil {
+		return nil
+	}
+	out := make([]model.RoomCommand, 0, 3)
+	for _, c := range []*model.RoomCommand{st.jump, st.lock, st.reload} {
+		if c != nil {
+			out = append(out, *c)
+		}
+	}
+	return out
 }
 
 func (h *Hub) Register(s *Session) {

--- a/packages/backend/internal/session/room_test.go
+++ b/packages/backend/internal/session/room_test.go
@@ -165,6 +165,177 @@ func TestRoomCommandCrossesPods(t *testing.T) {
 	}
 }
 
+// A member session receives a reload relay like any other room command — the
+// frame carries the action alone, since the definition is re-fetched from
+// Directus by the client rather than relayed.
+func TestBroadcastRoomRelaysReload(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	hub := NewHub(logger, 0)
+	s := roomSession(t, hub, "42")
+
+	hub.BroadcastRoom(model.RoomCommand{Room: "42", Action: model.RoomActionReload})
+	m := recvType(t, s)
+	if m.Type != "room_command" || m.Action != model.RoomActionReload {
+		t.Fatalf("reload frame = %+v", m)
+	}
+	if m.Time != "" || m.App != "" || m.Msg != "" || m.Target != "" || m.On != nil {
+		t.Fatalf("reload frame carries payload it must not: %+v", m)
+	}
+}
+
+// The catch-up path: a student who joins AFTER the teacher jumped, locked, and
+// pushed a definition update must still converge. The hub replays the room's
+// last-known state on join, in application order (jump, lock, reload), and
+// does NOT replay transient actions (focus/message) whose moment has passed.
+func TestJoinReplaysLastKnownRoomState(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	hub := NewHub(logger, 0)
+
+	target := time.Date(2001, 9, 11, 13, 3, 0, 0, time.UTC)
+	hub.BroadcastRoom(model.RoomCommand{Room: "42", Action: model.RoomActionJump, Time: target})
+	hub.BroadcastRoom(model.RoomCommand{Room: "42", Action: model.RoomActionLock, Target: model.RoomLockClock, On: true})
+	hub.BroadcastRoom(model.RoomCommand{Room: "42", Action: model.RoomActionMessage, Message: "already said"})
+	hub.BroadcastRoom(model.RoomCommand{Room: "42", Action: model.RoomActionFocus, App: "TV.app"})
+	hub.BroadcastRoom(model.RoomCommand{Room: "42", Action: model.RoomActionReload})
+
+	logger2 := slog.New(slog.NewTextHandler(io.Discard, nil))
+	s := NewSession(hub, nil, nil, logger2)
+	s.Init(time.Date(2001, 9, 11, 12, 40, 0, 0, time.UTC), nil)
+	drain(t, s)
+	s.JoinRoom("42")
+
+	jump := recvType(t, s)
+	if jump.Action != model.RoomActionJump || jump.Time != target.Format(time.RFC3339) {
+		t.Fatalf("first replayed frame = %+v, want the jump", jump)
+	}
+	lock := recvType(t, s)
+	if lock.Action != model.RoomActionLock || lock.Target != model.RoomLockClock {
+		t.Fatalf("second replayed frame = %+v, want the lock", lock)
+	}
+	if lock.On == nil || !*lock.On {
+		t.Fatalf("replayed lock on = %v, want true", lock.On)
+	}
+	reload := recvType(t, s)
+	if reload.Action != model.RoomActionReload {
+		t.Fatalf("third replayed frame = %+v, want the reload", reload)
+	}
+	select {
+	case data := <-s.send:
+		t.Fatalf("transient action replayed to a late joiner: %+v", decodeFrame(t, data))
+	default:
+	}
+}
+
+// Only the LAST jump is state; replaying a history of jumps would drag a late
+// joiner through every place the class has been.
+func TestJoinReplaysOnlyTheLatestJump(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	hub := NewHub(logger, 0)
+
+	first := time.Date(2001, 9, 11, 12, 46, 0, 0, time.UTC)
+	last := time.Date(2001, 9, 11, 13, 3, 0, 0, time.UTC)
+	hub.BroadcastRoom(model.RoomCommand{Room: "42", Action: model.RoomActionJump, Time: first})
+	hub.BroadcastRoom(model.RoomCommand{Room: "42", Action: model.RoomActionJump, Time: last})
+
+	s := NewSession(hub, nil, nil, logger)
+	s.JoinRoom("42")
+	m := recvType(t, s)
+	if m.Time != last.Format(time.RFC3339) {
+		t.Fatalf("replayed jump time = %q, want the latest (%q)", m.Time, last.Format(time.RFC3339))
+	}
+	select {
+	case data := <-s.send:
+		t.Fatalf("more than one jump replayed: %+v", decodeFrame(t, data))
+	default:
+	}
+}
+
+// An unlock is state too: the last lock command wins whatever its value, so a
+// joiner after lock-then-unlock sees on:false, not a stale lock.
+func TestJoinReplaysUnlockAfterLock(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	hub := NewHub(logger, 0)
+	hub.BroadcastRoom(model.RoomCommand{Room: "42", Action: model.RoomActionLock, Target: model.RoomLockClock, On: true})
+	hub.BroadcastRoom(model.RoomCommand{Room: "42", Action: model.RoomActionLock, Target: model.RoomLockClock, On: false})
+
+	s := NewSession(hub, nil, nil, logger)
+	s.JoinRoom("42")
+	m := recvType(t, s)
+	if m.Action != model.RoomActionLock || m.On == nil || *m.On {
+		t.Fatalf("replayed lock = %+v, want on:false", m)
+	}
+}
+
+// Rooms are isolated: joining an untouched room replays nothing, and another
+// room's state never leaks into this one's replay.
+func TestJoinReplaysNothingForAnUntouchedRoom(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	hub := NewHub(logger, 0)
+	hub.BroadcastRoom(model.RoomCommand{Room: "43", Action: model.RoomActionReload})
+
+	s := NewSession(hub, nil, nil, logger)
+	s.JoinRoom("42")
+	select {
+	case data := <-s.send:
+		t.Fatalf("untouched room replayed a frame: %+v", decodeFrame(t, data))
+	default:
+	}
+	s.LeaveRoom() // leaving must not replay either
+	select {
+	case data := <-s.send:
+		t.Fatalf("leaving replayed a frame: %+v", decodeFrame(t, data))
+	default:
+	}
+}
+
+// The cross-pod claim for the catch-up path: state recorded from the fanout bus
+// on pod B must be replayed to a student who joins on pod B, even though the
+// command was published from pod A and no member was connected when it landed.
+func TestJoinAfterCrossPodCommandReplaysState(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis.Run: %v", err)
+	}
+	defer mr.Close()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	rdbA := goredis.NewClient(&goredis.Options{Addr: mr.Addr()})
+	rdbB := goredis.NewClient(&goredis.Options{Addr: mr.Addr()})
+	defer rdbA.Close()
+	defer rdbB.Close()
+
+	busA := fanout.New[model.RoomCommand](rdbA, "room:command", logger)
+	hubB := NewHub(logger, 0)
+	busB := fanout.New[model.RoomCommand](rdbB, "room:command", logger)
+	busB.OnMessage(hubB.BroadcastRoom)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go busB.Run(ctx)
+
+	cmd := model.RoomCommand{Room: "42", Action: model.RoomActionReload}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := busA.Publish(ctx, cmd); err != nil {
+			t.Fatalf("publish from pod A: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+		if len(hubB.RoomState("42")) > 0 {
+			break
+		}
+	}
+	if len(hubB.RoomState("42")) == 0 {
+		t.Fatal("pod B never recorded the cross-pod command")
+	}
+
+	student := NewSession(hubB, nil, nil, logger)
+	student.JoinRoom("42")
+	m := recvType(t, student)
+	if m.Type != "room_command" || m.Action != model.RoomActionReload {
+		t.Fatalf("late joiner on pod B got %+v, want the reload replay", m)
+	}
+}
+
 // The lock frame must carry `on` in both directions. It rides a *bool in outMsg
 // precisely because an unlock is `false`, which plain omitempty would drop —
 // leaving the client unable to tell "unlock" from "no lock field at all".

--- a/packages/backend/internal/session/session.go
+++ b/packages/backend/internal/session/session.go
@@ -525,10 +525,22 @@ func (s *Session) PushAlert(item model.AlertItem) {
 // JoinRoom puts this session in a teacher-controlled room, replacing any
 // previous membership. The room id is the playlist the student is following;
 // it is opaque here (see model.RoomCommand). An empty id leaves the room.
+//
+// Joining replays the room's last-known control state (see Hub.RoomState) as
+// ordinary room_command frames, so a student who connects — or reconnects —
+// after the teacher jumped, locked, or pushed a definition update still
+// converges with the class. The client applies commands idempotently, so a
+// re-join that replays state it already holds is harmless.
 func (s *Session) JoinRoom(room string) {
 	s.mu.Lock()
 	s.room = room
 	s.mu.Unlock()
+	if room == "" || s.hub == nil {
+		return
+	}
+	for _, cmd := range s.hub.RoomState(room) {
+		s.SendRoomCommand(cmd)
+	}
 }
 
 // LeaveRoom drops this session's room membership.
@@ -560,6 +572,9 @@ func (s *Session) SendRoomCommand(cmd model.RoomCommand) {
 		out.Target = cmd.Target
 		on := cmd.On
 		out.On = &on
+	case model.RoomActionReload:
+		// No payload: the client re-fetches the published definition from
+		// Directus itself — the definition never rides this wire.
 	}
 	s.send_(out)
 }

--- a/packages/frontend/src/Providers/MediaStream/MediaStreamContext.ts
+++ b/packages/frontend/src/Providers/MediaStream/MediaStreamContext.ts
@@ -248,7 +248,7 @@ export interface WsHeartbeatAckMessage {
  * split over several replicas stays in step.
  */
 export interface RoomCommand {
-	action: "jump" | "focus" | "message" | "lock";
+	action: "jump" | "focus" | "message" | "lock" | "reload";
 	/** Virtual-clock target for "jump", as a UTC string. */
 	time?: string;
 	/** Classicy app id for "focus", e.g. "TV.app". */

--- a/packages/frontend/src/Providers/MediaStream/MediaStreamProvider.tsx
+++ b/packages/frontend/src/Providers/MediaStream/MediaStreamProvider.tsx
@@ -110,7 +110,7 @@ interface WsAlertsMessage {
 // so it arrives regardless of which replica this client's socket landed on.
 interface WsRoomCommandMessage {
 	type: "room_command";
-	action: "jump" | "focus" | "message" | "lock";
+	action: "jump" | "focus" | "message" | "lock" | "reload";
 	time?: string;
 	app?: string;
 	message?: string;

--- a/packages/frontend/src/Providers/MediaStream/playlistGating.test.tsx
+++ b/packages/frontend/src/Providers/MediaStream/playlistGating.test.tsx
@@ -94,6 +94,7 @@ const blockValue = (blockApp: PlaylistApp, blockId: string): PlaylistContextValu
 	active: true,
 	title: "T",
 	isItemAvailable: (app, itemId) => !(app === blockApp && itemId === blockId),
+	reloadDefinition: () => {},
 });
 
 const FLIGHTS_FRAME = {

--- a/packages/frontend/src/Providers/Playlist/PlaylistContext.ts
+++ b/packages/frontend/src/Providers/Playlist/PlaylistContext.ts
@@ -5,6 +5,13 @@ export interface PlaylistContextValue {
 	active: boolean;
 	title: string | null;
 	isItemAvailable: (app: PlaylistApp, itemId: string) => boolean;
+	/**
+	 * Re-fetch the published definition and re-evaluate it — the student end of
+	 * a teacher's "Push Update to Class" (a `reload` room command, applied by
+	 * RoomControlBridge). A failed re-fetch keeps the current definition; it
+	 * never touches room lock state.
+	 */
+	reloadDefinition: () => void;
 }
 
 // Default = no playlist: everything allowed. MediaStreamProvider consumes this
@@ -13,6 +20,7 @@ export const PlaylistContext = createContext<PlaylistContextValue>({
 	active: false,
 	title: null,
 	isItemAvailable: () => true,
+	reloadDefinition: () => {},
 });
 
 export const usePlaylist = (): PlaylistContextValue => useContext(PlaylistContext);

--- a/packages/frontend/src/Providers/Playlist/PlaylistProvider.test.tsx
+++ b/packages/frontend/src/Providers/Playlist/PlaylistProvider.test.tsx
@@ -29,7 +29,18 @@ vi.mock("classicy", async (importOriginal) => ({
 }));
 
 import { PlaylistProvider } from "./PlaylistProvider";
+import { usePlaylist, type PlaylistContextValue } from "./PlaylistContext";
 import { PERMISSION_DENIED } from "./playlistApps";
+
+/** Exposes the provider's context value to tests (reloadDefinition, title…).
+ * Read through `ctx()` — a call result is never narrowed, so assertions after
+ * `grabbed = null` see the value the render actually wrote. */
+let grabbed: PlaylistContextValue | null = null;
+const ctx = () => grabbed;
+function Grab() {
+	grabbed = usePlaylist();
+	return <p>kid</p>;
+}
 
 const definition = {
 	version: 1,
@@ -286,6 +297,72 @@ describe("PlaylistProvider", () => {
 				),
 			).toBe(true),
 		);
+	});
+
+	// --- mid-class definition push (reloadDefinition) ----------------------
+
+	const rowWith = (title: string, entries: unknown[] = []) =>
+		new Response(
+			JSON.stringify({
+				data: {
+					title,
+					status: "published",
+					definition: { version: 1, mode: "annotate", entries },
+				},
+			}),
+			{ status: 200 },
+		);
+
+	it("reloadDefinition re-fetches and swaps in the new definition", async () => {
+		grabbed = null;
+		const f = vi.fn(async () => rowWith("Before"));
+		vi.stubGlobal("fetch", f);
+		render(
+			<PlaylistProvider>
+				<Grab />
+			</PlaylistProvider>,
+		);
+		await waitFor(() => expect(ctx()?.title).toBe("Before"));
+
+		f.mockImplementation(async () => rowWith("After"));
+		ctx()!.reloadDefinition();
+		await waitFor(() => expect(ctx()?.title).toBe("After"));
+		expect(f).toHaveBeenCalledTimes(2);
+		// The refresh must not touch the clock or the room lock: no clock write,
+		// no lock/unlock dispatch — only playlist-engine reconciliation runs.
+		expect(mockClock.setDateTime).not.toHaveBeenCalled();
+		expect(
+			dispatched.some(
+				(a) =>
+					a.type === "ClassicyManagerDateTimeLock" ||
+					a.type === "ClassicyManagerDateTimeUnlock",
+			),
+		).toBe(false);
+	});
+
+	it("a failed reload keeps the current definition and stays quiet", async () => {
+		grabbed = null;
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const f = vi.fn(async () => rowWith("Before"));
+		vi.stubGlobal("fetch", f);
+		render(
+			<PlaylistProvider>
+				<Grab />
+			</PlaylistProvider>,
+		);
+		await waitFor(() => expect(ctx()?.title).toBe("Before"));
+
+		f.mockImplementation(async () => new Response("x", { status: 404 }));
+		ctx()!.reloadDefinition();
+		await waitFor(() => expect(f).toHaveBeenCalledTimes(2));
+		// Unlike the initial load, a mid-lesson flake must not tear the lesson
+		// down: no error dialog, definition unchanged.
+		expect(ctx()?.title).toBe("Before");
+		expect(ctx()?.active).toBe(true);
+		expect(
+			dispatched.some((a) => a.type === "ClassicyDesktopShowErrorDialog"),
+		).toBe(false);
+		warn.mockRestore();
 	});
 
 	it("shows a load-failure dialog and stays fail-open", async () => {

--- a/packages/frontend/src/Providers/Playlist/PlaylistProvider.tsx
+++ b/packages/frontend/src/Providers/Playlist/PlaylistProvider.tsx
@@ -240,13 +240,56 @@ export const PlaylistProvider: FC<{ children: ReactNode }> = ({ children }) => {
 		}
 	}, [definition, snapshot, apps, dispatch]);
 
+	/**
+	 * The student end of a teacher's "Push Update to Class" (`reload` room
+	 * command, applied by RoomControlBridge): re-fetch the published definition
+	 * and swap it in live.
+	 *
+	 * The swap is treated as a fresh activation — `prevMsRef` resets so the
+	 * next tick fires the new definition's in-window focus entries (exactly
+	 * what a student joining fresh would get from `initialFocusEvents`), and
+	 * `settingsSeededRef` resets so newly pushed settings entries seed instead
+	 * of silently doing nothing. `evaluate()` is a pure function of
+	 * (definition, clock), so every state effect above reconciles on its own.
+	 * Room lock state (`dateTimeLocked`) is deliberately untouched: a
+	 * definition refresh must not unlock a locked classroom.
+	 *
+	 * Fails open the QUIET way: mid-lesson, a flaky re-fetch keeps the current
+	 * definition rather than tearing the lesson down with an error dialog —
+	 * unlike the initial load, the student already has a working playlist.
+	 * Serialized via `reloadInFlightRef`: loadPlaylist must never run
+	 * concurrently with itself (parallel same-path api-beta fetches can return
+	 * mixed bodies — see loadPlaylist.ts), and a burst of reload commands
+	 * collapses into one fetch of the same final definition anyway.
+	 */
+	const reloadInFlightRef = useRef(false);
+	const reloadDefinition = useCallback(() => {
+		const id = playlistIdFromSearch(window.location.search);
+		if (!id || reloadInFlightRef.current) return;
+		reloadInFlightRef.current = true;
+		loadPlaylist(id)
+			.then((loaded) => {
+				prevMsRef.current = null;
+				settingsSeededRef.current = false;
+				setDefinition(loaded.definition);
+				setTitle(loaded.title);
+			})
+			.catch((err) => {
+				console.warn("playlist reload failed:", err);
+			})
+			.finally(() => {
+				reloadInFlightRef.current = false;
+			});
+	}, []);
+
 	const value = useMemo<PlaylistContextValue>(
 		() => ({
 			active: definition !== null,
 			title,
 			isItemAvailable: snapshot.isItemAvailable,
+			reloadDefinition,
 		}),
-		[definition, title, snapshot],
+		[definition, title, snapshot, reloadDefinition],
 	);
 
 	return <PlaylistContext.Provider value={value}>{children}</PlaylistContext.Provider>;

--- a/packages/frontend/src/Providers/Playlist/RoomControlBridge.test.tsx
+++ b/packages/frontend/src/Providers/Playlist/RoomControlBridge.test.tsx
@@ -5,6 +5,7 @@ import type { RoomCommand } from "../MediaStream/MediaStreamContext";
 const hooks = vi.hoisted(() => ({
 	setDateTime: undefined as unknown as ReturnType<typeof vi.fn>,
 	dispatch: undefined as unknown as ReturnType<typeof vi.fn>,
+	reload: undefined as unknown as ReturnType<typeof vi.fn>,
 	locked: false,
 }));
 
@@ -30,6 +31,7 @@ vi.mock("classicy", () => ({
 }));
 
 import { MediaStreamContext } from "../MediaStream/MediaStreamContext";
+import { PlaylistContext, type PlaylistContextValue } from "./PlaylistContext";
 import { RoomControlBridge } from "./RoomControlBridge";
 
 afterEach(() => {
@@ -40,21 +42,27 @@ afterEach(() => {
 function mount(roomCommand: RoomCommand | null, locked = false) {
 	hooks.setDateTime = vi.fn();
 	hooks.dispatch = vi.fn();
+	hooks.reload = vi.fn();
 	hooks.locked = locked;
-	const value = { roomCommand } as unknown as React.ContextType<typeof MediaStreamContext>;
-	const view = render(
-		<MediaStreamContext.Provider value={value}>
-			<RoomControlBridge />
-		</MediaStreamContext.Provider>,
-	);
-	return (next: RoomCommand | null) =>
-		view.rerender(
+	// The bridge reads reloadDefinition from the playlist context, exactly as it
+	// does mounted under PlaylistProvider in the real desktop tree.
+	const playlist: PlaylistContextValue = {
+		active: true,
+		title: null,
+		isItemAvailable: () => true,
+		reloadDefinition: hooks.reload as unknown as () => void,
+	};
+	const wrap = (cmd: RoomCommand | null) => (
+		<PlaylistContext.Provider value={playlist}>
 			<MediaStreamContext.Provider
-				value={{ roomCommand: next } as unknown as React.ContextType<typeof MediaStreamContext>}
+				value={{ roomCommand: cmd } as unknown as React.ContextType<typeof MediaStreamContext>}
 			>
 				<RoomControlBridge />
-			</MediaStreamContext.Provider>,
-		);
+			</MediaStreamContext.Provider>
+		</PlaylistContext.Provider>
+	);
+	const view = render(wrap(roomCommand));
+	return (next: RoomCommand | null) => view.rerender(wrap(next));
 }
 
 describe("RoomControlBridge", () => {
@@ -135,5 +143,30 @@ describe("RoomControlBridge lock", () => {
 	it("ignores a target it cannot act on", () => {
 		mount({ action: "lock", target: "content", on: true, seq: 1 } as never);
 		expect(hooks.dispatch).not.toHaveBeenCalled();
+	});
+});
+
+describe("RoomControlBridge reload", () => {
+	it("re-fetches the definition through the playlist context", () => {
+		mount({ action: "reload", seq: 1 });
+		expect(hooks.reload).toHaveBeenCalledTimes(1);
+	});
+
+	// A definition refresh and the room lock are independent surfaces — a
+	// reload that unlocked the clock would free a classroom the teacher locked.
+	it("leaves room lock state alone", () => {
+		mount({ action: "reload", seq: 1 });
+		expect(hooks.dispatch).not.toHaveBeenCalled();
+		expect(hooks.setDateTime).not.toHaveBeenCalled();
+	});
+
+	// Replay-on-join arrives as an ordinary frame with a fresh seq; a teacher
+	// may also push twice. Both must re-apply.
+	it("re-applies when seq advances, and only then", () => {
+		const rerender = mount({ action: "reload", seq: 1 });
+		rerender({ action: "reload", seq: 1 });
+		expect(hooks.reload).toHaveBeenCalledTimes(1);
+		rerender({ action: "reload", seq: 2 });
+		expect(hooks.reload).toHaveBeenCalledTimes(2);
 	});
 });

--- a/packages/frontend/src/Providers/Playlist/RoomControlBridge.tsx
+++ b/packages/frontend/src/Providers/Playlist/RoomControlBridge.tsx
@@ -13,6 +13,7 @@ import { setDateTimeFromUtc } from "../../Applications/TimeMachine/setVirtualClo
 import { MediaStreamContext } from "../MediaStream/MediaStreamContext";
 import classroomIconPng from "./classroom.png";
 import { playlistAppMeta } from "./playlistApps";
+import { usePlaylist } from "./PlaylistContext";
 
 const appId = "RoomControl.app";
 const appName = "Classroom";
@@ -52,17 +53,21 @@ export function RoomControlBridge() {
 	const dateTimeLocked = useAppManager(
 		(s) => s.System.Manager.DateAndTime.dateTimeLocked,
 	);
+	// The definition-refresh seam for a teacher's "reload" push. The bridge is a
+	// desktop child, mounted inside PlaylistProvider, so the parent's context is
+	// readable here even though the command itself arrives on the WebSocket.
+	const { reloadDefinition } = usePlaylist();
 	const [note, setNote] = useState<{ seq: number; body: string } | null>(null);
 
 	// The effect below must see the latest writers without re-running when only
 	// they change — it runs on a new command, nothing else.
-	const latest = useRef({ setDateTime, dispatch, dateTimeLocked });
-	latest.current = { setDateTime, dispatch, dateTimeLocked };
+	const latest = useRef({ setDateTime, dispatch, dateTimeLocked, reloadDefinition });
+	latest.current = { setDateTime, dispatch, dateTimeLocked, reloadDefinition };
 
 	const seq = roomCommand?.seq ?? 0;
 	useEffect(() => {
 		if (!roomCommand || seq === 0) return;
-		const { setDateTime, dispatch, dateTimeLocked } = latest.current;
+		const { setDateTime, dispatch, dateTimeLocked, reloadDefinition } = latest.current;
 
 		switch (roomCommand.action) {
 			case "jump": {
@@ -101,6 +106,13 @@ export function RoomControlBridge() {
 						? "ClassicyManagerDateTimeLock"
 						: "ClassicyManagerDateTimeUnlock",
 				});
+				return;
+			}
+			case "reload": {
+				// Re-fetch the published definition and re-evaluate. Deliberately
+				// touches nothing else — in particular it must not clear room
+				// lock state, which is an independent surface.
+				reloadDefinition();
 				return;
 			}
 		}

--- a/packages/frontend/src/Providers/Playlist/roomApi.test.ts
+++ b/packages/frontend/src/Providers/Playlist/roomApi.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { ROOM_BASE } from "../../lib/endpoints";
-import { RoomCommandError, sendRoomLock } from "./roomApi";
+import { RoomCommandError, sendRoomLock, sendRoomReload } from "./roomApi";
 
 const ok = () => new Response(null, { status: 202 });
 
@@ -52,5 +52,36 @@ describe("sendRoomLock", () => {
 		await expect(
 			sendRoomLock("p1", "clock", true, f as unknown as typeof fetch),
 		).rejects.toBeInstanceOf(RoomCommandError);
+	});
+});
+
+describe("sendRoomReload", () => {
+	// Reload deliberately has no payload: students re-fetch the published
+	// definition from Directus themselves — it never rides the wire.
+	it("posts the bare reload command to the streamer", async () => {
+		const f = vi.fn().mockResolvedValue(ok());
+		await sendRoomReload("p1", f as unknown as typeof fetch);
+
+		const [url, init] = f.mock.calls[0] as [string, RequestInit];
+		expect(url).toBe(`${ROOM_BASE}/room`);
+		expect(init.method).toBe("POST");
+		expect(init.credentials).toBe("include");
+		expect(JSON.parse(String(init.body))).toEqual({ room: "p1", action: "reload" });
+	});
+
+	it.each([
+		[401, "Sign in to control this playlist."],
+		[403, "Only the person who created this playlist can control it."],
+		[429, "Too many commands — wait a moment."],
+	])("explains a %i", async (status, message) => {
+		const f = vi.fn().mockResolvedValue(new Response(null, { status }));
+		await expect(sendRoomReload("p1", f as unknown as typeof fetch)).rejects.toThrow(message);
+	});
+
+	it("reports an unreachable server rather than throwing a raw network error", async () => {
+		const f = vi.fn().mockRejectedValue(new TypeError("network"));
+		await expect(sendRoomReload("p1", f as unknown as typeof fetch)).rejects.toBeInstanceOf(
+			RoomCommandError,
+		);
 	});
 });

--- a/packages/frontend/src/Providers/Playlist/roomApi.ts
+++ b/packages/frontend/src/Providers/Playlist/roomApi.ts
@@ -20,17 +20,10 @@ const REASONS: Record<number, string> = {
 	429: "Too many commands — wait a moment.",
 };
 
-/**
- * Lock or unlock one control surface for everyone following `room`.
- *
- * `on` is absolute, never "flip it": the streamer holds no lock state, so the
- * caller owns the toggle and sends the value it wants.
- */
-export async function sendRoomLock(
-	room: string,
-	target: RoomLockTarget,
-	on: boolean,
-	fetchFn: typeof fetch = fetch,
+/** Shared POST /room shape: every command differs only in its body. */
+async function postRoomCommand(
+	body: Record<string, unknown>,
+	fetchFn: typeof fetch,
 ): Promise<void> {
 	let res: Response;
 	try {
@@ -38,7 +31,7 @@ export async function sendRoomLock(
 			method: "POST",
 			credentials: "include",
 			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ room, action: "lock", target, on }),
+			body: JSON.stringify(body),
 		});
 	} catch {
 		throw new RoomCommandError("Could not reach the server.");
@@ -46,4 +39,32 @@ export async function sendRoomLock(
 	if (!res.ok) {
 		throw new RoomCommandError(REASONS[res.status] ?? `Command failed (${res.status}).`);
 	}
+}
+
+/**
+ * Lock or unlock one control surface for everyone following `room`.
+ *
+ * `on` is absolute, never "flip it": the caller owns the toggle and sends the
+ * value it wants. (The streamer remembers the last lock per room only to
+ * replay it to late joiners — there is no read-back a toggle could consult.)
+ */
+export async function sendRoomLock(
+	room: string,
+	target: RoomLockTarget,
+	on: boolean,
+	fetchFn: typeof fetch = fetch,
+): Promise<void> {
+	await postRoomCommand({ room, action: "lock", target, on }, fetchFn);
+}
+
+/**
+ * Tell everyone following `room` to re-fetch the published playlist definition
+ * and re-evaluate it — the teacher's "Push Update to Class". The definition
+ * never rides the wire; students re-read it from Directus themselves.
+ */
+export async function sendRoomReload(
+	room: string,
+	fetchFn: typeof fetch = fetch,
+): Promise<void> {
+	await postRoomCommand({ room, action: "reload" }, fetchFn);
 }


### PR DESCRIPTION
Part of #259 — PR 1 of 2 (PR 2, teacher-side controls, is stacked on this branch).

## What this does

**Room state catch-up (B).** The streamer now remembers the last-known control state per room — the latest `jump`, the latest `lock`, and whether a `reload` was pushed — and replays it as ordinary `room_command` frames when a session sends `join_room`. Late joiners and reconnecting students converge with the class with **no new client logic**: the replayed frames are the same commands a live student saw, and the bridge applies them idempotently by `seq` (verified — no replay-idempotence change was needed). Transient actions (`focus`, `message`) are deliberately not replayed.

The memory follows the existing in-memory + fanout pattern: it is fed by the Redis pub/sub bus (`Hub.BroadcastRoom`, which every pod runs including the publisher via self-echo), so all live pods converge; a pod restart starts empty and self-heals on the teacher's next command. It is keyed by playlist id and written only by the owner-authorised `POST /room` path, so it cannot grow under client control.

**Mid-class definition push (E).** New room action `reload` (wire-format change, so it rides with B): the teacher's saved edits reach students already in class. No payload — students re-fetch the published definition from Directus and re-evaluate. Client side:

- `PlaylistProvider.reloadDefinition()` — serialized re-fetch (parallel same-path api-beta fetches can mix bodies), treats the swap as a fresh activation (in-window focus entries fire, newly pushed settings seed), and keeps the current definition quietly on a failed fetch — a mid-lesson flake must not tear the lesson down.
- `RoomControlBridge` applies `reload` via the playlist context and deliberately does **not** touch room lock state — a definition refresh that unlocked the clock would free a locked classroom.

`docs/websocket-protocol.md` updated in the same PR (room-control section: `reload`, replay-on-join semantics, per-pod memory bounds).

## Tests

- Go (`go test ./...`, all green): join-after-jump/lock/reload replay (order + latest-only + unlock-wins), no replay for untouched rooms or on leave, fanout relay of `reload`, cross-pod record-then-join replay, `reload` accepted by the operator endpoint's validators; existing ownership 403 coverage unchanged.
- Frontend (`vitest run`: 245 files / 2269 tests green; `tsc -b` clean; `eslint .` 0 errors): `sendRoomReload` sender, bridge `reload` handling (re-fetch, lock state untouched, seq-keyed re-application), provider reload (swap on success, keep-quiet on failure, no clock/lock writes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)