### PR TITLE
Playlist rooms: teacher live controls + Copy Student Link

### DIFF
--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistDocumentWindow.test.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistDocumentWindow.test.tsx
@@ -42,6 +42,9 @@ vi.mock("classicy", async (importOriginal) => ({
 		</div>
 	),
 	useAppManagerDispatch: () => dispatchMock,
+	// A fixed teacher clock so "Sync Students to My Clock" is deterministic:
+	// dateTime is the canonical UTC value the window snapshots into its ref.
+	useClassicyDateTime: () => ({ dateTime: "2001-09-11T13:03:00.000Z" }),
 }));
 
 const playlistApi = vi.hoisted(() => ({
@@ -54,6 +57,20 @@ vi.mock("../../Providers/Auth/playlistApi", async (importOriginal) => ({
 	...(await importOriginal<object>()),
 	...playlistApi,
 }));
+
+// The senders are mocked, the RoomCommandError class stays real (importOriginal
+// spread) so the window's `instanceof` error mapping is exercised.
+const roomApi = vi.hoisted(() => ({
+	sendRoomJump: vi.fn().mockResolvedValue(undefined),
+	sendRoomFocus: vi.fn().mockResolvedValue(undefined),
+	sendRoomMessage: vi.fn().mockResolvedValue(undefined),
+	sendRoomReload: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../../Providers/Playlist/roomApi", async (importOriginal) => ({
+	...(await importOriginal<object>()),
+	...roomApi,
+}));
+import { RoomCommandError } from "../../Providers/Playlist/roomApi";
 
 vi.mock("./PlaylistEditorMain", () => ({
 	PlaylistEditorMain: () => <div data-testid="body" />,
@@ -431,6 +448,114 @@ describe("PlaylistDocumentWindow", () => {
 		// The new entry is edited in the shared Settings window, so adding
 		// must also reveal it.
 		expect(openSettingsWindowMock).toHaveBeenCalled();
+	});
+
+	// The Control menu's live commands belong to THIS window, so every send
+	// must carry this window's playlist id — never the active document's.
+	describe("Control menu live commands", () => {
+		it("Sync Students to My Clock jumps the room to this desktop's time", async () => {
+			renderWindow();
+			act(() => item("control", "playlist_control_sync").onClickFunc?.());
+			await waitFor(() =>
+				expect(roomApi.sendRoomJump).toHaveBeenCalledWith("p1", "2001-09-11T13:03:00.000Z"),
+			);
+		});
+
+		it("Bring App to Front sends the chosen app id", async () => {
+			renderWindow();
+			const focus = item("control", "playlist_control_focus");
+			const radio = focus.menuChildren?.find(
+				(c) => c.id === "playlist_control_focus_RadioScanner.app",
+			);
+			if (!radio) throw new Error("no RadioScanner focus item");
+			act(() => radio.onClickFunc?.());
+			await waitFor(() =>
+				expect(roomApi.sendRoomFocus).toHaveBeenCalledWith("p1", "RadioScanner.app"),
+			);
+		});
+
+		it("Send Message… opens the dialog and sends the note", async () => {
+			renderWindow();
+			act(() => item("control", "playlist_control_message").onClickFunc?.());
+
+			fireEvent.change(screen.getByLabelText("Message"), {
+				target: { value: "Look at channel 4" },
+			});
+			fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+			await waitFor(() =>
+				expect(roomApi.sendRoomMessage).toHaveBeenCalledWith("p1", "Look at channel 4"),
+			);
+			// The dialog is one-shot: sending dismisses it.
+			expect(screen.queryByLabelText("Message")).toBeNull();
+		});
+
+		it("cancelling the message dialog sends nothing", () => {
+			renderWindow();
+			act(() => item("control", "playlist_control_message").onClickFunc?.());
+			fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+			expect(roomApi.sendRoomMessage).not.toHaveBeenCalled();
+		});
+
+		it("Push Update to Class sends a reload for a saved, published playlist", async () => {
+			renderWindow({ status: "published", dirty: false });
+			const push = item("control", "playlist_control_push");
+			expect(push.disabled).toBe(false);
+			act(() => push.onClickFunc?.());
+			await waitFor(() => expect(roomApi.sendRoomReload).toHaveBeenCalledWith("p1"));
+		});
+
+		it("disables Push Update to Class while dirty or draft", () => {
+			renderWindow({ status: "draft", dirty: false });
+			expect(item("control", "playlist_control_push").disabled).toBe(true);
+			cleanup();
+			renderWindow({ status: "published", dirty: true });
+			expect(item("control", "playlist_control_push").disabled).toBe(true);
+		});
+
+		it("surfaces a refused command in a Control alert", async () => {
+			roomApi.sendRoomJump.mockRejectedValueOnce(
+				new RoomCommandError("Only the person who created this playlist can control it."),
+			);
+			renderWindow();
+			act(() => item("control", "playlist_control_sync").onClickFunc?.());
+			await waitFor(() =>
+				expect(screen.getByTestId("alert").textContent).toContain(
+					"Only the person who created this playlist can control it.",
+				),
+			);
+			// OK dismisses it.
+			fireEvent.click(screen.getByRole("button", { name: "OK" }));
+			expect(screen.queryByTestId("alert")).toBeNull();
+		});
+	});
+
+	describe("File > Copy Student Link", () => {
+		const withClipboard = (writeText: () => Promise<void>) => {
+			Object.defineProperty(navigator, "clipboard", {
+				value: { writeText },
+				configurable: true,
+			});
+		};
+
+		it("copies the anonymous join link for a published playlist", () => {
+			const writeText = vi.fn().mockResolvedValue(undefined);
+			withClipboard(writeText);
+			renderWindow({ status: "published" });
+
+			const link = item("file", "playlist_file_copy_link");
+			expect(link.disabled).toBe(false);
+			act(() => link.onClickFunc?.());
+
+			expect(writeText).toHaveBeenCalledWith(`${location.origin}/?playlist=p1`);
+		});
+
+		it("is disabled, with the reason ballooned, for a draft", () => {
+			renderWindow({ status: "draft" });
+			const link = item("file", "playlist_file_copy_link");
+			expect(link.disabled).toBe(true);
+			expect(link.balloon?.content).toContain("Drafts aren't joinable");
+		});
 	});
 
 	// Not reachable from PlaylistEditorProvider today — it batches `openIds`

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistDocumentWindow.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistDocumentWindow.tsx
@@ -1,8 +1,12 @@
 import {
 	ClassicyAlert, type ClassicyMenuItem, ClassicyWindow, useAppManager, useAppManagerDispatch,
+	useClassicyDateTime,
 } from "classicy";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { deletePlaylist, duplicatePlaylist, getPlaylist, updatePlaylist } from "../../Providers/Auth/playlistApi";
+import {
+	RoomCommandError, sendRoomFocus, sendRoomJump, sendRoomMessage, sendRoomReload,
+} from "../../Providers/Playlist/roomApi";
 import { ADD_ACTIONS, type AddAction, runAddAction, runAddSettings } from "./addActions";
 import {
 	addMenuItems, documentControlMenu, documentEditMenu, documentFileMenu, documentViewMenu,
@@ -13,6 +17,7 @@ import { PLAYLIST_EDITOR_APP_ID, playlistSetTimelineZoom } from "./PlaylistEdito
 import { MAX_ZOOM, MIN_ZOOM, normalizeZoom, steppedZoom } from "./timelineLayout";
 import { usePlaylistEditor } from "./PlaylistEditorProvider";
 import { RenameDialog } from "./RenameDialog";
+import { SendMessageDialog } from "./SendMessageDialog";
 import { useSavePlaylist } from "./useSavePlaylist";
 
 /** Cascade so a second window does not land exactly on the first. */
@@ -45,7 +50,41 @@ export function PlaylistDocumentWindow({
 
 	const [pending, setPending] = useState<Pending>(null);
 	const [renaming, setRenaming] = useState(false);
+	const [messaging, setMessaging] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const [controlError, setControlError] = useState<string | null>(null);
+
+	// The teacher's current virtual instant, for "Sync Students to My Clock".
+	// Held in a ref because the appMenu memo below deliberately does not rebuild
+	// per clock tick — the click handler reads the ref, so the time sent is the
+	// time on the teacher's desktop at the moment of the click, not at the
+	// moment the menu was last built. `dateTime` is the canonical UTC value
+	// (frontend CLAUDE.md: state.System.Manager.DateAndTime.dateTime); tick so
+	// the ref is at 1 s resolution rather than the bare hook's minute cadence.
+	const { dateTime } = useClassicyDateTime({ tick: true });
+	const clockRef = useRef(dateTime);
+	clockRef.current = dateTime;
+
+	/**
+	 * Fire one live room command for THIS window's playlist. One at a time,
+	 * checked synchronously via a ref — the same double-fire gap
+	 * PlaylistEditorProvider's toggleClockLock closes with `inFlight` — and
+	 * failures surface in the Control error alert, mirroring Lock Clock's
+	 * accept-then-report shape (these commands hold no state to flip, so
+	 * "accept" is the whole success path).
+	 */
+	const roomCommandBusy = useRef(false);
+	const runRoomCommand = useCallback((command: () => Promise<void>) => {
+		if (roomCommandBusy.current) return;
+		roomCommandBusy.current = true;
+		command()
+			.catch((e) =>
+				setControlError(e instanceof RoomCommandError ? e.message : "Command failed."),
+			)
+			.finally(() => {
+				roomCommandBusy.current = false;
+			});
+	}, []);
 
 	// Open THEN focus, the same idiom PlaylistEditor's `reveal` uses:
 	// ClassicyWindowFocus does not clear `closed`, so focusing a window the
@@ -173,6 +212,12 @@ export function PlaylistDocumentWindow({
 					},
 					onDelete: () => setPending({ kind: "delete" }),
 					onSetStatus: (status) => edit(playlistId, { type: "setStatus", status }),
+					// Same link the list window's Copy Link produces — the
+					// anonymous student entry point (?playlist=<id>).
+					onCopyStudentLink: () =>
+						void navigator.clipboard.writeText(
+							`${location.origin}/?playlist=${playlistId}`,
+						),
 					quitItem,
 				}),
 				documentEditMenu({
@@ -190,7 +235,19 @@ export function PlaylistDocumentWindow({
 				}),
 				documentControlMenu({
 					lock: locks[playlistId] ?? { clock: false, busy: false },
+					dirty: state.dirty,
+					status: state.status,
 					onToggleClock: () => void toggleClockLock(playlistId),
+					// The ref read happens inside the click, so the jump carries
+					// the teacher's clock at click time, not menu-build time.
+					onSyncClock: () =>
+						runRoomCommand(() =>
+							sendRoomJump(playlistId, new Date(clockRef.current).toISOString()),
+						),
+					onSendMessage: () => setMessaging(true),
+					onFocusApp: (focusAppId) =>
+						runRoomCommand(() => sendRoomFocus(playlistId, focusAppId)),
+					onPushUpdate: () => runRoomCommand(() => sendRoomReload(playlistId)),
 				}),
 				windowMenu({
 					onFocusTools,
@@ -201,6 +258,10 @@ export function PlaylistDocumentWindow({
 				}),
 			];
 		},
+		// `runRoomCommand` is this component's own empty-dep useCallback (stable
+		// for its whole lifetime) and reads the clock through `clockRef` at
+		// click time, so the Control menu's live-command closures never go
+		// stale either.
 		// `edit`, `openPlaylist`, `refreshList`, and `toggleClockLock` come from
 		// PlaylistEditorProvider: `edit`/`openPlaylist`/`refreshList` are
 		// useCallbacks with an empty dep array (stable for the component's
@@ -238,6 +299,16 @@ export function PlaylistDocumentWindow({
 					title="Control" label={lockError.message}
 					buttons={[{ id: "ok", label: "OK", role: "default", onClick: dismissLockError }]}
 					onClose={dismissLockError}
+				/>
+			);
+		}
+		if (controlError) {
+			return (
+				<ClassicyAlert
+					id={`${windowId}_control_error`} appId={appId} alertType="stop"
+					title="Control" label={controlError}
+					buttons={[{ id: "ok", label: "OK", role: "default", onClick: () => setControlError(null) }]}
+					onClose={() => setControlError(null)}
 				/>
 			);
 		}
@@ -386,6 +457,18 @@ export function PlaylistDocumentWindow({
 				/>
 			</ClassicyWindow>
 			{alert}
+			{messaging && (
+				<SendMessageDialog
+					appId={appId}
+					playlistId={playlistId}
+					icon={appIcon}
+					onSend={(message) => {
+						setMessaging(false);
+						runRoomCommand(() => sendRoomMessage(playlistId, message));
+					}}
+					onCancel={() => setMessaging(false)}
+				/>
+			)}
 			{renaming && (
 				<RenameDialog
 					appId={appId}

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditorProvider.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditorProvider.tsx
@@ -149,11 +149,13 @@ export function PlaylistEditorProvider({
 	}, []);
 
 	/**
-	 * Lock state is held here rather than read back from the server, because
-	 * the streamer keeps none: a room command is fire-and-forget, so there is
-	 * nothing to query. Two consequences worth knowing: the checkmark resets
-	 * when the app is reopened (students stay locked — only the menu forgets),
-	 * and two teachers driving one playlist will not see each other's state.
+	 * Lock state is held here rather than read back from the server: the
+	 * streamer remembers the last lock per room only to replay it to late
+	 * joiners (see the backend's websocket-protocol.md "Room control") and
+	 * exposes no read-back API, so there is nothing to query. Two consequences
+	 * worth knowing: the checkmark resets when the app is reopened (students
+	 * stay locked — only the menu forgets), and two teachers driving one
+	 * playlist will not see each other's state.
 	 *
 	 * `busy` in `LockState` is a display flag for consumers (disable the menu
 	 * item) — it is NOT what guards against a second invocation for the same

--- a/packages/frontend/src/Applications/PlaylistEditor/SendMessageDialog.test.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/SendMessageDialog.test.tsx
@@ -1,0 +1,46 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SendMessageDialogForm } from "./SendMessageDialog";
+
+afterEach(cleanup);
+
+describe("SendMessageDialogForm", () => {
+	it("sends the trimmed message", () => {
+		const onSend = vi.fn();
+		render(<SendMessageDialogForm onSend={onSend} onCancel={vi.fn()} />);
+
+		fireEvent.change(screen.getByLabelText("Message"), {
+			target: { value: "  Look at channel 4  " },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+		expect(onSend).toHaveBeenCalledWith("Look at channel 4");
+	});
+
+	// A blank note would pop an empty box on every student's desktop.
+	it("refuses to send a blank message", () => {
+		const onSend = vi.fn();
+		render(<SendMessageDialogForm onSend={onSend} onCancel={vi.fn()} />);
+
+		const send = screen.getByRole("button", { name: "Send" }) as HTMLButtonElement;
+		expect(send.disabled).toBe(true);
+		fireEvent.click(send);
+
+		fireEvent.change(screen.getByLabelText("Message"), { target: { value: "   " } });
+		fireEvent.click(send);
+
+		expect(onSend).not.toHaveBeenCalled();
+	});
+
+	it("cancels without sending", () => {
+		const onSend = vi.fn();
+		const onCancel = vi.fn();
+		render(<SendMessageDialogForm onSend={onSend} onCancel={onCancel} />);
+
+		fireEvent.change(screen.getByLabelText("Message"), { target: { value: "hello" } });
+		fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+		expect(onCancel).toHaveBeenCalled();
+		expect(onSend).not.toHaveBeenCalled();
+	});
+});

--- a/packages/frontend/src/Applications/PlaylistEditor/SendMessageDialog.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/SendMessageDialog.tsx
@@ -1,0 +1,81 @@
+import { ClassicyButton, ClassicyInput, ClassicyWindow } from "classicy";
+import { useState } from "react";
+
+export interface SendMessageDialogFormProps {
+	onSend: (message: string) => void;
+	onCancel: () => void;
+	/** DOM id for the message field; must be per-playlist when several document
+	 * windows can each mount this dialog. */
+	inputId?: string;
+}
+
+/**
+ * The teacher's "Send Message…" note to a class — delivered to every student
+ * in the room as a `message` room command (see Providers/Playlist/roomApi.ts).
+ *
+ * Split from the window shell exactly like RenameDialog/RenameDialogForm so
+ * the form is testable without classicy window chrome, and a window rather
+ * than a ClassicyAlert for the same reason: an alert's contract is "only an
+ * icon, text, and buttons", and this needs a text field.
+ */
+export function SendMessageDialogForm({
+	onSend,
+	onCancel,
+	inputId = "playlist-send-message",
+}: SendMessageDialogFormProps) {
+	const [message, setMessage] = useState("");
+	const trimmed = message.trim();
+	// A blank note would pop an empty box on every student's desktop.
+	const send = () => {
+		if (trimmed !== "") onSend(trimmed);
+	};
+
+	return (
+		<div className="playlistSendMessageDialog">
+			<ClassicyInput
+				id={inputId}
+				labelTitle="Message"
+				labelPosition="left"
+				prefillValue=""
+				onChangeFunc={(e) => setMessage(e.target.value)}
+				onEnterFunc={send}
+			/>
+			<ClassicyButton isDefault={true} disabled={trimmed === ""} onClickFunc={send}>
+				Send
+			</ClassicyButton>
+			<ClassicyButton onClickFunc={onCancel}>Cancel</ClassicyButton>
+		</div>
+	);
+}
+
+export function SendMessageDialog({
+	appId,
+	playlistId,
+	icon,
+	...formProps
+}: SendMessageDialogFormProps & { appId: string; playlistId: string; icon: string }) {
+	return (
+		<ClassicyWindow
+			// Per playlist, not a singleton — same store-collision reasoning as
+			// RenameDialog: one of these can mount inside every document window.
+			id={`playlist_send_message_${playlistId}`}
+			appId={appId}
+			title="Send Message to Class"
+			icon={icon}
+			modal={true}
+			closable={true}
+			resizable={false}
+			zoomable={false}
+			collapsable={false}
+			scrollable={false}
+			initialSize={[340, 0]}
+			initialPosition={[400, 240]}
+			onCloseFunc={formProps.onCancel}
+		>
+			<SendMessageDialogForm
+				{...formProps}
+				inputId={`playlist-send-message-${playlistId}`}
+			/>
+		</ClassicyWindow>
+	);
+}

--- a/packages/frontend/src/Applications/PlaylistEditor/playlistMenus.test.ts
+++ b/packages/frontend/src/Applications/PlaylistEditor/playlistMenus.test.ts
@@ -20,7 +20,14 @@ const child = (menu: ClassicyMenuItem, id: string): ClassicyMenuItem => {
 
 const noopFile = {
 	onOpenList: vi.fn(), onSave: vi.fn(), onRename: vi.fn(), onDuplicate: vi.fn(),
-	onDelete: vi.fn(), onSetStatus: vi.fn(), quitItem: { id: "quit", title: "Quit" },
+	onDelete: vi.fn(), onSetStatus: vi.fn(), onCopyStudentLink: vi.fn(),
+	quitItem: { id: "quit", title: "Quit" },
+};
+
+const noopControl = {
+	lock: { clock: false, busy: false }, dirty: false, status: "published" as const,
+	onToggleClock: vi.fn(), onSyncClock: vi.fn(), onSendMessage: vi.fn(),
+	onFocusApp: vi.fn(), onPushUpdate: vi.fn(),
 };
 
 describe("documentFileMenu", () => {
@@ -36,6 +43,34 @@ describe("documentFileMenu", () => {
 
 		expect(draft?.checked).toBe(false);
 		expect(published?.checked).toBe(true);
+	});
+
+	// Drafts aren't joinable (the anonymous student loader refuses them), so
+	// the share item is disabled with the reason in its balloon rather than
+	// hidden — a teacher looking for it should find it and learn why.
+	it("enables Copy Student Link only for a published playlist, explaining why not", () => {
+		const published = child(
+			documentFileMenu({ ...noopFile, dirty: false, status: "published" }),
+			"playlist_file_copy_link",
+		);
+		expect(published.disabled).toBe(false);
+		expect(published.balloon?.content).toContain("join");
+
+		const draft = child(
+			documentFileMenu({ ...noopFile, dirty: false, status: "draft" }),
+			"playlist_file_copy_link",
+		);
+		expect(draft.disabled).toBe(true);
+		expect(draft.balloon?.content).toContain("Drafts aren't joinable");
+	});
+
+	it("Copy Student Link fires its handler", () => {
+		const onCopyStudentLink = vi.fn();
+		child(
+			documentFileMenu({ ...noopFile, onCopyStudentLink, dirty: false, status: "published" }),
+			"playlist_file_copy_link",
+		).onClickFunc?.();
+		expect(onCopyStudentLink).toHaveBeenCalled();
 	});
 });
 
@@ -60,21 +95,86 @@ describe("documentEditMenu", () => {
 
 describe("documentControlMenu", () => {
 	it("checkmarks a locked clock and disables the item while in flight", () => {
-		const locked = documentControlMenu({ lock: { clock: true, busy: false }, onToggleClock: vi.fn() });
+		const locked = documentControlMenu({ ...noopControl, lock: { clock: true, busy: false } });
 		expect(child(locked, "playlist_control_clock").checked).toBe(true);
 		expect(child(locked, "playlist_control_clock").disabled).toBe(false);
 
-		const busy = documentControlMenu({ lock: { clock: false, busy: true }, onToggleClock: vi.fn() });
+		const busy = documentControlMenu({ ...noopControl, lock: { clock: false, busy: true } });
 		expect(child(busy, "playlist_control_clock").disabled).toBe(true);
 	});
 
 	// Content locking is not built; the item exists so the pair reads as the
 	// pair it will become.
 	it("always disables Lock Contents and wires no handler", () => {
-		const menu = documentControlMenu({ lock: { clock: false, busy: false }, onToggleClock: vi.fn() });
+		const menu = documentControlMenu({ ...noopControl });
 		const contents = child(menu, "playlist_control_contents");
 		expect(contents.disabled).toBe(true);
 		expect(contents.onClickFunc).toBeUndefined();
+	});
+
+	it("fires the sync and message handlers, with balloons on both", () => {
+		const onSyncClock = vi.fn();
+		const onSendMessage = vi.fn();
+		const menu = documentControlMenu({ ...noopControl, onSyncClock, onSendMessage });
+
+		expect(child(menu, "playlist_control_sync").balloon?.content).toBeTruthy();
+		child(menu, "playlist_control_sync").onClickFunc?.();
+		expect(onSyncClock).toHaveBeenCalled();
+
+		expect(child(menu, "playlist_control_message").balloon?.content).toBeTruthy();
+		child(menu, "playlist_control_message").onClickFunc?.();
+		expect(onSendMessage).toHaveBeenCalled();
+	});
+
+	// The submenu's ids/names mirror PLAYLIST_APP_IDS — the same ids the
+	// student-side bridge resolves — so a drifted id would silently focus
+	// nothing on the students' desktops.
+	it("lists the four playlist apps under Bring App to Front and passes their app ids", () => {
+		const onFocusApp = vi.fn();
+		const focus = child(documentControlMenu({ ...noopControl, onFocusApp }), "playlist_control_focus");
+		expect(focus.menuChildren?.map((c) => c.title)).toEqual([
+			"TV", "Radio Scanner", "News", "Flight Tracker",
+		]);
+
+		focus.menuChildren?.[0].onClickFunc?.();
+		expect(onFocusApp).toHaveBeenCalledWith("TV.app");
+		focus.menuChildren?.[3].onClickFunc?.();
+		expect(onFocusApp).toHaveBeenCalledWith("FlightTracker.app");
+	});
+
+	// Push only works when students can fetch what they're told to fetch:
+	// unsaved edits aren't on the server, and drafts are refused by the
+	// anonymous loader. Dirty is the more actionable reason, so it wins the
+	// balloon when both apply.
+	it("gates Push Update to Class on a saved, published playlist", () => {
+		const onPushUpdate = vi.fn();
+		const ready = child(
+			documentControlMenu({ ...noopControl, onPushUpdate }),
+			"playlist_control_push",
+		);
+		expect(ready.disabled).toBe(false);
+		ready.onClickFunc?.();
+		expect(onPushUpdate).toHaveBeenCalled();
+
+		const dirty = child(
+			documentControlMenu({ ...noopControl, dirty: true }),
+			"playlist_control_push",
+		);
+		expect(dirty.disabled).toBe(true);
+		expect(dirty.balloon?.content).toContain("Save first");
+
+		const draft = child(
+			documentControlMenu({ ...noopControl, status: "draft" }),
+			"playlist_control_push",
+		);
+		expect(draft.disabled).toBe(true);
+		expect(draft.balloon?.content).toContain("published");
+
+		const both = child(
+			documentControlMenu({ ...noopControl, dirty: true, status: "draft" }),
+			"playlist_control_push",
+		);
+		expect(both.balloon?.content).toContain("Save first");
 	});
 });
 

--- a/packages/frontend/src/Applications/PlaylistEditor/playlistMenus.ts
+++ b/packages/frontend/src/Applications/PlaylistEditor/playlistMenus.ts
@@ -15,8 +15,18 @@ export interface DocumentFileMenuOptions {
 	onDuplicate: () => void;
 	onDelete: () => void;
 	onSetStatus: (status: "draft" | "published") => void;
+	onCopyStudentLink: () => void;
 	quitItem: ClassicyMenuItem;
 }
+
+export const COPY_LINK_BALLOONS = {
+	published:
+		"Copies the address students use to join this playlist. Anyone with the " +
+		"link can follow along — no sign-in needed.",
+	draft:
+		"Drafts aren't joinable. Set Status to Published (and Save) before " +
+		"sharing a link with students.",
+} as const;
 
 export function documentFileMenu(o: DocumentFileMenuOptions): ClassicyMenuItem {
 	return {
@@ -54,6 +64,19 @@ export function documentFileMenu(o: DocumentFileMenuOptions): ClassicyMenuItem {
 						onClickFunc: () => o.onSetStatus("published"),
 					},
 				],
+			},
+			// Disabled-with-a-reason rather than hidden: a teacher looking for the
+			// share affordance should find it, and the balloon says why a draft
+			// can't be shared yet (loadPlaylist refuses unpublished playlists).
+			{
+				id: "playlist_file_copy_link",
+				title: "Copy Student Link",
+				disabled: o.status !== "published",
+				balloon: {
+					title: "Copy Student Link",
+					content: COPY_LINK_BALLOONS[o.status],
+				},
+				onClickFunc: o.onCopyStudentLink,
 			},
 			SPACER,
 			{ id: "playlist_file_delete", title: "Delete…", onClickFunc: o.onDelete },
@@ -178,15 +201,73 @@ export const CLOCK_LOCK_BALLOON =
 	"Students following this playlist cannot change the time until you unlock the clock.";
 export const CONTENTS_LOCK_BALLOON =
 	"Not yet available. This will stop students from switching channels or stations on their own.";
+export const SYNC_CLOCK_BALLOON =
+	"Moves every student's clock to the time on your desktop right now. " +
+	"One move — their clocks keep running on their own afterwards unless the clock is locked.";
+export const SEND_MESSAGE_BALLOON =
+	"Shows a short note on every student's desktop.";
+export const FOCUS_APP_BALLOON =
+	"Opens the chosen app and brings it to the front on every student's desktop.";
+export const PUSH_UPDATE_BALLOONS = {
+	ready:
+		"Students re-load this playlist's latest saved version without leaving " +
+		"the class. Use it after saving a mid-class edit.",
+	dirty: "Save first — students can only receive what has been saved.",
+	draft: "Only a published playlist can be followed by students.",
+} as const;
+
+/** The four playlist-app focus targets, in the order the submenu lists them.
+ * Ids/names mirror Providers/Playlist/playlistApps.ts (PLAYLIST_APP_IDS /
+ * APP_NAMES) — the same ids RoomControlBridge resolves on the student side. */
+export const FOCUS_APPS: { appId: string; name: string }[] = [
+	{ appId: "TV.app", name: "TV" },
+	{ appId: "RadioScanner.app", name: "Radio Scanner" },
+	{ appId: "News.app", name: "News" },
+	{ appId: "FlightTracker.app", name: "Flight Tracker" },
+];
 
 export function documentControlMenu(o: {
 	lock: LockState;
+	dirty: boolean;
+	status: "draft" | "published";
 	onToggleClock: () => void;
+	onSyncClock: () => void;
+	onSendMessage: () => void;
+	onFocusApp: (appId: string) => void;
+	onPushUpdate: () => void;
 }): ClassicyMenuItem {
+	// Push needs the students to be able to fetch what they're told to fetch:
+	// unsaved edits aren't on the server, and a draft is refused by the
+	// anonymous student loader. Dirty is the more actionable reason, so it wins
+	// the balloon when both apply.
+	const pushBlocked = o.dirty ? "dirty" : o.status !== "published" ? "draft" : null;
 	return {
 		id: "control",
 		title: "Control",
 		menuChildren: [
+			{
+				id: "playlist_control_sync",
+				title: "Sync Students to My Clock",
+				balloon: { title: "Sync Students to My Clock", content: SYNC_CLOCK_BALLOON },
+				onClickFunc: o.onSyncClock,
+			},
+			{
+				id: "playlist_control_focus",
+				title: "Bring App to Front",
+				balloon: { title: "Bring App to Front", content: FOCUS_APP_BALLOON },
+				menuChildren: FOCUS_APPS.map((app) => ({
+					id: `playlist_control_focus_${app.appId}`,
+					title: app.name,
+					onClickFunc: () => o.onFocusApp(app.appId),
+				})),
+			},
+			{
+				id: "playlist_control_message",
+				title: "Send Message…",
+				balloon: { title: "Send Message…", content: SEND_MESSAGE_BALLOON },
+				onClickFunc: o.onSendMessage,
+			},
+			SPACER,
 			{
 				id: "playlist_control_clock",
 				title: "Lock Clock",
@@ -204,6 +285,17 @@ export function documentControlMenu(o: {
 				checked: false,
 				disabled: true,
 				balloon: { title: "Lock Contents", content: CONTENTS_LOCK_BALLOON },
+			},
+			SPACER,
+			{
+				id: "playlist_control_push",
+				title: "Push Update to Class",
+				disabled: pushBlocked !== null,
+				balloon: {
+					title: "Push Update to Class",
+					content: PUSH_UPDATE_BALLOONS[pushBlocked ?? "ready"],
+				},
+				onClickFunc: o.onPushUpdate,
 			},
 		],
 	};

--- a/packages/frontend/src/Providers/Playlist/roomApi.test.ts
+++ b/packages/frontend/src/Providers/Playlist/roomApi.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { ROOM_BASE } from "../../lib/endpoints";
-import { RoomCommandError, sendRoomLock, sendRoomReload } from "./roomApi";
+import {
+	RoomCommandError, sendRoomFocus, sendRoomJump, sendRoomLock, sendRoomMessage,
+	sendRoomReload,
+} from "./roomApi";
 
 const ok = () => new Response(null, { status: 202 });
 
@@ -83,5 +86,47 @@ describe("sendRoomReload", () => {
 		await expect(sendRoomReload("p1", f as unknown as typeof fetch)).rejects.toBeInstanceOf(
 			RoomCommandError,
 		);
+	});
+});
+
+// The three teacher one-shots share postRoomCommand with lock/reload (whose
+// suites above already pin credentials and the error mapping), so each needs
+// only its body shape pinned here.
+describe("teacher one-shot commands", () => {
+	it("sendRoomJump posts the jump with its UTC instant", async () => {
+		const f = vi.fn().mockResolvedValue(ok());
+		await sendRoomJump("p1", "2001-09-11T13:03:00.000Z", f as unknown as typeof fetch);
+		expect(JSON.parse(String((f.mock.calls[0][1] as RequestInit).body))).toEqual({
+			room: "p1",
+			action: "jump",
+			time: "2001-09-11T13:03:00.000Z",
+		});
+	});
+
+	it("sendRoomFocus posts the app to bring to front", async () => {
+		const f = vi.fn().mockResolvedValue(ok());
+		await sendRoomFocus("p1", "TV.app", f as unknown as typeof fetch);
+		expect(JSON.parse(String((f.mock.calls[0][1] as RequestInit).body))).toEqual({
+			room: "p1",
+			action: "focus",
+			app: "TV.app",
+		});
+	});
+
+	it("sendRoomMessage posts the note body", async () => {
+		const f = vi.fn().mockResolvedValue(ok());
+		await sendRoomMessage("p1", "Look at channel 4", f as unknown as typeof fetch);
+		expect(JSON.parse(String((f.mock.calls[0][1] as RequestInit).body))).toEqual({
+			room: "p1",
+			action: "message",
+			message: "Look at channel 4",
+		});
+	});
+
+	it("maps a refusal to the shared human-readable reason", async () => {
+		const f = vi.fn().mockResolvedValue(new Response(null, { status: 403 }));
+		await expect(
+			sendRoomJump("p1", "2001-09-11T13:03:00.000Z", f as unknown as typeof fetch),
+		).rejects.toThrow("Only the person who created this playlist can control it.");
 	});
 });

--- a/packages/frontend/src/Providers/Playlist/roomApi.ts
+++ b/packages/frontend/src/Providers/Playlist/roomApi.ts
@@ -68,3 +68,37 @@ export async function sendRoomReload(
 ): Promise<void> {
 	await postRoomCommand({ room, action: "reload" }, fetchFn);
 }
+
+/**
+ * Move every student's virtual clock to `timeIso` (a UTC RFC3339 instant) —
+ * the teacher's "Sync Students to My Clock". Students route it through the
+ * sanctioned clock seam, so forced clock mode still outranks it client-side.
+ */
+export async function sendRoomJump(
+	room: string,
+	timeIso: string,
+	fetchFn: typeof fetch = fetch,
+): Promise<void> {
+	await postRoomCommand({ room, action: "jump", time: timeIso }, fetchFn);
+}
+
+/**
+ * Bring one desktop app to the front on every student's desktop. `app` is a
+ * Classicy app id (e.g. "TV.app").
+ */
+export async function sendRoomFocus(
+	room: string,
+	app: string,
+	fetchFn: typeof fetch = fetch,
+): Promise<void> {
+	await postRoomCommand({ room, action: "focus", app }, fetchFn);
+}
+
+/** Show a short note on every student's desktop. */
+export async function sendRoomMessage(
+	room: string,
+	message: string,
+	fetchFn: typeof fetch = fetch,
+): Promise<void> {
+	await postRoomCommand({ room, action: "message", message }, fetchFn);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 18.1.2
       classicy:
         specifier: latest
-        version: 0.72.8(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/dlv@1.1.5)(@types/react@19.2.18)(immer@11.1.16)(react-dom@19.2.8(react@19.2.8))(react-player@3.4.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zustand@5.0.14(@types/react@19.2.18)(immer@11.1.16)(react@19.2.8))
+        version: 0.72.9(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/dlv@1.1.5)(@types/react@19.2.18)(immer@11.1.16)(react-dom@19.2.8(react@19.2.8))(react-player@3.4.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zustand@5.0.14(@types/react@19.2.18)(immer@11.1.16)(react@19.2.8))
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -1035,8 +1035,8 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
-  classicy@0.72.8:
-    resolution: {integrity: sha512-QTnKXlUhe7TTHEF29mcs6/zFAmkRjviTQ4SJ1Dm5ccIl5B/mD/RIOH+aavhF3aszGc8+ZAsBzElCnwO313gmdA==}
+  classicy@0.72.9:
+    resolution: {integrity: sha512-iIClCSfjeNW1OMDBmZeJxQt772T5hbNIblGuwkMHyzOmFSKSOcsljUJ9CePNWJ1KbXKrZ8Y2TfzCm8jvyYl/0Q==}
     peerDependencies:
       '@tanstack/react-table': ^8.21.3
       immer: ^11.1.8
@@ -3462,7 +3462,7 @@ snapshots:
       readdirp: 5.0.0
     optional: true
 
-  classicy@0.72.8(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/dlv@1.1.5)(@types/react@19.2.18)(immer@11.1.16)(react-dom@19.2.8(react@19.2.8))(react-player@3.4.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zustand@5.0.14(@types/react@19.2.18)(immer@11.1.16)(react@19.2.8)):
+  classicy@0.72.9(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/dlv@1.1.5)(@types/react@19.2.18)(immer@11.1.16)(react-dom@19.2.8(react@19.2.8))(react-player@3.4.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zustand@5.0.14(@types/react@19.2.18)(immer@11.1.16)(react@19.2.8)):
     dependencies:
       '@analytics/google-tag-manager': 0.6.0
       '@noble/hashes': 2.3.0


### PR DESCRIPTION
Fixes #259 — PR 2 of 2, **stacked on #405** (`claude/issue-259-room-sync`): this PR is opened with that branch as its base so the diff shows only the teacher-side work. Merge #405 first, then retarget/merge this one.

Frontend only.

## What this does

**Teacher live control (A).** The Control menu on each playlist document window grows the live teaching surface, every command scoped to *that window's* playlist (never the active document):

- **Sync Students to My Clock** — jumps the room to the teacher's current virtual instant. The clock is read from a ref at click time, so the jump carries the time on the teacher's desktop at the moment of the click, not at menu build.
- **Bring App to Front** — submenu of the four playlist apps (TV, Radio Scanner, News, Flight Tracker), sending the same Classicy app ids the student-side `RoomControlBridge` resolves.
- **Send Message…** — a small modal dialog (the `RenameDialog` shape: window shell + separately-testable form), sending a `message` room command; blank notes are refused.
- **Push Update to Class** — sends the `reload` command from PR 1. Disabled while the document is dirty or a draft, with the reason ballooned (students can only fetch what is saved and published; dirty is the more actionable reason when both apply).

The one-shots reuse Lock Clock's shape: a synchronous in-flight guard (the same double-fire gap `toggleClockLock` closes with its ref), and refusals surfacing in a "Control" alert with the shared human-readable reasons (`RoomCommandError`).

**Share affordance (D).** File menu gains **Copy Student Link** — the same `${origin}/?playlist=<id>` URL the list window's Copy Link produces (the anonymous, no-sign-in student entry point). Enabled when published; disabled for drafts with "Drafts aren't joinable…" ballooned rather than hidden, so a teacher looking for the share affordance finds it and learns why.

`roomApi` gains `sendRoomJump` / `sendRoomFocus` / `sendRoomMessage` over the `postRoomCommand` helper PR 1 factored out, and `PlaylistEditorProvider`'s now-stale "the streamer keeps none" lock-state comment is corrected.

## Tests

`vitest run`: 246 files / 2290 tests green; `tsc -b` clean; `eslint .` 0 errors. New coverage: the three senders' body shapes + shared error mapping; menu construction (focus submenu ids/names, push gating with per-reason balloons, Copy Student Link enable/balloon); document-window wiring (each command carries this window's playlist id, click-time clock read, message dialog send/cancel, refused command → Control alert, clipboard write); `SendMessageDialogForm` (trimming, blank refusal, cancel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)