### PR TITLE
feat(parties): enrich identifications from the 9/11 Commission's own clip index

### DIFF
--- a/packages/tools/video-grabber/tests/test_parties_commission.py
+++ b/packages/tools/video-grabber/tests/test_parties_commission.py
@@ -1,0 +1,228 @@
+"""The Commission-source join, and the two-document containment gate."""
+import pytest
+
+from video_grabber.parties.commission import (
+    MIN_SLUG_OVERLAP,
+    load_clip_index,
+    match_commission_clip,
+    slug_overlap,
+)
+from video_grabber.parties.identify import (
+    SOURCE_COMMISSION,
+    SOURCE_TRANSCRIPT,
+    validate_enriched_parties,
+)
+
+# Two clips a minute apart on the real morning, catalogued by the Commission with
+# very different titles. The stamps are what our filenames carry.
+TRANSCRIPT = "Gofer zero six, this is Washington Center, do you have him in sight."
+COMMISSION = (
+    "093800 Gofer 06 Aircraft is Down\n\n"
+    "Colin Scoggins at Boston Center relayed the report to NEADS."
+)
+
+
+# --- the shipped index ----------------------------------------------------
+
+def test_index_loads_and_is_keyed_by_six_digit_stamp():
+    index = load_clip_index()
+    assert len(index) > 100
+    assert all(len(k) == 6 and k.isdigit() for k in index)
+    assert all(entry["title"] and entry["source"] for entry in index.values())
+
+
+def test_index_is_cached_not_reread():
+    assert load_clip_index() is load_clip_index()
+
+
+# --- slug scoring ---------------------------------------------------------
+
+def test_overlap_ignores_flight_numbers_that_match_everything():
+    # Nothing but the stopworded callsign in common — not a match on the strength
+    # of a token that appears in half the corpus.
+    assert slug_overlap("aa77 taxi clearance", "aa77 dulles departure") < MIN_SLUG_OVERLAP
+
+
+def test_overlap_survives_our_canonical_rename_marker():
+    # The timezone fix appended "(canonical)" to renamed objects; it is our
+    # bookkeeping, not part of any title, and must not dilute the score.
+    plain = slug_overlap("gofer 06 aircraft is down", "Gofer 06 Aircraft is Down")
+    marked = slug_overlap("gofer 06 aircraft is down (canonical)", "Gofer 06 Aircraft is Down")
+    assert plain == marked == 1.0
+
+
+# --- matching -------------------------------------------------------------
+
+def test_no_leading_timestamp_never_matches():
+    assert match_commission_clip("audio/wcbs/2001-09-11-08-48-00-wcbs.mp3") is None
+
+
+def test_unknown_timestamp_returns_none():
+    assert match_commission_clip("audio/ZNY/999999 nothing here.mp3") is None
+
+
+def test_same_stamp_different_tape_is_rejected():
+    """The reason the slug is scored at all.
+
+    093800 is a real stamp in the index, held by 'Gofer 06 Aircraft is Down'. A
+    different recording that happens to share the second must not inherit the
+    Commission's description of the first — that would attach a narrative about
+    a shootdown report to an unrelated turn instruction.
+    """
+    index = load_clip_index()
+    if "093800" not in index:
+        pytest.skip("index no longer carries this stamp")
+    assert match_commission_clip("audio/DL1989/093800 d1989 turn right 31.mp3") is None
+
+
+def test_agreeing_title_matches_and_reports_its_source():
+    index = load_clip_index()
+    stamp, entry = next(iter(sorted(index.items())))
+    key = f"audio/ZNY/{entry['title']}.mp3"
+    clip = match_commission_clip(key)
+    assert clip is not None
+    assert clip.stamp == stamp
+    assert clip.overlap == 1.0
+    assert clip.title in clip.text
+
+
+# --- the two-document gate ------------------------------------------------
+
+def _parties(**over):
+    """A well-formed answer, so each test's own defect is the only one in play."""
+    base = {
+        "side_a": {"facility": None, "position": None, "person": None, "role": "atc"},
+        "side_b": {"facility": None, "position": None, "person": None, "role": "military"},
+        "aircraft": [],
+        "confidence": "high",
+        "evidence": "Gofer zero six, this is Washington Center",
+        "sources": {"evidence": SOURCE_TRANSCRIPT},
+    }
+    base.update(over)
+    base.setdefault("sources", {}).setdefault("evidence", SOURCE_TRANSCRIPT)
+    return base
+
+
+def _reason(reasons, needle):
+    """Assert some reason mentions `needle`, without pinning their order."""
+    assert any(needle in r for r in reasons), reasons
+
+
+def test_commission_sourced_name_survives_though_absent_from_transcript():
+    """The whole point of the second pass.
+
+    'Colin Scoggins' is nowhere in the audio. Under the single-document gate it
+    was correctly destroyed; here it is admissible because the Commission names
+    him and the answer says so.
+    """
+    cleaned, reasons = validate_enriched_parties(
+        _parties(
+            side_b={"facility": "NEADS", "position": None,
+                    "person": "Colin Scoggins", "role": "military"},
+            sources={"side_b.facility": SOURCE_COMMISSION,
+                     "side_b.person": SOURCE_COMMISSION},
+        ),
+        TRANSCRIPT,
+        COMMISSION,
+    )
+    assert cleaned["side_b"]["person"] == "Colin Scoggins"
+    assert cleaned["sources"]["side_b.person"] == SOURCE_COMMISSION
+    assert reasons == []
+
+
+def test_a_name_in_neither_document_is_still_destroyed():
+    cleaned, reasons = validate_enriched_parties(
+        _parties(
+            side_a={"facility": "Cleveland Center", "position": None,
+                    "person": None, "role": "atc"},
+            sources={"side_a.facility": SOURCE_COMMISSION},
+        ),
+        TRANSCRIPT,
+        COMMISSION,
+    )
+    assert cleaned["side_a"]["facility"] is None
+    assert cleaned["confidence"] == "low"
+    assert "commission_monograph never contains" in reasons[0]
+
+
+def test_claiming_the_transcript_for_a_commission_only_name_fails():
+    """Provenance is checked, not just recorded.
+
+    A model that mislabels where a value came from must not get it through — the
+    label decides which document the value is held against.
+    """
+    cleaned, _ = validate_enriched_parties(
+        _parties(
+            side_b={"facility": None, "position": None,
+                    "person": "Colin Scoggins", "role": "military"},
+            sources={"side_b.person": SOURCE_TRANSCRIPT},
+        ),
+        TRANSCRIPT,
+        COMMISSION,
+    )
+    assert cleaned["side_b"]["person"] is None
+
+
+def test_undeclared_source_is_held_to_the_transcript():
+    """Fail-closed. Saying nothing must not reach the looser document."""
+    cleaned, reasons = validate_enriched_parties(
+        _parties(
+            side_b={"facility": "NEADS", "position": None, "person": None,
+                    "role": "military"},
+            sources={},
+        ),
+        TRANSCRIPT,
+        COMMISSION,
+    )
+    assert cleaned["side_b"]["facility"] is None
+    assert "transcript never contains" in reasons[0]
+
+
+def test_unknown_source_name_is_rejected_not_trusted():
+    cleaned, reasons = validate_enriched_parties(
+        _parties(
+            side_a={"facility": "NEADS", "position": None, "person": None,
+                    "role": "military"},
+            sources={"side_a.facility": "my_own_knowledge"},
+        ),
+        TRANSCRIPT,
+        COMMISSION,
+    )
+    assert cleaned["side_a"]["facility"] is None
+    assert "unknown source" in reasons[0]
+
+
+def test_evidence_may_quote_the_commission_when_it_says_so():
+    quote = "Colin Scoggins at Boston Center relayed the report to NEADS."
+    cleaned, reasons = validate_enriched_parties(
+        _parties(evidence=quote, sources={"evidence": SOURCE_COMMISSION}),
+        TRANSCRIPT,
+        COMMISSION,
+    )
+    assert cleaned["evidence"] == quote
+    assert reasons == []
+
+
+def test_surviving_sources_map_is_rebuilt_from_what_passed():
+    """The stored map must describe the stored values, not the model's claims.
+
+    A consumer reading `parties.sources` is entitled to assume every path in it
+    names a field that is actually present and actually verified.
+    """
+    cleaned, _ = validate_enriched_parties(
+        _parties(
+            side_a={"facility": "Washington Center", "position": None,
+                    "person": None, "role": "atc"},
+            side_b={"facility": "Cleveland Center", "position": None,
+                    "person": None, "role": "atc"},
+            sources={"side_a.facility": SOURCE_TRANSCRIPT,
+                     "side_b.facility": SOURCE_COMMISSION},
+        ),
+        TRANSCRIPT,
+        COMMISSION,
+    )
+    assert cleaned["sources"] == {
+        "evidence": SOURCE_TRANSCRIPT,
+        "side_a.facility": SOURCE_TRANSCRIPT,
+    }
+    assert cleaned["side_b"]["facility"] is None

--- a/packages/tools/video-grabber/video_grabber/parties/commission.py
+++ b/packages/tools/video-grabber/video_grabber/parties/commission.py
@@ -1,0 +1,122 @@
+"""The 9/11 Commission's own index of these recordings, as a lookup table.
+
+Our audio corpus came from three Internet Archive collections
+(`NARA_FOIA_36411_FAA_RECORDS_Aug_19_2011`, `NARA_911_Commission_RG148_Audio_Monograph`,
+`RDOD_NEADS_AUDIO`) whose filenames are a six-digit timestamp and a terse slug —
+`093800 Gofer 06 Aircraft is Down`. The Commission staff who catalogued the same
+tapes wrote fuller titles, and Team 8's audio monograph (`team 8a audio monograph
+28.doc`) walks 76 of them in narrative prose naming the controllers, positions and
+facilities on each call. That is authority our transcripts do not carry, and it is
+what `commission_clips.json` holds.
+
+`commission_clips.json` was built from two IA items and is checked in rather than
+fetched, because the sources are a 3.6 MB Word 97 binary and a plain-text master
+file that need bespoke parsing (Word piece tables) to read at all:
+
+  - `NARA_911_Commission_RG148_Audio_Monograph/Master File 051704.txt`  — 111 clips,
+    titles stamped in **UTC**.
+  - `NARA_911_Commission_RG148_Audio_Monograph/team 8a audio monograph 28.doc` —
+    76 clips hyperlinked from Master File 061604, titles stamped in **ET**, each
+    with the surrounding monograph narrative.
+
+The two stampings are why our corpus contains the same recording twice under
+`08xxxx` and `12xxxx` names — see the timezone correction in issue #379.
+
+Matching is deliberately conservative. A six-digit timestamp is not unique (two
+unrelated calls share `093800`), so a candidate must agree on the slug as well:
+`MIN_SLUG_OVERLAP` of our filename's words must appear in the Commission title.
+The rejects are the point — `093800 d1989 turn right 31` and `093800 Gofer 06
+Aircraft is Down` are the same second of the same morning and different tapes.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+INDEX_PATH = Path(__file__).with_name("commission_clips.json")
+
+# Below this, the timestamp is doing all the work and the slug is contradicting it.
+MIN_SLUG_OVERLAP = 0.5
+
+_LEADING_STAMP = re.compile(r"^(\d{6})\b")
+_WORD = re.compile(r"[a-z0-9]+")
+
+# Flight numbers appear in every other title and match everything; "(canonical)" is
+# our own rename marker from the timezone fix, not part of anyone's title.
+_STOPWORDS = frozenset({"aa11", "aa77", "ua175", "ua93", "wav", "mp3", "canonical"})
+
+
+@dataclass(frozen=True)
+class CommissionClip:
+    """One catalogued recording, as the Commission described it."""
+
+    stamp: str
+    title: str
+    source: str
+    context: str | None
+    overlap: float
+
+    @property
+    def text(self) -> str:
+        """Everything the Commission says about this clip, as one blob.
+
+        This is what a monograph-sourced field is validated against, so it must
+        contain the title too: the title is where the callsigns and facility names
+        usually live, and the narrative is where the people do.
+        """
+        return self.title if not self.context else f"{self.title}\n\n{self.context}"
+
+
+@lru_cache(maxsize=1)
+def load_clip_index() -> dict[str, dict]:
+    """The shipped index, keyed by six-digit stamp. Cached — it never changes."""
+    return json.loads(INDEX_PATH.read_text())
+
+
+def _tokens(text: str) -> set[str]:
+    return {w for w in _WORD.findall(text.lower())} - _STOPWORDS
+
+
+def slug_overlap(our_stem: str, their_title: str) -> float:
+    """Fraction of our filename's words that the Commission title also uses.
+
+    Asymmetric on purpose: their titles are longer and more descriptive, so
+    scoring against theirs would penalise exactly the good matches. What we need
+    to know is whether *our* name is accounted for.
+    """
+    ours = _tokens(our_stem)
+    theirs = _tokens(their_title)
+    if not ours or not theirs:
+        return 0.0
+    return len(ours & theirs) / len(ours)
+
+
+def match_commission_clip(key: str) -> CommissionClip | None:
+    """Find the Commission's entry for one of our object keys, or None.
+
+    Returns None for a file with no leading timestamp, no catalogued clip at that
+    timestamp, or a clip whose title disagrees with ours.
+    """
+    stem = Path(key).stem
+    m = _LEADING_STAMP.match(stem)
+    if not m:
+        return None
+    stamp = m.group(1)
+    entry = load_clip_index().get(stamp)
+    if not entry:
+        return None
+    # Compare the slug only — the stamp already matched, and leaving it in would
+    # award every candidate a free point.
+    overlap = slug_overlap(stem[len(stamp):], entry["title"][len(stamp):])
+    if overlap < MIN_SLUG_OVERLAP:
+        return None
+    return CommissionClip(
+        stamp=stamp,
+        title=entry["title"],
+        source=entry["source"],
+        context=entry.get("context"),
+        overlap=round(overlap, 2),
+    )

--- a/packages/tools/video-grabber/video_grabber/parties/commission_clips.json
+++ b/packages/tools/video-grabber/video_grabber/parties/commission_clips.json
@@ -1,0 +1,826 @@
+{
+ "080918": {
+  "context": "At 8:00 on September 11, 2001, American Airlines Flight 11 began its takeoff roll at Logan Airport in Boston. A Boeing 767, American 11 was bound for Los Angeles with 81 passengers and 11 crewmembers.\u0002 By 8:09, American 11 had been passed from air traffic control at Logan Airport to Boston\u2019s regional en route center in Nashua, NH, some fifty miles from Boston.\u0002 The Boston controller at the Boston Sector Radar Position directed the flight to \u201cclimb and maintain level two eight zero.\u201d\u0002 4.1 FAA Awareness 4. AMERICAN 11 The controller followed this, at 8:10, with an instruction to \u201cclimb maintain flight level two niner zero,\u201d which was affirmed by American 11.\u0002 At 8:13, the controller instructed the flight to \u201cturn twenty degrees right,\u201d which the flight acknowledged: \u201ctwenty right American 11.\u201d\u0002 This was the last transmission to which the flight responded. Sixteen seconds after receiving the acknowledgment from the pilot of the turn, the controller instructed the flight to \u201cclimb maintain level three five zero,\u201d an ultimate cruising altitude of 35,000 feet.\u0002 When there was no response, the controller repeated the command ten seconds later, and then tried repeatedly to raise the flight",
+  "source": "monograph",
+  "title": "080918 AA11Checkin"
+ },
+ "081335": {
+  "context": "The controller followed this, at 8:10, with an instruction to \u201cclimb maintain flight level two niner zero,\u201d which was affirmed by American 11.\u0002 At 8:13, the controller instructed the flight to \u201cturn twenty degrees right,\u201d which the flight acknowledged: \u201ctwenty right American 11.\u201d\u0002 At 8:00 on September 11, 2001, American Airlines Flight 11 began its takeoff roll at Logan Airport in Boston. A Boeing 767, American 11 was bound for Los Angeles with 81 passengers and 11 crewmembers.\u0002 By 8:09, American 11 had been passed from air traffic control at Logan Airport to Boston\u2019s regional en route center in Nashua, NH, some fifty miles from Boston.\u0002 The Boston controller at the Boston Sector Radar Position directed the flight to \u201cclimb and maintain level two eight zero.\u201d\u0002 This was the last transmission to which the flight responded. Sixteen seconds after receiving the acknowledgment from the pilot of the turn, the controller instructed the flight to \u201cclimb maintain level three five zero,\u201d an ultimate cruising altitude of 35,000 feet.\u0002 When there was no response, the controller repeated the command ten seconds later, and then tried repeatedly to raise the flight. According to the controller, at",
+  "source": "monograph",
+  "title": "081335 AA11 20 Right"
+ },
+ "081352": {
+  "context": "Sixteen seconds after receiving the acknowledgment from the pilot of the turn, the controller instructed the flight to \u201cclimb maintain level three five zero,\u201d an ultimate cruising altitude of 35,000 feet.\u0002 When there was no response, the controller repeated the command ten seconds later, and then tried repeatedly to raise the flight. This was the last transmission to which the flight responded. The controller followed this, at 8:10, with an instruction to \u201cclimb maintain flight level two niner zero,\u201d which was affirmed by American 11.\u0002 At 8:13, the controller instructed the flight to \u201cturn twenty degrees right,\u201d which the flight acknowledged: \u201ctwenty right American 11.\u201d\u0002 According to the controller, at that point, he thought \u201cmaybe the pilots weren\u2019t paying attention, or there\u2019s something wrong with the frequency.\u201d He used the emergency frequency to try and get a hold of the pilot. There was still no response.\u201d\u0002 Indeed, numerous controllers interviewed at various FAA facilities stated it was a common occurrence prior to 9/11 to lose radio contact with pilots of commercial aircraft for a brief period of time. Controllers attributed the frequent losses of radio contact to electrical ",
+  "source": "monograph",
+  "title": "081352 AA11 Lost Contact"
+ },
+ "082350": {
+  "context": "At this point \u2013 from 8:15 until 8:24 on the transcript -- the Boston sector controller attempted to contact American 11 nine times, all unsuccessfully.\u0002 At 8:21, American 11 changed course, heading northwest, and someone turned off the transponder. With a turned off transponder the information available to the controller was severely compromised: controllers could receive data on the plane\u2019s location, but could only loosely approximate its speed, had no way of knowing or even guessing its altitude, and could only identify it as a \u201cprimary radar target,\u201d not as a specific squawking flight.\u0002 The controller \u201cvery quietly turned to the supervisor and said, `Would you please come over here? I think something is seriously wrong with this plane. I don\u2019t know what. It\u2019s either mechanical, electrical, I think, but I\u2019m not sure.\u2019\u201d At this point, neither the controller nor his supervisor suspected hijacking.\u0002 The supervisor instructed the controller to follow the standard operating procedures for the handling of a \u201cno radio\u201d (known as \u201cNORDO\u201d) aircraft.\u0002 Accordingly, the controller checked the working condition of his own equipment, then attempted to raise the flight on the 121.5 guard freque",
+  "source": "monograph",
+  "title": "082350 AA11 Check Everything Company"
+ },
+ "082444": {
+  "context": "At 8:24:38, American 11 began a turn to the south and the following transmission came from American 11: The controllers moved \u201call the airplanes \u2026 from Albany to New York to Syracuse, NY out of the way because that\u2019s the track he was going on,\u201d and searched from aircraft to aircraft on the company frequency in an effort to have another pilot contact American 11. About five minutes after the hijacking began, Flight Attendant Betty Ong contacted the American Airlines Southeastern Reservation Office in North Carolina to report an emergency aboard the flight. Following is a portion of the tape of that call. This Boston Sector controller heard something unintelligible over the radio, and did not hear the specific words \u201c[w]e have some planes\u201d at the time. The next transmission came seconds later: The controller has told the media and Commission staff during interviews, when he heard this second transmission, he \u201cfelt from those voices the terror\u201d and immediately knew something was very wrong. He knew it was a hijack.\u201d\u0002 Controllers at Boston Center discussed attempts to contact American 11, the aircraft\u2019s altitude and whether someone had taken over the cockpit of the aircraft:",
+  "source": "monograph",
+  "title": "082444 AA11 Keying 2 Transmissions"
+ },
+ "082453": {
+  "context": "Controllers at Boston Center discussed attempts to contact American 11, the aircraft\u2019s altitude and whether someone had taken over the cockpit of the aircraft: The controller has told the media and Commission staff during interviews, when he heard this second transmission, he \u201cfelt from those voices the terror\u201d and immediately knew something was very wrong. He knew it was a hijack.\u201d\u0002 This Boston Sector controller heard something unintelligible over the radio, and did not hear the specific words \u201c[w]e have some planes\u201d at the time. The next transmission came seconds later: The controller alerted his supervisor to the threatening communication. The supervisor assigned a senior controller to assist the American 11 controller, and redoubled efforts to ascertain the flight\u2019s altitude.\u0002 Because the initial transmission was not heard clearly, the Manager of Boston Center instructed the Center\u2019s Quality Assurance Specialist to \u201cpull the tape\u201d of the radio transmission, listen to it closely, and report on what he heard.\u0002 Between 8:25 and 8:32, in accordance with the FAA protocol, Boston Center managers started notifying their chain of command that American 11 had been hijacked. At 8:28, Bos",
+  "source": "monograph",
+  "title": "082453 AA11 Check Sup Already Did"
+ },
+ "082457": {
+  "context": "This Boston Sector controller heard something unintelligible over the radio, and did not hear the specific words \u201c[w]e have some planes\u201d at the time. The next transmission came seconds later: At 8:24:38, American 11 began a turn to the south and the following transmission came from American 11: The controllers moved \u201call the airplanes \u2026 from Albany to New York to Syracuse, NY out of the way because that\u2019s the track he was going on,\u201d and searched from aircraft to aircraft on the company frequency in an effort to have another pilot contact American 11. The controller has told the media and Commission staff during interviews, when he heard this second transmission, he \u201cfelt from those voices the terror\u201d and immediately knew something was very wrong. He knew it was a hijack.\u201d\u0002 Controllers at Boston Center discussed attempts to contact American 11, the aircraft\u2019s altitude and whether someone had taken over the cockpit of the aircraft:",
+  "source": "monograph",
+  "title": "082457 Nobody move"
+ },
+ "082542": {
+  "context": "Controllers at Boston Center discussed attempts to contact American 11, the aircraft\u2019s altitude and whether someone had taken over the cockpit of the aircraft: The controller has told the media and Commission staff during interviews, when he heard this second transmission, he \u201cfelt from those voices the terror\u201d and immediately knew something was very wrong. He knew it was a hijack.\u201d\u0002 The controller alerted his supervisor to the threatening communication. The supervisor assigned a senior controller to assist the American 11 controller, and redoubled efforts to ascertain the flight\u2019s altitude.\u0002 Because the initial transmission was not heard clearly, the Manager of Boston Center instructed the Center\u2019s Quality Assurance Specialist to \u201cpull the tape\u201d of the radio transmission, listen to it closely, and report on what he heard.\u0002 Between 8:25 and 8:32, in accordance with the FAA protocol, Boston Center managers started notifying their chain of command that American 11 had been hijacked. At 8:28, Boston Center called the Command Center in Herndon, Virginia to advise management that it believed American 11 had been hijacked and was heading toward New York Center\u2019s airspace. By this point i",
+  "source": "monograph",
+  "title": "082542 AA11 Point Out Enter New Route"
+ },
+ "082655": {
+  "context": "Controllers at Boston Center discussed attempts to contact American 11, the aircraft\u2019s altitude and whether someone had taken over the cockpit of the aircraft: The controller has told the media and Commission staff during interviews, when he heard this second transmission, he \u201cfelt from those voices the terror\u201d and immediately knew something was very wrong. He knew it was a hijack.\u201d\u0002 The controller alerted his supervisor to the threatening communication. The supervisor assigned a senior controller to assist the American 11 controller, and redoubled efforts to ascertain the flight\u2019s altitude.\u0002 Because the initial transmission was not heard clearly, the Manager of Boston Center instructed the Center\u2019s Quality Assurance Specialist to \u201cpull the tape\u201d of the radio transmission, listen to it closely, and report on what he heard.\u0002 Between 8:25 and 8:32, in accordance with the FAA protocol, Boston Center managers started notifying their chain of command that American 11 had been hijacked. At 8:28, Boston Center called the Command Center in Herndon, Virginia to advise management that it believed American 11 had been hijacked and was heading toward New York Center\u2019s airspace. By this point i",
+  "source": "monograph",
+  "title": "082655 AA11 Take Back Look West Albany"
+ },
+ "082924": {
+  "context": "The controller alerted his supervisor to the threatening communication. The supervisor assigned a senior controller to assist the American 11 controller, and redoubled efforts to ascertain the flight\u2019s altitude.\u0002 Because the initial transmission was not heard clearly, the Manager of Boston Center instructed the Center\u2019s Quality Assurance Specialist to \u201cpull the tape\u201d of the radio transmission, listen to it closely, and report on what he heard.\u0002 Between 8:25 and 8:32, in accordance with the FAA protocol, Boston Center managers started notifying their chain of command that American 11 had been hijacked. At 8:28, Boston Center called the Command Center in Herndon, Virginia to advise management that it believed American 11 had been hijacked and was heading toward New York Center\u2019s airspace. By this point in time, American 11 had taken a dramatic turn to the south. Command Center immediately established a teleconference between Boston, New York and Cleveland Centers to allow Boston Center to provide situational awareness to the centers that adjoined Boston in the event the rogue aircraft entered their airspace.\u0002 The Command Center subsequently provided the following update on the situat",
+  "source": "monograph",
+  "title": "082924 AA11 ZBW Notification ZOB ZNY 5115 Line"
+ },
+ "083053": {
+  "context": "The Command Center subsequently provided the following update on the situation to an unknown air traffic control facility: The controller alerted his supervisor to the threatening communication. The supervisor assigned a senior controller to assist the American 11 controller, and redoubled efforts to ascertain the flight\u2019s altitude.\u0002 Because the initial transmission was not heard clearly, the Manager of Boston Center instructed the Center\u2019s Quality Assurance Specialist to \u201cpull the tape\u201d of the radio transmission, listen to it closely, and report on what he heard.\u0002 Between 8:25 and 8:32, in accordance with the FAA protocol, Boston Center managers started notifying their chain of command that American 11 had been hijacked. At 8:28, Boston Center called the Command Center in Herndon, Virginia to advise management that it believed American 11 had been hijacked and was heading toward New York Center\u2019s airspace. By this point in time, American 11 had taken a dramatic turn to the south. Command Center immediately established a teleconference between Boston, New York and Cleveland Centers to allow Boston Center to provide situational awareness to the centers that adjoined Boston in the ev",
+  "source": "monograph",
+  "title": "083053 AA11 Pascione Summation to Unknown 5115 Line"
+ },
+ "083355": {
+  "context": "After Boston Center\u2019s managers notified the New England Region of the events concerning American 11, they did not wait for military assistance as notification was passed up the chain of command to FAA headquarters. In an attempt to get fighter aircraft airborne to track American 11, Boston Center\u2019s managers took the initiative and called a manager at the FAA Cape Cod facility at 8:34. They asked the Cape Cod manager to contact Otis Air Force Base in Cape Cod, Massachusetts to get fighters airborne to \u201ctail\u201d the hijacked aircraft.\u0002 4.2 Military Notification and Response Boston Center managers also tried to obtain assistance from a former alert site in Atlantic City, unaware that it had been phased out. At 8:37:52, Boston Center\u2019s persistence finally paid dividends. They called the North American Aerospace Defense Command\u2019s (NORAD) Northeast Air Defense Sector (NEADS) and notified NEADS about the suspected hijacking of American 11.\u0002",
+  "source": "monograph",
+  "title": "083355 Bueno Call to Cape Tracon"
+ },
+ "083359": {
+  "context": "At 8:34, as FAA headquarters received its initial notification that American 11 had been hijacked, the Boston sector controller received a third transmission from American 11. Also at 8:32, Michael Woodward of American Airlines took a call from Flight Attendant Madeline \u201cAmy\u201d Sweeney that lasted approximately twelve minutes. Although the call was not taped, Woodward\u2019s colleague, Nancy Wyatt, standing at his side, contacted Ray Howland in the American Airlines System Operations Center (SOC) to report the content of the ongoing call between Woodward and Amy Sweeney. Wyatt was able to relay information to the SOC as she heard Woodward\u2019s side of the conversation and read the notes he was taking. Following are two excerpts, which span several minutes, from the call to Howland. In succeeding minutes, controllers in both Boston Center and New York Center attempted to ascertain the altitude of the southbound American 11.\u0002 Information about what was going on within American 11 started to get conveyed within the ATC system. At 8:40, Boston Center, through the Command Center, provided a report to New York TRACON on American 11. And at 8:43, a Command Center air traffic specialist warned Washi",
+  "source": "monograph",
+  "title": "083359 Nobody Move Please Going Back to Airport"
+ },
+ "083556": {
+  "context": "In succeeding minutes, controllers in both Boston Center and New York Center attempted to ascertain the altitude of the southbound American 11.\u0002 At 8:34, as FAA headquarters received its initial notification that American 11 had been hijacked, the Boston sector controller received a third transmission from American 11. Information about what was going on within American 11 started to get conveyed within the ATC system. At 8:40, Boston Center, through the Command Center, provided a report to New York TRACON on American 11. And at 8:43, a Command Center air traffic specialist warned Washington en route center that American 11 was a \u201cpossible hijack\u201d and would be headed towards Washington Center\u2019s airspace if it continued on a southbound track. American 11 crashed into the North Tower of the World Trade Center at 8:46:40.",
+  "source": "monograph",
+  "title": "083556 AA11 ZNY Kingston point out to Kennedy"
+ },
+ "083724": {
+  "context": "At 8:37:52, Boston Center\u2019s persistence finally paid dividends. They called the North American Aerospace Defense Command\u2019s (NORAD) Northeast Air Defense Sector (NEADS) and notified NEADS about the suspected hijacking of American 11.\u0002 Boston Center managers also tried to obtain assistance from a former alert site in Atlantic City, unaware that it had been phased out. After Boston Center\u2019s managers notified the New England Region of the events concerning American 11, they did not wait for military assistance as notification was passed up the chain of command to FAA headquarters. In an attempt to get fighter aircraft airborne to track American 11, Boston Center\u2019s managers took the initiative and called a manager at the FAA Cape Cod facility at 8:34. They asked the Cape Cod manager to contact Otis Air Force Base in Cape Cod, Massachusetts to get fighters airborne to \u201ctail\u201d the hijacked aircraft.\u0002 The United States\u2019 military defense of its homeland on 9/11 began with this call. Indeed, this was the first notification received by the military \u2013 at any level \u2013 that American had been hijacked. NEADS promptly ordered to battle stations the two F-15 alert aircraft at Otis Air Force Base, Mas",
+  "source": "monograph",
+  "title": "083724 AA11 ZBW Call to Powell and Reaction"
+ },
+ "083800": {
+  "context": "NEADS personnel spent the next minutes searching their radar scopes for the elusive primary radar track, as NEADS\u2019 Identification (ID) Technicians contacted the Military Operations Specialist (MOS) Desk (a civilian employee position at FAA Centers) at Boston Center in an effort to locate the aircraft: The scramble order was passed from the Battle Commander (BC) to the Mission Crew Commander (MCC), who passed the order to the Weapons Director (WD).\u0002 Almost immediately, however, a problem arose. The Weapons Director asked: \u201cMCC. I don\u2019t know where I\u2019m scrambling these guys to. I need a direction, a destination.\u201d\u0002 Because the hijackers had turned off the plane\u2019s transponder, the plane appeared only as a primary track on radar. F-15 fighters were ordered scrambled at 8:46 from Otis Air Force Base and vectored toward military airspace off the coast of Long Island.\u0002 As the order to scramble Otis fighters came at 8:46, American 11 was hitting the World Trade Center and United 175 was being hijacked in New York Center\u2019s airspace. The military did not hear anything about United 175 until it crashed into the South Tower of the World Trade Center. Working over the phone with the FAA Center in",
+  "source": "monograph",
+  "title": "083800 AA11 NEADS ID Techs React to Powell"
+ },
+ "083815": {
+  "context": "At 8:37:52, Boston Center\u2019s persistence finally paid dividends. They called the North American Aerospace Defense Command\u2019s (NORAD) Northeast Air Defense Sector (NEADS) and notified NEADS about the suspected hijacking of American 11.\u0002 Boston Center managers also tried to obtain assistance from a former alert site in Atlantic City, unaware that it had been phased out. The United States\u2019 military defense of its homeland on 9/11 began with this call. Indeed, this was the first notification received by the military \u2013 at any level \u2013 that American had been hijacked. NEADS promptly ordered to battle stations the two F-15 alert aircraft at Otis Air Force Base, Massachusetts, about 153 miles away from New York City.\u0002 At NEADS, the reported hijack was relayed immediately to Battle Commander Colonel Robert Marr, who was stationed in the Battle Cab in preparation for a scheduled NORAD exercise. Col. Marr asked the same question \u2013 confirming that the hijacking was \u201creal-world\u201d -- then ordered fighter pilots at Otis Air Force Base in Massachusetts to battle-stations.\u0002",
+  "source": "monograph",
+  "title": "083815 AA11 Powell Cooper Deskins"
+ },
+ "083818": {
+  "context": "At 8:37, the Kingston sector controller asked the pilots of United 175, among other flights, to look for American 11. United Airlines Flight 175, a Boeing 767 carrying 65 passengers en route from Boston\u2019s Logan Airport to Los Angeles, took off from Logan Airport at 8:14, and made contact with the Boston Air Route Traffic Control Center at 8:19.\u0002 Five minutes later, the flight was cleared to a cruising altitude of 31,000 feet.\u0002 5.1 FAA Awareness 5. UNITED 175 The controller then turned United 175 thirty degrees to the right away from American 11.\u0002 The controller explained to Commission staff that he turned United 175 and directed the flight to maintain an altitude of 31,000 feet because of the unpredictable behavior of American 11.\u0002",
+  "source": "monograph",
+  "title": "083818 UA175 Affirms AA11 at FL29 Tape 20R"
+ },
+ "083922": {
+  "context": "The United States\u2019 military defense of its homeland on 9/11 began with this call. Indeed, this was the first notification received by the military \u2013 at any level \u2013 that American had been hijacked. NEADS promptly ordered to battle stations the two F-15 alert aircraft at Otis Air Force Base, Massachusetts, about 153 miles away from New York City.\u0002 At 8:37:52, Boston Center\u2019s persistence finally paid dividends. They called the North American Aerospace Defense Command\u2019s (NORAD) Northeast Air Defense Sector (NEADS) and notified NEADS about the suspected hijacking of American 11.\u0002 At NEADS, the reported hijack was relayed immediately to Battle Commander Colonel Robert Marr, who was stationed in the Battle Cab in preparation for a scheduled NORAD exercise. Col. Marr asked the same question \u2013 confirming that the hijacking was \u201creal-world\u201d -- then ordered fighter pilots at Otis Air Force Base in Massachusetts to battle-stations.\u0002 He then phoned Maj. General Larry Arnold, commanding General of the First Air Force and CONR. Col. Marr advised him of the situation, and sought authorization to scramble the Otis fighters in response to the reported hijacking. General Arnold instructed Col. Marr \u201c",
+  "source": "monograph",
+  "title": "083922 NEAADS Weapons and MCC Battle Stations"
+ },
+ "083942": {
+  "context": "American 11.\u0002 The controller then turned United 175 thirty degrees to the right away from At 8:37, the Kingston sector controller asked the pilots of United 175, among other flights, to look for American 11. The controller explained to Commission staff that he turned United 175 and directed the flight to maintain an altitude of 31,000 feet because of the unpredictable behavior of American 11.\u0002 United 175 was then passed to the New York Air Traffic Control Center at Ronkonkoma, NY, reporting in at 8:40.\u0002 The controller acknowledged United 175, then, like the Boston Center controller, engaged US Air Flight 583 in a discussion about American 11, asking whether Boston Center had asked the pilot to locate American 11. The pilot of US Air 583 responded affirmatively and gave an estimation of 29,000 feet for the altitude of American 11. \u0002 The controller noted that \u201cit looks like they shut off their transponder that\u2019s why the question about [where it is].\u201d At this point, at approximately 8:42, the pilot of United 175 broke in with the following transmission:",
+  "source": "monograph",
+  "title": "083942 UA175 Vectored 30 Right for Traffic Tape 20R"
+ },
+ "084000": {
+  "context": "The United States\u2019 military defense of its homeland on 9/11 began with this call. Indeed, this was the first notification received by the military \u2013 at any level \u2013 that American had been hijacked. NEADS promptly ordered to battle stations the two F-15 alert aircraft at Otis Air Force Base, Massachusetts, about 153 miles away from New York City.\u0002 At NEADS, the reported hijack was relayed immediately to Battle Commander Colonel Robert Marr, who was stationed in the Battle Cab in preparation for a scheduled NORAD exercise. Col. Marr asked the same question \u2013 confirming that the hijacking was \u201creal-world\u201d -- then ordered fighter pilots at Otis Air Force Base in Massachusetts to battle-stations.\u0002 He then phoned Maj. General Larry Arnold, commanding General of the First Air Force and CONR. Col. Marr advised him of the situation, and sought authorization to scramble the Otis fighters in response to the reported hijacking. General Arnold instructed Col. Marr \u201cto go ahead and scramble the airplanes and we\u2019d get permission later. And the reason for that is that the procedure \u2026 if you follow the book, is they [law enforcement officials] go to the duty officer of the national military center, ",
+  "source": "monograph",
+  "title": "084000 AA11 Panta 45 Battle Stations Cape Tape"
+ },
+ "084131": {
+  "context": "United 175 was then passed to the New York Air Traffic Control Center at Ronkonkoma, NY, reporting in at 8:40.\u0002 The controller acknowledged United 175, then, like the Boston Center controller, engaged US Air Flight 583 in a discussion about American 11, asking whether Boston Center had asked the pilot to locate American 11. The pilot of US Air 583 responded affirmatively and gave an estimation of 29,000 feet for the altitude of American 11. \u0002 The controller noted that \u201cit looks like they shut off their transponder that\u2019s why the question about [where it is].\u201d At this point, at approximately 8:42, the pilot of United 175 broke in with the following transmission: American 11.\u0002 The controller explained to Commission staff that he turned United 175 and directed the flight to maintain an altitude of 31,000 feet because of the unpredictable behavior of The controller turned United 175 away from the aircraft (American 11) as a safety precaution. At this point, United 175 had entered New York Center\u2019s airspace and unfortunately, the controller responsible for United 175 was the same controller assigned the job of tracking the hijacked American 11. At 8:47, nearly simultaneously with the im",
+  "source": "monograph",
+  "title": "084131 AA11 UA175 ZNY Report of Suspicious Transmission Boston"
+ },
+ "084259": {
+  "context": "The scramble order was passed from the Battle Commander (BC) to the Mission Crew Commander (MCC), who passed the order to the Weapons Director (WD).\u0002 Almost immediately, however, a problem arose. The Weapons Director asked: \u201cMCC. I don\u2019t know where I\u2019m scrambling these guys to. I need a direction, a destination.\u201d\u0002 Because the hijackers had turned off the plane\u2019s transponder, the plane appeared only as a primary track on radar. He then phoned Maj. General Larry Arnold, commanding General of the First Air Force and CONR. Col. Marr advised him of the situation, and sought authorization to scramble the Otis fighters in response to the reported hijacking. General Arnold instructed Col. Marr \u201cto go ahead and scramble the airplanes and we\u2019d get permission later. And the reason for that is that the procedure \u2026 if you follow the book, is they [law enforcement officials] go to the duty officer of the national military center, who in turn makes an inquiry to NORAD for the availability of fighters, who then gets permission from someone representing the Secretary of Defense. Once that is approved then we scramble an aircraft. We didn\u2019t wait for that.\u201d\u0002 General Arnold then picked up the phone an",
+  "source": "monograph",
+  "title": "084259 NEADS SOCC Work to Scramble"
+ },
+ "084555": {
+  "context": "F-15 fighters were ordered scrambled at 8:46 from Otis Air Force Base and vectored toward military airspace off the coast of Long Island.\u0002 NEADS personnel spent the next minutes searching their radar scopes for the elusive primary radar track, as NEADS\u2019 Identification (ID) Technicians contacted the Military Operations Specialist (MOS) Desk (a civilian employee position at FAA Centers) at Boston Center in an effort to locate the aircraft: As the order to scramble Otis fighters came at 8:46, American 11 was hitting the World Trade Center and United 175 was being hijacked in New York Center\u2019s airspace. The military did not hear anything about United 175 until it crashed into the South Tower of the World Trade Center. Working over the phone with the FAA Center in Boston, at least one NEADS tracker found a primary track roughly eight miles east-northeast of Manhattan, but the track faded before he could confirm it with Boston Center.\u0002 Unbeknownst to the military, the Otis fighters were scrambled nearly the exact time that American 11 crashed into the North Tower. Radar data show the Otis fighters were airborne at 8:53. \u0002 The Mission Crew Commander explained to the Battle Cab the plan:",
+  "source": "monograph",
+  "title": "084555 NEADS Powell Otis Scramble"
+ },
+ "084629": {
+  "context": "The Mission Crew Commander explained to the Battle Cab the plan: Working over the phone with the FAA Center in Boston, at least one NEADS tracker found a primary track roughly eight miles east-northeast of Manhattan, but the track faded before he could confirm it with Boston Center.\u0002 Unbeknownst to the military, the Otis fighters were scrambled nearly the exact time that American 11 crashed into the North Tower. Radar data show the Otis fighters were airborne at 8:53. \u0002 As the order to scramble Otis fighters came at 8:46, American 11 was hitting the World Trade Center and United 175 was being hijacked in New York Center\u2019s airspace. The military did not hear anything about United 175 until it crashed into the South Tower of the World Trade Center. Shortly after 8:50, while NEADS personnel struggled to locate American 11, word reached the floor that a plane had hit the World Trade Center.\u0002 \b The initial reaction of the Mission Crew Commander was to send the fighters directly to New York in response to the news of the crash. Upon being advised, however, that the quickest route would be to bring the fighters out away from the New York area traffic, the decision was made to bring the fi",
+  "source": "monograph",
+  "title": "084629 NEADS MCC Summary for BC 25 Miles Z Point"
+ },
+ "084739": {
+  "context": "American 11 crashed into the North Tower of the World Trade Center at 8:46:40. Information about what was going on within American 11 started to get conveyed within the ATC system. At 8:40, Boston Center, through the Command Center, provided a report to New York TRACON on American 11. And at 8:43, a Command Center air traffic specialist warned Washington en route center that American 11 was a \u201cpossible hijack\u201d and would be headed towards Washington Center\u2019s airspace if it continued on a southbound track. 4.2 Military Notification and Response After Boston Center\u2019s managers notified the New England Region of the events concerning American 11, they did not wait for military assistance as notification was passed up the chain of command to FAA headquarters. In an attempt to get fighter aircraft airborne to track American 11, Boston Center\u2019s managers took the initiative and called a manager at the FAA Cape Cod facility at 8:34. They asked the Cape Cod manager to contact Otis Air Force Base in Cape Cod, Massachusetts to get fighters airborne to \u201ctail\u201d the hijacked aircraft.\u0002",
+  "source": "monograph",
+  "title": "084739 AA11 Discussion To First Impact Line 5114"
+ },
+ "085017": {
+  "context": "American 11 crashed into the North Tower of the World Trade Center at 8:46:40. Information about what was going on within American 11 started to get conveyed within the ATC system. At 8:40, Boston Center, through the Command Center, provided a report to New York TRACON on American 11. And at 8:43, a Command Center air traffic specialist warned Washington en route center that American 11 was a \u201cpossible hijack\u201d and would be headed towards Washington Center\u2019s airspace if it continued on a southbound track. 4.2 Military Notification and Response After Boston Center\u2019s managers notified the New England Region of the events concerning American 11, they did not wait for military assistance as notification was passed up the chain of command to FAA headquarters. In an attempt to get fighter aircraft airborne to track American 11, Boston Center\u2019s managers took the initiative and called a manager at the FAA Cape Cod facility at 8:34. They asked the Cape Cod manager to contact Otis Air Force Base in Cape Cod, Massachusetts to get fighters airborne to \u201ctail\u201d the hijacked aircraft.\u0002 Boston Center managers also tried to obtain assistance from a former alert site in Atlantic City, unaware that it ",
+  "source": "monograph",
+  "title": "085017 AA11 ZNY Major Fire WTC"
+ },
+ "085146": {
+  "context": "Delta Airlines Flight 1489 radioed in at 8:50 and advised the same controller there was \u201ca lot of smoke in lower Manhattan\u201d and the World Trade Center looked like it was on fire. \u0002 The controller acknowledged the message at 8:51, and agreed to pass on any news, then noticed a change in the transponder reading from United 175. The controller asked United 175 to recycle its transponder to the proper code.\u0002 There was no response. The controller turned United 175 away from the aircraft (American 11) as a safety precaution. At this point, United 175 had entered New York Center\u2019s airspace and unfortunately, the controller responsible for United 175 was the same controller assigned the job of tracking the hijacked American 11. At 8:47, nearly simultaneously with the impact of American 11 into the World Trade Center, United 175\u2019s assigned transponder code changed from 1470 to 3020, and then again to 3321.\u0002 These changes were not noticed, however, for several minutes, as the controller was focused on trying to determine the location of American 11, which had disappeared as a primary radar track. Indeed, New York Center was completely focused on the situation with American 11, as indicated i",
+  "source": "monograph",
+  "title": "085146 UA175 ZNY Recycle Transponder"
+ },
+ "085207": {
+  "context": "Shortly after 8:50, while NEADS personnel struggled to locate American 11, word reached the floor that a plane had hit the World Trade Center.\u0002 The Mission Crew Commander explained to the Battle Cab the plan: Working over the phone with the FAA Center in Boston, at least one NEADS tracker found a primary track roughly eight miles east-northeast of Manhattan, but the track faded before he could confirm it with Boston Center.\u0002 Unbeknownst to the military, the Otis fighters were scrambled nearly the exact time that American 11 crashed into the North Tower. Radar data show the Otis fighters were airborne at 8:53. \u0002 \b The initial reaction of the Mission Crew Commander was to send the fighters directly to New York in response to the news of the crash. Upon being advised, however, that the quickest route would be to bring the fighters out away from the New York area traffic, the decision was made to bring the fighters down to military air space and to \u201chold as needed.\u201d\u0002 4.3 Commission Findings and Assessment The interplay at the operational levels of the FAA and NORAD regarding American 11 is notable in several respects. First, and most important, Boston Center and NEADS took immediate ac",
+  "source": "monograph",
+  "title": "085207 NEADS Learns of WTC Continues Scramble"
+ },
+ "085323": {
+  "context": "At 8:53, after several unsuccessful attempts to reach United 175, the controller contacted another peer to discuss the situation. At 8:52, the controller made repeated attempts to reach the crew of United 175. Still, there was no response.\u0002 Delta Airlines Flight 1489 radioed in at 8:50 and advised the same controller there was \u201ca lot of smoke in lower Manhattan\u201d and the World Trade Center looked like it was on fire. \u0002 The controller acknowledged the message at 8:51, and agreed to pass on any news, then noticed a change in the transponder reading from United 175. The controller asked United 175 to recycle its transponder to the proper code.\u0002 There was no response. The controller explained to Commission staff that he became alarmed when he saw a change of altitude along with the change in the transponder frequency; prior to the change in altitude, he assumed that the change in transponder frequency was human or mechanical error.\u0002 US Air Flight 583 then radioed in and said he was getting \u201creports over the radio of a commuter plane hitting the World Trade Center\u201d.\u0002 The controller spent the next several minutes handing off the other flights on his scope to other controllers and moving a",
+  "source": "monograph",
+  "title": "085323 UA175 ZNY Report to Supe and Code 3321"
+ },
+ "085340": {
+  "context": "\b The initial reaction of the Mission Crew Commander was to send the fighters directly to New York in response to the news of the crash. Upon being advised, however, that the quickest route would be to bring the fighters out away from the New York area traffic, the decision was made to bring the fighters down to military air space and to \u201chold as needed.\u201d\u0002 Shortly after 8:50, while NEADS personnel struggled to locate American 11, word reached the floor that a plane had hit the World Trade Center.\u0002 4.3 Commission Findings and Assessment The interplay at the operational levels of the FAA and NORAD regarding American 11 is notable in several respects. First, and most important, Boston Center and NEADS took immediate actions to facilitate a quicker response than a strict following of the official protocols would have allowed for. Boston Center elected to request assistance directly from the Northeast Air Defense Sector. When the request reached NEADS, the Battle Commander and the CONR Commander, rather than seeking authorization to scramble aircraft through the chain of command and, ultimately, the Secretary of Defense, chose to authorize the action on their own and, as General Arnold ",
+  "source": "monograph",
+  "title": "085340 Panta Hold and work with FAA DRM 1 CH 2"
+ },
+ "085408": {
+  "context": "The controller explained to Commission staff that he became alarmed when he saw a change of altitude along with the change in the transponder frequency; prior to the change in altitude, he assumed that the change in transponder frequency was human or mechanical error.\u0002 US Air Flight 583 then radioed in and said he was getting \u201creports over the radio of a commuter plane hitting the World Trade Center\u201d.\u0002 The controller spent the next several minutes handing off the other flights on his scope to other controllers and moving aircraft out of the way of the unidentified aircraft (believed to be United 175) as it moved southwest and then turned northeast toward New York City.\u0002 At 8:53, after several unsuccessful attempts to reach United 175, the controller contacted another peer to discuss the situation. At approximately 8:55, the controller-in-charge notified the Operations Manager that she believed United 175 had also been hijacked.\u0002 During interviews with Commission staff, the Air Traffic Manager (ATM) for New York Center said he made more than one attempt to notify the FAA Eastern Region Offices that United 175 may be a hijacked aircraft but was told by a staffer there that the manage",
+  "source": "monograph",
+  "title": "085408 UA175 ZNY Controller works UA175 annd AA 11 issue"
+ },
+ "085634": {
+  "context": "The controller tracking American 77 told the Commission he first noticed the aircraft turning to the southwest, and then saw the data disappear. The controller looked for primary radar returns. He searched along its projected flight path and the airspace to the southwest where it had started to turn. No primary targets appeared. He tried the radios, first calling the aircraft directly, then the airline. Again there was nothing. At this point, the Indianapolis controller had no knowledge of the situation in New York. He did not know that other aircraft had been hijacked. He believed American 77 had experienced serious electrical and/or mechanical failure, and was gone. At 8:54, the flight began a left turn towards the south without authorization. Shortly after it began the turn, the aircraft was observed descending.\u0002 At 8:56, as the plane continued to deviate slightly to the south from its flight plan, it was lost from radar completely; the transponder signal was gone, and the plane also disappeared as a primary radar target.\u0002 In addition, the controller reached out to controllers in other sectors at Indianapolis Center to advise them of the situation.\u0002 The controllers agreed to \u201cst",
+  "source": "monograph",
+  "title": "085634 AA77 ZID Attempts to contact"
+ },
+ "085751": {
+  "context": "At approximately 8:55, the controller-in-charge notified the Operations Manager that she believed United 175 had also been hijacked.\u0002 During interviews with Commission staff, the Air Traffic Manager (ATM) for New York Center said he made more than one attempt to notify the FAA Eastern Region Offices that United 175 may be a hijacked aircraft but was told by a staffer there that the managers were discussing a hijacked aircraft (presumably American 11) and refused to be disturbed.\u0002 At 8:58, the New York Center controller searching for United 175 told another New York controller \u201cwe might have a hijack over here, two of them.\u201d\u0002 The controller explained to Commission staff that he became alarmed when he saw a change of altitude along with the change in the transponder frequency; prior to the change in altitude, he assumed that the change in transponder frequency was human or mechanical error.\u0002 US Air Flight 583 then radioed in and said he was getting \u201creports over the radio of a commuter plane hitting the World Trade Center\u201d.\u0002 The controller spent the next several minutes handing off the other flights on his scope to other controllers and moving aircraft out of the way of the unidentif",
+  "source": "monograph",
+  "title": "085751 UA175 ZNY ID as UA175 complex traffic"
+ },
+ "085850": {
+  "context": "The controller tracking American 77 told the Commission he first noticed the aircraft turning to the southwest, and then saw the data disappear. The controller looked for primary radar returns. He searched along its projected flight path and the airspace to the southwest where it had started to turn. No primary targets appeared. He tried the radios, first calling the aircraft directly, then the airline. Again there was nothing. At this point, the Indianapolis controller had no knowledge of the situation in New York. He did not know that other aircraft had been hijacked. He believed American 77 had experienced serious electrical and/or mechanical failure, and was gone. At 8:54, the flight began a left turn towards the south without authorization. Shortly after it began the turn, the aircraft was observed descending.\u0002 At 8:56, as the plane continued to deviate slightly to the south from its flight plan, it was lost from radar completely; the transponder signal was gone, and the plane also disappeared as a primary radar target.\u0002 In addition, the controller reached out to controllers in other sectors at Indianapolis Center to advise them of the situation.\u0002 The controllers agreed to \u201cst",
+  "source": "monograph",
+  "title": "085850 AA77 1st Contact AA Dispatchl"
+ },
+ "090021": {
+  "context": "While the Command Center was told about this \u201cother aircraft\u201d at 9:01, New York Center contacted New York terminal approach control and asked for help in locating United 175. The other situation New York Center referred to was United 175. The evidence suggests this conversation was the only notice received prior to the second crash by either FAA HQ or Command Center that there was a second hijack. Between 9:01 and 9:02, a manager from New York Center told the FAA Command Center, in Herndon, VA: The controllers observed the plane in a rapid descent; the radar data terminated over lower Manhattan.\u0002 At 9:03:02, United 175 crashed into World Trade Center\u2019s South Tower.\u0002 As United 175 was about to strike the South Tower, in a conversation monitored by FAA Command Center, a manager from Boston Center confirmed what was said by the hijackers on board American 11 during the first radio transmission:",
+  "source": "monograph",
+  "title": "090021 Hey Joe ZNY TRACON x1085 TMU"
+ },
+ "090113": {
+  "context": "Between 9:01 and 9:02, a manager from New York Center told the FAA Command Center, in Herndon, VA: At approximately 8:55, the controller-in-charge notified the Operations Manager that she believed United 175 had also been hijacked.\u0002 During interviews with Commission staff, the Air Traffic Manager (ATM) for New York Center said he made more than one attempt to notify the FAA Eastern Region Offices that United 175 may be a hijacked aircraft but was told by a staffer there that the managers were discussing a hijacked aircraft (presumably American 11) and refused to be disturbed.\u0002 At 8:58, the New York Center controller searching for United 175 told another New York controller \u201cwe might have a hijack over here, two of them.\u201d\u0002 The other situation New York Center referred to was United 175. The evidence suggests this conversation was the only notice received prior to the second crash by either FAA HQ or Command Center that there was a second hijack. While the Command Center was told about this \u201cother aircraft\u201d at 9:01, New York Center contacted New York terminal approach control and asked for help in locating United 175. The controllers observed the plane in a rapid descent; the radar da",
+  "source": "monograph",
+  "title": "090113 Mulligan Bell Escalating Big Time"
+ },
+ "090234": {
+  "context": "As United 175 was about to strike the South Tower, in a conversation monitored by FAA Command Center, a manager from Boston Center confirmed what was said by the hijackers on board American 11 during the first radio transmission: The controllers observed the plane in a rapid descent; the radar data terminated over lower Manhattan.\u0002 At 9:03:02, United 175 crashed into World Trade Center\u2019s South Tower.\u0002 After the impact into the South Tower, Boston Center updated the FAA\u2019s New England Region: Boston Center immediately advised the New England Region that it was going to stop all aircraft scheduled to depart from any airport within Boston Center.\u0002",
+  "source": "monograph",
+  "title": "090234 AA11 Jones thought some planes as in plural Line 5114"
+ },
+ "090247": {
+  "context": "The controllers observed the plane in a rapid descent; the radar data terminated over lower Manhattan.\u0002 At 9:03:02, United 175 crashed into World Trade Center\u2019s South Tower.\u0002 While the Command Center was told about this \u201cother aircraft\u201d at 9:01, New York Center contacted New York terminal approach control and asked for help in locating United 175. The other situation New York Center referred to was United 175. The evidence suggests this conversation was the only notice received prior to the second crash by either FAA HQ or Command Center that there was a second hijack. As United 175 was about to strike the South Tower, in a conversation monitored by FAA Command Center, a manager from Boston Center confirmed what was said by the hijackers on board American 11 during the first radio transmission: After the impact into the South Tower, Boston Center updated the FAA\u2019s New England Region:",
+  "source": "monograph",
+  "title": "090247 UA175 Visual Report Into Tower TRACON TMUDD"
+ },
+ "090248": {
+  "context": "After several minutes of searching, Indianapolis controllers once again contacted the airline: In addition, the controller reached out to controllers in other sectors at Indianapolis Center to advise them of the situation.\u0002 The controllers agreed to \u201csterilize the air space\u201d along the flight\u2019s projected westerly route so that other planes would not be affected by American 77.\u0002 At 8:59, Indianapolis Center began to work with controllers in other centers to protect the airspace of American 77\u2019s projected flight path to the west.\u0002 At 9:08, the Indianapolis Center\u2019s Operations Manager requested the Traffic Management Unit to notify Air Force Search and Rescue in Langley, Virginia, of a possible crash of American 77.\u0002 The Operations Manager also contacted the West Virginia State Police to advise them of the missing aircraft and ask whether they had any reports of a downed aircraft.\u0002 At 9:09, Indianapolis Center reported to the Great Lakes Regional Operations Center a possible aircraft accident involving American 77 because of the simultaneous loss of radio communications and all radar contact.\u0002 The Great Lakes Regional Operations Center passed this information along to FAA Headquarters ",
+  "source": "monograph",
+  "title": "090248 AA77 ZID 2d contact AA Dispatch"
+ },
+ "090322": {
+  "context": "After the impact into the South Tower, Boston Center updated the FAA\u2019s New England Region: As United 175 was about to strike the South Tower, in a conversation monitored by FAA Command Center, a manager from Boston Center confirmed what was said by the hijackers on board American 11 during the first radio transmission: Boston Center immediately advised the New England Region that it was going to stop all aircraft scheduled to depart from any airport within Boston Center.\u0002 At 9:05, Boston Center confirmed for both FAA Command Center and New England Region that the hijackers aboard American 11 said \u201cwe have planes.\u201d\u0002",
+  "source": "monograph",
+  "title": "090322 AA11 Nother One Just Hit Line 5114"
+ },
+ "090423": {
+  "context": "The controllers observed the plane in a rapid descent; the radar data terminated over lower Manhattan.\u0002 At 9:03:02, United 175 crashed into World Trade Center\u2019s South Tower.\u0002 While the Command Center was told about this \u201cother aircraft\u201d at 9:01, New York Center contacted New York terminal approach control and asked for help in locating United 175. As United 175 was about to strike the South Tower, in a conversation monitored by FAA Command Center, a manager from Boston Center confirmed what was said by the hijackers on board American 11 during the first radio transmission: After the impact into the South Tower, Boston Center updated the FAA\u2019s New England Region:",
+  "source": "monograph",
+  "title": "090423 UA175 ZNY 2d aircraft into WTC"
+ },
+ "090608": {
+  "context": "At 9:05, Boston Center confirmed for both FAA Command Center and New England Region that the hijackers aboard American 11 said \u201cwe have planes.\u201d\u0002 Boston Center immediately advised the New England Region that it was going to stop all aircraft scheduled to depart from any airport within Boston Center.\u0002 At exactly the same time that the \u201cwe have planes\u201d was confirmed, both Boston Center and New York Center closed down their airspace.\u0002 The result of this action was that aircraft were not permitted to depart from, arrive at, or travel through those Centers\u2019 airspace until further notice.\u0002 After the second WTC crash, the Boston Center Operations Manager feared there may be additional attacks. He asked a New England Regional security representative if warnings could be sent to airborne aircraft by the airlines via a text messaging system (ACARS).",
+  "source": "monograph",
+  "title": "090608 AA11 Confirmed on Tape We Have Planes Line 5114"
+ },
+ "090713": {
+  "context": "After the second WTC crash, the Boston Center Operations Manager feared there may be additional attacks. He asked a New England Regional security representative if warnings could be sent to airborne aircraft by the airlines via a text messaging system (ACARS). At exactly the same time that the \u201cwe have planes\u201d was confirmed, both Boston Center and New York Center closed down their airspace.\u0002 The result of this action was that aircraft were not permitted to depart from, arrive at, or travel through those Centers\u2019 airspace until further notice.\u0002 Within minutes of the second impact at the World Trade Center, Boston Center\u2019s Operations Manager instructed all air traffic controllers in his center to use the radio frequencies to inform all aircraft in Boston Center of the events unfolding in New York and to advise the aircraft to heighten cockpit security in light of those events.\u0002 Her are several examples of the cautionary radio transmissions sent by ZBW to other aircraft: At approximately 9:15, another Boston Center Manager asks Command Center to relay the message to all FAA centers in the country to use heightened cockpit security:",
+  "source": "monograph",
+  "title": "090713 ATCSCC ACARS Increase Security Internationals Line 5114"
+ },
+ "090727": {
+  "context": "The Mission Crew Commander\u2019s reaction to the second explosion at the World Trade Center was to reject the idea of holding the fighters in military air space away from Manhattan. The ID Technicians were on the phone with Boston Center seeking further information on United 175 when they found out that the plane may have crashed.\u0002 Before retrieving the flight\u2019s vital statistics for NEADS, Boston Center confirmed the second crash at the Trade Center.\u0002 There had been no prior notification that the plane was hijacked, or, for that matter, missing.\u0002 The fighters from Otis Air Force Base were south of Long Island at the time.\u0002 The first indication that the NEADS air defenders had of the second hijacked aircraft, United 175, came in a phone call from New York Center at 9:03. The FAA cleared the air space. Radar data show that at 9:13, when the Otis fighters were about 115 miles away from the city, the fighters exited their holding pattern and set a course direct for Manhattan. They arrived at 9:25 and established a combat air patrol (CAP) over the city.\u0002 Because the Otis fighters had expended a great deal of fuel in flying first to military air space and then to New York, the battle command",
+  "source": "monograph",
+  "title": "090727 Panta Over Manhattan Some Kind of Play DRM 1 CH 2"
+ },
+ "090830": {
+  "context": "Because the Otis fighters had expended a great deal of fuel in flying first to military air space and then to New York, the battle commanders were concerned about refueling. As NEADS personnel looked for refueling tankers in the vicinity of New York, the Mission Crew Commander considered scrambling the Langley fighters to New York to provide back-up for the Otis fighters until the NEADS Battle Cab ordered \u201c[b]attle stations only at Langley.\u201d\u0002 The FAA cleared the air space. Radar data show that at 9:13, when the Otis fighters were about 115 miles away from the city, the fighters exited their holding pattern and set a course direct for Manhattan. They arrived at 9:25 and established a combat air patrol (CAP) over the city.\u0002 The alert fighters at Langley Air Force Base were ordered to battle stations at 9:09. Col. Marr, the battle commander at NEADS, and General Arnold, the CONR Commander, both recall that the planes were held on battle stations, as opposed to scrambling, because they might be called upon to relieve the Otis fighters over New York City if a refueling tanker was not located, and also because of the general uncertainty of the situation in the sky.\u0002 According to retired ",
+  "source": "monograph",
+  "title": "090830 Langley Battle Stations not Scramble D1 CH 5"
+ },
+ "090925": {
+  "context": "The alert fighters at Langley Air Force Base were ordered to battle stations at 9:09. Because the Otis fighters had expended a great deal of fuel in flying first to military air space and then to New York, the battle commanders were concerned about refueling. As NEADS personnel looked for refueling tankers in the vicinity of New York, the Mission Crew Commander considered scrambling the Langley fighters to New York to provide back-up for the Otis fighters until the NEADS Battle Cab ordered \u201c[b]attle stations only at Langley.\u201d\u0002 The FAA cleared the air space. Radar data show that at 9:13, when the Otis fighters were about 115 miles away from the city, the fighters exited their holding pattern and set a course direct for Manhattan. They arrived at 9:25 and established a combat air patrol (CAP) over the city.\u0002 Col. Marr, the battle commander at NEADS, and General Arnold, the CONR Commander, both recall that the planes were held on battle stations, as opposed to scrambling, because they might be called upon to relieve the Otis fighters over New York City if a refueling tanker was not located, and also because of the general uncertainty of the situation in the sky.\u0002 According to retired ",
+  "source": "monograph",
+  "title": "090925 Langley BS Norfolk Tower"
+ },
+ "090933": {
+  "context": "Within minutes of the second impact at the World Trade Center, Boston Center\u2019s Operations Manager instructed all air traffic controllers in his center to use the radio frequencies to inform all aircraft in Boston Center of the events unfolding in New York and to advise the aircraft to heighten cockpit security in light of those events.\u0002 Her are several examples of the cautionary radio transmissions sent by ZBW to other aircraft: After the second WTC crash, the Boston Center Operations Manager feared there may be additional attacks. He asked a New England Regional security representative if warnings could be sent to airborne aircraft by the airlines via a text messaging system (ACARS). At approximately 9:15, another Boston Center Manager asks Command Center to relay the message to all FAA centers in the country to use heightened cockpit security: Commission staff has found no evidence to suggest that Command Center mangers acted on Boston\u2019s request to issue a nationwide alert to aircraft. One Command Center manager interviewed told Commission staff that the FAA mindset on 9/11 was such that they would never have relayed this message directly to all pilots. She said the FAA would pas",
+  "source": "monograph",
+  "title": "090933 Cockpit Security L2431 and ZBW 31R Tape"
+ },
+ "091042": {
+  "context": "Within minutes of the second impact at the World Trade Center, Boston Center\u2019s Operations Manager instructed all air traffic controllers in his center to use the radio frequencies to inform all aircraft in Boston Center of the events unfolding in New York and to advise the aircraft to heighten cockpit security in light of those events.\u0002 Her are several examples of the cautionary radio transmissions sent by ZBW to other aircraft: After the second WTC crash, the Boston Center Operations Manager feared there may be additional attacks. He asked a New England Regional security representative if warnings could be sent to airborne aircraft by the airlines via a text messaging system (ACARS). At approximately 9:15, another Boston Center Manager asks Command Center to relay the message to all FAA centers in the country to use heightened cockpit security: Commission staff has found no evidence to suggest that Command Center mangers acted on Boston\u2019s request to issue a nationwide alert to aircraft. One Command Center manager interviewed told Commission staff that the FAA mindset on 9/11 was such that they would never have relayed this message directly to all pilots. She said the FAA would pas",
+  "source": "monograph",
+  "title": "091042 Cockpit Security ZBW Advises 3 more planes 31R Tape"
+ },
+ "091154": {
+  "context": "After several minutes of searching, Indianapolis controllers once again contacted the airline: In addition, the controller reached out to controllers in other sectors at Indianapolis Center to advise them of the situation.\u0002 The controllers agreed to \u201csterilize the air space\u201d along the flight\u2019s projected westerly route so that other planes would not be affected by American 77.\u0002 At 8:59, Indianapolis Center began to work with controllers in other centers to protect the airspace of American 77\u2019s projected flight path to the west.\u0002 At 9:08, the Indianapolis Center\u2019s Operations Manager requested the Traffic Management Unit to notify Air Force Search and Rescue in Langley, Virginia, of a possible crash of American 77.\u0002 The Operations Manager also contacted the West Virginia State Police to advise them of the missing aircraft and ask whether they had any reports of a downed aircraft.\u0002 At 9:09, Indianapolis Center reported to the Great Lakes Regional Operations Center a possible aircraft accident involving American 77 because of the simultaneous loss of radio communications and all radar contact.\u0002 The Great Lakes Regional Operations Center passed this information along to FAA Headquarters ",
+  "source": "monograph",
+  "title": "091154 AA77 ZID 3d Contact AA Dispatch 2d WTC Impact"
+ },
+ "091626": {
+  "context": "While Indianapolis Center was busy looking for American 77 to the west, some American Airlines\u2019 representatives believed that American 77 might have hit the World Trade Center. In an ensuing conversation with the FAA Command Center about the status of American 11, an American Airlines representative mentioned that American 77 was lost.\u0002 6.2 Confusion Concerning the Fate of American 77 In sum, Indianapolis Center never saw American 77 turn around. By the time it reappeared in primary radar coverage, controllers had either stopped looking for the aircraft because they thought it had crashed or were looking toward the west. In addition, while the Command Center learned American 77 was missing, neither it nor FAA headquarters issued an \u201call points bulletin\u201d to surrounding centers to search for primary radar targets. American 77 traveled undetected for 36 minutes on a course heading due east for Washington, DC.\u0002 American Airlines\u2019 notification to the FAA Command Center that American 77 was lost prompted Command Center representatives to call Indianapolis Center and seek further information on the aircraft: That conversation led Command Center to notify some FAA field facilities that Ame",
+  "source": "monograph",
+  "title": "091626 AA11 AA77 ATCSCC King with Halleck AAL Pos 34B Line 5149"
+ },
+ "091836": {
+  "context": "American Airlines\u2019 notification to the FAA Command Center that American 77 was lost prompted Command Center representatives to call Indianapolis Center and seek further information on the aircraft: While Indianapolis Center was busy looking for American 77 to the west, some American Airlines\u2019 representatives believed that American 77 might have hit the World Trade Center. In an ensuing conversation with the FAA Command Center about the status of American 11, an American Airlines representative mentioned that American 77 was lost.\u0002 That conversation led Command Center to notify some FAA field facilities that American 77 was lost and could not be located on radar. By no later than 9:21, FAA\u2019s Command Center in Herndon, some FAA field facilities and American Airlines had started to search for American 77 and feared it had been hijacked. Four minutes later, at 9:25, Command Center reported to FAA Headquarters all the information Command Center had learned regarding American 77.\u0002 As previously stated, American 77 disappeared from radar at 8:56. By no later than 9:18, FAA centers in Indianapolis, Cleveland, and Washington were aware that American 77 was missing and two aircraft had struc",
+  "source": "monograph",
+  "title": "091836 AA77 Summersall to ZID from ATCSCC ZID TMU"
+ },
+ "092100": {
+  "context": "At 9:21, the military officer at Boston Center, who had been listening in on a FAA teleconference run by FAA HQ in Washington, called the NEADS ID Technician Unit: By no later than 9:21, FAA\u2019s Command Center in Herndon, some FAA field facilities and American Airlines had started to search for American 77 and feared it had been hijacked. Four minutes later, at 9:25, Command Center reported to FAA Headquarters all the information Command Center had learned regarding American 77.\u0002 The military was completely unaware the search for American 77 had begun. In fact, the military would hear once again about American 11, a plane that had already crashed, before they received any notification that American 77 was lost. The mention of a \u201cthird aircraft\u201d was not a reference to American 77. The report that American 11 was still airborne and heading toward Washington DC was relayed immediately from the Mission Crew Commander to the Battle Cab. After consulting with the Battle Commander, the MCC issued the order, at 9:23, to scramble the Langley fighters in response to American 11. The scramble order was processed and transmitted to Langley Air Force Base at 9:24. Shortly thereafter, NEADS comman",
+  "source": "monograph",
+  "title": "092100 AA11 Scoggins Still Airborne"
+ },
+ "092140": {
+  "context": "The mention of a \u201cthird aircraft\u201d was not a reference to American 77. The report that American 11 was still airborne and heading toward Washington DC was relayed immediately from the Mission Crew Commander to the Battle Cab. After consulting with the Battle Commander, the MCC issued the order, at 9:23, to scramble the Langley fighters in response to American 11. At 9:21, the military officer at Boston Center, who had been listening in on a FAA teleconference run by FAA HQ in Washington, called the NEADS ID Technician Unit: By no later than 9:21, FAA\u2019s Command Center in Herndon, some FAA field facilities and American Airlines had started to search for American 77 and feared it had been hijacked. Four minutes later, at 9:25, Command Center reported to FAA Headquarters all the information Command Center had learned regarding American 77.\u0002 The military was completely unaware the search for American 77 had begun. In fact, the military would hear once again about American 11, a plane that had already crashed, before they received any notification that American 77 was lost. The scramble order was processed and transmitted to Langley Air Force Base at 9:24. Shortly thereafter, NEADS comman",
+  "source": "monograph",
+  "title": "092140 AA11 Still Airborne Scramble Langley Tail Chase DRM1 CH2"
+ },
+ "092427": {
+  "context": "The scramble order was processed and transmitted to Langley Air Force Base at 9:24. Shortly thereafter, NEADS commanders cancelled the \u201ctail chase\u201d using the Otis fighters since pursuing the plane from behind would leave New York airspace unprotected. Instead, the heading of the Langley fighters would be adjusted to send them to the Baltimore area. When interviewed by Commission staff, the Mission Crew Commander explained that the purpose of this change in strategy was to continue to protect New York air space, and to vector the fighters from Langley to come between the southbound aircraft and the nation\u2019s capital.\u0002 Radar data show the Langley fighters airborne at 9:30. The mention of a \u201cthird aircraft\u201d was not a reference to American 77. The report that American 11 was still airborne and heading toward Washington DC was relayed immediately from the Mission Crew Commander to the Battle Cab. After consulting with the Battle Commander, the MCC issued the order, at 9:23, to scramble the Langley fighters in response to American 11. Based on the mistaken report that American 11 was heading towards Washington DC, NEADS personnel were actively seeking more information to assist in their s",
+  "source": "monograph",
+  "title": "092427 NEADS BC Update Forget Tail Chase DRM! CH2"
+ },
+ "092556": {
+  "context": "United 93 again radioed Cleveland Center at 9:25, checking in at 35,000 feet. The controller replied, \u201cUnited ninety-three, Cleveland, roger.\u201d\u0002 The controller then engaged in conversation with several aircraft about the evolving situation in New York City and the prospects for flights to be allowed to land in Philadelphia; while the controller was extremely discreet, it was clear what he was talking about. The time was 9:26. United Airlines Flight 93 began its takeoff roll from Newark International Airport at 8:42, some forty minutes late, and checked in with air traffic control at 8:43: \u201cUnited 93 fourteen hundred [feet] for twenty-five hundred.\u201d\u0002 All communications with Newark Tower, New York Tracon, and New York Air Route Traffic Center were normal; after reporting experiencing some \u201clight chop\u201d at 35,000 feet, the flight was handed off to Cleveland Center at 9:23.\u0002 Several seconds later, United 93 established radio contact with Cleveland Air Route Traffic Control Center: \u201cMorning Cleveland, United Ninety-three with you at, three-five-oh (35,000 feet), intermittent light chop.\u0002 The controller did not respond to this initial transmission as he had sixteen flights under his contro",
+  "source": "monograph",
+  "title": "092556 Midex 150 Philiadelphia"
+ },
+ "092847": {
+  "context": "Based on the mistaken report that American 11 was heading towards Washington DC, NEADS personnel were actively seeking more information to assist in their search for the aircraft: The scramble order was processed and transmitted to Langley Air Force Base at 9:24. Shortly thereafter, NEADS commanders cancelled the \u201ctail chase\u201d using the Otis fighters since pursuing the plane from behind would leave New York airspace unprotected. Instead, the heading of the Langley fighters would be adjusted to send them to the Baltimore area. When interviewed by Commission staff, the Mission Crew Commander explained that the purpose of this change in strategy was to continue to protect New York air space, and to vector the fighters from Langley to come between the southbound aircraft and the nation\u2019s capital.\u0002 Radar data show the Langley fighters airborne at 9:30. The military\u2019s situational awareness was summarized on the NEADS floor at 9:27, immediately after the Langley scramble, as follows: \u201cThree planes unaccounted for. American Airlines 11 may still be airborne but the flight that \u2013 United 175 to the World Trade Center. We\u2019re not sure who the other one is.\u201d\u0002 On the floor at NEADS, the ID Techni",
+  "source": "monograph",
+  "title": "092847 AA11 ID Summary call to Unknown"
+ },
+ "093100": {
+  "context": "Third, both the lead Langley pilot and the FAA\u2019s Norfolk TRACON facility \u2013 which was briefly controlling the aircraft once it departed the Langley AFB airspace \u2013 assumed the flight plan instruction to go \u201c090 for 60\u201d was newer guidance that superceded the original scramble order instructions. In fact, shortly after the fighters got airborne, the lead Langley pilot was asked by Norfolk TRACON in what direction he wanted to head After brief discussion between the lead pilot (identified as \u201cQuit 25\u201d) and Norfolk TRACON, it was mutually decided that the fighters would follow the flight plan guidance. Second, a \u201cgeneric\u201d flight plan assigned to the Langley fighters incorrectly led them to believe that they were being ordered to fly due east (090) for 60 miles. In order to launch aircraft, the Langley AFB Tower was required to file an automated flight plan specifically designating the direction and distance of intended flight. Prior to 9/11, the standard \u2013 or generic \u2013 flight plan for aircraft departing Langley AFB to the east was \u201c090 for 60\u201d \u2013 meaning head 90 degrees (due east) for 60 miles. The generic \u201c090 for 60\u201d flight plan was utilized to expeditiously get aircraft airborne and ou",
+  "source": "monograph",
+  "title": "093100 Langley What Heading would like hand off Giant Killer"
+ },
+ "093151": {
+  "context": "While Indianapolis Center was busy looking for American 77 to the west, some American Airlines\u2019 representatives believed that American 77 might have hit the World Trade Center. In an ensuing conversation with the FAA Command Center about the status of American 11, an American Airlines representative mentioned that American 77 was lost.\u0002 6.2 Confusion Concerning the Fate of American 77 In sum, Indianapolis Center never saw American 77 turn around. By the time it reappeared in primary radar coverage, controllers had either stopped looking for the aircraft because they thought it had crashed or were looking toward the west. In addition, while the Command Center learned American 77 was missing, neither it nor FAA headquarters issued an \u201call points bulletin\u201d to surrounding centers to search for primary radar targets. American 77 traveled undetected for 36 minutes on a course heading due east for Washington, DC.\u0002 American Airlines\u2019 notification to the FAA Command Center that American 77 was lost prompted Command Center representatives to call Indianapolis Center and seek further information on the aircraft: That conversation led Command Center to notify some FAA field facilities that Ame",
+  "source": "monograph",
+  "title": "093151 FAA TACNET Wrong Recap Line 5114"
+ },
+ "093212": {
+  "context": "On the floor at NEADS, the ID Technicians continued to attempt to locate American 11 after the Langley fighters were airborne. At the suggestion of the Boston Center Military Officer, the ID Technicians contacted Washington Center to ask whether they had located American 11. In that conversation, NEADS was told that Washington Center knew nothing about American 11 heading south. The NEADS ID Technicians then spoke with the Operations Manager at Washington Center: The military\u2019s situational awareness was summarized on the NEADS floor at 9:27, immediately after the Langley scramble, as follows: \u201cThree planes unaccounted for. American Airlines 11 may still be airborne but the flight that \u2013 United 175 to the World Trade Center. We\u2019re not sure who the other one is.\u201d\u0002 This discussion was the first notice to the military that American 77 was missing, and it had come by chance.\u0002 The time was 9:34. If NEADS had not placed that call to Washington Center, the NEADS air defenders would have received no information whatsoever that American 77 was even missing, although the FAA had been searching for it. No one at FAA headquarters ever asked for military assistance with American 77. At 9:36, the",
+  "source": "monograph",
+  "title": "093212 AA11 AA77 ID Summary ZDC loss of AA77"
+ },
+ "093536": {
+  "context": "At 9:36, the FAA\u2019s Boston Center called NEADS and relayed the discovery about an aircraft closing in on Washington, an aircraft that still had not been linked with the missing American 77. This discussion was the first notice to the military that American 77 was missing, and it had come by chance.\u0002 The time was 9:34. If NEADS had not placed that call to Washington Center, the NEADS air defenders would have received no information whatsoever that American 77 was even missing, although the FAA had been searching for it. No one at FAA headquarters ever asked for military assistance with American 77. On the floor at NEADS, the ID Technicians continued to attempt to locate American 11 after the Langley fighters were airborne. At the suggestion of the Boston Center Military Officer, the ID Technicians contacted Washington Center to ask whether they had located American 11. In that conversation, NEADS was told that Washington Center knew nothing about American 11 heading south. The NEADS ID Technicians then spoke with the Operations Manager at Washington Center: When pressed on whether the flight was in fact a deviating aircraft, Boston Center insisted that NEADS call Washington Center, w",
+  "source": "monograph",
+  "title": "093536 AA77 Scoggins VFR 6 Miles"
+ },
+ "093607": {
+  "context": "Just minutes before impact of American 77, Reagan Airport controllers vectored an unarmed National Guard C-130H cargo aircraft, which had just taken off en route to Minnesota, to identify and follow the suspicious aircraft that Dulles Tracon had pointed out to them. The cargo aircraft attempted to follow the path of the unidentified aircraft, and at 9:38, seconds after impact, reported to the control tower that the aircraft crashed into the Pentagon. While Command Center prevented any aircraft from entering the NAS, they also continued their efforts to locate American 77. At 9:21, FAA Command Center advised a supervisor at Dulles Tracon that the FAA had lost contact with American 77 and was trying to find the aircraft. At 9:21, controllers at Dulles Tracon were advised by the FAA Command Center that a commercial aircraft was missing and instructed to look for primary targets.\u0002 At 9:32 they found one. Several of the Dulles controllers \u201cobserved a primary target tracking eastbound at a high rate of speed\u201d and notified Reagan National Airport. FAA personnel at both Reagan National and Dulles Airports notified the Secret Service. The identity or aircraft type was unknown at the time. T",
+  "source": "monograph",
+  "title": "093607 Gofer 06 Traffic in Site 757 Low Altitude Tyson Tape"
+ },
+ "093621": {
+  "context": "It is fair to infer, from Washington Center\u2019s complete lack of knowledge concerning the aircraft approaching the White House, that Boston Center received the information about the aircraft from FAA headquarters. The startling information that a deviating aircraft was in close proximity to the White House prompted the Mission Crew Commander to order \u201cAFIO\u201d (Authorization for Interceptor Operations), which entailed taking immediate control of the Langley fighters from the FAA and responsibility for the safe flight path of the Langley fighters. When pressed on whether the flight was in fact a deviating aircraft, Boston Center insisted that NEADS call Washington Center, which is where the aircraft was located and could actually be seen on radar. At 9:39, just moments after the impact at the Pentagon, Washington Center disclaimed any knowledge of the plane near the White House. The Langley fighters were ordered to proceed directly to Washington, DC. The MCC then discovered, to his surprise, that the Langley fighters were not headed north toward the Baltimore area as previously instructed, but east over the ocean. \b A combination of three factors explains why the Langley fighters initial",
+  "source": "monograph",
+  "title": "093621 Langley Direct DC AFIO Monster Mash CRM1 CH2"
+ },
+ "093641": {
+  "context": "Just minutes before impact of American 77, Reagan Airport controllers vectored an unarmed National Guard C-130H cargo aircraft, which had just taken off en route to Minnesota, to identify and follow the suspicious aircraft that Dulles Tracon had pointed out to them. The cargo aircraft attempted to follow the path of the unidentified aircraft, and at 9:38, seconds after impact, reported to the control tower that the aircraft crashed into the Pentagon. While Command Center prevented any aircraft from entering the NAS, they also continued their efforts to locate American 77. At 9:21, FAA Command Center advised a supervisor at Dulles Tracon that the FAA had lost contact with American 77 and was trying to find the aircraft. At 9:21, controllers at Dulles Tracon were advised by the FAA Command Center that a commercial aircraft was missing and instructed to look for primary targets.\u0002 At 9:32 they found one. Several of the Dulles controllers \u201cobserved a primary target tracking eastbound at a high rate of speed\u201d and notified Reagan National Airport. FAA personnel at both Reagan National and Dulles Airports notified the Secret Service. The identity or aircraft type was unknown at the time. T",
+  "source": "monograph",
+  "title": "093641 Gofer 06 Vectored For Traffic Tyson Tape"
+ },
+ "093800": {
+  "context": "Just minutes before impact of American 77, Reagan Airport controllers vectored an unarmed National Guard C-130H cargo aircraft, which had just taken off en route to Minnesota, to identify and follow the suspicious aircraft that Dulles Tracon had pointed out to them. The cargo aircraft attempted to follow the path of the unidentified aircraft, and at 9:38, seconds after impact, reported to the control tower that the aircraft crashed into the Pentagon. While Command Center prevented any aircraft from entering the NAS, they also continued their efforts to locate American 77. At 9:21, FAA Command Center advised a supervisor at Dulles Tracon that the FAA had lost contact with American 77 and was trying to find the aircraft. At 9:21, controllers at Dulles Tracon were advised by the FAA Command Center that a commercial aircraft was missing and instructed to look for primary targets.\u0002 At 9:32 they found one. Several of the Dulles controllers \u201cobserved a primary target tracking eastbound at a high rate of speed\u201d and notified Reagan National Airport. FAA personnel at both Reagan National and Dulles Airports notified the Secret Service. The identity or aircraft type was unknown at the time. T",
+  "source": "monograph",
+  "title": "093800 Gofer 06 Aircraft is Down Tower Tyson Tape"
+ },
+ "093826": {
+  "context": "Just minutes before impact of American 77, Reagan Airport controllers vectored an unarmed National Guard C-130H cargo aircraft, which had just taken off en route to Minnesota, to identify and follow the suspicious aircraft that Dulles Tracon had pointed out to them. The cargo aircraft attempted to follow the path of the unidentified aircraft, and at 9:38, seconds after impact, reported to the control tower that the aircraft crashed into the Pentagon. While Command Center prevented any aircraft from entering the NAS, they also continued their efforts to locate American 77. At 9:21, FAA Command Center advised a supervisor at Dulles Tracon that the FAA had lost contact with American 77 and was trying to find the aircraft. At 9:21, controllers at Dulles Tracon were advised by the FAA Command Center that a commercial aircraft was missing and instructed to look for primary targets.\u0002 At 9:32 they found one. Several of the Dulles controllers \u201cobserved a primary target tracking eastbound at a high rate of speed\u201d and notified Reagan National Airport. FAA personnel at both Reagan National and Dulles Airports notified the Secret Service. The identity or aircraft type was unknown at the time. T",
+  "source": "monograph",
+  "title": "093826 Gofer 06 ac Crashed into West Side Pentagon Tyson Tape"
+ },
+ "093836": {
+  "context": "When pressed on whether the flight was in fact a deviating aircraft, Boston Center insisted that NEADS call Washington Center, which is where the aircraft was located and could actually be seen on radar. At 9:39, just moments after the impact at the Pentagon, Washington Center disclaimed any knowledge of the plane near the White House. At 9:36, the FAA\u2019s Boston Center called NEADS and relayed the discovery about an aircraft closing in on Washington, an aircraft that still had not been linked with the missing American 77. This discussion was the first notice to the military that American 77 was missing, and it had come by chance.\u0002 The time was 9:34. If NEADS had not placed that call to Washington Center, the NEADS air defenders would have received no information whatsoever that American 77 was even missing, although the FAA had been searching for it. No one at FAA headquarters ever asked for military assistance with American 77. It is fair to infer, from Washington Center\u2019s complete lack of knowledge concerning the aircraft approaching the White House, that Boston Center received the information about the aircraft from FAA headquarters. The startling information that a deviating air",
+  "source": "monograph",
+  "title": "093836 AA77 ID call to ZDC Boston Space Dont Know Anything"
+ },
+ "093927": {
+  "context": "Right after the Pentagon was hit, NEADS learned of another possible hijacked aircraft. It was an aircraft that in fact had not been hijacked at all. After the second World Trade Center crash, Boston Center managers recognized that both aircraft were transcontinental 767 jetliners that had departed Logan Airport. Remembering the \u201cwe have some planes\u201d remark, Boston Center guessed that Delta 1989 might also be hijacked. Boston Center called NEADS at 9:41 and identified Delta 1989; a 767 jet that had left Logan Airport for Las Vegas, as a possible hijack. 7. ANOTHER MISTAKEN REPORT: DELTA FLIGHT 1989 Even when FAA controllers at Dulles Tower did pick up the primary radar track of an unknown aircraft southwest of Washington, no one at FAA thought ask for military assistance. Once again, the NEADS air defenders received word of the unknown target from Boston Center\u2019s Military position, which happened to overhear the discussion of the sighting on a teleconference originating from Washington Because Delta 1989 had not turned off its transponder, NEADS never lost track of the aircraft as it moved west, reversed course over Toledo, headed east, and landed in Cleveland.\u0002 NEADS even ordered f",
+  "source": "monograph",
+  "title": "093927 D1989 ID Scoggins 3d ac is D1989"
+ },
+ "094232": {
+  "context": "After receiving the initial report from Boston Center, the NEADS ID Technicians called several FAA facilities to share the information they had learned about Delta 1989: Because Delta 1989 had not turned off its transponder, NEADS never lost track of the aircraft as it moved west, reversed course over Toledo, headed east, and landed in Cleveland.\u0002 NEADS even ordered fighter aircraft from Ohio and Michigan to intercept Delta 1989. Right after the Pentagon was hit, NEADS learned of another possible hijacked aircraft. It was an aircraft that in fact had not been hijacked at all. After the second World Trade Center crash, Boston Center managers recognized that both aircraft were transcontinental 767 jetliners that had departed Logan Airport. Remembering the \u201cwe have some planes\u201d remark, Boston Center guessed that Delta 1989 might also be hijacked. Boston Center called NEADS at 9:41 and identified Delta 1989; a 767 jet that had left Logan Airport for Las Vegas, as a possible hijack. The ID Technician advised that all of their fighters had been scrambled on the New York and Washington events, and that NEADS was looking for other fighters to scramble to intercept the Delta flight.\u0002 At app",
+  "source": "monograph",
+  "title": "094232 D1989 ID Alert Call to ZID"
+ },
+ "094452": {
+  "context": "After receiving the initial report from Boston Center, the NEADS ID Technicians called several FAA facilities to share the information they had learned about Delta 1989: Because Delta 1989 had not turned off its transponder, NEADS never lost track of the aircraft as it moved west, reversed course over Toledo, headed east, and landed in Cleveland.\u0002 NEADS even ordered fighter aircraft from Ohio and Michigan to intercept Delta 1989. The ID Technician advised that all of their fighters had been scrambled on the New York and Washington events, and that NEADS was looking for other fighters to scramble to intercept the Delta flight.\u0002 At approximately 9:45, while one NEADS ID technician was confirming 1989 as a hijack to Cleveland Center, another ID Technician received a call from the Boston Center Military position advising that Delta 1989 might not be a hijack after all: NEADS informed Boston Center that they were tracking Delta 1989 as it passed over Toledo. The NEADS air defenders continued to track Delta 1989 for the next several minutes, watching its every move until it landed in Cleveland.",
+  "source": "monograph",
+  "title": "094452 D1989 ID Alert Call to ZOB"
+ },
+ "095934": {
+  "context": "Just before 10:00, the Mission Crew Commander made the following report: The Mission Crew Commander, with his full complement of alert aircraft capping New York City and heading for Washington, decided to look for non-NORAD aircraft from the midwest to intercept the Delta flight. NEADS personnel contacted Toledo and Selfridge Air Force Bases and diverted fighters from training missions to intercept Delta 1989.\u0002 NEADS informed Boston Center that they were tracking Delta 1989 as it passed over Toledo. The NEADS air defenders continued to track Delta 1989 for the next several minutes, watching its every move until it landed in Cleveland. The Mission Crew Commander was advised, at approximately 10:00, that there was no authority to shoot the plane down; the rules of engagement only authorized NEADS to direct fighter aircraft to intercept, identify, and escort other aircraft.\u0002 The issue was moot with respect to Delta 1989, for at 9:58, the ID Technicians announced to the floor that \u201c1989 is no hijack, landing in Cleveland as a precautionary measure.\u201d The ID Technician called Boston Center at 9:59 and informed its military position: At 10:03, the ID Technicians called Indianapolis Center",
+  "source": "monograph",
+  "title": "095934 NEADS MCC What Are We Going To Do DRM1 CH2"
+ },
+ "100744": {
+  "context": "At 10:08, five minutes after United 93 crashed in a field in Pennsylvania, Command Center forwarded this update to headquarters: At 10:00, Command Center advised headquarters that \u201cUnited ninety three was spotted by a VFR at eight thousand feet, eleven, eleven miles south of Indianhead, just north of Cumberland, Maryland.\u0002 At 10:01, just two minutes before United 93 crashed, Command Center provided FAA headquarters with the following update: At 10:17, Command Center advised headquarters of its belief that United 93 had \u201ccrashed fifteen miles south of Johnstown, Pennsylvania\u201d.\u0002 \b No one from FAA headquarters requested military assistance regarding United 93. In fact, the executive level managers at FAA headquarters did not forward the information they received from Command Center regarding United 93 to the military. 8.2 Military Notification and Response NEADS first received a call about United 93 from the military liaison at Cleveland Center, at 10:07. This call was the first notification the military \u2013 at any level \u2013 received about United 93. Unaware that the aircraft had already crashed, Cleveland passed to NEADS the aircraft\u2019s last know latitude and longitude. NEADS was never ab",
+  "source": "monograph",
+  "title": "100744 UA93 Report of Black Smoke AA77 Q re Police Report"
+ },
+ "100901": {
+  "context": "When the information that United 93 had turned off its transponder and had a potential bomb on board reached the mission crew commander, he was dealing with the arrival of the Langley fighters over Washington and what their orders were with respect to potential targets. While NEADS searched for the radar track on United 93, the Mission Crew Commander and his Weapons Director engaged in the following conversation shortly after 10:10 concerning the rules of engagement: NEADS first received a call about United 93 from the military liaison at Cleveland Center, at 10:07. This call was the first notification the military \u2013 at any level \u2013 received about United 93. Unaware that the aircraft had already crashed, Cleveland passed to NEADS the aircraft\u2019s last know latitude and longitude. NEADS was never able to locate United 93 on radar because it was already in the ground. As the news of a bomb on board United 93 spread throughout the floor, the NEADS air defenders searched for the primary radar target and the Mission Crew Commander tried to locate assets to scramble toward the plane. At approximately 10:11, the commander got on the phone with an Air National Guard Unit in Syracuse: NEADS Id",
+  "source": "monograph",
+  "title": "100901 UA93 Negative Clearance to Shoot"
+ },
+ "101145": {
+  "context": "As the news of a bomb on board United 93 spread throughout the floor, the NEADS air defenders searched for the primary radar target and the Mission Crew Commander tried to locate assets to scramble toward the plane. At approximately 10:11, the commander got on the phone with an Air National Guard Unit in Syracuse: When the information that United 93 had turned off its transponder and had a potential bomb on board reached the mission crew commander, he was dealing with the arrival of the Langley fighters over Washington and what their orders were with respect to potential targets. While NEADS searched for the radar track on United 93, the Mission Crew Commander and his Weapons Director engaged in the following conversation shortly after 10:10 concerning the rules of engagement: NEADS Identification Technicians called Washington Center to provide a \u201cheads up\u201d to them about United 93, but Washington Center provided NEADS with startling new information on the flight: The time was 10:15 and the call was NEADS\u2019 first notice that United 93 had crashed.\u0002 The actual time of the crash was 10:03:11. By 10:15, the NEADS air defenders knew that two aircraft had crashed into the World Trade Cent",
+  "source": "monograph",
+  "title": "101145 NEADS Discussion with Syracuse Cdr"
+ },
+ "101418": {
+  "context": "NEADS Identification Technicians called Washington Center to provide a \u201cheads up\u201d to them about United 93, but Washington Center provided NEADS with startling new information on the flight: As the news of a bomb on board United 93 spread throughout the floor, the NEADS air defenders searched for the primary radar target and the Mission Crew Commander tried to locate assets to scramble toward the plane. At approximately 10:11, the commander got on the phone with an Air National Guard Unit in Syracuse: The time was 10:15 and the call was NEADS\u2019 first notice that United 93 had crashed.\u0002 The actual time of the crash was 10:03:11. By 10:15, the NEADS air defenders knew that two aircraft had crashed into the World Trade Center, a third had crashed into the Pentagon, Delta 1989 had landed safely in Cleveland and was not a hijack, and United 93 had crashed in Pennsylvania. The minutes after 10:15 were spent on the floor at NEADS attempting to mobilize other fighters from the eastern seaboard, and anticipating the arrival of Air Force Once in the Washington area. The Mission Crew Commander was notified at 10:25 that \u201cAir Force One is airborne out of Florida heading to Washington. We\u2019ve got ",
+  "source": "monograph",
+  "title": "101418 ZDC to NEADS UA93 is down"
+ },
+ "103200": {
+  "context": "Then, at 10:32, the MCC Technician read information that had just come across the Chat Log from CONR in Florida: The minutes after 10:15 were spent on the floor at NEADS attempting to mobilize other fighters from the eastern seaboard, and anticipating the arrival of Air Force Once in the Washington area. The Mission Crew Commander was notified at 10:25 that \u201cAir Force One is airborne out of Florida heading to Washington. We\u2019ve got those four F-15s coming out of Langley. They\u2019re done rolling. Two of them will be diverted to escort at the appropriate time.\u201d \u0002 By 10:15, the NEADS air defenders knew that two aircraft had crashed into the World Trade Center, a third had crashed into the Pentagon, Delta 1989 had landed safely in Cleveland and was not a hijack, and United 93 had crashed in Pennsylvania. The NEADS air defenders have expressed considerable confusion over the nature and effect of this order in interviews with Commission staff.\u0002 Indeed, Colonel Marr indicated to staff that he actually believes he withheld the order from the floor for several minutes because he was unsure of its ramifications,\u0002 while both the Mission Crew Commander and the Weapons Director indicated that they ",
+  "source": "monograph",
+  "title": "103200 Chat Log Shootdown Words"
+ },
+ "120918": {
+  "source": "masterfile",
+  "title": "120918 AA11Checkin"
+ },
+ "121015": {
+  "source": "masterfile",
+  "title": "121015 AA11 FL290"
+ },
+ "121335": {
+  "source": "masterfile",
+  "title": "121335 AA11 20 Right"
+ },
+ "121352": {
+  "source": "masterfile",
+  "title": "121352 AA11 Lost Contact"
+ },
+ "121713": {
+  "source": "masterfile",
+  "title": "121713 AA11 Attempts UAL175 checkin"
+ },
+ "121836": {
+  "source": "masterfile",
+  "title": "121836 AA11 Request Check Boston Approach"
+ },
+ "122350": {
+  "source": "masterfile",
+  "title": "122350 AA11 Check Everything Company"
+ },
+ "122444": {
+  "source": "masterfile",
+  "title": "122444 AA11 Keying 2 Transmissions"
+ },
+ "122453": {
+  "source": "masterfile",
+  "title": "122453 AA11 Check Sup Already Did"
+ },
+ "122542": {
+  "source": "masterfile",
+  "title": "122542 AA11 Point Out Enter New Route"
+ },
+ "122655": {
+  "source": "masterfile",
+  "title": "122655 AA11 Take Back Look West Albany"
+ },
+ "122732": {
+  "source": "masterfile",
+  "title": "122732 AA11 Notify ATCSCC ZNY ZOB"
+ },
+ "122740": {
+  "source": "masterfile",
+  "title": "122740 UA175 Depart ZBW"
+ },
+ "122748": {
+  "source": "masterfile",
+  "title": "122748 AA11 ZBW Notification 5115 Line"
+ },
+ "122816": {
+  "source": "masterfile",
+  "title": "122816 AA11 Tracking Primary Separating Traffic"
+ },
+ "122924": {
+  "source": "masterfile",
+  "title": "122924 AA11 ZBW Notification ZOB ZNY 5115 Line"
+ },
+ "123053": {
+  "source": "masterfile",
+  "title": "123053 AA11 Pascione Summation to Unknown 5115 Line"
+ },
+ "123203": {
+  "source": "masterfile",
+  "title": "123203 AA11 FL290 Confirmation"
+ },
+ "123347": {
+  "source": "masterfile",
+  "title": "123347 AA11 FL290 Not Confirmed"
+ },
+ "123358": {
+  "source": "masterfile",
+  "title": "123358 AA11 Cape TRACON call"
+ },
+ "123556": {
+  "source": "masterfile",
+  "title": "123556 AA11 ZNY Kingston point out to Kennedy"
+ },
+ "123647": {
+  "source": "masterfile",
+  "title": "123647 AA11 ZNY Heads Up Threatening Transmissions"
+ },
+ "123746": {
+  "source": "masterfile",
+  "title": "123746 AA11 Complete Cooper Powell Deskins"
+ },
+ "123806": {
+  "source": "masterfile",
+  "title": "123806 AA11 ZBW Cooper Powell"
+ },
+ "123914": {
+  "source": "masterfile",
+  "title": "123914 AA11 Notify NY TRACON ATCSCC to ZDC"
+ },
+ "123943": {
+  "source": "masterfile",
+  "title": "123943 AA11 ZBW Notification NY TRACON Doesnt See 5115 Line"
+ },
+ "123950": {
+  "source": "masterfile",
+  "title": "123950 AA77 Approach Indy Space"
+ },
+ "123955": {
+  "source": "masterfile",
+  "title": "123955 AA77 Bobcat or Henderson"
+ },
+ "124009": {
+  "source": "masterfile",
+  "title": "124009 AA11 ZNY Area B Point Out"
+ },
+ "124013": {
+  "source": "masterfile",
+  "title": "124013 AA77 ZID checkin Mode 3 Change"
+ },
+ "124022": {
+  "source": "masterfile",
+  "title": "124022 AA11 ZNY At Dueys FL290"
+ },
+ "124053": {
+  "source": "masterfile",
+  "title": "124053 AA11 ZNY FL Discussion FL290 Last Freq"
+ },
+ "124107": {
+  "source": "masterfile",
+  "title": "124107 AA11 ZNY Wolfie 11A TSD You Know What"
+ },
+ "124131": {
+  "source": "masterfile",
+  "title": "124131 AA11 UA175 ZNY Report of Suspicious Transmission Boston"
+ },
+ "124215": {
+  "source": "masterfile",
+  "title": "124215 AA11 Cape TRACON NEADS Panta"
+ },
+ "124302": {
+  "source": "masterfile",
+  "title": "124302 AA11 ATCSCC Notification ZDC Line 5115"
+ },
+ "124401": {
+  "source": "masterfile",
+  "title": "124401 AA11 ZNY USAIR 583 Report of ELT"
+ },
+ "124404": {
+  "source": "masterfile",
+  "title": "124404 AA77 ZID Climb maintain 350"
+ },
+ "124411": {
+  "source": "masterfile",
+  "title": "124411 AA11 McCormick Barrett AA Crew in Control"
+ },
+ "124524": {
+  "source": "masterfile",
+  "title": "124524 AA11 Barrett Biggio Conversation"
+ },
+ "124541": {
+  "source": "masterfile",
+  "title": "124541 AA11 ZNY Huntress ID Attempts to Call AMIS on R42"
+ },
+ "124635": {
+  "source": "masterfile",
+  "title": "124635 AA11 Thumser Barrett FL29 Not Verified"
+ },
+ "124702": {
+  "source": "masterfile",
+  "title": "124702 AA77 ZID Turn 10 Right for Traffic"
+ },
+ "124705": {
+  "source": "masterfile",
+  "title": "124705 AA11 ZNY Activate W105 Giant Killer"
+ },
+ "124739": {
+  "source": "masterfile",
+  "title": "124739 AA11 Discussion To First Impact Line 5114"
+ },
+ "124852": {
+  "source": "masterfile",
+  "title": "124852 AA11 Barrett Ruggieri Eastern Region Update"
+ },
+ "125017": {
+  "source": "masterfile",
+  "title": "125017 AA11 ZNY Major Fire WTC"
+ },
+ "125047": {
+  "source": "masterfile",
+  "title": "125047 AA11 TRACON Lost Radar Have ETMS"
+ },
+ "125051": {
+  "source": "masterfile",
+  "title": "125051 AA77 ZID Direct Falmouth Last Transmission"
+ },
+ "125146": {
+  "source": "masterfile",
+  "title": "125146 UA175 ZNY Recycle Transponder"
+ },
+ "125204": {
+  "source": "masterfile",
+  "title": "125204 AA11 McCormick TRACON Two Things Going On"
+ },
+ "125233": {
+  "source": "masterfile",
+  "title": "125233 AA11 Powell Scoggins Scramble"
+ },
+ "125244": {
+  "source": "masterfile",
+  "title": "125244 AA11 Barrett McCormick Fire at WTC"
+ },
+ "125255": {
+  "source": "masterfile",
+  "title": "125255 UA175 Kingston checks for East Texas not there"
+ },
+ "125323": {
+  "source": "masterfile",
+  "title": "125323 UA175 ZNY Report to Supe and Code 3321"
+ },
+ "125408": {
+  "source": "masterfile",
+  "title": "125408 UA175 ZNY Controller works UA175 annd AA 11 issue"
+ },
+ "125518": {
+  "source": "masterfile",
+  "title": "125518 UA175 ZNY Turn Eastbound out of 298"
+ },
+ "125634": {
+  "source": "masterfile",
+  "title": "125634 AA77 ZID Attempts to contact"
+ },
+ "125650": {
+  "source": "masterfile",
+  "title": "125650 UA175 ZNY Traffic ID as United 762"
+ },
+ "125751": {
+  "source": "masterfile",
+  "title": "125751 UA175 ZNY ID as UA175 complex traffic"
+ },
+ "125758": {
+  "source": "masterfile",
+  "title": "125758 UA175 ZNY Another ELT Report"
+ },
+ "125850": {
+  "source": "masterfile",
+  "title": "125850 AA77 1st Contact AA Dispatchl"
+ },
+ "125948": {
+  "source": "masterfile",
+  "title": "125948 AA11 ZBW Summary for NTSB Pulling Tapes Line 5114"
+ },
+ "130039": {
+  "source": "masterfile",
+  "title": "130039 AA11A Discussion UA175 Impact"
+ },
+ "130107": {
+  "source": "masterfile",
+  "title": "130107 AA77 ZID contact AAl2493"
+ },
+ "130234": {
+  "source": "masterfile",
+  "title": "130234 AA11 Jones thought some planes as in plural Line 5114"
+ },
+ "130248": {
+  "source": "masterfile",
+  "title": "130248 AA77 ZID 2d contact AA Dispatch"
+ },
+ "130322": {
+  "source": "masterfile",
+  "title": "130322 AA11 Nother One Just Hit Line 5114"
+ },
+ "130423": {
+  "source": "masterfile",
+  "title": "130423 UA175 ZNY 2d aircraft into WTC"
+ },
+ "130608": {
+  "source": "masterfile",
+  "title": "130608 AA11 Confirmed on Tape We Have Planes Line 5114"
+ },
+ "130710": {
+  "source": "masterfile",
+  "title": "130710 AA77 ZID Moved Track and Sterilized"
+ },
+ "130713": {
+  "source": "masterfile",
+  "title": "130713 ATCSCC ACARS Increase Security Internationals Line 5114"
+ },
+ "130911": {
+  "source": "masterfile",
+  "title": "130911 FAA HQ Activating Crisis Center Upstairs Line 5114"
+ },
+ "130954": {
+  "source": "masterfile",
+  "title": "130954 AA77 ZID Controller Discussion 11 77 WTC"
+ },
+ "131154": {
+  "source": "masterfile",
+  "title": "131154 AA77 ZID 3d Contact AA Dispatch 2d WTC Impact"
+ },
+ "131539": {
+  "source": "masterfile",
+  "title": "131539 AA77 ZID 4th AA Dispatch Call"
+ },
+ "131612": {
+  "source": "masterfile",
+  "title": "131612 FAA HQ Tactical Net First Transmission Line 5114"
+ },
+ "132100": {
+  "source": "masterfile",
+  "title": "132100 AA11 Scoggins Still Airborne"
+ },
+ "132144": {
+  "source": "masterfile",
+  "title": "132144 FAA HQ TACNET Bauer SIOC On Line 5114"
+ },
+ "132237": {
+  "source": "masterfile",
+  "title": "132237 AA11 ID call ZNY N334AA"
+ },
+ "132310": {
+  "source": "masterfile",
+  "title": "132310 AA11 ID First call to ZDC They have nothing"
+ },
+ "132401": {
+  "source": "masterfile",
+  "title": "132401 AA11 Scoggins 3 Aircraft Missing"
+ },
+ "132512": {
+  "source": "masterfile",
+  "title": "132512 AA11 2d ID call to ZDC Heard from Boston"
+ },
+ "132518": {
+  "source": "masterfile",
+  "title": "132518 AA11 AST call from Barrett not TRACON"
+ },
+ "132721": {
+  "source": "masterfile",
+  "title": "132721 AA11 3d ID Call to ZDC Becker"
+ },
+ "132847": {
+  "source": "masterfile",
+  "title": "132847 AA11 ID Summary call to Unknown"
+ },
+ "132919": {
+  "source": "masterfile",
+  "title": "132919 HQ FAA TACNET Arroyo and Falcone Start Line 5114"
+ },
+ "133019": {
+  "source": "masterfile",
+  "title": "133019 AA77 ZID Hold of AA77 Not Yet"
+ },
+ "133050": {
+  "source": "masterfile",
+  "title": "133050 FAA TACNET FBI Boston Requests Update 5114 Line"
+ },
+ "133116": {
+  "source": "masterfile",
+  "title": "133116 AA11 ID call to Scoggins 3 missing"
+ },
+ "133151": {
+  "source": "masterfile",
+  "title": "133151 FAA TACNET Wrong Recap Line 5114"
+ },
+ "133212": {
+  "source": "masterfile",
+  "title": "133212 AA11 AA77 ID Summary ZDC loss of AA77"
+ },
+ "133400": {
+  "source": "masterfile",
+  "title": "133400 FAA TACNET ATCSCC Sets Record Straight Line 5114"
+ },
+ "133504": {
+  "source": "masterfile",
+  "title": "133504 FAA TACNET Report of Fast Mover Line 5114"
+ },
+ "133536": {
+  "source": "masterfile",
+  "title": "133536 AA77 Scoggins VFR 6 Miles"
+ },
+ "133556": {
+  "source": "masterfile",
+  "title": "133556 ATCSCC Initiates Nationwide Ground Stop Line 5114"
+ },
+ "133602": {
+  "source": "masterfile",
+  "title": "133602 AA77 ID call to Indy Center"
+ },
+ "133803": {
+  "source": "masterfile",
+  "title": "133803 FAA TACNET Plane Hit West Side of Pentagon Line 5114"
+ },
+ "133836": {
+  "source": "masterfile",
+  "title": "133836 AA77 ID call to ZDC Boston Space Dont Know Anything"
+ },
+ "133838": {
+  "source": "masterfile",
+  "title": "133838 UA93 ZID Due South Dryer Climbing"
+ },
+ "133927": {
+  "source": "masterfile",
+  "title": "133927 D1989 ID Scoggins 3d ac is D1989"
+ },
+ "134012": {
+  "source": "masterfile",
+  "title": "134012 AA77 ZID Impel Turnover AA77 Status"
+ },
+ "134035": {
+  "source": "masterfile",
+  "title": "134035 FAA HQ Notifies FBI about UA93 Line 5114"
+ },
+ "134108": {
+  "source": "masterfile",
+  "title": "134108 UA93 ZID Keep Door Locket to MEDEX"
+ },
+ "134232": {
+  "source": "masterfile",
+  "title": "134232 D1989 ID Alert Call to ZID"
+ },
+ "134241": {
+  "source": "masterfile",
+  "title": "134241 AA11 D1989 ID Scoggins Extended Discussion ACARS"
+ },
+ "134452": {
+  "source": "masterfile",
+  "title": "134452 D1989 ID Alert Call to ZOB"
+ },
+ "134749": {
+  "source": "masterfile",
+  "title": "134749 Land Now ZID Passes FAA Advisory"
+ },
+ "135103": {
+  "source": "masterfile",
+  "title": "135103 D1989 Hijacking FAA TACNET Line 5114"
+ },
+ "135556": {
+  "source": "masterfile",
+  "title": "135556 UA93 ATCSCC Update 20 Miles Johnstown Line 5114"
+ },
+ "150728": {
+  "source": "masterfile",
+  "title": "150728 ZNY Otis Fighters Who is Working"
+ }
+}

--- a/packages/tools/video-grabber/video_grabber/parties/flows.py
+++ b/packages/tools/video-grabber/video_grabber/parties/flows.py
@@ -8,13 +8,16 @@ from prefect import flow, get_run_logger
 from video_grabber.catalogue.flows import _page_mp3_items, key_from_url
 from video_grabber.config import Config
 from video_grabber.directus.writer import _auth_headers
+from video_grabber.parties.commission import match_commission_clip
 from video_grabber.parties.identify import (
     TIER_TAPE,
     build_clip_messages,
+    build_enrichment_messages,
     build_tape_messages,
     parse_parties,
     should_identify,
     tier_for,
+    validate_enriched_parties,
     validate_parties,
 )
 from video_grabber.storage import wasabi
@@ -118,4 +121,95 @@ def identify_parties_flow(limit: int | None = None, force: bool = False,
     logger.info(
         "identify-parties: %d identified, %d skipped, %d broadcast (excluded), %d failed",
         done, skipped, broadcast, failed,
+    )
+
+
+@flow(name="enrich-parties-from-commission")
+def enrich_parties_from_commission_flow(
+    limit: int | None = None, force: bool = False, dry_run: bool = True
+) -> None:
+    """Re-identify the recordings the 9/11 Commission also catalogued.
+
+    `identify-parties` can only report what the audio says, and on a garbled
+    landline that is often nothing. For the subset of our corpus the Commission
+    indexed, their title and the Team 8 monograph narrative name the parties
+    outright — so those rows get a second pass with both documents in the prompt.
+
+    Every field the result keeps carries a `sources` entry saying which document
+    it came from, so a transcript-derived name stays as checkable as it was
+    before. Rows with no Commission match are left exactly as they are.
+
+    Idempotency marker is a `commission` block on the existing parties object;
+    pass force=True to redo them.
+    """
+    logger = get_run_logger()
+    cfg = Config()
+    if not cfg.anthropic_api_key:
+        raise RuntimeError("ANTHROPIC_API_KEY is not set")
+    complete = anthropic_completer(cfg, model=cfg.parties_model, max_tokens=PARTIES_MAX_TOKENS)
+
+    done = skipped = failed = unmatched = 0
+    for row in _page_mp3_items(cfg, "id,url,subtitles,calc_duration,parties"):
+        if limit is not None and done >= limit:
+            break
+        key = key_from_url(row["url"])
+
+        if not should_identify(key):
+            continue
+        clip = match_commission_clip(key)
+        if clip is None:
+            unmatched += 1
+            continue
+        existing = row.get("parties") or {}
+        if existing.get("commission") and not force:
+            skipped += 1
+            continue
+
+        # Unlike identify-parties, a missing transcript is not disqualifying: the
+        # Commission text alone can carry an identification, and the gate will
+        # reject anything that claims the empty transcript as its source.
+        transcript = ""
+        if row.get("subtitles"):
+            transcript = srt_text_to_plain(
+                wasabi.read_text(key_from_url(row["subtitles"]), cfg)
+            )
+
+        tier = tier_for(row.get("calc_duration"))
+        excerpt = transcript
+        if tier == TIER_TAPE:
+            excerpt = "\n\n---\n\n".join(sample_windows(transcript))
+        system, user = build_enrichment_messages(excerpt, clip.text, tier)
+
+        try:
+            parsed = parse_parties(complete(system, user))
+        except ValueError as exc:
+            logger.warning("enrich-parties: %s unparseable: %s", key, exc)
+            failed += 1
+            continue
+
+        cleaned, reasons = validate_enriched_parties(parsed, excerpt, clip.text)
+        cleaned["tier"] = tier
+        cleaned["model"] = cfg.parties_model
+        cleaned["generated_at"] = datetime.now(timezone.utc).isoformat()
+        cleaned["commission"] = {
+            "title": clip.title,
+            "source": clip.source,
+            "stamp": clip.stamp,
+            "slug_overlap": clip.overlap,
+        }
+        if reasons:
+            cleaned["gate_reasons"] = reasons
+            logger.info("enrich-parties: %s downgraded: %s", key, reasons)
+
+        if dry_run:
+            logger.info("DRY RUN %s -> %s", key, cleaned)
+        else:
+            pr = httpx.patch(f"{cfg.directus_url}/items/mp3_items/{row['id']}",
+                             json={"parties": cleaned}, headers=_auth_headers(cfg))
+            pr.raise_for_status()
+        done += 1
+
+    logger.info(
+        "enrich-parties: %d enriched, %d already done, %d no Commission clip, %d failed",
+        done, skipped, unmatched, failed,
     )

--- a/packages/tools/video-grabber/video_grabber/parties/identify.py
+++ b/packages/tools/video-grabber/video_grabber/parties/identify.py
@@ -138,6 +138,65 @@ def parse_parties(raw: str) -> dict:
     return parsed
 
 
+SOURCE_TRANSCRIPT = "transcript"
+SOURCE_COMMISSION = "commission_monograph"
+
+_ENRICH_SYSTEM = """\
+You identify who is speaking in a recording of September 11, 2001 air traffic \
+control, military, and emergency audio.
+
+You are given TWO documents:
+1. TRANSCRIPT — an automatic transcript of the recording itself. Imperfect: \
+callsigns and names are often garbled or missing.
+2. COMMISSION — how the 9/11 Commission catalogued this same recording: their \
+title for it, and where available the passage of the Team 8 audio monograph that \
+discusses it. This names people, positions and facilities the transcript may not.
+
+Rules you must follow:
+- Every value you return must come from one of those two documents. Do not use \
+anything you know about September 11 from any other source.
+- For every field you fill in, record which document it came from in `sources`, \
+using the exact key path (e.g. "side_a.facility") and the value "transcript" or \
+"commission_monograph".
+- Prefer the transcript when both documents support a field. Use the Commission \
+only to fill in what the transcript leaves unknown or garbled.
+- The COMMISSION document describes this recording, so what it says about who is \
+on the call applies. But it also gives surrounding narrative about the wider \
+morning — do not pull in people or facilities it does not connect to THIS call.
+- If neither document tells you, return null. That is a correct answer.
+- `evidence` must be an exact quote copied character-for-character from whichever \
+document you cite in sources["evidence"].
+
+Return ONLY a JSON object:
+{"tier":"clip"|"tape",
+ "side_a":{"facility":str|null,"position":str|null,"person":str|null,"role":str|null},
+ "side_b":{"facility":str|null,"position":str|null,"person":str|null,"role":str|null},
+ "link":"air-ground"|"landline"|"internal"|"unknown",
+ "aircraft":[str],
+ "confidence":"high"|"medium"|"low",
+ "evidence":str,
+ "sources":{"<field path>":"transcript"|"commission_monograph"}}
+
+`role` is one of: atc, military, airline, emergency, aircraft, unknown."""
+
+
+def build_enrichment_messages(
+    transcript: str, commission_text: str, tier: str
+) -> tuple[str, str]:
+    """Prompt for identifying a recording the Commission also catalogued."""
+    system = _ENRICH_SYSTEM
+    if tier == TIER_TAPE:
+        system += (
+            "\n\nThis is a long continuous recording of ONE position. side_a is "
+            'that position; set side_b.facility to "various".'
+        )
+    user = (
+        f"COMMISSION:\n\n{commission_text}\n\n"
+        f"=====\n\nTRANSCRIPT:\n\n{transcript}"
+    )
+    return system, user
+
+
 def _normalise(s: str) -> str:
     return re.sub(r"\s+", " ", s or "").strip().lower()
 
@@ -201,6 +260,85 @@ def validate_parties(parsed: dict, transcript: str) -> tuple[dict, list[str]]:
             reasons.append(f"aircraft {name!r} not present in transcript")
     cleaned["aircraft"] = kept
 
+    if reasons:
+        cleaned["confidence"] = "low"
+    return cleaned, reasons
+
+
+def validate_enriched_parties(
+    parsed: dict, transcript: str, commission_text: str
+) -> tuple[dict, list[str]]:
+    """The containment gate, parameterised by which document a field claims.
+
+    `validate_parties` asks one question of every value: is it in the transcript?
+    Here there are two admissible documents, so the question becomes: is it in the
+    one it says it came from? The guarantee is unchanged — nothing survives that
+    isn't written down somewhere we can point at — and it stays checkable after the
+    fact, because the surviving `sources` map says where to look.
+
+    A field that declares no source is held to the transcript. Silence must not be
+    a way to reach the looser document.
+    """
+    texts = {SOURCE_TRANSCRIPT: transcript, SOURCE_COMMISSION: commission_text}
+    cleaned = json.loads(json.dumps(parsed))
+    declared = cleaned.get("sources")
+    if not isinstance(declared, dict):
+        declared = {}
+    reasons: list[str] = []
+    kept_sources: dict[str, str] = {}
+
+    def resolve(path: str) -> str | None:
+        claimed = declared.get(path)
+        if claimed is None:
+            return SOURCE_TRANSCRIPT
+        if claimed not in texts:
+            reasons.append(f"{path} claims unknown source {claimed!r}")
+            return None
+        return claimed
+
+    evidence_source = resolve("evidence")
+    if evidence_source is None or not evidence_is_verbatim(
+        cleaned.get("evidence", ""), texts[evidence_source]
+    ):
+        if evidence_source is not None:
+            reasons.append(f"evidence is not a verbatim quote from the {evidence_source}")
+        cleaned["evidence"] = None
+    else:
+        kept_sources["evidence"] = evidence_source
+
+    for side in ("side_a", "side_b"):
+        block = cleaned.get(side) or {}
+        for field in ("facility", "position", "person"):
+            path = f"{side}.{field}"
+            value = block.get(field)
+            if not value or value == "various":
+                continue
+            source = resolve(path)
+            if source is None:
+                block[field] = None
+                continue
+            missing = unsupported_words(value, texts[source])
+            if missing:
+                reasons.append(
+                    f"{path}={value!r} names {missing} which the {source} never contains"
+                )
+                block[field] = None
+            else:
+                kept_sources[path] = source
+        cleaned[side] = block
+
+    aircraft_source = resolve("aircraft")
+    kept = []
+    for name in cleaned.get("aircraft") or []:
+        if aircraft_source and _callsign_supported(str(name), texts[aircraft_source]):
+            kept.append(name)
+        else:
+            reasons.append(f"aircraft {name!r} not present in the {aircraft_source}")
+    cleaned["aircraft"] = kept
+    if kept and aircraft_source:
+        kept_sources["aircraft"] = aircraft_source
+
+    cleaned["sources"] = kept_sources
     if reasons:
         cleaned["confidence"] = "low"
     return cleaned, reasons


### PR DESCRIPTION
## Why

The `parties` blobs are thin, and the reason is structural rather than a bug: `identify-parties` is a *reading* task by design, gated so that every name it returns already appears in the transcript. On a garbled 2001 landline recording the transcript frequently names nobody, so the correct output is nulls — which is what we got.

The 9/11 Commission catalogued these same tapes, and their descriptions are far richer than our filenames:

| Source (IA, `NARA_911_Commission_RG148_Audio_Monograph`) | Clips | Stamped in |
|---|---|---|
| `Master File 051704.txt` | 111 | **UTC** |
| `team 8a audio monograph 28.doc` (via Master File 061604) | 76 | **ET** |

The monograph does not just title the clips — it walks them in narrative prose, naming the controllers, positions and facilities on each call.

## What this does

- **`commission_clips.json`** (106 KB, 187 clips, 76 carrying narrative) — checked in rather than fetched, because reading the sources means parsing a 3.6 MB Word 97 binary via its piece table.
- **`parties/commission.py`** — loads the index and joins it to our object keys.
- **`enrich-parties-from-commission`** — a second pass that puts both documents in front of the model, for the subset of rows that match.

Against the current corpus: **149 rows match** (131 approved), all of them with narrative context.

## The containment gate is parameterised, not relaxed

This is the part worth reviewing. Naming a party the audio never states is a change in what `parties` *means*, so the guarantee is kept checkable rather than dropped:

- every retained field declares its document in a `sources` map (`"side_a.facility": "commission_monograph"`), and is validated **against that document**;
- an **undeclared** source is held to the transcript — silence must not be a way to reach the looser document;
- an **unrecognised** source name is rejected outright, not trusted;
- the stored `sources` map is rebuilt from what actually passed, so it always describes the values that are there.

A consumer can therefore still ask "is this name in the audio?" and get a true answer, which was the original point.

Matching is deliberately conservative. A six-digit stamp is not unique: `093800` is both *"Gofer 06 Aircraft is Down"* and an unrelated DL1989 turn instruction. Candidates must agree on the slug too (`MIN_SLUG_OVERLAP = 0.5`), which rejected 9 timestamp-only matches.

## Incidental finding

Master File 051704 stamps its titles in **UTC**; 061604 stamps in **ET**. That independently confirms the four-hour correction applied in #379, and explains why the corpus held the same recording twice under `08xxxx` and `12xxxx` names.

## Testing

`test_parties_commission.py` — 15 tests covering the index, the slug scoring (including the `093800` collision), and each gate rule above. Full suite: 548 passed, 8 skipped; `ruff check` clean. (`test_migrations.py` errors without a local Postgres, as documented.)

**Not yet run against the database.** The flow defaults to `dry_run=True`; the enrichment pass over the 149 matched rows happens once this lands and the worker image rolls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
