### PR TITLE
feat(parties): schema 2 — n-party, per-field confidence, subjects and search tags

### DIFF
--- a/packages/tools/video-grabber/CLAUDE.md
+++ b/packages/tools/video-grabber/CLAUDE.md
@@ -27,6 +27,14 @@ Also stitches per-channel continuous HLS streams + EPG guide JSON.
   manually-triggered `dispatch-normalize` only — normalize files in place
   (dynaudnorm + two-pass EBU R128 loudnorm), archiving originals to
   `audio-original/` first (first-write-wins). See [`docs/normalization.md`](docs/normalization.md).
+- `video_grabber/parties/` — a **fifth pipeline**: identify who each `audio/*.mp3`
+  recording's traffic is between and tag it for searching, writing `mp3_items.parties`
+  and `mp3_items.tags`. No state table — `parties.schema_version` is the idempotency
+  marker. Every name the model returns must appear in a document it was shown; where
+  the 9/11 Commission catalogued the same clip (`commission_clips.json`) their
+  narrative is admitted as a second source, with per-field provenance. See
+  [`docs/party-identification.md`](docs/party-identification.md) — read it before
+  changing the prompt or the gate, and do not weaken the gate to raise yield.
 - `k8s/` — deployment manifests (see Deploy below).
 - `tests/` — pytest. `test_migrations.py` needs a live Postgres; it **errors** (not
   fails) when none is reachable — that's an environment gap, not a regression.

--- a/packages/tools/video-grabber/docs/party-identification.md
+++ b/packages/tools/video-grabber/docs/party-identification.md
@@ -1,0 +1,112 @@
+# Party identification and tagging
+
+Populates `mp3_items.parties` (who a recording's traffic is between, and what it
+is about) and `mp3_items.tags` (a flat, namespaced index for searching).
+
+One Prefect flow, `identify-parties`, manual-only and `dry_run=True` by default.
+
+## The containment gate is the whole design
+
+The model knows how September 11 turned out. Asked who is speaking on a garbled
+tape, it will supply "NEADS" or "Colin Scoggins" from background knowledge rather
+than from the audio. So identification is built as a **reading** task, not a
+recall task:
+
+- every name the model returns must already appear in a document it was shown;
+- `evidence` must be a verbatim quote;
+- `subject` must be written in words that appear in the source (the same rule
+  `transcript/summarize.py` applies to minute summaries);
+- anything unsupported is **removed**, and the removal is recorded in
+  `gate_reasons`.
+
+This is why so many blobs are sparse, and that is correct behaviour rather than a
+bug. A clip whose entire transcript is *"American 77, climb and maintain, flight
+level 3-5-0."* never says Indianapolis, so `facility: null` is the right answer.
+
+### Two admissible documents
+
+Where the 9/11 Commission catalogued the same recording (see
+[`parties/commission.py`](../video_grabber/parties/commission.py)), their title and
+Team 8 monograph narrative go into the prompt alongside the transcript. The gate
+is **parameterised, not relaxed**: each value declares which document it came
+from and is validated against that one. Two rules stop provenance becoming
+decorative —
+
+- an **undeclared** source is held to the transcript, so silence cannot reach the
+  looser document;
+- an **unrecognised** source name is rejected outright rather than trusted.
+
+The stored `sources` map is rebuilt from what survived, so it always describes
+the values that are actually there.
+
+## Schema 2
+
+`parties.schema_version` is the idempotency marker; a re-run refreshes rows on an
+older shape and skips current ones.
+
+| Field | Notes |
+|---|---|
+| `participants[]` | One entry per party, however many. Each carries its own `role`, `confidence` and `source`. |
+| `mentions` | Facilities/aircraft/people **talked about** but not taking part. |
+| `aircraft[]` | Callsigns of aircraft on the call. |
+| `subject` | One line, in the source's own words. |
+| `topics[]` | From the closed list in [`vocab.py`](../video_grabber/parties/vocab.py). |
+| `link` | `air-ground`, `landline`, `internal`, `conference`, `unknown`. |
+| `evidence` | Verbatim quote. |
+| `sources` | Path → document, for the flat fields. Participants carry theirs inline. |
+| `confidence` | Overall; capped at `medium` if the gate rejected anything. |
+| `commission` | Present when a Commission clip was matched. |
+
+Two things schema 2 fixed, both measured on the schema-1 corpus:
+
+- **`side_a`/`side_b` could not describe the material.** 179 of 755 rows were
+  position tapes reduced to the placeholder `side_b.facility = "various"`, and
+  conference calls (ATCSCC, the NEADS floor, FAA HQ) are inherently n-party.
+  `"various"` is now rejected rather than stored.
+- **A single rejection crushed the whole answer to `low`.** 546 rows read `low`,
+  but only 189 had been downgraded by the gate — the other 357 were the model's
+  own verdict. Per-participant confidence keeps those distinguishable.
+
+## Tags
+
+`build_tags()` is a pure function of the parties block. Tags are **derived, never
+separately generated** — asking the model for both would produce two accounts of
+one recording that quietly disagree. Only `topic:` has no equivalent in the block.
+
+Namespaced (`facility:zob`, not `zob`) because a bare list cannot be filtered by
+kind and names collide across kinds — Boston is a facility and also a surname.
+
+```
+tier:clip  link:landline  role:atc  agency:faa  agency:norad
+facility:indianapolis-center  facility:neads
+person:jim-mcdonald  aircraft:aal77  topic:loss-of-contact
+```
+
+Participating and merely-mentioned entities both get tagged: someone searching
+for Cleveland Center wants the calls that discuss it, not only the ones it spoke
+on. The parties block keeps the distinction.
+
+Callsigns are normalised so `American 11`, `AAL11` and `AA 11` collapse to
+`aircraft:aal11`. Military callsigns keep their own prefix (`gofer6`) — the goal
+is collapsing spellings, not forcing everything into an airline scheme.
+
+## Operating it
+
+```sh
+# dry run over a handful, printing what would be written
+identify-parties  limit=5  dry_run=true
+
+# apply, refreshing anything not already on the current schema
+identify-parties  dry_run=false
+
+# rebuild everything from scratch
+identify-parties  dry_run=false  force=true
+```
+
+WINS and WCBS are excluded by an **affirmative allow-list** (`MEDIA_KIND`), never
+a deny-list: a deny-list that fails to load silently re-admits news radio and
+produces confident nonsense about a broadcast that has no counterparty.
+
+`PARTIES_MAX_TOKENS` is 5000 and the headroom is deliberate — `max_tokens` caps
+thinking and text together, and a budget consumed entirely by thinking returns an
+empty string with no error. See the comment on the constant.

--- a/packages/tools/video-grabber/tests/test_parties_commission.py
+++ b/packages/tools/video-grabber/tests/test_parties_commission.py
@@ -10,7 +10,7 @@ from video_grabber.parties.commission import (
 from video_grabber.parties.identify import (
     SOURCE_COMMISSION,
     SOURCE_TRANSCRIPT,
-    validate_enriched_parties,
+    validate_parties,
 )
 
 # Two clips a minute apart on the real morning, catalogued by the Commission with
@@ -91,9 +91,13 @@ def test_agreeing_title_matches_and_reports_its_source():
 def _parties(**over):
     """A well-formed answer, so each test's own defect is the only one in play."""
     base = {
-        "side_a": {"facility": None, "position": None, "person": None, "role": "atc"},
-        "side_b": {"facility": None, "position": None, "person": None, "role": "military"},
+        "tier": "clip",
+        "participants": [],
+        "link": "landline",
         "aircraft": [],
+        "mentions": {"facilities": [], "aircraft": [], "people": []},
+        "subject": None,
+        "topics": [],
         "confidence": "high",
         "evidence": "Gofer zero six, this is Washington Center",
         "sources": {"evidence": SOURCE_TRANSCRIPT},
@@ -109,92 +113,85 @@ def _reason(reasons, needle):
 
 
 def test_commission_sourced_name_survives_though_absent_from_transcript():
-    """The whole point of the second pass.
+    """The whole point of consulting a second document.
 
-    'Colin Scoggins' is nowhere in the audio. Under the single-document gate it
-    was correctly destroyed; here it is admissible because the Commission names
-    him and the answer says so.
+    'Colin Scoggins' is nowhere in the audio. Held to the transcript alone he is
+    correctly destroyed; here he is admissible because the Commission names him
+    and the answer says that is where he came from.
     """
-    cleaned, reasons = validate_enriched_parties(
-        _parties(
-            side_b={"facility": "NEADS", "position": None,
-                    "person": "Colin Scoggins", "role": "military"},
-            sources={"side_b.facility": SOURCE_COMMISSION,
-                     "side_b.person": SOURCE_COMMISSION},
-        ),
+    cleaned, reasons = validate_parties(
+        _parties(participants=[{
+            "facility": "NEADS", "position": None, "person": "Colin Scoggins",
+            "role": "military", "confidence": "high", "source": SOURCE_COMMISSION,
+        }]),
         TRANSCRIPT,
         COMMISSION,
     )
-    assert cleaned["side_b"]["person"] == "Colin Scoggins"
-    assert cleaned["sources"]["side_b.person"] == SOURCE_COMMISSION
+    assert cleaned["participants"][0]["person"] == "Colin Scoggins"
+    assert cleaned["participants"][0]["source"] == SOURCE_COMMISSION
     assert reasons == []
 
 
 def test_a_name_in_neither_document_is_still_destroyed():
-    cleaned, reasons = validate_enriched_parties(
-        _parties(
-            side_a={"facility": "Cleveland Center", "position": None,
-                    "person": None, "role": "atc"},
-            sources={"side_a.facility": SOURCE_COMMISSION},
-        ),
+    cleaned, reasons = validate_parties(
+        _parties(participants=[{
+            "facility": "Cleveland Center", "position": None, "person": None,
+            "role": "atc", "confidence": "high", "source": SOURCE_COMMISSION,
+        }]),
         TRANSCRIPT,
         COMMISSION,
     )
-    assert cleaned["side_a"]["facility"] is None
-    assert cleaned["confidence"] == "low"
-    assert "commission_monograph never contains" in reasons[0]
+    assert cleaned["participants"] == []
+    _reason(reasons, "commission_monograph never contains")
 
 
 def test_claiming_the_transcript_for_a_commission_only_name_fails():
-    """Provenance is checked, not just recorded.
+    """Provenance is checked, not merely recorded.
 
     A model that mislabels where a value came from must not get it through — the
     label decides which document the value is held against.
     """
-    cleaned, _ = validate_enriched_parties(
-        _parties(
-            side_b={"facility": None, "position": None,
-                    "person": "Colin Scoggins", "role": "military"},
-            sources={"side_b.person": SOURCE_TRANSCRIPT},
-        ),
+    cleaned, _ = validate_parties(
+        _parties(participants=[{
+            "facility": None, "position": None, "person": "Colin Scoggins",
+            "role": "military", "confidence": "high", "source": SOURCE_TRANSCRIPT,
+        }]),
         TRANSCRIPT,
         COMMISSION,
     )
-    assert cleaned["side_b"]["person"] is None
+    assert cleaned["participants"] == []
 
 
 def test_undeclared_source_is_held_to_the_transcript():
     """Fail-closed. Saying nothing must not reach the looser document."""
-    cleaned, reasons = validate_enriched_parties(
-        _parties(
-            side_b={"facility": "NEADS", "position": None, "person": None,
-                    "role": "military"},
-            sources={},
-        ),
+    cleaned, reasons = validate_parties(
+        _parties(participants=[{
+            "facility": "NEADS", "position": None, "person": None,
+            "role": "military", "confidence": "high",
+        }]),
         TRANSCRIPT,
         COMMISSION,
     )
-    assert cleaned["side_b"]["facility"] is None
-    assert "transcript never contains" in reasons[0]
+    assert cleaned["participants"] == []
+    _reason(reasons, "transcript never contains")
 
 
 def test_unknown_source_name_is_rejected_not_trusted():
-    cleaned, reasons = validate_enriched_parties(
-        _parties(
-            side_a={"facility": "NEADS", "position": None, "person": None,
-                    "role": "military"},
-            sources={"side_a.facility": "my_own_knowledge"},
-        ),
+    cleaned, reasons = validate_parties(
+        _parties(participants=[{
+            "facility": "NEADS", "position": None, "person": None,
+            "role": "military", "confidence": "high", "source": "my_own_knowledge",
+        }]),
         TRANSCRIPT,
         COMMISSION,
     )
-    assert cleaned["side_a"]["facility"] is None
-    assert "unknown source" in reasons[0]
+    assert cleaned["participants"] == []
+    _reason(reasons, "unknown source")
 
 
 def test_evidence_may_quote_the_commission_when_it_says_so():
     quote = "Colin Scoggins at Boston Center relayed the report to NEADS."
-    cleaned, reasons = validate_enriched_parties(
+    cleaned, reasons = validate_parties(
         _parties(evidence=quote, sources={"evidence": SOURCE_COMMISSION}),
         TRANSCRIPT,
         COMMISSION,
@@ -204,25 +201,26 @@ def test_evidence_may_quote_the_commission_when_it_says_so():
 
 
 def test_surviving_sources_map_is_rebuilt_from_what_passed():
-    """The stored map must describe the stored values, not the model's claims.
-
-    A consumer reading `parties.sources` is entitled to assume every path in it
-    names a field that is actually present and actually verified.
-    """
-    cleaned, _ = validate_enriched_parties(
-        _parties(
-            side_a={"facility": "Washington Center", "position": None,
-                    "person": None, "role": "atc"},
-            side_b={"facility": "Cleveland Center", "position": None,
-                    "person": None, "role": "atc"},
-            sources={"side_a.facility": SOURCE_TRANSCRIPT,
-                     "side_b.facility": SOURCE_COMMISSION},
-        ),
+    """The stored map must describe the stored values, not the model's claims."""
+    cleaned, _ = validate_parties(
+        _parties(aircraft=["Gofer 06"], sources={"aircraft": SOURCE_COMMISSION}),
         TRANSCRIPT,
         COMMISSION,
     )
     assert cleaned["sources"] == {
         "evidence": SOURCE_TRANSCRIPT,
-        "side_a.facility": SOURCE_TRANSCRIPT,
+        "aircraft": SOURCE_COMMISSION,
     }
-    assert cleaned["side_b"]["facility"] is None
+
+
+def test_with_no_commission_text_the_gate_reduces_to_transcript_only():
+    """The single-document case is the degenerate case, not a separate path."""
+    cleaned, reasons = validate_parties(
+        _parties(participants=[{
+            "facility": "NEADS", "position": None, "person": None,
+            "role": "military", "confidence": "high", "source": SOURCE_COMMISSION,
+        }]),
+        TRANSCRIPT,
+    )
+    assert cleaned["participants"] == []
+    assert reasons

--- a/packages/tools/video-grabber/tests/test_parties_identify.py
+++ b/packages/tools/video-grabber/tests/test_parties_identify.py
@@ -3,8 +3,11 @@ import pytest
 from video_grabber.parties.identify import (
     BROADCAST,
     CONVERSATION,
+    SCHEMA_VERSION,
+    SOURCE_TRANSCRIPT,
     TIER_CLIP,
     TIER_TAPE,
+    build_messages,
     media_kind,
     parse_parties,
     should_identify,
@@ -67,15 +70,42 @@ def test_missing_duration_raises_rather_than_defaulting():
         tier_for(None)
 
 
+# --- prompt shape ---------------------------------------------------------
+
+def test_topics_vocabulary_is_in_the_prompt():
+    """The closed list only works if the model is shown it."""
+    system, _ = build_messages("x", TIER_CLIP)
+    assert "hijack-report" in system and "shootdown-authority" in system
+
+
+def test_second_document_only_described_when_supplied():
+    bare, user = build_messages("x", TIER_CLIP)
+    assert "COMMISSION" not in bare and "COMMISSION" not in user
+    with_doc, user2 = build_messages("x", TIER_CLIP, "093800 Gofer 06")
+    assert "COMMISSION" in with_doc and "COMMISSION" in user2
+
+
+def test_tape_tier_is_told_not_to_invent_a_placeholder():
+    system, _ = build_messages("x", TIER_TAPE)
+    assert "do not invent a placeholder" in system
+
+
 # --- the containment gate -------------------------------------------------
 
 GOOD = {
     "tier": "clip",
-    "side_a": {"facility": "Indianapolis Center", "position": None, "person": None,
-               "role": "atc"},
-    "side_b": {"facility": "American", "position": "dispatch", "person": "Jim McDonald",
-               "role": "airline"},
-    "link": "landline", "aircraft": ["AAL77"], "confidence": "high",
+    "participants": [
+        {"facility": "Indianapolis Center", "position": None, "person": None,
+         "role": "atc", "confidence": "high"},
+        {"facility": "American", "position": "dispatch", "person": "Jim McDonald",
+         "role": "airline", "confidence": "high"},
+    ],
+    "link": "landline",
+    "aircraft": ["AAL77"],
+    "mentions": {"facilities": [], "aircraft": [], "people": []},
+    "subject": "Indianapolis Center trying to get a hold of American 77",
+    "topics": ["loss-of-contact"],
+    "confidence": "high",
     "evidence": "This is Indianapolis Center, trying to get a hold of American 77",
 }
 
@@ -84,32 +114,62 @@ def test_gate_accepts_names_the_transcript_contains():
     cleaned, reasons = validate_parties(GOOD, TRANSCRIPT)
     assert reasons == []
     assert cleaned["confidence"] == "high"
-    assert cleaned["side_b"]["person"] == "Jim McDonald"
+    assert cleaned["schema_version"] == SCHEMA_VERSION
+    assert [p["person"] for p in cleaned["participants"]] == [None, "Jim McDonald"]
 
 
 def test_gate_drops_a_facility_the_transcript_never_names():
     # The failure this exists to prevent: the model knows 9/11 and supplies
     # NEADS from memory rather than from the audio.
-    bad = {**GOOD, "side_a": {"facility": "NEADS", "position": None, "person": None,
-                              "role": "military"}}
+    bad = {**GOOD, "participants": [
+        {"facility": "NEADS", "position": None, "person": None,
+         "role": "military", "confidence": "high"},
+        GOOD["participants"][1],
+    ]}
     cleaned, reasons = validate_parties(bad, TRANSCRIPT)
-    assert cleaned["side_a"]["facility"] is None
-    assert cleaned["confidence"] == "low"
+    # The NEADS entry names nobody once its invented facility is stripped, so it
+    # is dropped rather than left as a contentless role.
+    assert [p["facility"] for p in cleaned["participants"]] == ["American"]
     assert any("neads" in r.lower() for r in reasons)
 
 
 def test_gate_drops_an_invented_person():
-    bad = {**GOOD, "side_b": {"facility": "American", "position": "dispatch",
-                              "person": "Colin Scoggins", "role": "airline"}}
+    bad = {**GOOD, "participants": [
+        {"facility": "American", "position": "dispatch", "person": "Colin Scoggins",
+         "role": "airline", "confidence": "high"},
+    ]}
     cleaned, reasons = validate_parties(bad, TRANSCRIPT)
-    assert cleaned["side_b"]["person"] is None
-    assert cleaned["confidence"] == "low"
+    assert cleaned["participants"][0]["person"] is None
+    assert cleaned["participants"][0]["facility"] == "American"
+    assert any("scoggins" in r.lower() for r in reasons)
+
+
+def test_a_gate_hit_caps_confidence_at_medium_rather_than_crushing_it():
+    """Schema 1 forced 'low' on any rejection, which lost real information.
+
+    189 rows were downgraded that way and became indistinguishable from the 357
+    the model itself could not read. A trimmed answer may not claim certainty,
+    but what survived is still worth grading.
+    """
+    bad = {**GOOD, "aircraft": ["AAL77", "UAL93"]}
+    cleaned, reasons = validate_parties(bad, TRANSCRIPT)
+    assert reasons
+    assert cleaned["confidence"] == "medium"
+
+
+def test_per_participant_confidence_survives_independently():
+    mixed = {**GOOD, "participants": [
+        {**GOOD["participants"][0], "confidence": "high"},
+        {**GOOD["participants"][1], "confidence": "low"},
+    ]}
+    cleaned, _ = validate_parties(mixed, TRANSCRIPT)
+    assert [p["confidence"] for p in cleaned["participants"]] == ["high", "low"]
 
 
 def test_gate_rejects_evidence_that_is_not_verbatim():
     bad = {**GOOD, "evidence": "Indianapolis Center said they lost the aircraft"}
     cleaned, reasons = validate_parties(bad, TRANSCRIPT)
-    assert cleaned["confidence"] == "low"
+    assert cleaned["evidence"] is None
     assert any("verbatim" in r for r in reasons)
 
 
@@ -134,13 +194,69 @@ def test_gate_drops_a_callsign_the_transcript_never_mentions():
     assert any("93" in r for r in reasons)
 
 
-def test_gate_leaves_various_alone_on_tape_tier():
-    tape = {**GOOD, "tier": "tape",
-            "side_b": {"facility": "various", "position": None, "person": None,
-                       "role": None}}
-    cleaned, reasons = validate_parties(tape, TRANSCRIPT)
-    assert cleaned["side_b"]["facility"] == "various"
+def test_various_is_no_longer_an_accepted_answer():
+    """Schema 1 needed the placeholder; schema 2 has participants instead.
+
+    Letting it through would put `facility:various` into the tag index as though
+    it were a real facility.
+    """
+    tape = {**GOOD, "tier": "tape", "participants": [
+        {"facility": "various", "position": None, "person": None,
+         "role": "unknown", "confidence": "low"},
+    ]}
+    cleaned, _ = validate_parties(tape, TRANSCRIPT)
+    assert cleaned["participants"] == []
+
+
+# --- the new fields -------------------------------------------------------
+
+def test_subject_must_use_words_from_the_source():
+    bad = {**GOOD, "subject": "Cleveland Center reports a hijacking in progress"}
+    cleaned, reasons = validate_parties(bad, TRANSCRIPT)
+    assert cleaned["subject"] is None
+    assert any("subject introduced words" in r for r in reasons)
+
+
+def test_subject_survives_when_built_from_source_words():
+    cleaned, reasons = validate_parties(GOOD, TRANSCRIPT)
+    assert cleaned["subject"] == GOOD["subject"]
+    assert cleaned["sources"]["subject"] == SOURCE_TRANSCRIPT
     assert reasons == []
+
+
+def test_topic_outside_the_vocabulary_is_dropped():
+    bad = {**GOOD, "topics": ["loss-of-contact", "everyone-is-worried"]}
+    cleaned, reasons = validate_parties(bad, TRANSCRIPT)
+    assert cleaned["topics"] == ["loss-of-contact"]
+    assert any("controlled vocabulary" in r for r in reasons)
+
+
+def test_mentioned_people_are_gated_like_participants():
+    bad = {**GOOD, "mentions": {"facilities": ["NEADS"], "aircraft": [], "people": []}}
+    cleaned, reasons = validate_parties(bad, TRANSCRIPT)
+    assert cleaned["mentions"]["facilities"] == []
+    assert any("neads" in r.lower() for r in reasons)
+
+
+def test_mentions_are_kept_separate_from_participants():
+    ok = {**GOOD, "mentions": {"facilities": [], "aircraft": ["AAL77"], "people": []}}
+    cleaned, _ = validate_parties(ok, TRANSCRIPT)
+    assert cleaned["mentions"]["aircraft"] == ["AAL77"]
+    assert all(p["facility"] != "AAL77" for p in cleaned["participants"])
+
+
+def test_unknown_link_value_falls_back_rather_than_persisting():
+    bad = {**GOOD, "link": "carrier-pigeon"}
+    cleaned, _ = validate_parties(bad, TRANSCRIPT)
+    assert cleaned["link"] == "unknown"
+
+
+def test_unknown_role_falls_back_to_unknown():
+    bad = {**GOOD, "participants": [
+        {**GOOD["participants"][0], "role": "wizard"},
+    ]}
+    cleaned, _ = validate_parties(bad, TRANSCRIPT)
+    assert cleaned["participants"][0]["role"] == "unknown"
 
 
 # --- parsing --------------------------------------------------------------

--- a/packages/tools/video-grabber/tests/test_parties_tags.py
+++ b/packages/tools/video-grabber/tests/test_parties_tags.py
@@ -1,0 +1,97 @@
+"""Tag derivation: what a searcher can actually filter on."""
+from video_grabber.parties.tags import build_tags, normalize_callsign, slugify
+from video_grabber.parties.vocab import agency_for
+
+FULL = {
+    "tier": "clip",
+    "link": "landline",
+    "participants": [
+        {"facility": "Indianapolis Center", "position": "R86", "person": None,
+         "role": "atc", "confidence": "high"},
+        {"facility": "American", "position": "dispatch", "person": "Jim McDonald",
+         "role": "airline", "confidence": "high"},
+    ],
+    "aircraft": ["American 77"],
+    "mentions": {"facilities": ["NEADS"], "aircraft": ["UAL93"], "people": ["Ben Sliney"]},
+    "topics": ["loss-of-contact", "hijack-report"],
+}
+
+
+def test_every_tag_is_namespaced():
+    """A bare tag list cannot be filtered by kind, and names collide across kinds."""
+    assert all(":" in t for t in build_tags(FULL))
+
+
+def test_tags_are_sorted_and_deduped():
+    tags = build_tags(FULL)
+    assert tags == sorted(set(tags))
+
+
+def test_participants_and_mentions_both_reach_the_index():
+    """Someone searching for NEADS wants the calls that discuss it, too."""
+    tags = build_tags(FULL)
+    assert "facility:indianapolis-center" in tags   # participant
+    assert "facility:neads" in tags                 # merely mentioned
+    assert "person:jim-mcdonald" in tags
+    assert "person:ben-sliney" in tags
+
+
+def test_agency_is_inferred_from_facility():
+    tags = build_tags(FULL)
+    assert "agency:faa" in tags and "agency:norad" in tags
+
+
+def test_only_vocabulary_topics_become_tags():
+    tags = build_tags({**FULL, "topics": ["hijack-report", "everyone-is-worried"]})
+    assert "topic:hijack-report" in tags
+    assert not any(t.startswith("topic:everyone") for t in tags)
+
+
+def test_various_never_becomes_a_facility():
+    """Schema 1's placeholder must not enter the index as a real place."""
+    tags = build_tags({"participants": [{"facility": "various", "role": "atc"}]})
+    assert "facility:various" not in tags
+
+
+def test_empty_block_yields_no_tags():
+    assert build_tags({}) == []
+
+
+# --- callsign normalisation ----------------------------------------------
+
+def test_spoken_and_coded_callsigns_collapse_to_one_tag():
+    """'American 11', 'AAL11' and 'AA11' are one aircraft, so one tag."""
+    assert {normalize_callsign(c) for c in ("American 11", "AAL11", "AA 11")} == {"aal11"}
+
+
+def test_military_callsigns_keep_their_own_prefix():
+    # The point is collapsing spellings, not forcing everything into an airline.
+    # Leading zeros are stripped so the spellings below agree; see the next test.
+    assert normalize_callsign("Gofer 06") == "gofer6"
+    assert normalize_callsign("Quit 2-5") == "quit25"
+
+
+def test_leading_zeros_do_not_split_an_aircraft_in_two():
+    assert normalize_callsign("Gofer 06") == normalize_callsign("GOFER6")
+
+
+def test_aircraft_tags_use_the_normalised_form():
+    tags = build_tags(FULL)
+    assert "aircraft:aal77" in tags and "aircraft:ual93" in tags
+
+
+# --- helpers --------------------------------------------------------------
+
+def test_slugify_collapses_punctuation_and_case():
+    assert slugify("Washington Center (ZDC)") == "washington-center-zdc"
+
+
+def test_agency_prefers_the_longest_matching_key():
+    # 'us airways' must not be shadowed by a shorter carrier key, and
+    # 'port authority' must beat any substring.
+    assert agency_for("US Airways") == "airline"
+    assert agency_for("Port Authority Police") == "panynj"
+
+
+def test_unknown_facility_has_no_agency():
+    assert agency_for("Somewhere Nobody Listed") is None

--- a/packages/tools/video-grabber/video_grabber/parties/flows.py
+++ b/packages/tools/video-grabber/video_grabber/parties/flows.py
@@ -1,6 +1,11 @@
-"""Identify who each recording's traffic is between and write mp3_items.parties."""
+"""Identify who each recording's traffic is between, and tag it for searching.
+
+One flow, one pass. The Commission clip index is consulted per row rather than
+run as a separate enrichment pass: a second pass would mean a second model call
+for the same recording, and a half-finished one would leave two different shapes
+in the same column.
+"""
 from datetime import datetime, timezone
-from pathlib import Path
 
 import httpx
 from prefect import flow, get_run_logger
@@ -10,16 +15,15 @@ from video_grabber.config import Config
 from video_grabber.directus.writer import _auth_headers
 from video_grabber.parties.commission import match_commission_clip
 from video_grabber.parties.identify import (
+    SCHEMA_VERSION,
     TIER_TAPE,
-    build_clip_messages,
-    build_enrichment_messages,
-    build_tape_messages,
+    build_messages,
     parse_parties,
     should_identify,
     tier_for,
-    validate_enriched_parties,
     validate_parties,
 )
+from video_grabber.parties.tags import build_tags
 from video_grabber.storage import wasabi
 from video_grabber.transcript.summarize_flows import anthropic_completer
 
@@ -35,7 +39,8 @@ SAMPLE_CHARS = 2000
 # The same clip at 4000 -> end_turn, 2813 output tokens, ['thinking', 'text'].
 # Failure is silent and self-selecting for the ambiguous clips that most need the
 # reasoning, so leave real headroom rather than trimming to the observed maximum.
-PARTIES_MAX_TOKENS = 4000
+# Schema 2 asks for more fields, so the text half of the budget grew too.
+PARTIES_MAX_TOKENS = 5000
 
 
 def srt_text_to_plain(srt: str) -> str:
@@ -56,10 +61,15 @@ def sample_windows(text: str, n: int = SAMPLE_WINDOWS, size: int = SAMPLE_CHARS)
 @flow(name="identify-parties")
 def identify_parties_flow(limit: int | None = None, force: bool = False,
                           dry_run: bool = True) -> None:
-    """Identify communication parties for every eligible mp3_items row.
+    """Identify parties and derive search tags for every eligible mp3_items row.
 
-    Idempotency marker is `parties IS NOT NULL`, so the flow is resumable
-    without a jobs table; pass force=True to re-identify.
+    Where the 9/11 Commission catalogued the same recording, their title and
+    monograph narrative go into the prompt alongside the transcript, and every
+    value the model keeps records which of the two it came from.
+
+    Idempotency marker is `parties.schema_version`, so re-running picks up rows
+    left on an older shape and skips ones already current; pass force=True to
+    redo everything.
     """
     logger = get_run_logger()
     cfg = Config()
@@ -67,7 +77,7 @@ def identify_parties_flow(limit: int | None = None, force: bool = False,
         raise RuntimeError("ANTHROPIC_API_KEY is not set")
     complete = anthropic_completer(cfg, model=cfg.parties_model, max_tokens=PARTIES_MAX_TOKENS)
 
-    done = skipped = failed = broadcast = 0
+    done = skipped = failed = broadcast = enriched = 0
     for row in _page_mp3_items(cfg, "id,url,subtitles,calc_duration,parties"):
         if limit is not None and done >= limit:
             break
@@ -76,24 +86,33 @@ def identify_parties_flow(limit: int | None = None, force: bool = False,
         if not should_identify(key):
             broadcast += 1
             continue
-        if row.get("parties") and not force:
-            skipped += 1
-            continue
-        if not row.get("subtitles"):
-            logger.warning("identify-parties: %s has no subtitles; skipping", key)
+        existing = row.get("parties") or {}
+        if existing.get("schema_version") == SCHEMA_VERSION and not force:
             skipped += 1
             continue
 
-        transcript = srt_text_to_plain(wasabi.read_text(key_from_url(row["subtitles"]), cfg))
-        if not transcript.strip():
+        clip = match_commission_clip(key)
+
+        # A missing transcript is not disqualifying when the Commission
+        # catalogued the recording: their text alone can carry an
+        # identification, and the gate rejects anything claiming the empty
+        # transcript as its source.
+        transcript = ""
+        if row.get("subtitles"):
+            transcript = srt_text_to_plain(
+                wasabi.read_text(key_from_url(row["subtitles"]), cfg)
+            )
+        if not transcript.strip() and clip is None:
+            logger.warning("identify-parties: %s has no transcript and no clip", key)
             skipped += 1
             continue
 
         tier = tier_for(row.get("calc_duration"))
+        excerpt = transcript
         if tier == TIER_TAPE:
-            system, user = build_tape_messages(Path(key).name, sample_windows(transcript))
-        else:
-            system, user = build_clip_messages(transcript)
+            excerpt = "\n\n---\n\n".join(sample_windows(transcript))
+        commission_text = clip.text if clip else ""
+        system, user = build_messages(excerpt, tier, commission_text)
 
         try:
             parsed = parse_parties(complete(system, user))
@@ -102,114 +121,35 @@ def identify_parties_flow(limit: int | None = None, force: bool = False,
             failed += 1
             continue
 
-        cleaned, reasons = validate_parties(parsed, transcript)
+        cleaned, reasons = validate_parties(parsed, excerpt, commission_text)
         cleaned["tier"] = tier
         cleaned["model"] = cfg.parties_model
         cleaned["generated_at"] = datetime.now(timezone.utc).isoformat()
+        if clip:
+            enriched += 1
+            cleaned["commission"] = {
+                "title": clip.title,
+                "source": clip.source,
+                "stamp": clip.stamp,
+                "slug_overlap": clip.overlap,
+            }
         if reasons:
             cleaned["gate_reasons"] = reasons
-            logger.info("identify-parties: %s downgraded: %s", key, reasons)
+            logger.info("identify-parties: %s gated: %s", key, reasons)
+
+        tags = build_tags(cleaned)
 
         if dry_run:
-            logger.info("DRY RUN %s -> %s", key, cleaned)
+            logger.info("DRY RUN %s -> %s | tags=%s", key, cleaned, tags)
         else:
             pr = httpx.patch(f"{cfg.directus_url}/items/mp3_items/{row['id']}",
-                             json={"parties": cleaned}, headers=_auth_headers(cfg))
+                             json={"parties": cleaned, "tags": tags},
+                             headers=_auth_headers(cfg))
             pr.raise_for_status()
         done += 1
 
     logger.info(
-        "identify-parties: %d identified, %d skipped, %d broadcast (excluded), %d failed",
-        done, skipped, broadcast, failed,
-    )
-
-
-@flow(name="enrich-parties-from-commission")
-def enrich_parties_from_commission_flow(
-    limit: int | None = None, force: bool = False, dry_run: bool = True
-) -> None:
-    """Re-identify the recordings the 9/11 Commission also catalogued.
-
-    `identify-parties` can only report what the audio says, and on a garbled
-    landline that is often nothing. For the subset of our corpus the Commission
-    indexed, their title and the Team 8 monograph narrative name the parties
-    outright — so those rows get a second pass with both documents in the prompt.
-
-    Every field the result keeps carries a `sources` entry saying which document
-    it came from, so a transcript-derived name stays as checkable as it was
-    before. Rows with no Commission match are left exactly as they are.
-
-    Idempotency marker is a `commission` block on the existing parties object;
-    pass force=True to redo them.
-    """
-    logger = get_run_logger()
-    cfg = Config()
-    if not cfg.anthropic_api_key:
-        raise RuntimeError("ANTHROPIC_API_KEY is not set")
-    complete = anthropic_completer(cfg, model=cfg.parties_model, max_tokens=PARTIES_MAX_TOKENS)
-
-    done = skipped = failed = unmatched = 0
-    for row in _page_mp3_items(cfg, "id,url,subtitles,calc_duration,parties"):
-        if limit is not None and done >= limit:
-            break
-        key = key_from_url(row["url"])
-
-        if not should_identify(key):
-            continue
-        clip = match_commission_clip(key)
-        if clip is None:
-            unmatched += 1
-            continue
-        existing = row.get("parties") or {}
-        if existing.get("commission") and not force:
-            skipped += 1
-            continue
-
-        # Unlike identify-parties, a missing transcript is not disqualifying: the
-        # Commission text alone can carry an identification, and the gate will
-        # reject anything that claims the empty transcript as its source.
-        transcript = ""
-        if row.get("subtitles"):
-            transcript = srt_text_to_plain(
-                wasabi.read_text(key_from_url(row["subtitles"]), cfg)
-            )
-
-        tier = tier_for(row.get("calc_duration"))
-        excerpt = transcript
-        if tier == TIER_TAPE:
-            excerpt = "\n\n---\n\n".join(sample_windows(transcript))
-        system, user = build_enrichment_messages(excerpt, clip.text, tier)
-
-        try:
-            parsed = parse_parties(complete(system, user))
-        except ValueError as exc:
-            logger.warning("enrich-parties: %s unparseable: %s", key, exc)
-            failed += 1
-            continue
-
-        cleaned, reasons = validate_enriched_parties(parsed, excerpt, clip.text)
-        cleaned["tier"] = tier
-        cleaned["model"] = cfg.parties_model
-        cleaned["generated_at"] = datetime.now(timezone.utc).isoformat()
-        cleaned["commission"] = {
-            "title": clip.title,
-            "source": clip.source,
-            "stamp": clip.stamp,
-            "slug_overlap": clip.overlap,
-        }
-        if reasons:
-            cleaned["gate_reasons"] = reasons
-            logger.info("enrich-parties: %s downgraded: %s", key, reasons)
-
-        if dry_run:
-            logger.info("DRY RUN %s -> %s", key, cleaned)
-        else:
-            pr = httpx.patch(f"{cfg.directus_url}/items/mp3_items/{row['id']}",
-                             json={"parties": cleaned}, headers=_auth_headers(cfg))
-            pr.raise_for_status()
-        done += 1
-
-    logger.info(
-        "enrich-parties: %d enriched, %d already done, %d no Commission clip, %d failed",
-        done, skipped, unmatched, failed,
+        "identify-parties: %d identified (%d with Commission sources), "
+        "%d skipped, %d broadcast (excluded), %d failed",
+        done, enriched, skipped, broadcast, failed,
     )

--- a/packages/tools/video-grabber/video_grabber/parties/identify.py
+++ b/packages/tools/video-grabber/video_grabber/parties/identify.py
@@ -1,4 +1,4 @@
-"""Decide who a recording's traffic is between. Pure logic only.
+"""Decide who a recording's traffic is between, and what it is about. Pure logic.
 
 The network call is injected, so every rule here is unit-testable without a key —
 same split as transcript/summarize.py, and for the same reason: the judgments that
@@ -8,13 +8,36 @@ The containment gate is the point of this module. The model knows how September 
 turned out. Asked who is speaking on a garbled tape it will confidently supply
 "NEADS" or "Colin Scoggins" from background knowledge rather than from the audio.
 Identification has to be a reading task, not a recall task, so every name the model
-returns must already be in the transcript and its evidence quote must be verbatim.
+returns must already be in a document it was shown, and its evidence quote must be
+verbatim.
+
+Schema 2 widens what a recording can say about itself without widening what the
+model is allowed to invent:
+
+- **`participants` replaces `side_a`/`side_b`.** Two sides could not describe a
+  conference call or a position tape, and 179 tapes were reduced to the
+  placeholder `side_b.facility = "various"` for exactly that reason.
+- **`mentions` separates who is talked about from who is talking**, which was
+  previously discarded entirely.
+- **`subject` and `topics`** say what the call is about. `topics` comes from a
+  closed vocabulary (`vocab.TOPICS`) because free text does not survive contact
+  with a search box.
+- **Confidence is per participant**, not per blob. Under schema 1 a single
+  rejected field dragged the whole answer to "low", which made 189 partly-good
+  rows indistinguishable from ones the model genuinely could not read.
+
+Provenance is carried two ways for one reason: participants are objects, so their
+`source` and `confidence` live inline where they cannot be knocked out of
+alignment by a dropped entry, while the flat fields use a path-keyed `sources`
+map. Array indices in a path map would shift whenever the gate drops a
+participant, silently re-labelling the survivors.
 """
 from __future__ import annotations
 
 import json
 import re
 
+from video_grabber.parties.vocab import LINKS, ROLES, TOPICS
 from video_grabber.transcript.summarize import unsupported_words
 
 CONVERSATION = "conversation"
@@ -23,6 +46,13 @@ BROADCAST = "broadcast"
 TIER_CLIP = "clip"
 TIER_TAPE = "tape"
 CLIP_MAX_SECONDS = 300
+
+SCHEMA_VERSION = 2
+
+SOURCE_TRANSCRIPT = "transcript"
+SOURCE_COMMISSION = "commission_monograph"
+
+CONFIDENCE_ORDER = {"low": 0, "medium": 1, "high": 2}
 
 # Keyed on the first path segment under audio/. A module constant rather than an
 # env var: this is a property of the corpus, not the deployment, and an env var is
@@ -69,43 +99,87 @@ def tier_for(duration_seconds: int | None) -> str:
 
 
 _SYSTEM = """\
-You identify who is speaking in a transcript of September 11, 2001 air traffic \
-control, military, and emergency audio.
+You identify who is speaking in a recording of September 11, 2001 air traffic \
+control, military, and emergency audio, and say what the recording is about.
 
 Rules you must follow:
-- Use ONLY what the transcript says. Do not use anything you know about the events \
-of September 11 from any other source.
-- If the transcript does not name a facility, position, or person, return null for \
-that field. Do not infer it.
-- The `evidence` field must be an exact quote copied character-for-character from \
-the transcript.
-- If you cannot tell who is speaking, say so with confidence "low" and null sides. \
-That is a correct answer, not a failure.
+- Every value you return must come from a document you were given. Do not use \
+anything you know about September 11 from any other source.
+- If the documents do not tell you, return null or an empty list. That is a \
+correct answer, not a failure.
+- `evidence` must be an exact quote copied character-for-character from a \
+document.
+- `subject` must be written using words that appear in the documents.
+
+`participants` lists everyone taking part in the communication — one entry per \
+party, however many there are. Do not force a conversation into two sides. Each \
+participant carries its own `confidence`, because you will often be sure of one \
+party and unsure of another.
+
+`mentions` is for facilities, aircraft and people that are TALKED ABOUT but are \
+not taking part. Keep them out of `participants`.
+
+`topics` must be chosen from this list, and nothing else:
+%s
 
 Return ONLY a JSON object:
-{"tier":"clip",
- "side_a":{"facility":str|null,"position":str|null,"person":str|null,"role":str|null},
- "side_b":{"facility":str|null,"position":str|null,"person":str|null,"role":str|null},
- "link":"air-ground"|"landline"|"internal"|"unknown",
+{"tier":"clip"|"tape",
+ "participants":[{"facility":str|null,"position":str|null,"person":str|null,
+                  "role":"atc"|"military"|"airline"|"emergency"|"aircraft"|"unknown",
+                  "confidence":"high"|"medium"|"low"}],
+ "link":"air-ground"|"landline"|"internal"|"conference"|"unknown",
  "aircraft":[str],
+ "mentions":{"facilities":[str],"aircraft":[str],"people":[str]},
+ "subject":str|null,
+ "topics":[str],
  "confidence":"high"|"medium"|"low",
- "evidence":str}
-
-`role` is one of: atc, military, airline, emergency, aircraft, unknown."""
+ "evidence":str}"""
 
 
-def build_clip_messages(transcript: str) -> tuple[str, str]:
-    return _SYSTEM, f"Transcript:\n\n{transcript}"
+_TAPE_NOTE = """
+
+This is a long continuous recording of ONE position, and you are seeing sampled \
+excerpts rather than the whole thing. List that position as the first \
+participant. Add the counterparties you can actually identify in the excerpts as \
+further participants — do not invent a placeholder for the ones you cannot."""
+
+_TWO_DOC_NOTE = """
+
+You are given TWO documents. TRANSCRIPT is an automatic transcript of the \
+recording, and is imperfect: callsigns and names are often garbled or missing. \
+COMMISSION is how the 9/11 Commission catalogued this same recording — their \
+title for it, and where available the passage of the Team 8 audio monograph that \
+discusses it.
+
+For every value you fill in, record which document it came from: on a \
+participant use its `source` field, and for the flat fields use the `sources` \
+map keyed by field name ("subject", "evidence", "aircraft", "mentions.people", \
+"mentions.facilities", "mentions.aircraft"). Use "transcript" or \
+"commission_monograph".
+
+Prefer the transcript where both support a value. Use the Commission to fill in \
+what the transcript leaves unknown or garbled. The Commission passage also gives \
+narrative about the wider morning — do not pull in people or facilities it does \
+not connect to THIS recording."""
 
 
-def build_tape_messages(filename: str, samples: list[str]) -> tuple[str, str]:
-    system = _SYSTEM.replace('"tier":"clip"', '"tier":"tape"') + (
-        "\n\nThis is a long continuous recording of ONE position. side_a is that "
-        "position. side_b represents the many counterparties, so set its facility "
-        'to "various". Identify the position from the filename and the samples.'
-    )
-    joined = "\n\n---\n\n".join(samples)
-    return system, f"Filename: {filename}\n\nSampled excerpts:\n\n{joined}"
+def build_messages(
+    transcript: str, tier: str, commission_text: str = ""
+) -> tuple[str, str]:
+    """The one prompt builder: clip or tape, with or without a second document.
+
+    Schema 1 had three near-identical builders that drifted apart. The tier and
+    the presence of Commission text are just two flags on one task.
+    """
+    system = _SYSTEM % "\n".join(f"  {t}" for t in sorted(TOPICS))
+    if tier == TIER_TAPE:
+        system += _TAPE_NOTE
+    if commission_text:
+        system += _TWO_DOC_NOTE
+        user = f"COMMISSION:\n\n{commission_text}\n\n=====\n\nTRANSCRIPT:\n\n{transcript}"
+    else:
+        user = f"Transcript:\n\n{transcript}"
+    return system, user
 
 
 _FENCE = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.S)
@@ -138,77 +212,18 @@ def parse_parties(raw: str) -> dict:
     return parsed
 
 
-SOURCE_TRANSCRIPT = "transcript"
-SOURCE_COMMISSION = "commission_monograph"
-
-_ENRICH_SYSTEM = """\
-You identify who is speaking in a recording of September 11, 2001 air traffic \
-control, military, and emergency audio.
-
-You are given TWO documents:
-1. TRANSCRIPT — an automatic transcript of the recording itself. Imperfect: \
-callsigns and names are often garbled or missing.
-2. COMMISSION — how the 9/11 Commission catalogued this same recording: their \
-title for it, and where available the passage of the Team 8 audio monograph that \
-discusses it. This names people, positions and facilities the transcript may not.
-
-Rules you must follow:
-- Every value you return must come from one of those two documents. Do not use \
-anything you know about September 11 from any other source.
-- For every field you fill in, record which document it came from in `sources`, \
-using the exact key path (e.g. "side_a.facility") and the value "transcript" or \
-"commission_monograph".
-- Prefer the transcript when both documents support a field. Use the Commission \
-only to fill in what the transcript leaves unknown or garbled.
-- The COMMISSION document describes this recording, so what it says about who is \
-on the call applies. But it also gives surrounding narrative about the wider \
-morning — do not pull in people or facilities it does not connect to THIS call.
-- If neither document tells you, return null. That is a correct answer.
-- `evidence` must be an exact quote copied character-for-character from whichever \
-document you cite in sources["evidence"].
-
-Return ONLY a JSON object:
-{"tier":"clip"|"tape",
- "side_a":{"facility":str|null,"position":str|null,"person":str|null,"role":str|null},
- "side_b":{"facility":str|null,"position":str|null,"person":str|null,"role":str|null},
- "link":"air-ground"|"landline"|"internal"|"unknown",
- "aircraft":[str],
- "confidence":"high"|"medium"|"low",
- "evidence":str,
- "sources":{"<field path>":"transcript"|"commission_monograph"}}
-
-`role` is one of: atc, military, airline, emergency, aircraft, unknown."""
-
-
-def build_enrichment_messages(
-    transcript: str, commission_text: str, tier: str
-) -> tuple[str, str]:
-    """Prompt for identifying a recording the Commission also catalogued."""
-    system = _ENRICH_SYSTEM
-    if tier == TIER_TAPE:
-        system += (
-            "\n\nThis is a long continuous recording of ONE position. side_a is "
-            'that position; set side_b.facility to "various".'
-        )
-    user = (
-        f"COMMISSION:\n\n{commission_text}\n\n"
-        f"=====\n\nTRANSCRIPT:\n\n{transcript}"
-    )
-    return system, user
-
-
 def _normalise(s: str) -> str:
     return re.sub(r"\s+", " ", s or "").strip().lower()
 
 
-def evidence_is_verbatim(evidence: str, transcript: str) -> bool:
+def evidence_is_verbatim(evidence: str, source: str) -> bool:
     if not (evidence or "").strip():
         return False
-    return _normalise(evidence) in _normalise(transcript)
+    return _normalise(evidence) in _normalise(source)
 
 
-def _callsign_supported(callsign: str, transcript: str) -> bool:
-    """A callsign is supported when its flight number appears in the transcript.
+def _callsign_supported(callsign: str, source: str) -> bool:
+    """A callsign is supported when its flight number appears in the source.
 
     'AAL77' is a normalisation of the spoken 'American 77', not a quotation, so
     requiring the literal token would reject every correct answer. The flight
@@ -217,67 +232,28 @@ def _callsign_supported(callsign: str, transcript: str) -> bool:
     digits = _DIGITS.findall(callsign or "")
     if not digits:
         return False
-    return all(d in transcript for d in digits)
+    return all(d in source for d in digits)
 
 
-def validate_parties(parsed: dict, transcript: str) -> tuple[dict, list[str]]:
-    """Drop every name the transcript does not support; return (cleaned, reasons).
-
-    Any rejection forces confidence to 'low' rather than discarding the whole
-    answer: a partly-supported identification is still worth keeping, but it must
-    not claim to be certain.
-    """
-    cleaned = json.loads(json.dumps(parsed))
-    reasons: list[str] = []
-
-    if not evidence_is_verbatim(cleaned.get("evidence", ""), transcript):
-        reasons.append("evidence is not a verbatim quote from the transcript")
-        cleaned["evidence"] = None
-
-    for side in ("side_a", "side_b"):
-        block = cleaned.get(side) or {}
-        for field in ("facility", "position", "person"):
-            value = block.get(field)
-            # 'various' is the tape tier's deliberate placeholder for "many
-            # counterparties", not a claim about the transcript.
-            if not value or value == "various":
-                continue
-            missing = unsupported_words(value, transcript)
-            if missing:
-                reasons.append(
-                    f"{side}.{field}={value!r} names {missing} which the transcript "
-                    f"never contains"
-                )
-                block[field] = None
-        cleaned[side] = block
-
-    aircraft = cleaned.get("aircraft") or []
-    kept = []
-    for name in aircraft:
-        if _callsign_supported(str(name), transcript):
-            kept.append(name)
-        else:
-            reasons.append(f"aircraft {name!r} not present in transcript")
-    cleaned["aircraft"] = kept
-
-    if reasons:
-        cleaned["confidence"] = "low"
-    return cleaned, reasons
-
-
-def validate_enriched_parties(
-    parsed: dict, transcript: str, commission_text: str
+def validate_parties(
+    parsed: dict, transcript: str, commission_text: str = ""
 ) -> tuple[dict, list[str]]:
-    """The containment gate, parameterised by which document a field claims.
+    """Drop everything the cited document does not support; return (cleaned, reasons).
 
-    `validate_parties` asks one question of every value: is it in the transcript?
-    Here there are two admissible documents, so the question becomes: is it in the
-    one it says it came from? The guarantee is unchanged — nothing survives that
-    isn't written down somewhere we can point at — and it stays checkable after the
-    fact, because the surviving `sources` map says where to look.
+    The gate asks one question of every value: is it in the document it claims to
+    have come from? With no Commission text this reduces to the original rule —
+    everything is held to the transcript — so a single-document run is the
+    degenerate case rather than a separate code path.
 
-    A field that declares no source is held to the transcript. Silence must not be
-    a way to reach the looser document.
+    Two rules keep provenance from becoming decorative: an **undeclared** source
+    is held to the transcript, so silence cannot reach the looser document, and an
+    **unrecognised** source name is rejected outright rather than trusted.
+
+    Unlike schema 1 this no longer crushes the whole answer to "low" on any
+    rejection. Fields carry their own confidence, and a blanket downgrade made
+    partly-good rows indistinguishable from unreadable ones. A gate hit caps the
+    overall figure at "medium" instead — something was wrong, so it may not claim
+    certainty, but what survived is still worth grading.
     """
     texts = {SOURCE_TRANSCRIPT: transcript, SOURCE_COMMISSION: commission_text}
     cleaned = json.loads(json.dumps(parsed))
@@ -287,8 +263,9 @@ def validate_enriched_parties(
     reasons: list[str] = []
     kept_sources: dict[str, str] = {}
 
-    def resolve(path: str) -> str | None:
-        claimed = declared.get(path)
+    def resolve(path: str, claimed: str | None = None) -> str | None:
+        if claimed is None:
+            claimed = declared.get(path)
         if claimed is None:
             return SOURCE_TRANSCRIPT
         if claimed not in texts:
@@ -296,6 +273,46 @@ def validate_enriched_parties(
             return None
         return claimed
 
+    def check_name(value: str, source: str, path: str) -> bool:
+        missing = unsupported_words(value, texts[source])
+        if missing:
+            reasons.append(
+                f"{path}={value!r} names {missing} which the {source} never contains"
+            )
+            return False
+        return True
+
+    # --- participants ---------------------------------------------------
+    participants = []
+    for i, raw in enumerate(cleaned.get("participants") or []):
+        if not isinstance(raw, dict):
+            continue
+        source = resolve(f"participants[{i}]", raw.get("source"))
+        if source is None:
+            continue
+        entry = {}
+        for field in ("facility", "position", "person"):
+            value = raw.get(field)
+            # 'various' was schema 1's placeholder for "many counterparties".
+            # Schema 2 has participants, so it is no longer a legitimate answer.
+            if not value or str(value).lower() == "various":
+                entry[field] = None
+                continue
+            entry[field] = value if check_name(
+                str(value), source, f"participants[{i}].{field}"
+            ) else None
+        role = raw.get("role")
+        entry["role"] = role if role in ROLES else "unknown"
+        confidence = raw.get("confidence")
+        entry["confidence"] = confidence if confidence in CONFIDENCE_ORDER else "low"
+        entry["source"] = source
+        # An entry naming nobody says only "somebody with this role spoke", which
+        # every recording already implies. Drop it rather than pad the list.
+        if any(entry[f] for f in ("facility", "position", "person")):
+            participants.append(entry)
+    cleaned["participants"] = participants
+
+    # --- evidence ---------------------------------------------------------
     evidence_source = resolve("evidence")
     if evidence_source is None or not evidence_is_verbatim(
         cleaned.get("evidence", ""), texts[evidence_source]
@@ -306,39 +323,79 @@ def validate_enriched_parties(
     else:
         kept_sources["evidence"] = evidence_source
 
-    for side in ("side_a", "side_b"):
-        block = cleaned.get(side) or {}
-        for field in ("facility", "position", "person"):
-            path = f"{side}.{field}"
-            value = block.get(field)
-            if not value or value == "various":
-                continue
-            source = resolve(path)
-            if source is None:
-                block[field] = None
-                continue
-            missing = unsupported_words(value, texts[source])
-            if missing:
-                reasons.append(
-                    f"{path}={value!r} names {missing} which the {source} never contains"
-                )
-                block[field] = None
-            else:
-                kept_sources[path] = source
-        cleaned[side] = block
+    # --- subject ----------------------------------------------------------
+    subject = (cleaned.get("subject") or "").strip()
+    subject_source = resolve("subject")
+    if not subject or subject_source is None:
+        cleaned["subject"] = None
+    else:
+        missing = unsupported_words(subject, texts[subject_source])
+        if missing:
+            reasons.append(
+                f"subject introduced words absent from the {subject_source}: "
+                f"{', '.join(missing[:6])}"
+            )
+            cleaned["subject"] = None
+        else:
+            cleaned["subject"] = subject
+            kept_sources["subject"] = subject_source
 
+    # --- aircraft ---------------------------------------------------------
     aircraft_source = resolve("aircraft")
-    kept = []
+    kept_aircraft = []
     for name in cleaned.get("aircraft") or []:
         if aircraft_source and _callsign_supported(str(name), texts[aircraft_source]):
-            kept.append(name)
+            kept_aircraft.append(name)
         else:
             reasons.append(f"aircraft {name!r} not present in the {aircraft_source}")
-    cleaned["aircraft"] = kept
-    if kept and aircraft_source:
+    cleaned["aircraft"] = kept_aircraft
+    if kept_aircraft and aircraft_source:
         kept_sources["aircraft"] = aircraft_source
 
+    # --- mentions ---------------------------------------------------------
+    mentions_in = cleaned.get("mentions") or {}
+    mentions_out: dict[str, list] = {"facilities": [], "aircraft": [], "people": []}
+    for kind in ("facilities", "people"):
+        path = f"mentions.{kind}"
+        source = resolve(path)
+        if source is None:
+            continue
+        for value in mentions_in.get(kind) or []:
+            if check_name(str(value), source, path):
+                mentions_out[kind].append(value)
+        if mentions_out[kind]:
+            kept_sources[path] = source
+    source = resolve("mentions.aircraft")
+    if source:
+        for value in mentions_in.get("aircraft") or []:
+            if _callsign_supported(str(value), texts[source]):
+                mentions_out["aircraft"].append(value)
+            else:
+                reasons.append(f"mentioned aircraft {value!r} not present in the {source}")
+        if mentions_out["aircraft"]:
+            kept_sources["mentions.aircraft"] = source
+    cleaned["mentions"] = mentions_out
+
+    # --- closed vocabularies ----------------------------------------------
+    topics = []
+    for topic in cleaned.get("topics") or []:
+        if topic in TOPICS:
+            topics.append(topic)
+        else:
+            reasons.append(f"topic {topic!r} is not in the controlled vocabulary")
+    cleaned["topics"] = sorted(set(topics))
+
+    if cleaned.get("link") not in LINKS:
+        cleaned["link"] = "unknown"
+
+    # --- overall confidence -------------------------------------------------
+    overall = cleaned.get("confidence")
+    if overall not in CONFIDENCE_ORDER:
+        overall = "low"
+    if reasons and CONFIDENCE_ORDER[overall] > CONFIDENCE_ORDER["medium"]:
+        overall = "medium"
+    cleaned["confidence"] = overall
+
     cleaned["sources"] = kept_sources
-    if reasons:
-        cleaned["confidence"] = "low"
+    cleaned["schema_version"] = SCHEMA_VERSION
     return cleaned, reasons

--- a/packages/tools/video-grabber/video_grabber/parties/tags.py
+++ b/packages/tools/video-grabber/video_grabber/parties/tags.py
@@ -1,0 +1,105 @@
+"""Turn an identified `parties` block into flat, searchable tags.
+
+Tags are **derived**, never separately generated. Asking the model for tags as
+well as parties would give you two accounts of the same recording that quietly
+disagree — a `facility:zob` tag on a row whose parties block says Cleveland.
+Everything here is a pure function of the block, so the only way a tag can be
+wrong is if the block is, and the containment gate already governs that.
+
+The one exception is `topic:`, which has no equivalent in the block and comes
+from the model's pick out of `vocab.TOPICS`.
+
+Tags are namespaced (`facility:zob`, not `zob`) for two reasons: a bare tag list
+cannot be filtered by kind, and names collide across kinds — "Boston" is a
+facility, and Boston is also a surname.
+
+Participating and merely-mentioned entities both get tagged. Someone searching
+for Cleveland Center wants the calls that discuss it, not only the ones it spoke
+on; the parties block keeps the distinction for anyone who needs it.
+"""
+from __future__ import annotations
+
+import re
+
+from video_grabber.parties.vocab import TOPICS, agency_for
+
+_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+_CALLSIGN = re.compile(r"^([a-z]*)0*(\d+)$")
+
+# Spoken airline names and their ICAO-ish prefixes, so "American 11", "AAL11"
+# and "AA11" all land on one tag instead of three.
+_AIRLINE_PREFIX: dict[str, str] = {
+    "american": "aal", "aa": "aal", "aal": "aal",
+    "united": "ual", "ua": "ual", "ual": "ual",
+    "delta": "dal", "dl": "dal", "dal": "dal",
+    "continental": "coa", "coa": "coa",
+    "usair": "usa", "usairways": "usa",
+    "midwest": "mep", "northwest": "nwa", "nwa": "nwa",
+}
+
+
+def slugify(value: str) -> str:
+    return _NON_ALNUM.sub("-", (value or "").lower()).strip("-")
+
+
+def normalize_callsign(callsign: str) -> str:
+    """`American 11` / `AAL11` / `AA 11` -> `aal11`; `Gofer 06` -> `gofer06`.
+
+    Military and unmatched callsigns keep their own prefix — the point is to
+    collapse the ways one aircraft is written, not to force everything into an
+    airline scheme. Leading zeros go so `Quit 2-5` and `QUIT25` agree.
+    """
+    compact = _NON_ALNUM.sub("", (callsign or "").lower())
+    m = _CALLSIGN.match(compact)
+    if not m:
+        return compact
+    prefix, digits = m.group(1), m.group(2)
+    return f"{_AIRLINE_PREFIX.get(prefix, prefix)}{digits}"
+
+
+def build_tags(parties: dict) -> list[str]:
+    """Every tag implied by an identified parties block, sorted and deduped."""
+    tags: set[str] = set()
+
+    if parties.get("tier"):
+        tags.add(f"tier:{slugify(parties['tier'])}")
+    if parties.get("link"):
+        tags.add(f"link:{slugify(parties['link'])}")
+
+    facilities: list[str] = []
+    for p in parties.get("participants") or []:
+        if p.get("role"):
+            tags.add(f"role:{slugify(p['role'])}")
+        if p.get("facility"):
+            facilities.append(p["facility"])
+        if p.get("person"):
+            tags.add(f"person:{slugify(p['person'])}")
+
+    mentions = parties.get("mentions") or {}
+    facilities += list(mentions.get("facilities") or [])
+    for person in mentions.get("people") or []:
+        tags.add(f"person:{slugify(person)}")
+
+    for facility in facilities:
+        slug = slugify(facility)
+        if not slug:
+            continue
+        tags.add(f"facility:{slug}")
+        agency = agency_for(facility)
+        if agency:
+            tags.add(f"agency:{agency}")
+
+    aircraft = list(parties.get("aircraft") or []) + list(mentions.get("aircraft") or [])
+    for callsign in aircraft:
+        slug = normalize_callsign(str(callsign))
+        if slug:
+            tags.add(f"aircraft:{slug}")
+
+    for topic in parties.get("topics") or []:
+        if topic in TOPICS:
+            tags.add(f"topic:{topic}")
+
+    # 'various' is the tape tier's placeholder for "many counterparties"; it is
+    # not a facility and must never become one.
+    tags.discard("facility:various")
+    return sorted(tags)

--- a/packages/tools/video-grabber/video_grabber/parties/vocab.py
+++ b/packages/tools/video-grabber/video_grabber/parties/vocab.py
@@ -1,0 +1,95 @@
+"""Closed vocabularies for the searchable parts of a recording's metadata.
+
+Free-text topics do not survive contact with a search box. Ask a model to say
+what 755 recordings are about and you get 700 distinct phrasings — "hijacking
+reported", "report of hijack", "possible hijack" — which is prose, not an index.
+So the model picks from a fixed list and anything else is dropped.
+
+The list is scoped to what this corpus actually contains: FAA/ATC position and
+landline audio, NEADS/NORAD floor tapes, the four hijacked flights, and FDNY
+dispatch. It is deliberately short. A vocabulary nobody can hold in their head
+gets used inconsistently, which puts you back where you started.
+"""
+from __future__ import annotations
+
+# What a recording is ABOUT. The model may pick several; anything outside this
+# set is discarded by the validator rather than passed through.
+TOPICS: frozenset[str] = frozenset({
+    # the emergency itself
+    "hijack-report",
+    "loss-of-contact",
+    "transponder-off",
+    "primary-target-tracking",
+    "unaccounted-aircraft",
+    "bomb-threat",
+    "aircraft-down",
+    "wtc-impact",
+    "pentagon-impact",
+    "casualty-report",
+    # the military response
+    "scramble-order",
+    "military-escort",
+    "shootdown-authority",
+    "rules-of-engagement",
+    # the civil response
+    "ground-stop",
+    "airspace-closure",
+    "landing-diversion",
+    "evacuation",
+    "notification-to-hq",
+    "coordination-call",
+    # ordinary traffic, which is most of the pre-attack corpus
+    "routine-clearance",
+    "position-handoff",
+    "traffic-advisory",
+    "weather",
+    # a participant relaying what they are seeing on television, which happens
+    # more than you would expect and is not the same as a first-hand report
+    "media-report",
+})
+
+# Which organisation a facility belongs to. Keys are matched case-insensitively
+# as substrings of the facility name, longest first, so "Boston Center" and
+# "Boston" both resolve without listing every phrasing.
+AGENCY_BY_FACILITY: dict[str, str] = {
+    # FAA en-route centres, TRACONs and towers
+    "atcscc": "faa", "zbw": "faa", "zdc": "faa", "zny": "faa", "zob": "faa",
+    "zid": "faa", "zau": "faa", "zme": "faa",
+    "boston": "faa", "new york": "faa", "washington": "faa", "cleveland": "faa",
+    "indianapolis": "faa", "chicago": "faa", "memphis": "faa",
+    "iad": "faa", "dca": "faa", "ewr": "faa", "bos": "faa", "pit": "faa",
+    "dulles": "faa", "national": "faa", "newark": "faa", "logan": "faa",
+    "command center": "faa", "faa": "faa", "herndon": "faa",
+    # air defence
+    "neads": "norad", "norad": "norad", "conr": "norad", "huntress": "norad",
+    "otis": "usaf", "langley": "usaf", "andrews": "usaf", "adw": "usaf",
+    "nmcc": "dod", "pentagon": "dod",
+    # civil emergency services
+    "fdny": "fdny", "nypd": "nypd", "pafd": "panynj", "port authority": "panynj",
+    # carriers
+    "american": "airline", "united": "airline", "delta": "airline",
+    "continental": "airline", "us airways": "airline",
+}
+
+ROLES: frozenset[str] = frozenset({
+    "atc", "military", "airline", "emergency", "aircraft", "unknown",
+})
+
+LINKS: frozenset[str] = frozenset({
+    "air-ground", "landline", "internal", "conference", "unknown",
+})
+
+
+def agency_for(facility: str | None) -> str | None:
+    """Best-guess agency for a facility name, or None.
+
+    Longest key first so "port authority" wins over a bare substring, and
+    "us airways" is not shadowed by a shorter carrier key.
+    """
+    if not facility:
+        return None
+    haystack = facility.lower()
+    for key in sorted(AGENCY_BY_FACILITY, key=len, reverse=True):
+        if key in haystack:
+            return AGENCY_BY_FACILITY[key]
+    return None


### PR DESCRIPTION
Follow-on to #409. Measuring the schema-1 corpus (755 identified rows) showed the thin `parties` blobs had **three separate causes**, not one — and only the first was about coverage.

| Slot | Filled |
|---|---|
| `side_a.role` / `evidence` | 99% |
| `aircraft` | 54% |
| `side_b.facility` | 34% |
| `side_a.facility` | 27% |
| `side_a.position` | 19% |
| `side_b.person` | 11% |
| `side_a.person` | 7% |
| `side_b.position` | 4% |

## 1. The two-sided shape could not describe the material

**179 of 755 rows** are position tapes reduced to the placeholder `side_b.facility = "various"`, and the ATCSCC / NEADS-floor / FAA-HQ calls are inherently n-party. `participants[]` replaces `side_a`/`side_b`, one entry per party however many there are.

`"various"` is now **rejected** rather than stored — it was one step away from entering the tag index as a real facility.

## 2. A single rejection crushed the whole answer

**546 rows read `confidence: low`** — but only **189** had been downgraded by the gate. The other **357** were the model's own verdict. Those two populations were indistinguishable, which made the field hard to trust and hard to triage.

Confidence is now **per participant**, and a gate hit caps the overall figure at `medium` rather than flattening it. Something was wrong, so it may not claim certainty — but what survived is still worth grading.

## 3. The schema discarded information the transcripts already held

The only prose kept was one `evidence` quote. Added:

- **`subject`** — one line on what the call is about, gated by the same content-word containment `validate_abstract` already applies to minute summaries.
- **`mentions`** — facilities/aircraft/people *talked about*, as distinct from those *talking*. Previously thrown away entirely.
- **`topics[]`** — from a closed vocabulary (`vocab.py`). Free text does not survive contact with a search box: ask a model what 755 recordings are about and you get 700 phrasings of the same dozen ideas.

## The new `mp3_items.tags` column

A flat, namespaced index derived **purely from the parties block** — never separately generated, because two accounts of one recording quietly disagree. Only `topic:` has no equivalent in the block.

```
tier:clip  link:landline  role:atc  agency:faa  agency:norad
facility:indianapolis-center  facility:neads
person:jim-mcdonald  aircraft:aal77  topic:loss-of-contact
```

Namespaced because a bare list cannot be filtered by kind, and names collide across kinds — "Boston" is a facility and also a surname. Callsign spellings collapse, so `American 11`, `AAL11` and `AA 11` all land on `aircraft:aal77`-style single tags. Participating *and* merely-mentioned entities are both indexed: someone searching for Cleveland Center wants the calls that discuss it, not only the ones it spoke on.

The Directus field is already created (`json` + `cast-json`, `tags` interface), checked against `pg_stat_activity`/backup state first per the earlier schema-op incident.

## The gate is unchanged in strength

Every name must still appear in a document the model was shown; `evidence` must still be verbatim; unsupported values are still removed and the removal recorded in `gate_reasons`. #409's two-document provenance rules carry over intact — undeclared source falls back to the transcript, unrecognised source names are rejected, and the stored `sources` map is rebuilt from what passed.

## Consolidation

The Commission enrichment folds into this same pass instead of running as a second flow over the same rows — two passes means two model calls per recording, and a half-finished second pass leaves two shapes in one column.

That also fixes an oversight in #409: `enrich_parties_from_commission_flow` was never registered in `serve.py`, so it was unreachable as a deployment. Three prompt builders and two validators collapse into one of each, with the single-document case now the degenerate case of the two-document gate rather than its own code path.

`parties.schema_version` is the idempotency marker, so a re-run refreshes rows on the old shape and skips current ones.

## Testing

575 passed, 8 skipped; `ruff check` clean. New `test_parties_tags.py` (16 tests) plus rewritten gate tests. Nothing consumes `parties` in the frontend or streamer (verified: zero references), so the shape change needs no migration.

Docs: new `docs/party-identification.md`, and the parties pipeline is now listed in the package `CLAUDE.md`, which had never mentioned it.

**Not yet run against the database.** The flow still defaults to `dry_run=True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
