### PR TITLE
fix(parties): three defects the first schema-2 dry run exposed

### DIFF
--- a/packages/tools/video-grabber/tests/test_parties_identify.py
+++ b/packages/tools/video-grabber/tests/test_parties_identify.py
@@ -210,11 +210,24 @@ def test_various_is_no_longer_an_accepted_answer():
 
 # --- the new fields -------------------------------------------------------
 
-def test_subject_must_use_words_from_the_source():
+def test_subject_may_not_name_a_facility_the_source_never_had():
     bad = {**GOOD, "subject": "Cleveland Center reports a hijacking in progress"}
     cleaned, reasons = validate_parties(bad, TRANSCRIPT)
     assert cleaned["subject"] is None
-    assert any("subject introduced words" in r for r in reasons)
+    assert any("subject names" in r for r in reasons)
+
+
+def test_subject_may_use_ordinary_words_the_source_lacks():
+    """The rule that shipped first rejected every subject in the corpus.
+
+    Whole-phrase containment works for a minute summary drawn from a long
+    source; against a two-sentence transcript it flags "reports" and "routine"
+    as inventions. Only names and numbers are policed now.
+    """
+    ok = {**GOOD, "subject": "Indianapolis Center is trying to reach American 77"}
+    cleaned, reasons = validate_parties(ok, TRANSCRIPT)
+    assert cleaned["subject"] == ok["subject"]
+    assert reasons == []
 
 
 def test_subject_survives_when_built_from_source_words():
@@ -222,6 +235,40 @@ def test_subject_survives_when_built_from_source_words():
     assert cleaned["subject"] == GOOD["subject"]
     assert cleaned["sources"]["subject"] == SOURCE_TRANSCRIPT
     assert reasons == []
+
+
+def test_subject_may_not_invent_a_flight_number():
+    bad = {**GOOD, "subject": "Indianapolis Center is trying to reach American 93"}
+    cleaned, reasons = validate_parties(bad, TRANSCRIPT)
+    assert cleaned["subject"] is None
+    assert any("93" in r for r in reasons)
+
+
+# --- spoken digits --------------------------------------------------------
+
+SPOKEN = "Quit 2-5, contact Washington Center 1-3-4-0-0."
+
+
+def test_callsign_matches_a_transcript_that_spells_the_number_out():
+    """Controllers read numbers digit by digit and the transcriber follows.
+
+    'Quit 2-5' is right there in the audio, but a callsign normalised to
+    'Quit 25' looked absent — which is why `aircraft` sat at 54% fill.
+    """
+    ok = {**GOOD, "aircraft": ["Quit 25"], "evidence": "Quit 2-5, contact Washington Center",
+          "subject": None, "participants": []}
+    cleaned, reasons = validate_parties(ok, SPOKEN)
+    assert cleaned["aircraft"] == ["Quit 25"]
+    assert reasons == []
+
+
+def test_spoken_digit_joining_does_not_merge_separate_numbers():
+    """'190, 230' are two altitudes, not the number 190230."""
+    bad = {**GOOD, "aircraft": ["Flight 190230"], "evidence": "passing through 190, 230",
+           "subject": None, "participants": []}
+    cleaned, reasons = validate_parties(bad, "Philadelphia passing through 190, 230.")
+    assert cleaned["aircraft"] == []
+    assert reasons
 
 
 def test_topic_outside_the_vocabulary_is_dropped():

--- a/packages/tools/video-grabber/tests/test_parties_tags.py
+++ b/packages/tools/video-grabber/tests/test_parties_tags.py
@@ -53,6 +53,16 @@ def test_various_never_becomes_a_facility():
     assert "facility:various" not in tags
 
 
+def test_airframe_models_do_not_become_callsign_tags():
+    """'we have a 757 inbound' is a type, not a flight.
+
+    `aircraft:757` is worse than no tag — it collides every Boeing on the
+    morning into one bucket.
+    """
+    tags = build_tags({"aircraft": ["757"], "mentions": {"aircraft": ["767"]}})
+    assert not any(t.startswith("aircraft:7") for t in tags)
+
+
 def test_empty_block_yields_no_tags():
     assert build_tags({}) == []
 

--- a/packages/tools/video-grabber/video_grabber/parties/identify.py
+++ b/packages/tools/video-grabber/video_grabber/parties/identify.py
@@ -109,7 +109,12 @@ anything you know about September 11 from any other source.
 correct answer, not a failure.
 - `evidence` must be an exact quote copied character-for-character from a \
 document.
-- `subject` must be written using words that appear in the documents.
+- `subject` is one short phrase saying what the recording is about. Write it in \
+lower case, capitalising ONLY proper names — facilities, people, callsigns. \
+Every name and number you put in it must appear in the documents; the ordinary \
+words are yours to choose. Example: "Boston Center tells New York Center that \
+American 11 is not responding" — every capitalised word there is a name that \
+must be in the documents, and the rest is ordinary prose.
 
 `participants` lists everyone taking part in the communication — one entry per \
 party, however many there are. Do not force a conversation into two sides. Each \
@@ -185,6 +190,21 @@ def build_messages(
 _FENCE = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.S)
 _DIGITS = re.compile(r"\d+")
 
+# Controllers read numbers out digit by digit, and the transcriber writes what it
+# hears: "Quit 2-5", "contact Washington Center 1-3-4-0-0". A callsign normalised
+# to "Quit 25" then looks absent from a transcript that says it plainly. Join runs
+# of digits that are separated only by hyphens or spaces — a comma still separates,
+# so "190, 230" does not silently become the number 190230.
+_SPOKEN_DIGITS = re.compile(r"(?<=\d)[-‑\s]+(?=\d)")
+
+# Capitalised inside the phrase, or carrying a digit: the tokens in a subject that
+# could name something the model was never shown.
+_IDENTITY_TOKEN = re.compile(r"\b(?:[A-Z][\w'-]*|[\w'-]*\d[\w'-]*)\b")
+
+
+def _join_spoken_digits(text: str) -> str:
+    return _SPOKEN_DIGITS.sub("", text or "")
+
 
 def parse_parties(raw: str) -> dict:
     """Parse the model's reply, tolerating a markdown fence."""
@@ -232,7 +252,29 @@ def _callsign_supported(callsign: str, source: str) -> bool:
     digits = _DIGITS.findall(callsign or "")
     if not digits:
         return False
-    return all(d in source for d in digits)
+    joined = _join_spoken_digits(source)
+    return all(d in source or d in joined for d in digits)
+
+
+def unsupported_identities(subject: str, source: str) -> list[str]:
+    """Names and numbers in a subject line that the source does not contain.
+
+    A subject is a paraphrase, so the whole-phrase containment rule that governs
+    minute summaries is the wrong instrument: it rejected every subject in the
+    first dry run because ordinary summary words ("reports", "routine",
+    "shortly") are not in a two-sentence transcript.
+
+    What actually needs policing is narrower — the model naming a facility,
+    person or flight it was never shown. Those tokens are capitalised or carry a
+    digit, and the prompt asks for the rest in lower case so the signal is
+    reliable rather than incidental.
+    """
+    joined = _join_spoken_digits(source)
+    missing = []
+    for token in _IDENTITY_TOKEN.findall(subject or ""):
+        if unsupported_words(token, source) and unsupported_words(token, joined):
+            missing.append(token)
+    return sorted(set(missing))
 
 
 def validate_parties(
@@ -329,11 +371,11 @@ def validate_parties(
     if not subject or subject_source is None:
         cleaned["subject"] = None
     else:
-        missing = unsupported_words(subject, texts[subject_source])
+        missing = unsupported_identities(subject, texts[subject_source])
         if missing:
             reasons.append(
-                f"subject introduced words absent from the {subject_source}: "
-                f"{', '.join(missing[:6])}"
+                f"subject names {missing[:6]} which the {subject_source} "
+                f"never contains"
             )
             cleaned["subject"] = None
         else:

--- a/packages/tools/video-grabber/video_grabber/parties/tags.py
+++ b/packages/tools/video-grabber/video_grabber/parties/tags.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import re
 
-from video_grabber.parties.vocab import TOPICS, agency_for
+from video_grabber.parties.vocab import AIRCRAFT_TYPES, TOPICS, agency_for
 
 _NON_ALNUM = re.compile(r"[^a-z0-9]+")
 _CALLSIGN = re.compile(r"^([a-z]*)0*(\d+)$")
@@ -92,7 +92,7 @@ def build_tags(parties: dict) -> list[str]:
     aircraft = list(parties.get("aircraft") or []) + list(mentions.get("aircraft") or [])
     for callsign in aircraft:
         slug = normalize_callsign(str(callsign))
-        if slug:
+        if slug and slug not in AIRCRAFT_TYPES:
             tags.add(f"aircraft:{slug}")
 
     for topic in parties.get("topics") or []:

--- a/packages/tools/video-grabber/video_grabber/parties/vocab.py
+++ b/packages/tools/video-grabber/video_grabber/parties/vocab.py
@@ -71,6 +71,15 @@ AGENCY_BY_FACILITY: dict[str, str] = {
     "continental": "airline", "us airways": "airline",
 }
 
+# Airframe models, which the audio names constantly ("we have a 757 inbound").
+# They are not callsigns, and `aircraft:757` in the tag index is worse than no
+# tag: it collides every Boeing on the morning into one bucket.
+AIRCRAFT_TYPES: frozenset[str] = frozenset({
+    "727", "737", "747", "757", "767", "777",
+    "310", "319", "320", "321", "330", "340",
+    "md80", "md11", "dc9", "dc10",
+})
+
 ROLES: frozenset[str] = frozenset({
     "atc", "military", "airline", "emergency", "aircraft", "unknown",
 })


### PR DESCRIPTION
Dry-running schema 2 over five live rows (one Commission-matched, one plain clip, one NEADS tape) found three defects. Two would have shipped silently; one predates schema 2.

The dry run also confirmed schema 2 does what it was meant to — the NEADS tape went from `{position: "MCC", side_b: "various", confidence: low}` to **5 named participants, 9 mentioned people, 4 facilities, 3 aircraft, 6 topics and 26 tags** — so these are polish on a working pass, not a rethink.

## 1. `subject` was rejected in 5 of 5 rows

Reusing `validate_abstract`'s whole-phrase containment rule does not transfer. It works on a minute summary drawn from a long source; against a two-sentence transcript it flags ordinary summary words as inventions:

```
subject introduced words absent from the transcript: 25, aircraft, handoff, instructions
subject introduced words absent from the transcript: alerted, contact, reports, suggesting, suspected
```

The feature was dead on arrival — every subject came back `null`.

What actually needs policing is narrower: **the model naming a facility, person or flight it was never shown**. Those tokens are capitalised or carry a digit, so `unsupported_identities` checks only those, and the prompt now asks for the rest in lower case so the signal is reliable rather than incidental.

Verified against the exact strings from the dry run:

| Subject | Verdict |
|---|---|
| `Quit 25 handoff instructions and frequency changes` | **keep** |
| `routine clearance for American 11 shortly after departure` | **keep** |
| `Cleveland Center reports a hijacking` | drop — `Center`, `Cleveland` |
| `American 77 is not responding` (transcript has only AA11) | drop — `77` |

## 2. Callsigns failed whenever the transcript spelled the number out

Controllers read numbers digit by digit and the transcriber follows. `Quit 2-5` is in the audio **verbatim**, but a callsign normalised to `Quit 25` looked absent:

```
aircraft 'Quit 25' not present in the transcript
```

This predates schema 2 and is the likeliest reason `aircraft` sat at 54% fill across the corpus. Digits separated only by hyphens or spaces are now joined before the check. A comma still separates, so `190, 230` (two altitudes) does not silently become `190230` — there's a test pinning that.

## 3. Airframe models became callsign tags

`we have a 757 inbound` is a type, not a flight. `aircraft:757` is worse than no tag: it collides every Boeing on the morning into one bucket.

## Testing

580 passed, 8 skipped; `ruff check` clean. Each fix carries a regression test naming the dry-run case that exposed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
