### PR TITLE
fix(parties): read callsign numbers the way the radio says them

### DIFF
--- a/packages/tools/video-grabber/tests/test_parties_spoken.py
+++ b/packages/tools/video-grabber/tests/test_parties_spoken.py
@@ -1,0 +1,96 @@
+"""Numbers as the radio says them.
+
+The corpus writes one number three ways — "2-5", "two five", "twenty five" — and
+before this a callsign written any of them scored as absent from a transcript
+written any other.
+"""
+import pytest
+
+from video_grabber.parties.identify import _callsign_supported, unsupported_identities
+from video_grabber.parties.spoken import digit_candidates, spoken_to_digits
+from video_grabber.parties.tags import normalize_callsign
+
+
+# --- the two readings -----------------------------------------------------
+
+@pytest.mark.parametrize("spoken,expected", [
+    # Digit-by-digit: no tens word, so each word is one digit.
+    ("niner seven five", "975"),
+    ("two five", "25"),
+    ("one three four zero zero", "13400"),
+    ("seven five", "75"),
+    # Natural: a tens or teens word cannot be read digit by digit.
+    ("eighty nine", "89"),
+    ("ninety three", "93"),
+    ("seventeen", "17"),
+    ("one thousand two hundred", "1200"),
+])
+def test_the_reading_is_chosen_by_whether_a_tens_word_is_present(spoken, expected):
+    assert spoken_to_digits(spoken) == expected
+
+
+def test_aviation_pronunciations_are_understood():
+    """Controllers say these and the transcriber writes them down verbatim."""
+    assert spoken_to_digits("niner fife tree") == "953"
+
+
+def test_surrounding_words_are_left_alone():
+    assert spoken_to_digits("Delta Eighty Nine heavy") == "Delta 89 heavy"
+
+
+def test_candidates_offer_both_readings():
+    both = digit_candidates("eighty nine")
+    assert "89" in both.split() and "809" in both.split()
+
+
+def test_candidates_are_separated_so_a_search_cannot_span_two():
+    # "89 975" must not satisfy a search for "897".
+    assert "897" not in digit_candidates("eighty nine niner seven five")
+
+
+# --- what this fixes end to end -------------------------------------------
+
+def test_callsign_spelled_out_by_the_model_matches_a_spelled_out_transcript():
+    """The observed failure: the model echoes the audio's phrasing back.
+
+    'Delta Eighty Nine' carries no digits at all, so the digit check rejected it
+    outright even though the transcript said exactly that.
+    """
+    assert _callsign_supported("Delta Eighty Nine", "roger, Delta eighty nine is with you")
+
+
+def test_callsign_in_digits_matches_a_spelled_out_transcript():
+    assert _callsign_supported("United 93", "united ninety three is not responding")
+    assert _callsign_supported("AAL 975", "american niner seven five, descend")
+
+
+def test_callsign_spelled_out_matches_a_digit_transcript():
+    assert _callsign_supported("Delta Eighty Nine", "DAL89 checking in")
+
+
+def test_an_invented_flight_number_is_still_rejected():
+    """Widening the readings must not widen what can be invented."""
+    assert not _callsign_supported("United 93", "american niner seven five, descend")
+    assert not _callsign_supported("Delta Eighty Nine", "delta eighty eight is with you")
+
+
+def test_a_callsign_with_no_number_at_all_is_still_rejected():
+    # "a Delta out of Boston" names an airline, not an aircraft.
+    assert not _callsign_supported("Delta", "we have a Delta out of Boston")
+
+
+def test_subject_may_cite_a_number_the_transcript_only_spells_out():
+    assert unsupported_identities(
+        "Delta 89 is diverting", "roger, delta eighty nine is diverting"
+    ) == []
+
+
+# --- tags -----------------------------------------------------------------
+
+def test_spelled_out_callsign_reaches_the_same_tag_as_the_coded_one():
+    assert normalize_callsign("Delta Eighty Nine") == normalize_callsign("DAL89") == "dal89"
+
+
+def test_spoken_digits_reach_the_same_tag():
+    assert normalize_callsign("Niner Seven Five") == "975"
+    assert normalize_callsign("United Ninety Three") == "ual93"

--- a/packages/tools/video-grabber/video_grabber/parties/identify.py
+++ b/packages/tools/video-grabber/video_grabber/parties/identify.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import json
 import re
 
+from video_grabber.parties.spoken import digit_candidates, spoken_to_digits
 from video_grabber.parties.vocab import LINKS, ROLES, TOPICS
 from video_grabber.transcript.summarize import unsupported_words
 
@@ -206,6 +207,21 @@ def _join_spoken_digits(text: str) -> str:
     return _SPOKEN_DIGITS.sub("", text or "")
 
 
+def digit_haystack(source: str) -> str:
+    """The source, plus every other way its numbers could have been written.
+
+    Three spellings of one number all appear in this corpus — "2-5" (spoken
+    digits, hyphenated by the transcriber), "twenty five" and "two five" — and a
+    callsign written any of those ways has to match a source written any other.
+    Rather than guess which is canonical, search them all.
+    """
+    return " ".join((
+        source or "",
+        _join_spoken_digits(source),
+        digit_candidates(source or ""),
+    ))
+
+
 def parse_parties(raw: str) -> dict:
     """Parse the model's reply, tolerating a markdown fence."""
     text = (raw or "").strip()
@@ -249,11 +265,14 @@ def _callsign_supported(callsign: str, source: str) -> bool:
     requiring the literal token would reject every correct answer. The flight
     number is the part that cannot be invented without inventing an aircraft.
     """
-    digits = _DIGITS.findall(callsign or "")
+    # The model echoes the audio's own phrasing back, so the callsign itself
+    # arrives spelled out as often as the transcript does: 'Delta Eighty Nine'
+    # carries no digits at all until it is read as a number.
+    digits = _DIGITS.findall(spoken_to_digits(callsign or ""))
     if not digits:
         return False
-    joined = _join_spoken_digits(source)
-    return all(d in source or d in joined for d in digits)
+    haystack = digit_haystack(source)
+    return all(d in haystack for d in digits)
 
 
 def unsupported_identities(subject: str, source: str) -> list[str]:
@@ -269,10 +288,10 @@ def unsupported_identities(subject: str, source: str) -> list[str]:
     digit, and the prompt asks for the rest in lower case so the signal is
     reliable rather than incidental.
     """
-    joined = _join_spoken_digits(source)
+    haystack = digit_haystack(source)
     missing = []
     for token in _IDENTITY_TOKEN.findall(subject or ""):
-        if unsupported_words(token, source) and unsupported_words(token, joined):
+        if unsupported_words(token, haystack):
             missing.append(token)
     return sorted(set(missing))
 

--- a/packages/tools/video-grabber/video_grabber/parties/spoken.py
+++ b/packages/tools/video-grabber/video_grabber/parties/spoken.py
@@ -1,0 +1,137 @@
+"""Read numbers the way the radio says them.
+
+Nobody on this audio says "seventy-five". They say "seven five", or "niner seven
+five", or — for a flight number — "eighty nine". Whisper transcribes what it
+hears, so the corpus is full of numbers written as words, and any check that
+looks for the digit form silently fails on them. `Quit 2-5` and
+`Delta Eighty Nine` were both in the audio plainly and both scored as absent.
+
+Two readings are in play and both are legitimate:
+
+- **concatenated** — each word is one digit: "niner seven five" is 975.
+- **natural** — the run is an ordinary English number: "eighty nine" is 89.
+
+Which one a speaker meant is not recoverable from the words alone, so for
+matching we generate both and accept either. For the single canonical form a tag
+needs, the presence of a tens or teens word decides it: "eighty nine" cannot be
+a digit-by-digit reading, while "seven five" cannot be anything else.
+
+Aviation pronunciations are included ("niner", "fife", "tree") because
+controllers use them and the transcriber writes them down verbatim.
+"""
+from __future__ import annotations
+
+import re
+
+UNITS: dict[str, int] = {
+    "zero": 0, "oh": 0, "naught": 0,
+    "one": 1, "two": 2, "three": 3, "tree": 3, "four": 4, "fower": 4,
+    "five": 5, "fife": 5, "six": 6, "seven": 7, "eight": 8,
+    "nine": 9, "niner": 9,
+}
+TEENS: dict[str, int] = {
+    "ten": 10, "eleven": 11, "twelve": 12, "thirteen": 13, "fourteen": 14,
+    "fifteen": 15, "sixteen": 16, "seventeen": 17, "eighteen": 18, "nineteen": 19,
+}
+TENS: dict[str, int] = {
+    "twenty": 20, "thirty": 30, "forty": 40, "fifty": 50,
+    "sixty": 60, "seventy": 70, "eighty": 80, "ninety": 90,
+}
+SCALES: dict[str, int] = {"hundred": 100, "thousand": 1000}
+
+NUMBER_WORDS = frozenset(UNITS) | frozenset(TEENS) | frozenset(TENS) | frozenset(SCALES)
+
+_TOKEN = re.compile(r"[A-Za-z]+|\d+")
+
+
+def _concatenated(run: list[str]) -> str:
+    """Digit-by-digit: 'niner seven five' -> '975'."""
+    out = []
+    for word in run:
+        if word in UNITS:
+            out.append(str(UNITS[word]))
+        elif word in TEENS:
+            out.append(str(TEENS[word]))
+        elif word in TENS:
+            out.append(str(TENS[word]))
+        else:
+            return ""  # a scale word has no digit-by-digit reading
+    return "".join(out)
+
+
+def _natural(run: list[str]) -> str:
+    """Ordinary English: 'eighty nine' -> '89', 'one thousand two hundred' -> '1200'."""
+    total = current = 0
+    for word in run:
+        if word in UNITS:
+            current += UNITS[word]
+        elif word in TEENS:
+            current += TEENS[word]
+        elif word in TENS:
+            current += TENS[word]
+        elif word == "hundred":
+            current = (current or 1) * 100
+        elif word == "thousand":
+            total += (current or 1) * 1000
+            current = 0
+        else:
+            return ""
+    return str(total + current)
+
+
+def _runs(text: str) -> list[list[str]]:
+    """Maximal consecutive runs of number words, lower-cased."""
+    runs, current = [], []
+    for token in _TOKEN.findall(text or ""):
+        word = token.lower()
+        if word in NUMBER_WORDS:
+            current.append(word)
+        elif current:
+            runs.append(current)
+            current = []
+    if current:
+        runs.append(current)
+    return runs
+
+
+def digit_candidates(text: str) -> str:
+    """Every digit string the spoken numbers in `text` could be written as.
+
+    Space-separated so a substring search cannot match across two candidates —
+    "89 975" must not satisfy a search for "897".
+    """
+    found: list[str] = []
+    for run in _runs(text):
+        for reading in (_concatenated(run), _natural(run)):
+            if reading and reading not in found:
+                found.append(reading)
+    return " ".join(found)
+
+
+def spoken_to_digits(text: str) -> str:
+    """Rewrite spoken numbers in `text` as digits, picking one reading.
+
+    A tens or teens word settles it — "eighty nine" cannot be read digit by
+    digit, and "seven five" cannot be read any other way.
+    """
+    tokens = _TOKEN.findall(text or "")
+    out: list[str] = []
+    run: list[str] = []
+
+    def flush():
+        if not run:
+            return
+        compound = any(w in TENS or w in TEENS or w in SCALES for w in run)
+        reading = _natural(run) if compound else _concatenated(run)
+        out.append(reading or " ".join(run))
+        run.clear()
+
+    for token in tokens:
+        word = token.lower()
+        if word in NUMBER_WORDS:
+            run.append(word)
+        else:
+            flush()
+            out.append(token)
+    flush()
+    return " ".join(out)

--- a/packages/tools/video-grabber/video_grabber/parties/tags.py
+++ b/packages/tools/video-grabber/video_grabber/parties/tags.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import re
 
+from video_grabber.parties.spoken import spoken_to_digits
 from video_grabber.parties.vocab import AIRCRAFT_TYPES, TOPICS, agency_for
 
 _NON_ALNUM = re.compile(r"[^a-z0-9]+")
@@ -49,7 +50,8 @@ def normalize_callsign(callsign: str) -> str:
     collapse the ways one aircraft is written, not to force everything into an
     airline scheme. Leading zeros go so `Quit 2-5` and `QUIT25` agree.
     """
-    compact = _NON_ALNUM.sub("", (callsign or "").lower())
+    # "Delta Eighty Nine" has to reach the same tag as "DAL89".
+    compact = _NON_ALNUM.sub("", spoken_to_digits(callsign or "").lower())
     m = _CALLSIGN.match(compact)
     if not m:
         return compact


### PR DESCRIPTION
Nobody on this audio says "seventy-five". They say **"seven five"**, or **"niner seven five"**, or — for a flight number — **"eighty nine"**. Whisper writes down what it hears, so the corpus is full of numbers spelled out as words, and the digit check in `_callsign_supported` silently failed on every one.

It fails on **both sides**, which is what the last dry run caught:

```
aircraft 'Delta Eighty Nine' not present in the transcript
mentioned aircraft 'Bravo Zero Eight Nine' not present in the transcript
```

The model echoes the audio's own phrasing back, so the callsign itself arrives spelled out — `Delta Eighty Nine` carries no digits at all, and was rejected outright even though the transcript said exactly that.

## Two readings, both legitimate

Which one a speaker meant is not recoverable from the words:

| Reading | Example | Result |
|---|---|---|
| **concatenated** — each word is one digit | `niner seven five` | `975` |
| **natural** — an ordinary English number | `eighty nine` | `89` |

For **matching** we generate both and accept either. For the **single canonical form** a tag needs, the presence of a tens or teens word settles it: "eighty nine" cannot be read digit by digit, and "seven five" cannot be read any other way.

Aviation pronunciations (`niner`, `fife`, `tree`, `fower`) are included — controllers use them and the transcriber writes them verbatim.

The haystack now covers all three spellings one number appears in (`2-5`, `two five`, `twenty five`). Candidates are space-separated so a substring search cannot match across two of them — `"89 975"` must not satisfy a search for `"897"`, and there's a test pinning that.

## This widens matching, not invention

The containment guarantee is unchanged, with tests for each:

- `United 93` is still rejected against a transcript that only says "niner seven five".
- `Delta Eighty Nine` is still rejected against "delta eighty **eight**".
- A callsign with no number at all — "a Delta out of Boston" — is still dropped.

## Tags collapse accordingly

`Delta Eighty Nine` and `DAL89` now both reach `aircraft:dal89`; `United Ninety Three` reaches `aircraft:ual93`.

## Testing

600 passed, 8 skipped; `ruff check` clean. New `test_parties_spoken.py` (20 tests) covering both readings, the aviation pronunciations, the cross-candidate guard, and the rejection cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
