### PR TITLE
fix(parties): match callsign numbers whole, not as substrings

### DIFF
--- a/packages/tools/video-grabber/tests/test_parties_spoken.py
+++ b/packages/tools/video-grabber/tests/test_parties_spoken.py
@@ -74,6 +74,29 @@ def test_an_invented_flight_number_is_still_rejected():
     assert not _callsign_supported("Delta Eighty Nine", "delta eighty eight is with you")
 
 
+def test_a_short_number_does_not_match_a_longer_one_containing_it():
+    """Found on the NEADS floor tape, and it predates the spoken-number work.
+
+    That transcript never says 93 — it says "US 9-37". Substring matching
+    accepted "United 93" against it. Numbers are matched whole.
+    """
+    assert not _callsign_supported("United 93", "we have US 9-37 inbound")
+    assert not _callsign_supported("American 11", "flight 1180 is climbing")
+    assert _callsign_supported("US 937", "we have US 9-37 inbound")
+
+
+def test_a_long_spoken_readout_does_not_match_every_short_callsign():
+    # "twelve hours thirty minutes twenty five seconds" concatenates to a long
+    # digit string; it must not vouch for an arbitrary flight number inside it.
+    readout = "12 hours, 30 minutes, 25 seconds, 30 minutes, 30 seconds"
+    assert not _callsign_supported("Delta 53", readout)
+
+
+def test_leading_zeros_are_a_spelling_not_a_difference():
+    assert _callsign_supported("Gofer 06", "gofer 6, say position")
+    assert _callsign_supported("Gofer 6", "gofer zero six, say position")
+
+
 def test_a_callsign_with_no_number_at_all_is_still_rejected():
     # "a Delta out of Boston" names an airline, not an aircraft.
     assert not _callsign_supported("Delta", "we have a Delta out of Boston")

--- a/packages/tools/video-grabber/video_grabber/parties/identify.py
+++ b/packages/tools/video-grabber/video_grabber/parties/identify.py
@@ -222,6 +222,19 @@ def digit_haystack(source: str) -> str:
     ))
 
 
+def source_numbers(source: str) -> set[str]:
+    """Every whole number the source states, under any of its spellings.
+
+    Whole numbers, not substrings. Checking `"93" in text` accepts a transcript
+    whose only number is 937 — a real false positive found on the NEADS floor
+    tape, where "United 93" scored as supported by audio that mentions US 9-37
+    and never says 93 at all. Synthesised readings make it worse, because a
+    concatenated run of a time readout is a 21-digit string containing almost
+    every short number as a substring.
+    """
+    return set(_DIGITS.findall(digit_haystack(source)))
+
+
 def parse_parties(raw: str) -> dict:
     """Parse the model's reply, tolerating a markdown fence."""
     text = (raw or "").strip()
@@ -271,8 +284,9 @@ def _callsign_supported(callsign: str, source: str) -> bool:
     digits = _DIGITS.findall(spoken_to_digits(callsign or ""))
     if not digits:
         return False
-    haystack = digit_haystack(source)
-    return all(d in haystack for d in digits)
+    stated = source_numbers(source)
+    # Leading zeros are a spelling ("Gofer 06" / "Gofer 6"), not a difference.
+    return all(d in stated or d.lstrip("0") in stated for d in digits)
 
 
 def unsupported_identities(subject: str, source: str) -> list[str]:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 18.1.2
       classicy:
         specifier: latest
-        version: 0.72.10(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/dlv@1.1.5)(@types/react@19.2.18)(immer@11.1.16)(react-dom@19.2.8(react@19.2.8))(react-player@3.4.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zustand@5.0.14(@types/react@19.2.18)(immer@11.1.16)(react@19.2.8))
+        version: 0.72.11(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/dlv@1.1.5)(@types/react@19.2.18)(immer@11.1.16)(react-dom@19.2.8(react@19.2.8))(react-player@3.4.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zustand@5.0.14(@types/react@19.2.18)(immer@11.1.16)(react@19.2.8))
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -1035,8 +1035,8 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
-  classicy@0.72.10:
-    resolution: {integrity: sha512-YrsdHN/3d97pkyUdmbBshbrPJxcFZGk6SYDY6erHUvzzYkqZClyFI2mZ1ipu6vJoF0bI4Sr95k/fuOh/YIBB5Q==}
+  classicy@0.72.11:
+    resolution: {integrity: sha512-6ahosumiAtRNqn2/NWBdA9AtCtDh9YbJ9o93C5Zck+2QweNB5zSeCDGMvXE/VXhzQ0bpfX6pJx6je3WYh2wrSA==}
     peerDependencies:
       '@tanstack/react-table': ^8.21.3
       immer: ^11.1.8
@@ -3462,7 +3462,7 @@ snapshots:
       readdirp: 5.0.0
     optional: true
 
-  classicy@0.72.10(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/dlv@1.1.5)(@types/react@19.2.18)(immer@11.1.16)(react-dom@19.2.8(react@19.2.8))(react-player@3.4.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zustand@5.0.14(@types/react@19.2.18)(immer@11.1.16)(react@19.2.8)):
+  classicy@0.72.11(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/dlv@1.1.5)(@types/react@19.2.18)(immer@11.1.16)(react-dom@19.2.8(react@19.2.8))(react-player@3.4.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zustand@5.0.14(@types/react@19.2.18)(immer@11.1.16)(react@19.2.8)):
     dependencies:
       '@analytics/google-tag-manager': 0.6.0
       '@noble/hashes': 2.3.0


### PR DESCRIPTION
Verifying #413 against the real NEADS floor tape found a **false positive**, so this tightens the check before the corpus run.

## What went wrong

`United 93` scored as supported by a transcript that never says 93 at all:

```
literal 93 in transcript: False
digit candidates containing "93": ['937']
```

The tape says **"US 9-37"**, and `"93"` is a substring of `"937"`.

**This predates #413.** The original check was `d in source`, so `"93"` always matched a raw transcript containing `937`. But the synthesised readings made it much worse — a concatenated time readout (*"12 hours, 30 minutes, 25 seconds…"*) becomes a **21-digit string** containing nearly every short number, so on a long tape almost any flight number could find support.

That is a weakening of the containment gate, which #413 explicitly promised not to do. My verification claim there was too narrow: I tested that invented numbers were rejected, not that *unrelated* numbers were.

## The fix

Numbers are compared as **whole tokens** against the set the source states, under any of its spellings, rather than as substrings. Leading zeros remain a spelling rather than a difference, so `Gofer 06` and `Gofer 6` still agree.

## The genuine matches are unaffected

Checked against the same real tape, which says:

> *"…that guy that you're telling us, **Bravo Zero Eight Nine** is **Delta Eighty Nine**?"*

| Callsign | Before #413 | Now |
|---|---|---|
| `Delta Eighty Nine` | dropped | `aircraft:dal89` |
| `Bravo Zero Eight Nine` | dropped | `aircraft:bravo89` |
| `United 93` (not in the audio) | — | **rejected** |

## Testing

603 passed, 8 skipped; `ruff check` clean. New regression tests cover the `93`/`937` case, the long-readout case, and leading zeros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
