### PR TITLE
fix(parties): tell the model to word names exactly as the document does

### DIFF
--- a/packages/tools/video-grabber/tests/test_parties_identify.py
+++ b/packages/tools/video-grabber/tests/test_parties_identify.py
@@ -85,6 +85,18 @@ def test_second_document_only_described_when_supplied():
     assert "COMMISSION" in with_doc and "COMMISSION" in user2
 
 
+def test_prompt_forbids_expanding_a_name_the_document_abbreviates():
+    """The commonest gate hit in the first live batch, and a prompt problem.
+
+    The model expanded a transcript's "Boston" to "Boston Center" — correct as
+    fact, but added knowledge, so the gate dropped the whole facility when
+    "Boston" would have survived.
+    """
+    system, _ = build_messages("x", TIER_CLIP)
+    assert "EXACTLY as the document words it" in system
+    assert "Boston Center" in system
+
+
 def test_tape_tier_is_told_not_to_invent_a_placeholder():
     system, _ = build_messages("x", TIER_TAPE)
     assert "do not invent a placeholder" in system

--- a/packages/tools/video-grabber/video_grabber/parties/identify.py
+++ b/packages/tools/video-grabber/video_grabber/parties/identify.py
@@ -108,6 +108,11 @@ Rules you must follow:
 anything you know about September 11 from any other source.
 - If the documents do not tell you, return null or an empty list. That is a \
 correct answer, not a failure.
+- Word every name EXACTLY as the document words it. Do not expand it, complete \
+it, or add words to it. If the document says "Boston", write "Boston" — not \
+"Boston Center", even when you are confident that is the facility meant. If it \
+never says what someone's position is, leave `position` null rather than \
+writing a generic one like "controller".
 - `evidence` must be an exact quote copied character-for-character from a \
 document.
 - `subject` is one short phrase saying what the recording is about. Write it in \


### PR DESCRIPTION
The first live batch (25 rows, writes enabled) gated 8 of 25. **Three were the same shape:**

```
participants[0].facility='Boston Center' names ['center'] which the transcript never contains
```

The transcript says "Boston"; the model expanded it to "Boston Center".

The gate is **right** to reject that — the expansion is added knowledge, and "Boston" alone could be Center, Tower or Approach. But the cost is losing the facility altogether, when the unexpanded "Boston" would have been kept. A fourth hit was the same instinct applied to a position (`'controller'`, which the audio never says).

So this is a prompt problem, not a gate problem — the model is answering a question the gate did not ask. It is now told to word every name exactly as the document words it, and to leave `position` null rather than supply a generic one.

Worth fixing before the full corpus run rather than after: a re-run costs a second model pass over all 758 rows.

## Batch results so far

| Field | Filled |
|---|---|
| `topics` | 25/25 |
| `subject` | 19/25 |
| `participants` | 17/25 |
| `mentions` | 17/25 |
| `aircraft` | 12/25 |

604 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)