### PR TITLE
feat(parties): resolve facility names to one tag per facility

### DIFF
--- a/packages/tools/video-grabber/tests/test_parties_tags.py
+++ b/packages/tools/video-grabber/tests/test_parties_tags.py
@@ -1,6 +1,6 @@
 """Tag derivation: what a searcher can actually filter on."""
 from video_grabber.parties.tags import build_tags, normalize_callsign, slugify
-from video_grabber.parties.vocab import agency_for
+from video_grabber.parties.vocab import agency_for, canonical_facility
 
 FULL = {
     "tier": "clip",
@@ -105,3 +105,48 @@ def test_agency_prefers_the_longest_matching_key():
 
 def test_unknown_facility_has_no_agency():
     assert agency_for("Somewhere Nobody Listed") is None
+
+
+# --- facility aliasing ----------------------------------------------------
+
+def test_the_three_names_for_one_center_reach_one_tag():
+    """The reason this table exists.
+
+    One clip's transcript says "Boston", another says "Boston Center", a third
+    says "ZBW". The record stores whichever was said — so without resolution the
+    index splits one facility three ways and a search for any misses the others.
+    """
+    def facility_tags(name):
+        return [t for t in build_tags({"participants": [{"facility": name}]})
+                if t.startswith("facility:")]
+
+    assert facility_tags("Boston") == facility_tags("Boston Center") \
+        == facility_tags("ZBW") == ["facility:boston-center"]
+
+
+def test_the_longest_alias_wins_so_an_airport_is_not_read_as_its_center():
+    # "Washington National" contains "washington", which alone means the Center.
+    assert canonical_facility("Washington National") == "washington-national"
+    assert canonical_facility("Washington Center") == "washington-center"
+
+
+def test_a_callsign_for_a_unit_resolves_to_the_unit():
+    # "Huntress" is NEADS's own callsign, not a separate facility.
+    assert canonical_facility("Huntress") == "neads"
+
+
+def test_an_unlisted_facility_keeps_its_own_slug_rather_than_vanishing():
+    tags = build_tags({"participants": [{"facility": "Somewhere Nobody Listed"}]})
+    assert "facility:somewhere-nobody-listed" in tags
+
+
+def test_agency_still_resolves_through_the_canonical_name():
+    tags = build_tags({"participants": [{"facility": "ZBW"}]})
+    assert "agency:faa" in tags
+
+
+def test_resolution_is_index_only_and_does_not_touch_the_record():
+    """The licence for inferring at all: `parties` still says what was said."""
+    parties = {"participants": [{"facility": "Boston"}]}
+    build_tags(parties)
+    assert parties["participants"][0]["facility"] == "Boston"

--- a/packages/tools/video-grabber/video_grabber/parties/tags.py
+++ b/packages/tools/video-grabber/video_grabber/parties/tags.py
@@ -22,7 +22,12 @@ from __future__ import annotations
 import re
 
 from video_grabber.parties.spoken import spoken_to_digits
-from video_grabber.parties.vocab import AIRCRAFT_TYPES, TOPICS, agency_for
+from video_grabber.parties.vocab import (
+    AIRCRAFT_TYPES,
+    TOPICS,
+    agency_for,
+    canonical_facility,
+)
 
 _NON_ALNUM = re.compile(r"[^a-z0-9]+")
 _CALLSIGN = re.compile(r"^([a-z]*)0*(\d+)$")
@@ -83,11 +88,14 @@ def build_tags(parties: dict) -> list[str]:
         tags.add(f"person:{slugify(person)}")
 
     for facility in facilities:
-        slug = slugify(facility)
+        # Resolve to the index's name for the place, so "Boston", "Boston Center"
+        # and "ZBW" are one tag instead of three. Unlisted facilities keep their
+        # own slug rather than being dropped.
+        slug = canonical_facility(facility) or slugify(facility)
         if not slug:
             continue
         tags.add(f"facility:{slug}")
-        agency = agency_for(facility)
+        agency = agency_for(facility) or agency_for(slug)
         if agency:
             tags.add(f"agency:{agency}")
 

--- a/packages/tools/video-grabber/video_grabber/parties/vocab.py
+++ b/packages/tools/video-grabber/video_grabber/parties/vocab.py
@@ -80,6 +80,53 @@ AIRCRAFT_TYPES: frozenset[str] = frozenset({
     "md80", "md11", "dc9", "dc10",
 })
 
+# One facility, one tag. The transcript calls Boston Center "Boston", "Boston
+# Center" and "ZBW" in different clips, and the record faithfully stores whichever
+# was said — so without this the index splits one facility across three tags and
+# a search for any of them misses the other two.
+#
+# This is the same normalisation `tags._AIRLINE_PREFIX` already does for
+# callsigns, and it carries the same licence: the *record* stays literal, so
+# `parties` still says exactly what the audio said. Only the index resolves it.
+#
+# Some of these are inferences, deliberately. Bare "Boston" on an ATC landline is
+# nearly always the Center, but it could be the tower — mapping it is a judgment,
+# made here in a short reviewable table rather than by the model, and made where
+# being wrong costs a search hit rather than a false claim about the recording.
+#
+# Matched case-insensitively as substrings, longest key first, so "Washington
+# National" resolves to the airport and not to Washington Center.
+FACILITY_ALIASES: dict[str, str] = {
+    # FAA en-route centres
+    "boston center": "boston-center", "zbw": "boston-center", "boston": "boston-center",
+    "new york center": "new-york-center", "zny": "new-york-center", "new york": "new-york-center",
+    "cleveland center": "cleveland-center", "zob": "cleveland-center",
+    "cleveland": "cleveland-center",
+    "washington center": "washington-center", "zdc": "washington-center",
+    "indianapolis center": "indianapolis-center", "zid": "indianapolis-center",
+    "indianapolis": "indianapolis-center",
+    "chicago center": "chicago-center", "zau": "chicago-center",
+    "memphis center": "memphis-center", "zme": "memphis-center",
+    # The command centre, which the tapes call three different things
+    "air traffic control system command center": "atcscc",
+    "command center": "atcscc", "atcscc": "atcscc", "herndon": "atcscc",
+    # Air defence. "Huntress" is NEADS's own callsign, not a separate unit.
+    "neads": "neads", "huntress": "neads",
+    "norad": "norad", "conr": "conr", "nmcc": "nmcc",
+    "otis": "otis-angb", "langley": "langley-afb",
+    "andrews": "andrews-afb", "adw": "andrews-afb",
+    # Airports and terminal facilities. Listed after the centres above only for
+    # readability — resolution is by key length, not by order.
+    "washington national": "washington-national", "dca": "washington-national",
+    "dulles": "dulles", "iad": "dulles",
+    "logan": "logan", "bos": "logan",
+    "newark": "newark", "ewr": "newark",
+    "pittsburgh": "pittsburgh", "pit": "pittsburgh",
+    "boston departure": "boston-tracon",
+    # Civil emergency services
+    "fdny": "fdny", "nypd": "nypd", "port authority": "panynj",
+}
+
 ROLES: frozenset[str] = frozenset({
     "atc", "military", "airline", "emergency", "aircraft", "unknown",
 })
@@ -87,6 +134,19 @@ ROLES: frozenset[str] = frozenset({
 LINKS: frozenset[str] = frozenset({
     "air-ground", "landline", "internal", "conference", "unknown",
 })
+
+
+def canonical_facility(facility: str) -> str | None:
+    """The index's name for a facility, or None if nobody has listed it.
+
+    Longest key first, so "Washington National" resolves to the airport rather
+    than being caught by the shorter "washington" that means the Center.
+    """
+    haystack = (facility or "").lower()
+    for key in sorted(FACILITY_ALIASES, key=len, reverse=True):
+        if key in haystack:
+            return FACILITY_ALIASES[key]
+    return None
 
 
 def agency_for(facility: str | None) -> str | None:


### PR DESCRIPTION
Completes the fix started in #416.

#416 stopped the model expanding a transcript's "Boston" into "Boston Center", so the facility survives the gate instead of being destroyed. But that alone **fragments the index**: a clip that said "Boston" gets `facility:boston`, one that said "Boston Center" gets `facility:boston-center`, and "ZBW" gets a third. One facility, three tags, and a search for any misses the others — which defeats the point of having tags.

## The distinction that resolves it

The code already made this distinction; it had just only been applied to callsigns.

| | Role | Rule |
|---|---|---|
| `parties` | **record** — what the document says | containment gate polices it |
| `tags` | **index** — what the record means | already normalises |

`build_tags` maps "American 11", "AAL11" and "AA 11" onto `aircraft:aal11` today, and that isn't a provenance violation because `parties.aircraft` still holds the literal string. Facilities now get the same treatment.

## The inference, stated plainly

Some entries **are** inferences. Bare "Boston" on an ATC landline is nearly always the Center, but it could be the tower. Three things make that acceptable here:

1. It lives in the **index**, not the record — `parties.participants[0].facility` still reads `"Boston"`, and there's a test pinning that `build_tags` doesn't mutate its input.
2. It's a **short reviewable table**, not a model judgment.
3. Being wrong costs a search hit, not a false claim about what the audio said.

## Details

- Longest key wins, so `Washington National` → `washington-national` rather than being caught by the `washington` that means the Center.
- `Huntress` → `neads` (it's NEADS's own callsign, not a separate unit).
- `command center` / `herndon` / `atcscc` → `atcscc`.
- Unlisted facilities keep their own slug rather than being dropped.

610 passed, 8 skipped; `ruff check` clean.

Last change before the corpus run — the index should be built once, correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)