### PR TITLE
feat(radio): split Radio Tuner app out of Radio Scanner

### DIFF
--- a/packages/frontend/src/Applications/RadioScanner/RadioScanner.test.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/RadioScanner.test.tsx
@@ -283,21 +283,30 @@ describe("RadioScanner schedule visibility", () => {
 		expect(screen.getByText("Coming Up")).toBeTruthy();
 	});
 
-	it("hides Coming Up on WINS (continuous broadcast)", () => {
-		renderScanner("WINS");
-		expect(screen.queryByText("Coming Up")).toBeNull();
-	});
-
-	it("hides Coming Up on WCBS (continuous broadcast)", () => {
-		renderScanner("WCBS");
-		expect(screen.queryByText("Coming Up")).toBeNull();
-	});
-
 	it("labels each Previous item with its start time in the display timezone", () => {
 		renderScanner("ATC");
 		expect(screen.getByText("Previous")).toBeTruthy();
 		// 12:00 UTC shifted by the -4 display offset.
 		expect(screen.getByText("9/11, 8:00 AM")).toBeTruthy();
+	});
+});
+
+describe("RadioScanner broadcast-station split", () => {
+	afterEach(cleanup);
+
+	it("excludes the Radio Tuner's broadcast stations from the strip", () => {
+		renderScanner("ATC");
+		// ATC renders in both the display and its strip button — presence is the point.
+		expect(screen.getAllByText("ATC").length).toBeGreaterThan(0);
+		expect(screen.queryByText("WINS")).toBeNull();
+		expect(screen.queryByText("WCBS")).toBeNull();
+	});
+
+	it("falls back to the first station when the persisted station is a broadcast", () => {
+		// A pre-split persisted activeStation of WCBS no longer exists here.
+		renderScanner("WCBS");
+		const station = stationPlayerProps.current?.station as { key: string };
+		expect(station.key).toBe("ATC");
 	});
 });
 
@@ -310,7 +319,7 @@ describe("RadioScanner All Traffic view", () => {
 		expect(screen.getByText("All Traffic")).toBeTruthy();
 	});
 
-	it("aggregates every non-live station's audio and lists per-channel checkboxes", () => {
+	it("aggregates every station's audio and lists per-channel checkboxes", () => {
 		renderScanner("__all_traffic__");
 		// The player is fed the synthetic aggregate station...
 		const station = stationPlayerProps.current?.station as {
@@ -318,12 +327,13 @@ describe("RadioScanner All Traffic view", () => {
 			items: MediaItem[];
 		};
 		expect(station.key).toBe("__all_traffic__");
-		// ...carrying the live ATC clip (id 3) but NOT the continuous WINS/WCBS.
+		// ...carrying the live ATC clip (id 3) but NOT the Radio Tuner's
+		// broadcast stations WINS/WCBS.
 		expect(station.items.map((i) => i.id)).toContain(3);
 		expect(station.items.some((i) => i.source === "WINS")).toBe(false);
 		expect(station.items.some((i) => i.source === "WCBS")).toBe(false);
 
-		// A checkbox exists for the non-live channel, but not the live ones.
+		// A checkbox exists for the scanner channel, but not the broadcasts.
 		expect(screen.getByLabelText("ATC")).toBeTruthy();
 		expect(screen.queryByLabelText("WINS")).toBeNull();
 		expect(screen.queryByLabelText("WCBS")).toBeNull();
@@ -334,7 +344,7 @@ describe("RadioScanner All Traffic view", () => {
 		const before = stationPlayerProps.current?.station as { items: MediaItem[] };
 		expect(before.items.length).toBeGreaterThan(0);
 
-		// Untick ATC (the only non-live channel) — the aggregate empties out.
+		// Untick ATC (the only channel) — the aggregate empties out.
 		act(() => {
 			fireEvent.click(screen.getByLabelText("ATC"));
 		});
@@ -360,7 +370,7 @@ describe("RadioScanner audio-unlock overlay", () => {
 
 	it("is already visible on mount when audio was blocked before render", () => {
 		markAudioBlocked("test-gate");
-		renderScanner("WINS");
+		renderScanner("ATC");
 		expect(screen.getByText(/click anywhere to start audio/i)).toBeTruthy();
 	});
 });

--- a/packages/frontend/src/Applications/RadioScanner/RadioScanner.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/RadioScanner.tsx
@@ -2,15 +2,9 @@ import {
     ClassicyApp,
     ClassicyButton,
     ClassicyCheckbox,
-    ClassicyColorPicker,
-    ClassicyControlGroup,
-    ClassicyControlLabel,
     ClassicyIcons,
-    ClassicyRadioInput,
-    ClassicySlider,
     ClassicyWindow,
     intToHex,
-    MAC_OS_8_CRAYONS,
     quitMenuItemHelper,
     useAppManager,
     useAppManagerDispatch,
@@ -18,7 +12,6 @@ import {
 } from "classicy";
 import type React from "react";
 import {
-    type ChangeEvent,
     useCallback,
     useContext,
     useEffect,
@@ -43,18 +36,17 @@ import {
     sanitizeItemIds,
 } from "./radioPlayback";
 import {
-    CAPTION_FONT_VARS,
     DEFAULT_RADIO_SCANNER_SETTINGS,
-    isVizMode,
     nextVizMode,
     radioScannerSetSettings,
     type RadioScannerSettings,
     readRadioScannerSettings,
-    VIZ_MODES,
 } from "./radioScannerSettings";
+import { RadioSettingsWindow } from "./RadioSettingsWindow";
 import { StationPlayer } from "./StationPlayer";
 import {
     activeSegments,
+    BROADCAST_STATIONS,
     combinedPrevious,
     combinedUpcoming,
     countdownLabel,
@@ -70,12 +62,10 @@ import { StationButtonContent } from "./StationButtonContent";
 
 type RadioScannerProps = Record<string, never>;
 
-// These stations are continuous broadcasts — no Coming Up / Previous schedule.
-const CONTINUOUS_STATIONS = new Set(["WCBS", "WINS"]);
-
 // The "All Traffic" pseudo-station: a synthetic station, appended to the end of
-// the strip, that aggregates every non-live (non-continuous) station into one
-// view and mixes their audio together — a scanner "monitor everything" mode.
+// the strip, that aggregates every station into one view and mixes their audio
+// together — a scanner "monitor everything" mode. (The continuous broadcast
+// stations live in the Radio Tuner app, not here — see BROADCAST_STATIONS.)
 // The key is a sentinel that can never collide with a real source name.
 const ALL_TRAFFIC_KEY = "__all_traffic__";
 const ALL_TRAFFIC_LABEL = "All Traffic";
@@ -223,19 +213,17 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
         return () => clearInterval(id);
     }, []);
 
+    // The scanner's stations are the comm-traffic sources only — the continuous
+    // broadcast stations (WCBS/WINS) belong to the Radio Tuner app.
     const stations = useMemo(
-        () => mergeWithSources(sources.audio, items),
+        () =>
+            mergeWithSources(sources.audio, items).filter(
+                (s) => !BROADCAST_STATIONS.has(s.key),
+            ),
         [sources.audio, items],
     );
 
-    // Non-live stations = everything except the continuous broadcasts. These are
-    // what "All Traffic" aggregates and what its channel checkboxes control.
-    const nonLiveStations = useMemo(
-        () => stations.filter((s) => !CONTINUOUS_STATIONS.has(s.key)),
-        [stations],
-    );
-
-    // All Traffic view: which non-live channels the user has switched OFF. Stored
+    // All Traffic view: which channels the user has switched OFF. Stored
     // as the disabled set (ephemeral, not persisted) so channels that appear
     // later default to ON. Toggling a checkbox flips membership.
     const [disabledTrafficChannels, setDisabledTrafficChannels] = useState<
@@ -252,8 +240,8 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
         [],
     );
     const enabledTrafficStations = useMemo(
-        () => nonLiveStations.filter((s) => !disabledTrafficChannels.has(s.key)),
-        [nonLiveStations, disabledTrafficChannels],
+        () => stations.filter((s) => !disabledTrafficChannels.has(s.key)),
+        [stations, disabledTrafficChannels],
     );
     const isAllTraffic = activeStation === ALL_TRAFFIC_KEY;
 
@@ -264,9 +252,14 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
         [tick, getUpcomingMp3Items], // eslint-disable-line react-hooks/exhaustive-deps
     );
 
-    // Select the first station once stations arrive.
+    // Select the first station once stations arrive. A persisted activeStation
+    // may be a broadcast station from before the Radio Tuner split — those no
+    // longer exist here, so fall back to the first station too.
     useEffect(() => {
-        if (activeStation === "" && stations.length > 0) {
+        if (
+            (activeStation === "" || BROADCAST_STATIONS.has(activeStation)) &&
+            stations.length > 0
+        ) {
             setActiveStation(stations[0].key);
         }
     }, [stations, activeStation]);
@@ -345,7 +338,7 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
     ];
 
     // The "All Traffic" aggregate: a synthetic station whose items are every
-    // ENABLED non-live station's items combined. activeSegments/StationPlayer
+    // ENABLED station's items combined. activeSegments/StationPlayer
     // then treat it exactly like a real station — mixing all of their audio and
     // listing every in-window clip. Memoized so its identity is stable for the
     // playingSegments memo and StationPlayer's volume effect.
@@ -395,8 +388,7 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
         [mutedItems, soloItemId, playingSegments],
     );
 
-    const showSchedule =
-        activeStation !== "" && !CONTINUOUS_STATIONS.has(activeStation);
+    const showSchedule = activeStation !== "";
 
     // True while the browser's autoplay policy is holding audio back (Safari
     // refuses gesture-less sound on page load). The document-level unlock
@@ -441,15 +433,15 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
         [stations, upcomingItems, nowMs],
     );
 
-    // Indicator light for the All Traffic button: on-air if ANY non-live station
-    // is playing now, upcoming if any has a queued item, else offline. Uses all
-    // non-live stations (not just enabled ones) so the light reflects available
+    // Indicator light for the All Traffic button: on-air if ANY station is
+    // playing now, upcoming if any has a queued item, else offline. Uses all
+    // stations (not just enabled ones) so the light reflects available
     // traffic regardless of the user's channel filter.
-    const allTrafficStatus = nonLiveStations.some(
+    const allTrafficStatus = stations.some(
         (s) => activeSegments(s, nowMs).length > 0,
     )
         ? ("on-air" as const)
-        : combinedUpcoming(nonLiveStations, upcomingItems, nowMs).length > 0
+        : combinedUpcoming(stations, upcomingItems, nowMs).length > 0
             ? ("upcoming" as const)
             : ("offline" as const);
 
@@ -461,246 +453,16 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
             defaultWindow={`${appId}_main`}
         >
             {showSettings && (
-                <ClassicyWindow
-                    id={`${appId}_settings`}
-                    title="Settings"
-                    icon={appIcon}
+                <RadioSettingsWindow
                     appId={appId}
-                    closable={true}
-                    resizable={false}
-                    zoomable={false}
-                    scrollable={false}
-                    collapsable={false}
-                    initialSize={[370, 0]}
-                    initialPosition={[250, 150]}
-                    modal={true}
+                    appIcon={appIcon}
                     appMenu={appMenu}
-                    onCloseFunc={() => setShowSettings(false)}
-                >
-                    <div className={styles.rsSettings}>
-                        <ClassicyControlGroup label="Waveform Style">
-                            <ClassicyRadioInput
-                                name="radioscanner_settings_viz_mode"
-                                inputs={VIZ_MODES.map((m) => ({
-                                    id: m,
-                                    label: m,
-                                    checked: settingsForm.vizMode === m,
-                                }))}
-                                onClickFunc={(id: string) =>
-                                    setSettingsForm((f) =>
-                                        isVizMode(id) ? { ...f, vizMode: id } : f,
-                                    )
-                                }
-                            />
-                        </ClassicyControlGroup>
-                        <ClassicyControlGroup label="Audio">
-                            <ClassicyCheckbox
-                                id="radioscanner_settings_play_original"
-                                label="Play original recording (more noise)"
-                                checked={settingsForm.playOriginalAudio}
-                                onClickFunc={(checked: boolean) =>
-                                    setSettingsForm((f) => ({
-                                        ...f,
-                                        playOriginalAudio: checked,
-                                    }))
-                                }
-                            />
-                        </ClassicyControlGroup>
-                        <ClassicyControlGroup label="Waveform Colors">
-                            <ClassicyCheckbox
-                                id="radioscanner_settings_use_theme"
-                                label="Use theme colors"
-                                checked={settingsForm.useThemeColors}
-                                onClickFunc={(checked: boolean) =>
-                                    setSettingsForm((f) => ({
-                                        ...f,
-                                        useThemeColors: checked,
-                                    }))
-                                }
-                            />
-                            {!settingsForm.useThemeColors && (
-                                <>
-                                    <ClassicyColorPicker
-                                        id="radioscanner_settings_color_bright"
-                                        labelTitle="Bright"
-                                        value={settingsForm.colorBright}
-                                        crayons={MAC_OS_8_CRAYONS}
-                                        onChangeFunc={(color: number) =>
-                                            setSettingsForm((f) => ({
-                                                ...f,
-                                                colorBright: color,
-                                            }))
-                                        }
-                                    />
-                                    <ClassicyColorPicker
-                                        id="radioscanner_settings_color_dim"
-                                        labelTitle="Dim"
-                                        value={settingsForm.colorDim}
-                                        crayons={MAC_OS_8_CRAYONS}
-                                        onChangeFunc={(color: number) =>
-                                            setSettingsForm((f) => ({
-                                                ...f,
-                                                colorDim: color,
-                                            }))
-                                        }
-                                    />
-                                </>
-                            )}
-                        </ClassicyControlGroup>
-                        <ClassicyControlGroup label="Volume">
-                            <ClassicySlider
-                                id="radioscanner_settings_max_volume"
-                                labelTitle="Max volume:"
-                                labelPosition="left"
-                                value={settingsForm.maxVolume}
-                                min={0}
-                                max={100}
-                                step={1}
-                                tickInterval={10}
-                                valueLabel={`${settingsForm.maxVolume}%`}
-                                onChangeFunc={(e: ChangeEvent<HTMLInputElement>) =>
-                                    setSettingsForm((f) => ({
-                                        ...f,
-                                        maxVolume: parseInt(e.target.value, 10),
-                                    }))
-                                }
-                            />
-                        </ClassicyControlGroup>
-                        <ClassicyControlGroup label="Captions">
-                            <ClassicyControlLabel label="Font" />
-                            <div className={styles.rsCaptionFontRow}>
-                                {CAPTION_FONT_VARS.map(([varName, label]) => (
-                                    <ClassicyButton
-                                        key={varName}
-                                        buttonSize="small"
-                                        margin="sm"
-                                        padding="sm"
-                                        depressed={
-                                            settingsForm.captionStyle.font ===
-                                            varName
-                                        }
-                                        onClickFunc={() =>
-                                            setSettingsForm((f) => ({
-                                                ...f,
-                                                captionStyle: {
-                                                    ...f.captionStyle,
-                                                    font: varName,
-                                                },
-                                            }))
-                                        }
-                                    >
-                                        {label}
-                                    </ClassicyButton>
-                                ))}
-                            </div>
-                            <ClassicyColorPicker
-                                id="radioscanner_settings_cc_text_color"
-                                labelTitle="Text Color"
-                                value={settingsForm.captionStyle.color}
-                                crayons={MAC_OS_8_CRAYONS}
-                                onChangeFunc={(color: number) =>
-                                    setSettingsForm((f) => ({
-                                        ...f,
-                                        captionStyle: {
-                                            ...f.captionStyle,
-                                            color,
-                                        },
-                                    }))
-                                }
-                            />
-                            <ClassicySlider
-                                id="radioscanner_settings_cc_text_opacity"
-                                labelTitle="Text Opacity"
-                                labelPosition="left"
-                                value={settingsForm.captionStyle.colorOpacity}
-                                min={0}
-                                max={1}
-                                step={0.05}
-                                valueLabel={`${Math.round(
-                                    settingsForm.captionStyle.colorOpacity * 100,
-                                )}%`}
-                                onChangeFunc={(e: ChangeEvent<HTMLInputElement>) =>
-                                    setSettingsForm((f) => ({
-                                        ...f,
-                                        captionStyle: {
-                                            ...f.captionStyle,
-                                            colorOpacity: parseFloat(
-                                                e.target.value,
-                                            ),
-                                        },
-                                    }))
-                                }
-                            />
-                            <ClassicyColorPicker
-                                id="radioscanner_settings_cc_bg_color"
-                                labelTitle="Background Color"
-                                value={settingsForm.captionStyle.bgColor}
-                                crayons={MAC_OS_8_CRAYONS}
-                                onChangeFunc={(color: number) =>
-                                    setSettingsForm((f) => ({
-                                        ...f,
-                                        captionStyle: {
-                                            ...f.captionStyle,
-                                            bgColor: color,
-                                        },
-                                    }))
-                                }
-                            />
-                            <ClassicySlider
-                                id="radioscanner_settings_cc_bg_opacity"
-                                labelTitle="Background Opacity"
-                                labelPosition="left"
-                                value={settingsForm.captionStyle.bgOpacity}
-                                min={0}
-                                max={1}
-                                step={0.05}
-                                valueLabel={`${Math.round(
-                                    settingsForm.captionStyle.bgOpacity * 100,
-                                )}%`}
-                                onChangeFunc={(e: ChangeEvent<HTMLInputElement>) =>
-                                    setSettingsForm((f) => ({
-                                        ...f,
-                                        captionStyle: {
-                                            ...f.captionStyle,
-                                            bgOpacity: parseFloat(e.target.value),
-                                        },
-                                    }))
-                                }
-                            />
-                            <ClassicySlider
-                                id="radioscanner_settings_cc_size"
-                                labelTitle="Size"
-                                labelPosition="left"
-                                value={settingsForm.captionStyle.size}
-                                min={50}
-                                max={200}
-                                step={10}
-                                tickInterval={10}
-                                valueLabel={`${settingsForm.captionStyle.size}%`}
-                                onChangeFunc={(e: ChangeEvent<HTMLInputElement>) =>
-                                    setSettingsForm((f) => ({
-                                        ...f,
-                                        captionStyle: {
-                                            ...f.captionStyle,
-                                            size: parseInt(e.target.value, 10),
-                                        },
-                                    }))
-                                }
-                            />
-                        </ClassicyControlGroup>
-                        <div className={styles.rsSettingsButtons}>
-                            <ClassicyButton onClickFunc={() => setShowSettings(false)}>
-                                Cancel
-                            </ClassicyButton>
-                            <ClassicyButton
-                                isDefault={true}
-                                onClickFunc={saveSettingsForm}
-                            >
-                                Save
-                            </ClassicyButton>
-                        </div>
-                    </div>
-                </ClassicyWindow>
+                    idPrefix="radioscanner_settings"
+                    form={settingsForm}
+                    setForm={setSettingsForm}
+                    onCancel={() => setShowSettings(false)}
+                    onSave={saveSettingsForm}
+                />
             )}
             <ClassicyWindow
                 id={`${appId}_main`}
@@ -763,7 +525,7 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
                                                         styles.rsTrafficChannelList
                                                     }
                                                 >
-                                                    {nonLiveStations.length === 0 ? (
+                                                    {stations.length === 0 ? (
                                                         <span
                                                             className={
                                                                 styles.rsScheduleItem
@@ -772,7 +534,7 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
                                                             No traffic channels
                                                         </span>
                                                     ) : (
-                                                        nonLiveStations.map((s) => (
+                                                        stations.map((s) => (
                                                             <ClassicyCheckbox
                                                                 key={s.key}
                                                                 id={`rs_traffic_${s.key}`}
@@ -968,7 +730,7 @@ export const RadioScanner: React.FC<RadioScannerProps> = () => {
                                     </ClassicyButton>
                                 );
                             })}
-                            {/* All Traffic: always last, aggregates every non-live station. */}
+                            {/* All Traffic: always last, aggregates every station. */}
                             <ClassicyButton
                                 key={ALL_TRAFFIC_KEY}
                                 depressed={isAllTraffic}

--- a/packages/frontend/src/Applications/RadioScanner/RadioSettingsWindow.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/RadioSettingsWindow.tsx
@@ -1,0 +1,278 @@
+import {
+    ClassicyButton,
+    ClassicyCheckbox,
+    ClassicyColorPicker,
+    ClassicyControlGroup,
+    ClassicyControlLabel,
+    ClassicyRadioInput,
+    ClassicySlider,
+    ClassicyWindow,
+    MAC_OS_8_CRAYONS,
+} from "classicy";
+import type React from "react";
+import type { ChangeEvent, ComponentProps, Dispatch, SetStateAction } from "react";
+import styles from "./RadioScanner.module.scss";
+import {
+    CAPTION_FONT_VARS,
+    isVizMode,
+    type RadioScannerSettings,
+    VIZ_MODES,
+} from "./radioScannerSettings";
+
+interface RadioSettingsWindowProps {
+    appId: string;
+    appIcon: string;
+    appMenu: ComponentProps<typeof ClassicyWindow>["appMenu"];
+    /** Control-id prefix, e.g. "radioscanner_settings" — keeps ids unique per app. */
+    idPrefix: string;
+    form: RadioScannerSettings;
+    setForm: Dispatch<SetStateAction<RadioScannerSettings>>;
+    onCancel: () => void;
+    onSave: () => void;
+}
+
+/**
+ * The Settings window shared by Radio Scanner and Radio Tuner — both apps
+ * persist the same RadioScannerSettings shape (waveform, audio, captions,
+ * volume), each under its own appId. Draft-style: the parent seeds `form`
+ * from persisted settings on open and dispatches only on Save.
+ */
+export const RadioSettingsWindow: React.FC<RadioSettingsWindowProps> = ({
+    appId,
+    appIcon,
+    appMenu,
+    idPrefix,
+    form,
+    setForm,
+    onCancel,
+    onSave,
+}) => (
+    <ClassicyWindow
+        id={`${appId}_settings`}
+        title="Settings"
+        icon={appIcon}
+        appId={appId}
+        closable={true}
+        resizable={false}
+        zoomable={false}
+        scrollable={false}
+        collapsable={false}
+        initialSize={[370, 0]}
+        initialPosition={[250, 150]}
+        modal={true}
+        appMenu={appMenu}
+        onCloseFunc={onCancel}
+    >
+        <div className={styles.rsSettings}>
+            <ClassicyControlGroup label="Waveform Style">
+                <ClassicyRadioInput
+                    name={`${idPrefix}_viz_mode`}
+                    inputs={VIZ_MODES.map((m) => ({
+                        id: m,
+                        label: m,
+                        checked: form.vizMode === m,
+                    }))}
+                    onClickFunc={(id: string) =>
+                        setForm((f) =>
+                            isVizMode(id) ? { ...f, vizMode: id } : f,
+                        )
+                    }
+                />
+            </ClassicyControlGroup>
+            <ClassicyControlGroup label="Audio">
+                <ClassicyCheckbox
+                    id={`${idPrefix}_play_original`}
+                    label="Play original recording (more noise)"
+                    checked={form.playOriginalAudio}
+                    onClickFunc={(checked: boolean) =>
+                        setForm((f) => ({
+                            ...f,
+                            playOriginalAudio: checked,
+                        }))
+                    }
+                />
+            </ClassicyControlGroup>
+            <ClassicyControlGroup label="Waveform Colors">
+                <ClassicyCheckbox
+                    id={`${idPrefix}_use_theme`}
+                    label="Use theme colors"
+                    checked={form.useThemeColors}
+                    onClickFunc={(checked: boolean) =>
+                        setForm((f) => ({
+                            ...f,
+                            useThemeColors: checked,
+                        }))
+                    }
+                />
+                {!form.useThemeColors && (
+                    <>
+                        <ClassicyColorPicker
+                            id={`${idPrefix}_color_bright`}
+                            labelTitle="Bright"
+                            value={form.colorBright}
+                            crayons={MAC_OS_8_CRAYONS}
+                            onChangeFunc={(color: number) =>
+                                setForm((f) => ({
+                                    ...f,
+                                    colorBright: color,
+                                }))
+                            }
+                        />
+                        <ClassicyColorPicker
+                            id={`${idPrefix}_color_dim`}
+                            labelTitle="Dim"
+                            value={form.colorDim}
+                            crayons={MAC_OS_8_CRAYONS}
+                            onChangeFunc={(color: number) =>
+                                setForm((f) => ({
+                                    ...f,
+                                    colorDim: color,
+                                }))
+                            }
+                        />
+                    </>
+                )}
+            </ClassicyControlGroup>
+            <ClassicyControlGroup label="Volume">
+                <ClassicySlider
+                    id={`${idPrefix}_max_volume`}
+                    labelTitle="Max volume:"
+                    labelPosition="left"
+                    value={form.maxVolume}
+                    min={0}
+                    max={100}
+                    step={1}
+                    tickInterval={10}
+                    valueLabel={`${form.maxVolume}%`}
+                    onChangeFunc={(e: ChangeEvent<HTMLInputElement>) =>
+                        setForm((f) => ({
+                            ...f,
+                            maxVolume: parseInt(e.target.value, 10),
+                        }))
+                    }
+                />
+            </ClassicyControlGroup>
+            <ClassicyControlGroup label="Captions">
+                <ClassicyControlLabel label="Font" />
+                <div className={styles.rsCaptionFontRow}>
+                    {CAPTION_FONT_VARS.map(([varName, label]) => (
+                        <ClassicyButton
+                            key={varName}
+                            buttonSize="small"
+                            margin="sm"
+                            padding="sm"
+                            depressed={form.captionStyle.font === varName}
+                            onClickFunc={() =>
+                                setForm((f) => ({
+                                    ...f,
+                                    captionStyle: {
+                                        ...f.captionStyle,
+                                        font: varName,
+                                    },
+                                }))
+                            }
+                        >
+                            {label}
+                        </ClassicyButton>
+                    ))}
+                </div>
+                <ClassicyColorPicker
+                    id={`${idPrefix}_cc_text_color`}
+                    labelTitle="Text Color"
+                    value={form.captionStyle.color}
+                    crayons={MAC_OS_8_CRAYONS}
+                    onChangeFunc={(color: number) =>
+                        setForm((f) => ({
+                            ...f,
+                            captionStyle: {
+                                ...f.captionStyle,
+                                color,
+                            },
+                        }))
+                    }
+                />
+                <ClassicySlider
+                    id={`${idPrefix}_cc_text_opacity`}
+                    labelTitle="Text Opacity"
+                    labelPosition="left"
+                    value={form.captionStyle.colorOpacity}
+                    min={0}
+                    max={1}
+                    step={0.05}
+                    valueLabel={`${Math.round(
+                        form.captionStyle.colorOpacity * 100,
+                    )}%`}
+                    onChangeFunc={(e: ChangeEvent<HTMLInputElement>) =>
+                        setForm((f) => ({
+                            ...f,
+                            captionStyle: {
+                                ...f.captionStyle,
+                                colorOpacity: parseFloat(e.target.value),
+                            },
+                        }))
+                    }
+                />
+                <ClassicyColorPicker
+                    id={`${idPrefix}_cc_bg_color`}
+                    labelTitle="Background Color"
+                    value={form.captionStyle.bgColor}
+                    crayons={MAC_OS_8_CRAYONS}
+                    onChangeFunc={(color: number) =>
+                        setForm((f) => ({
+                            ...f,
+                            captionStyle: {
+                                ...f.captionStyle,
+                                bgColor: color,
+                            },
+                        }))
+                    }
+                />
+                <ClassicySlider
+                    id={`${idPrefix}_cc_bg_opacity`}
+                    labelTitle="Background Opacity"
+                    labelPosition="left"
+                    value={form.captionStyle.bgOpacity}
+                    min={0}
+                    max={1}
+                    step={0.05}
+                    valueLabel={`${Math.round(form.captionStyle.bgOpacity * 100)}%`}
+                    onChangeFunc={(e: ChangeEvent<HTMLInputElement>) =>
+                        setForm((f) => ({
+                            ...f,
+                            captionStyle: {
+                                ...f.captionStyle,
+                                bgOpacity: parseFloat(e.target.value),
+                            },
+                        }))
+                    }
+                />
+                <ClassicySlider
+                    id={`${idPrefix}_cc_size`}
+                    labelTitle="Size"
+                    labelPosition="left"
+                    value={form.captionStyle.size}
+                    min={50}
+                    max={200}
+                    step={10}
+                    tickInterval={10}
+                    valueLabel={`${form.captionStyle.size}%`}
+                    onChangeFunc={(e: ChangeEvent<HTMLInputElement>) =>
+                        setForm((f) => ({
+                            ...f,
+                            captionStyle: {
+                                ...f.captionStyle,
+                                size: parseInt(e.target.value, 10),
+                            },
+                        }))
+                    }
+                />
+            </ClassicyControlGroup>
+            <div className={styles.rsSettingsButtons}>
+                <ClassicyButton onClickFunc={onCancel}>Cancel</ClassicyButton>
+                <ClassicyButton isDefault={true} onClickFunc={onSave}>
+                    Save
+                </ClassicyButton>
+            </div>
+        </div>
+    </ClassicyWindow>
+);

--- a/packages/frontend/src/Applications/RadioScanner/stationGrouping.ts
+++ b/packages/frontend/src/Applications/RadioScanner/stationGrouping.ts
@@ -196,6 +196,14 @@ export function combinedPrevious(
 		.sort((a, b) => toMs(b.start_date) - toMs(a.start_date));
 }
 
+/**
+ * Continuous, long-form live broadcasts (full-run commercial radio). These are
+ * the Radio Tuner's catalogue; every other audio source is short comm traffic
+ * and belongs to the Radio Scanner. Both apps partition the shared mp3 stream
+ * with this one set so a station can never appear in both.
+ */
+export const BROADCAST_STATIONS = new Set(["WCBS", "WINS"]);
+
 /** Stations pinned to the front of the strip regardless of online state. */
 export const PINNED_STATIONS = ["WINS", "WCBS"];
 

--- a/packages/frontend/src/Applications/RadioTuner/RadioTuner.test.tsx
+++ b/packages/frontend/src/Applications/RadioTuner/RadioTuner.test.tsx
@@ -1,0 +1,368 @@
+import {
+	act,
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+} from "@testing-library/react";
+import type React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	clearAudioBlocked,
+	markAudioBlocked,
+} from "../RadioScanner/audioBlocked";
+import type { MediaItem } from "../../Providers/MediaStream/MediaStreamContext";
+import {
+	MediaStreamContext,
+	type MediaStreamContextValue,
+} from "../../Providers/MediaStream/MediaStreamContext";
+
+// Stub the playback-heavy children — this suite only asserts the tuner's
+// station partition and settings chrome around them.
+const stationPlayerProps = vi.hoisted(
+	() => ({ current: null as Record<string, unknown> | null }),
+);
+vi.mock("../RadioScanner/StationPlayer", () => ({
+	StationPlayer: (props: Record<string, unknown>) => {
+		stationPlayerProps.current = props;
+		return <div data-testid="station-player" />;
+	},
+}));
+vi.mock("../RadioScanner/NowPlayingList", () => ({
+	NowPlayingList: () => <div data-testid="now-playing" />,
+}));
+vi.mock("../../openreplay", () => ({
+	trackAppToggle: () => {},
+}));
+
+const mockAppData = vi.hoisted(
+	() => ({ current: {} as Record<string, unknown> }),
+);
+const mockDispatch = vi.hoisted(() => vi.fn());
+
+vi.mock("classicy", () => ({
+	ClassicyApp: ({ children }: { children: React.ReactNode }) => (
+		<div>{children}</div>
+	),
+	ClassicyWindow: ({
+		children,
+		appMenu,
+		title,
+	}: {
+		children?: React.ReactNode;
+		title?: string;
+		appMenu?: {
+			menuChildren?: {
+				id?: string;
+				title?: string;
+				onClickFunc?: () => void;
+			}[];
+		}[];
+	}) => (
+		<div data-window-title={title}>
+			{appMenu
+				?.flatMap((m) => m.menuChildren ?? [])
+				.map((mi, i) =>
+					mi.title ? (
+						<button
+							type="button"
+							key={mi.id ?? i}
+							onClick={mi.onClickFunc}
+						>
+							{mi.title}
+						</button>
+					) : null,
+				)}
+			{children}
+		</div>
+	),
+	ClassicyControlGroup: ({
+		label,
+		children,
+	}: {
+		label?: string;
+		children?: React.ReactNode;
+	}) => (
+		<fieldset>
+			<legend>{label}</legend>
+			{children}
+		</fieldset>
+	),
+	ClassicyControlLabel: ({ label }: { label?: string }) => (
+		<span>{label}</span>
+	),
+	ClassicyRadioInput: ({
+		inputs,
+		onClickFunc,
+	}: {
+		inputs: { id: string; label: string; checked: boolean }[];
+		onClickFunc: (id: string) => void;
+	}) => (
+		<div>
+			{inputs.map((i) => (
+				<button type="button" key={i.id} onClick={() => onClickFunc(i.id)}>
+					{i.label}
+				</button>
+			))}
+		</div>
+	),
+	ClassicyCheckbox: ({
+		label,
+		checked,
+		onClickFunc,
+	}: {
+		label?: string;
+		checked?: boolean;
+		onClickFunc?: (checked: boolean) => void;
+	}) => (
+		<label>
+			<input
+				type="checkbox"
+				checked={checked ?? false}
+				onChange={() => onClickFunc?.(!checked)}
+			/>
+			{label}
+		</label>
+	),
+	ClassicyColorPicker: ({
+		labelTitle,
+		value,
+	}: {
+		labelTitle?: string;
+		value?: number;
+	}) => <div data-color-value={value}>{labelTitle}</div>,
+	ClassicySlider: ({
+		id,
+		value,
+		min,
+		max,
+		step,
+		tickInterval,
+		onChangeFunc,
+	}: {
+		id?: string;
+		value?: number;
+		min?: number;
+		max?: number;
+		step?: number;
+		tickInterval?: number | "center";
+		onChangeFunc?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+	}) => (
+		<input
+			type="range"
+			data-testid={id}
+			value={value}
+			min={min}
+			max={max}
+			step={step}
+			data-tick-interval={tickInterval}
+			onChange={onChangeFunc}
+		/>
+	),
+	MAC_OS_8_CRAYONS: [],
+	ClassicyButton: ({
+		children,
+		onClickFunc,
+	}: {
+		children?: React.ReactNode;
+		onClickFunc?: () => void;
+	}) => (
+		<button type="button" onClick={onClickFunc}>
+			{children}
+		</button>
+	),
+	ClassicyIcons: {
+		applications: { radio: { app: "radio.png" } },
+		controlPanels: { soundManager: { sound33: "sound.png" } },
+	},
+	quitMenuItemHelper: () => ({}),
+	registerAppEventHandler: () => {},
+	registerApp: () => {},
+	useClassicyHelpMenu: () => {},
+	intToHex: (c: number) => `#${c.toString(16).padStart(6, "0")}`,
+	useAppManager: (sel: (s: unknown) => unknown) =>
+		sel({
+			System: {
+				Manager: {
+					Applications: {
+						apps: {
+							"RadioTuner.app": {
+								open: true,
+								data: mockAppData.current,
+							},
+						},
+					},
+				},
+			},
+		}),
+	useAppManagerDispatch: () => mockDispatch,
+	useClassicyDateTime: () => ({
+		dateTime: "2001-09-11T12:40:00.000Z",
+		paused: true,
+		tzOffset: -4,
+	}),
+}));
+
+import { RadioTuner } from "./RadioTuner";
+
+function item(
+	id: number,
+	source: string,
+	start: string,
+	over: Partial<MediaItem> = {},
+): MediaItem {
+	return {
+		id,
+		title: `${source} broadcast ${id}`,
+		full_title: `${source} broadcast ${id}`,
+		source,
+		start_date: start,
+		calc_duration: 3600,
+		url: `https://example.test/${id}.mp3`,
+		format: "mp3",
+		approved: 1,
+		mute: 0,
+		volume: 1,
+		jump: 0,
+		trim: 0,
+		...over,
+	};
+}
+
+function renderTuner(data: Record<string, unknown> = {}): void {
+	mockAppData.current = data;
+	const ctx: Partial<MediaStreamContextValue> = {
+		mp3Items: [
+			item(1, "WINS", "2001-09-11T12:30:00.000Z"),
+			item(2, "WCBS", "2001-09-11T12:30:00.000Z"),
+			item(3, "ATC", "2001-09-11T12:30:00.000Z"),
+		],
+		mp3History: [],
+		sources: {
+			video: [],
+			audio: ["WINS", "WCBS", "ATC"],
+			pager: [],
+			usenet: [],
+		},
+		subscribeMp3: () => {},
+		unsubscribeMp3: () => {},
+		getUpcomingMp3Items: () => [],
+	};
+	render(
+		<MediaStreamContext.Provider value={ctx as MediaStreamContextValue}>
+			<RadioTuner />
+		</MediaStreamContext.Provider>,
+	);
+}
+
+describe("RadioTuner station partition", () => {
+	afterEach(() => {
+		mockDispatch.mockClear();
+		stationPlayerProps.current = null;
+		cleanup();
+	});
+
+	it("lists only the broadcast stations in the strip", () => {
+		renderTuner();
+		// WINS renders twice (display + strip button) — the point is presence.
+		expect(screen.getAllByText("WINS").length).toBeGreaterThan(0);
+		expect(screen.getAllByText("WCBS").length).toBeGreaterThan(0);
+		expect(screen.queryByText("ATC")).toBeNull();
+	});
+
+	it("selects the first broadcast station by default and feeds it to the player", () => {
+		renderTuner();
+		const station = stationPlayerProps.current?.station as {
+			key: string;
+			items: MediaItem[];
+		};
+		expect(station.key).toBe("WINS");
+		expect(station.items.map((i) => i.id)).toEqual([1]);
+	});
+
+	it("has no Coming Up schedule or All Traffic aggregate", () => {
+		renderTuner();
+		expect(screen.queryByText("Coming Up")).toBeNull();
+		expect(screen.queryByText("Previous")).toBeNull();
+		expect(screen.queryByText("All Traffic")).toBeNull();
+	});
+
+	it("tunes another station from its strip button", () => {
+		renderTuner();
+		fireEvent.click(screen.getByText("WCBS"));
+		const station = stationPlayerProps.current?.station as { key: string };
+		expect(station.key).toBe("WCBS");
+	});
+
+	it("applies a remote tune command case-insensitively", () => {
+		renderTuner({ command: { seq: 1, kind: "tune", station: "wcbs" } });
+		const station = stationPlayerProps.current?.station as { key: string };
+		expect(station.key).toBe("WCBS");
+	});
+});
+
+describe("RadioTuner audio-unlock overlay", () => {
+	afterEach(() => {
+		clearAudioBlocked("test-gate");
+		cleanup();
+	});
+
+	it("appears while audio is gesture-blocked and leaves once unblocked", () => {
+		renderTuner();
+		expect(screen.queryByText(/click anywhere to start audio/i)).toBeNull();
+		act(() => markAudioBlocked("test-gate"));
+		expect(screen.getByText(/click anywhere to start audio/i)).toBeTruthy();
+		act(() => clearAudioBlocked("test-gate"));
+		expect(screen.queryByText(/click anywhere to start audio/i)).toBeNull();
+	});
+});
+
+describe("RadioTuner settings", () => {
+	afterEach(() => {
+		mockDispatch.mockClear();
+		stationPlayerProps.current = null;
+		cleanup();
+	});
+
+	it("passes default settings (Wave, theme colors) to StationPlayer", () => {
+		renderTuner();
+		expect(stationPlayerProps.current).toMatchObject({
+			vizMode: "Wave",
+			waveColors: null,
+			maxVolume: 1,
+		});
+	});
+
+	it("cycling the viz mode dispatches a tuner-namespaced settings update", () => {
+		renderTuner();
+		const cycle = stationPlayerProps.current?.onCycleVizMode as () => void;
+		act(() => cycle());
+		expect(mockDispatch).toHaveBeenCalledWith({
+			type: "ClassicyAppRadioTunerSetSettings",
+			settings: expect.objectContaining({ vizMode: "Bars" }), // Wave → Bars
+		});
+	});
+
+	it("opens Settings from the menu, saves a new mode, and closes", () => {
+		renderTuner();
+		expect(screen.queryByText("Save")).toBeNull();
+		fireEvent.click(screen.getAllByText("Settings…")[0]);
+		fireEvent.click(screen.getByText("Bars"));
+		fireEvent.click(screen.getByText("Save"));
+		expect(mockDispatch).toHaveBeenCalledWith({
+			type: "ClassicyAppRadioTunerSetSettings",
+			settings: expect.objectContaining({ vizMode: "Bars" }),
+		});
+		expect(screen.queryByText("Save")).toBeNull();
+	});
+
+	it("persists state under the tuner's own action namespace", () => {
+		renderTuner();
+		expect(mockDispatch).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: "ClassicyAppRadioTunerSetState",
+				activeStation: "WINS",
+			}),
+		);
+	});
+});

--- a/packages/frontend/src/Applications/RadioTuner/RadioTuner.tsx
+++ b/packages/frontend/src/Applications/RadioTuner/RadioTuner.tsx
@@ -1,0 +1,453 @@
+import {
+    ClassicyApp,
+    ClassicyButton,
+    ClassicyIcons,
+    ClassicyWindow,
+    intToHex,
+    quitMenuItemHelper,
+    useAppManager,
+    useAppManagerDispatch,
+    useClassicyDateTime,
+} from "classicy";
+import type React from "react";
+import {
+    useCallback,
+    useContext,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    useSyncExternalStore,
+} from "react";
+import { useAboutApp } from "../../Components/AboutApp/AboutApp";
+import { MediaStreamContext } from "../../Providers/MediaStream/MediaStreamContext";
+import type { MediaItem } from "../../Providers/MediaStream/MediaStreamContext";
+import { trackAppToggle } from "../../openreplay";
+import { isAudioBlocked, subscribeAudioBlocked } from "../RadioScanner/audioBlocked";
+import { NowPlayingList } from "../RadioScanner/NowPlayingList";
+import {
+    effectiveMutedIds,
+    sanitizeActiveStation,
+    sanitizeItemIds,
+} from "../RadioScanner/radioPlayback";
+import styles from "../RadioScanner/RadioScanner.module.scss";
+import {
+    DEFAULT_RADIO_SCANNER_SETTINGS,
+    nextVizMode,
+    type RadioScannerSettings,
+    readRadioScannerSettings,
+} from "../RadioScanner/radioScannerSettings";
+import { RadioSettingsWindow } from "../RadioScanner/RadioSettingsWindow";
+import { StationButtonContent } from "../RadioScanner/StationButtonContent";
+import { StationPlayer } from "../RadioScanner/StationPlayer";
+import {
+    activeSegments,
+    BROADCAST_STATIONS,
+    mergeWithSources,
+    stationStatus,
+} from "../RadioScanner/stationGrouping";
+import "./RadioTunerContext";
+import type { RadioTunerRemoteCommand } from "./RadioTunerContext";
+import { radioTunerSetSettings } from "./RadioTunerContext";
+
+type RadioTunerProps = Record<string, never>;
+
+/**
+ * The Radio Tuner: full-run live radio broadcasts (WCBS, 1010 WINS — see
+ * BROADCAST_STATIONS) played continuously against the virtual clock. Visually
+ * the Radio Scanner's sibling — same strip/display/player chrome — but with
+ * none of the scanner's short-clip machinery: continuous stations have no
+ * Coming Up / Previous schedule and no "All Traffic" aggregate.
+ */
+export const RadioTuner: React.FC<RadioTunerProps> = () => {
+    const appName = "Radio Tuner";
+    const appId = "RadioTuner.app";
+    const appIcon = ClassicyIcons.applications.radio.app as string;
+    const aboutWindow = useAboutApp(appId, appIcon);
+
+    const desktopEventDispatch = useAppManagerDispatch();
+    const appState = useAppManager(
+        (state) =>
+            state.System.Manager.Applications.apps[appId]?.data as
+            | Record<string, unknown>
+            | undefined,
+    );
+
+    // Waveform/caption preferences — the same RadioScannerSettings shape the
+    // scanner persists, stored under this app's own data.settings.
+    const settings = useMemo(
+        () => readRadioScannerSettings(appState),
+        [appState],
+    );
+
+    const saveSettings = useCallback(
+        (next: RadioScannerSettings) =>
+            desktopEventDispatch(radioTunerSetSettings(next)),
+        [desktopEventDispatch],
+    );
+
+    const onCycleVizMode = useCallback(() => {
+        saveSettings({ ...settings, vizMode: nextVizMode(settings.vizMode) });
+    }, [saveSettings, settings]);
+
+    const waveColors = useMemo(
+        () =>
+            settings.useThemeColors
+                ? null
+                : {
+                    bright: intToHex(settings.colorBright),
+                    dim: intToHex(settings.colorDim),
+                },
+        [settings],
+    );
+
+    // Settings store percent (slider-native); players take a 0..1 fraction.
+    const maxVolume = settings.maxVolume / 100;
+
+    // Settings window draft (TimeMachine pattern): seeded from the persisted
+    // settings on open, dispatched only on Save.
+    const [showSettings, setShowSettings] = useState(false);
+    const [settingsForm, setSettingsForm] = useState<RadioScannerSettings>(
+        DEFAULT_RADIO_SCANNER_SETTINGS,
+    );
+    const openSettings = useCallback(() => {
+        setSettingsForm(settings);
+        setShowSettings(true);
+    }, [settings]);
+    const saveSettingsForm = useCallback(() => {
+        saveSettings(settingsForm);
+        setShowSettings(false);
+    }, [saveSettings, settingsForm]);
+
+    const isOpen = useAppManager(
+        (state) => state.System.Manager.Applications.apps[appId]?.open ?? false,
+    );
+    const prevIsOpenRef = useRef<boolean | undefined>(undefined);
+    useEffect(() => {
+        if (prevIsOpenRef.current === undefined) {
+            prevIsOpenRef.current = isOpen;
+            return;
+        }
+        if (prevIsOpenRef.current === isOpen) return;
+        prevIsOpenRef.current = isOpen;
+        trackAppToggle(appId, isOpen ? "open" : "close");
+    }, [isOpen]);
+
+    const {
+        mp3Items: items,
+        subscribeMp3,
+        unsubscribeMp3,
+        sources,
+        getUpcomingMp3Items,
+    } = useContext(MediaStreamContext);
+    // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally mount-only
+    useEffect(() => {
+        subscribeMp3(appId);
+        return () => unsubscribeMp3(appId);
+    }, [subscribeMp3, unsubscribeMp3, appId]);
+
+    const { dateTime, paused: clockPaused } = useClassicyDateTime();
+
+    const [captionsOn, setCaptionsOn] = useState<boolean>(false);
+    const [activeStation, setActiveStation] = useState<string>(
+        sanitizeActiveStation(appState?.activeStation),
+    );
+    const [mutedItems, setMutedItems] = useState<number[]>(
+        sanitizeItemIds(appState?.mutedItems),
+    );
+    const [showWaveform, setShowWaveform] = useState<boolean>(
+        (appState?.showWaveform as boolean) ?? true,
+    );
+    // Solo (ephemeral, not persisted): while set, every other playing item is
+    // muted via effectiveMutedIds. Manual mutedItems stay untouched, so
+    // un-soloing restores them exactly.
+    const [soloItemId, setSoloItemId] = useState<number | null>(null);
+
+    // Fine virtual clock: the stored dateTime advances per minute, so add the
+    // real time elapsed since its last update to recover sub-minute precision.
+    const dateTimeRef = useRef(dateTime);
+    dateTimeRef.current = dateTime;
+    const clockPausedRef = useRef(clockPaused);
+    clockPausedRef.current = clockPaused;
+    const dateTimeUpdatedAtRef = useRef<number>(Date.now());
+    // biome-ignore lint/correctness/useExhaustiveDependencies: trigger-only dep
+    useEffect(() => {
+        dateTimeUpdatedAtRef.current = Date.now();
+    }, [dateTime]);
+
+    const getNowMs = useCallback(() => {
+        const elapsed = clockPausedRef.current
+            ? 0
+            : Date.now() - dateTimeUpdatedAtRef.current;
+        return new Date(dateTimeRef.current).getTime() + elapsed;
+    }, []);
+    const nowMs = getNowMs();
+
+    // Re-render every second so nowMs tracks the clock at ~1s resolution.
+    const [tick, setTick] = useState(0);
+    useEffect(() => {
+        const id = setInterval(() => setTick((n) => n + 1), 1000);
+        return () => clearInterval(id);
+    }, []);
+
+    // Only the continuous broadcast stations — the comm-traffic sources are the
+    // Radio Scanner's, and this filter is the flip side of the scanner's.
+    const stations = useMemo(
+        () =>
+            mergeWithSources(sources.audio, items).filter((s) =>
+                BROADCAST_STATIONS.has(s.key),
+            ),
+        [sources.audio, items],
+    );
+
+    // Snapshot of items waiting in the reveal buffer — refreshed every second.
+    // Feeds the strip's on-air/upcoming/offline indicator lights only.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: tick is the intended dependency
+    const upcomingItems = useMemo(
+        () => getUpcomingMp3Items(),
+        [tick, getUpcomingMp3Items], // eslint-disable-line react-hooks/exhaustive-deps
+    );
+
+    // Select the first station once stations arrive.
+    useEffect(() => {
+        if (activeStation === "" && stations.length > 0) {
+            setActiveStation(stations[0].key);
+        }
+    }, [stations, activeStation]);
+
+    // Persist state on every change.
+    useEffect(() => {
+        desktopEventDispatch({
+            type: "ClassicyAppRadioTunerSetState",
+            activeStation,
+            mutedItems,
+            showWaveform,
+        });
+    }, [activeStation, mutedItems, showWaveform, desktopEventDispatch]);
+
+    // Apply each remote tune command (playlist engine, etc.) exactly once,
+    // tracked by its monotonic seq — the scanner's command pattern. If the
+    // station isn't in the list yet, the seq is left unconsumed so the effect
+    // retries when `stations` updates.
+    const command = appState?.command as RadioTunerRemoteCommand | undefined;
+    const lastCommandSeqRef = useRef(0);
+    useEffect(() => {
+        if (!command || command.seq <= lastCommandSeqRef.current) return;
+        if (command.kind !== "tune") {
+            lastCommandSeqRef.current = command.seq;
+            return;
+        }
+        const lc = command.station.toLowerCase();
+        const match = stations.find((s) => s.key.toLowerCase() === lc);
+        if (!match) return; // not in the list yet — retry on next update
+        lastCommandSeqRef.current = command.seq;
+        setActiveStation(match.key);
+    }, [command, stations]);
+
+    const toggleItemMute = (id: number) => {
+        setMutedItems((prev) =>
+            prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id],
+        );
+    };
+
+    const toggleSoloItem = useCallback((id: number) => {
+        setSoloItemId((prev) => (prev === id ? null : id));
+    }, []);
+
+    // Solo is scoped to the station it was started on.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: reset-on-change effect
+    useEffect(() => {
+        setSoloItemId(null);
+    }, [activeStation]);
+
+    const appMenu = [
+        {
+            id: "file",
+            title: "File",
+            menuChildren: [
+                {
+                    id: "settings",
+                    title: "Settings…",
+                    onClickFunc: openSettings,
+                },
+                quitMenuItemHelper(appId, appName, appIcon),
+            ],
+        },
+        {
+            id: "view",
+            title: "View",
+            menuChildren: [
+                {
+                    id: "toggle-waveform",
+                    title: `${showWaveform ? "✓ " : "  "}Show Waveform`,
+                    onClickFunc: () => setShowWaveform((v) => !v),
+                },
+            ],
+        },
+    ];
+
+    const activeStationObj = stations.find((s) => s.key === activeStation);
+
+    // The active station's in-window segments — shared by the now-playing
+    // list, the solo lifecycle, and the effective-mute derivation.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: nowMs is the clock dep
+    const playingSegments = useMemo(
+        () => (activeStationObj ? activeSegments(activeStationObj, nowMs) : []),
+        [activeStationObj, nowMs],
+    );
+
+    // A soloed clip that finishes (or expires on seek) releases the solo, so
+    // the rest of the mix comes back rather than staying silent.
+    useEffect(() => {
+        if (
+            soloItemId !== null &&
+            !playingSegments.some((i) => i.id === soloItemId)
+        ) {
+            setSoloItemId(null);
+        }
+    }, [playingSegments, soloItemId]);
+
+    // What the audio elements actually honor: manual mutes, or — while a solo
+    // is active — everything in the mix except the soloed item.
+    const playerMutedItems = useMemo(
+        () =>
+            effectiveMutedIds(
+                mutedItems,
+                soloItemId,
+                playingSegments.map((i: MediaItem) => i.id),
+            ),
+        [mutedItems, soloItemId, playingSegments],
+    );
+
+    // True while the browser's autoplay policy is holding audio back — same
+    // document-level unlock listeners the scanner relies on.
+    const audioBlocked = useSyncExternalStore(
+        subscribeAudioBlocked,
+        isAudioBlocked,
+    );
+
+    return (
+        <ClassicyApp
+            id={appId}
+            name={appName}
+            icon={appIcon}
+            defaultWindow={`${appId}_main`}
+        >
+            {showSettings && (
+                <RadioSettingsWindow
+                    appId={appId}
+                    appIcon={appIcon}
+                    appMenu={appMenu}
+                    idPrefix="radiotuner_settings"
+                    form={settingsForm}
+                    setForm={setSettingsForm}
+                    onCancel={() => setShowSettings(false)}
+                    onSave={saveSettingsForm}
+                />
+            )}
+            <ClassicyWindow
+                id={`${appId}_main`}
+                title={appName}
+                appId={appId}
+                icon={appIcon}
+                closable={true}
+                resizable={true}
+                zoomable={true}
+                scrollable={false}
+                collapsable={true}
+                initialSize={["50%", "40%"]}
+                initialPosition={["center", "top"]}
+                minimumSize={[500, 280]}
+                modal={false}
+                appMenu={appMenu}
+            >
+                <div className={styles.rsContainer}>
+                    {audioBlocked && (
+                        <div className={styles.rsUnlockOverlay}>
+                            <div className={styles.rsUnlockOverlayBox}>
+                                <p className={styles.rsUnlockOverlayTitle}>
+                                    Click anywhere to start audio
+                                </p>
+                                <p className={styles.rsUnlockOverlayHint}>
+                                    Your browser paused sound until you
+                                    interact with the page
+                                </p>
+                            </div>
+                        </div>
+                    )}
+                    <div className={styles.rsMainArea}>
+                        {activeStationObj && (
+                            <>
+                                <div className={styles.rsDisplay}>
+                                    <p className={styles.rsDisplaySource}>
+                                        {activeStationObj.label}
+                                    </p>
+                                    <NowPlayingList
+                                        segments={playingSegments}
+                                        mutedItems={mutedItems}
+                                        onToggleMute={toggleItemMute}
+                                        soloItemId={soloItemId}
+                                        onToggleSolo={toggleSoloItem}
+                                    />
+                                </div>
+                                <StationPlayer
+                                    station={activeStationObj}
+                                    nowMs={nowMs}
+                                    getNowMs={getNowMs}
+                                    stationMuted={false}
+                                    mutedItems={playerMutedItems}
+                                    clockPaused={clockPaused}
+                                    showWaveform={showWaveform}
+                                    captionsOn={captionsOn}
+                                    captionStyle={settings.captionStyle}
+                                    vizMode={settings.vizMode}
+                                    onCycleVizMode={onCycleVizMode}
+                                    waveColors={waveColors}
+                                    maxVolume={maxVolume}
+                                    playOriginalAudio={settings.playOriginalAudio}
+                                />
+                            </>
+                        )}
+                    </div>
+
+                    {/* Bottom row: control panel + one button per station */}
+                    <div className={styles.rsBottomRow}>
+                        <div className={styles.rsControlPanel}>
+                            <ClassicyButton
+                                buttonSize="small"
+                                onClickFunc={() => setCaptionsOn((v) => !v)}
+                                depressed={captionsOn}
+                            >
+                                {captionsOn ? "CC On" : "CC Off"}
+                            </ClassicyButton>
+                        </div>
+                        <div className={styles.rsStationStrip}>
+                            {stations.map((station) => {
+                                const isActive = station.key === activeStation;
+                                return (
+                                    <ClassicyButton
+                                        key={station.key}
+                                        depressed={isActive}
+                                        onClickFunc={() =>
+                                            setActiveStation(station.key)
+                                        }
+                                    >
+                                        <StationButtonContent
+                                            label={station.label}
+                                            status={stationStatus(
+                                                station,
+                                                upcomingItems,
+                                                nowMs,
+                                            )}
+                                        />
+                                    </ClassicyButton>
+                                );
+                            })}
+                        </div>
+                    </div>
+                </div>
+            </ClassicyWindow>
+            {aboutWindow}
+        </ClassicyApp>
+    );
+};

--- a/packages/frontend/src/Applications/RadioTuner/RadioTunerContext.test.ts
+++ b/packages/frontend/src/Applications/RadioTuner/RadioTunerContext.test.ts
@@ -1,0 +1,96 @@
+import type { ClassicyStore } from "classicy";
+import { describe, expect, it } from "vitest";
+import {
+	classicyRadioTunerEventHandler,
+	radioTunerSetSettings,
+	radioTunerTuneStation,
+} from "./RadioTunerContext";
+import type { RadioScannerSettings } from "../RadioScanner/radioScannerSettings";
+
+function storeWithApp(data: Record<string, unknown> = {}): ClassicyStore {
+	return {
+		System: {
+			Manager: {
+				Applications: { apps: { "RadioTuner.app": { data } } },
+			},
+		},
+	} as unknown as ClassicyStore;
+}
+
+describe("classicyRadioTunerEventHandler", () => {
+	it("persists activeStation, mutedItems, and showWaveform", () => {
+		const ds = storeWithApp();
+		const out = classicyRadioTunerEventHandler(ds, {
+			type: "ClassicyAppRadioTunerSetState",
+			activeStation: "WCBS",
+			mutedItems: [101],
+			showWaveform: false,
+		});
+		const data = out.System.Manager.Applications.apps["RadioTuner.app"].data;
+		expect(data).toMatchObject({
+			activeStation: "WCBS",
+			mutedItems: [101],
+			showWaveform: false,
+		});
+	});
+
+	it("ignores unrelated actions and missing app", () => {
+		const ds = storeWithApp({ showWaveform: true });
+		expect(classicyRadioTunerEventHandler(ds, { type: "SomethingElse" })).toBe(ds);
+		const empty = { System: { Manager: { Applications: { apps: {} } } } } as unknown as ClassicyStore;
+		expect(classicyRadioTunerEventHandler(empty, { type: "ClassicyAppRadioTunerSetState" })).toBe(empty);
+	});
+});
+
+describe("classicyRadioTunerEventHandler settings", () => {
+	const settings = {
+		vizMode: "Bars",
+		useThemeColors: false,
+		colorBright: 0xff0000,
+		colorDim: 0x330000,
+	} as unknown as RadioScannerSettings;
+
+	it("persists settings under data.settings", () => {
+		const ds = storeWithApp();
+		const out = classicyRadioTunerEventHandler(
+			ds,
+			radioTunerSetSettings(settings),
+		);
+		expect(
+			out.System.Manager.Applications.apps["RadioTuner.app"].data,
+		).toMatchObject({ settings });
+	});
+
+	it("SetSettings preserves SetState fields", () => {
+		const ds = storeWithApp({ activeStation: "WINS", mutedItems: [7] });
+		const out = classicyRadioTunerEventHandler(
+			ds,
+			radioTunerSetSettings(settings),
+		);
+		const data = out.System.Manager.Applications.apps["RadioTuner.app"].data;
+		expect(data).toMatchObject({
+			activeStation: "WINS",
+			mutedItems: [7],
+			settings,
+		});
+	});
+});
+
+describe("classicyRadioTunerEventHandler — remote tune command", () => {
+	it("writes a seq-command with the station slug", () => {
+		const ds = storeWithApp();
+		const out = classicyRadioTunerEventHandler(ds, radioTunerTuneStation("wcbs"));
+		expect(
+			out.System.Manager.Applications.apps["RadioTuner.app"].data,
+		).toMatchObject({ command: { seq: 1, kind: "tune", station: "wcbs" } });
+	});
+
+	it("increments seq monotonically across commands", () => {
+		const ds = storeWithApp();
+		classicyRadioTunerEventHandler(ds, radioTunerTuneStation("wcbs"));
+		const out = classicyRadioTunerEventHandler(ds, radioTunerTuneStation("wins"));
+		expect(
+			out.System.Manager.Applications.apps["RadioTuner.app"].data,
+		).toMatchObject({ command: { seq: 2, kind: "tune", station: "wins" } });
+	});
+});

--- a/packages/frontend/src/Applications/RadioTuner/RadioTunerContext.ts
+++ b/packages/frontend/src/Applications/RadioTuner/RadioTunerContext.ts
@@ -1,28 +1,37 @@
 import type { ActionMessage, ClassicyStore } from "classicy";
 import { registerApp } from "classicy";
 import { z } from "zod";
-import type { RadioScannerSettings } from "./radioScannerSettings";
+import type { RadioScannerSettings } from "../RadioScanner/radioScannerSettings";
 
-const appId = "RadioScanner.app";
+const appId = "RadioTuner.app";
 
 /**
- * One-shot remote tune command delivered through the store (TVContext's
- * pattern): `seq` is monotonic so the component applies each command exactly
- * once, retrying while the station list doesn't contain the slug yet.
+ * One-shot remote tune command delivered through the store (the Radio
+ * Scanner/TV pattern): `seq` is monotonic so the component applies each
+ * command exactly once, retrying while the station list doesn't contain the
+ * slug yet.
  */
-export interface RadioRemoteCommand {
+export interface RadioTunerRemoteCommand {
 	seq: number;
 	kind: "tune";
 	station: string;
 }
 
-/** Tune the scanner to a station by its slug (station key). */
-export const radioTuneStation = (station: string): ActionMessage => ({
-	type: "ClassicyAppRadioScannerTuneStation",
+/** Tune the Radio Tuner to a broadcast station by its slug (station key). */
+export const radioTunerTuneStation = (station: string): ActionMessage => ({
+	type: "ClassicyAppRadioTunerTuneStation",
 	station,
 });
 
-export const classicyRadioScannerEventHandler = (
+/** Persist the whole settings object in one dispatch. */
+export const radioTunerSetSettings = (
+	settings: RadioScannerSettings,
+): ActionMessage => ({
+	type: "ClassicyAppRadioTunerSetSettings",
+	settings,
+});
+
+export const classicyRadioTunerEventHandler = (
 	ds: ClassicyStore,
 	action: ActionMessage,
 ) => {
@@ -31,7 +40,7 @@ export const classicyRadioScannerEventHandler = (
 	const appData = app.data ?? {};
 
 	switch (action.type) {
-		case "ClassicyAppRadioScannerSetState":
+		case "ClassicyAppRadioTunerSetState":
 			app.data = {
 				...appData,
 				activeStation: action.activeStation,
@@ -39,17 +48,19 @@ export const classicyRadioScannerEventHandler = (
 				showWaveform: action.showWaveform,
 			};
 			return ds;
-		case "ClassicyAppRadioScannerTuneStation":
+		case "ClassicyAppRadioTunerTuneStation":
 			app.data = {
 				...appData,
 				command: {
-					seq: ((appData.command as RadioRemoteCommand | undefined)?.seq ?? 0) + 1,
+					seq:
+						((appData.command as RadioTunerRemoteCommand | undefined)?.seq ??
+							0) + 1,
 					kind: "tune",
 					station: action.station as string,
-				} satisfies RadioRemoteCommand,
+				} satisfies RadioTunerRemoteCommand,
 			};
 			return ds;
-		case "ClassicyAppRadioScannerSetSettings":
+		case "ClassicyAppRadioTunerSetSettings":
 			app.data = {
 				...appData,
 				settings: action.settings as RadioScannerSettings,
@@ -60,7 +71,7 @@ export const classicyRadioScannerEventHandler = (
 	}
 };
 
-export const RadioScannerDataSchema = z.looseObject({
+export const RadioTunerDataSchema = z.looseObject({
 	activeStation: z.string().optional().describe("Slug of the station currently tuned."),
 	mutedItems: z.array(z.number()).optional().describe("Ids of media items the user has muted."),
 	showWaveform: z.boolean().optional().describe("Whether the waveform visualizer overlay is shown."),
@@ -87,32 +98,33 @@ export const RadioScannerDataSchema = z.looseObject({
 		.describe("The Settings window's persisted preferences."),
 });
 
-export type RadioScannerData = z.infer<typeof RadioScannerDataSchema>;
+export type RadioTunerData = z.infer<typeof RadioTunerDataSchema>;
 
 registerApp({
 	id: appId,
-	description: "Listen to synchronized 9/11 radio and scanner recordings by station.",
-	prefix: "ClassicyAppRadioScanner",
-	handler: classicyRadioScannerEventHandler,
+	description:
+		"Listen to full-run live radio broadcasts from September 11, 2001, synchronized to the virtual clock.",
+	prefix: "ClassicyAppRadioTuner",
+	handler: classicyRadioTunerEventHandler,
 	actions: {
-		ClassicyAppRadioScannerSetState: {
-			description: "Persist the active station, per-station mutes, and waveform visibility.",
+		ClassicyAppRadioTunerSetState: {
+			description: "Persist the active station, per-item mutes, and waveform visibility.",
 			params: z.object({
 				activeStation: z.string().describe("Tuned station's slug."),
 				mutedItems: z.array(z.number()).describe("Muted media items' ids."),
 				showWaveform: z.boolean().describe("Whether the waveform overlay is shown."),
 			}),
 		},
-		ClassicyAppRadioScannerTuneStation: {
-			description: "Tune the scanner to a station by slug (one-shot; retries until the station list has it).",
+		ClassicyAppRadioTunerTuneStation: {
+			description: "Tune to a broadcast station by slug (one-shot; retries until the station list has it).",
 			params: z.object({ station: z.string().describe("Station slug to tune to.") }),
 		},
-		ClassicyAppRadioScannerSetSettings: {
+		ClassicyAppRadioTunerSetSettings: {
 			description: "Replace the whole persisted settings object.",
 			params: z.object({
 				settings: z.record(z.string(), z.unknown()).describe("Full RadioScannerSettings object."),
 			}),
 		},
 	},
-	state: RadioScannerDataSchema,
+	state: RadioTunerDataSchema,
 });

--- a/packages/frontend/src/Components/AboutApp/appWiring.test.tsx
+++ b/packages/frontend/src/Components/AboutApp/appWiring.test.tsx
@@ -11,6 +11,7 @@ const APP_FILES: Record<string, string> = {
 	"News.app": "News/News.tsx",
 	"Newsgroups.app": "Newsgroups/Newsgroups.tsx",
 	"RadioScanner.app": "RadioScanner/RadioScanner.tsx",
+	"RadioTuner.app": "RadioTuner/RadioTuner.tsx",
 	"TV.app": "TV/TV.tsx",
 	"Weather.app": "Weather/Weather.tsx",
 };

--- a/packages/frontend/src/Desktop.tsx
+++ b/packages/frontend/src/Desktop.tsx
@@ -32,6 +32,7 @@ import { PagerDecoder } from "./Applications/PagerDecoder/PagerDecoder";
 import { PlaylistEditor } from "./Applications/PlaylistEditor/PlaylistEditor";
 import { Readme } from "./Applications/README/README";
 import { RadioScanner } from "./Applications/RadioScanner/RadioScanner";
+import { RadioTuner } from "./Applications/RadioTuner/RadioTuner";
 import { TimeMachine } from "./Applications/TimeMachine/TimeMachine";
 import { TV } from "./Applications/TV/TV";
 import { Weather } from "./Applications/Weather/Weather";
@@ -142,6 +143,7 @@ export default function Desktop() {
 			<PagerDecoder />
 			<Readme />
 			<RadioScanner />
+			<RadioTuner />
 			<TV />
 			<Weather />
 		</ClassicyDesktop>

--- a/packages/frontend/src/Providers/Playlist/PlaylistProvider.tsx
+++ b/packages/frontend/src/Providers/Playlist/PlaylistProvider.tsx
@@ -26,6 +26,8 @@ import { browserNavigate } from "../../Applications/Browser/BrowserContext";
 import { flightTrackerFocusFlight } from "../../Applications/FlightTracker/flightTrackerCommands";
 import { newsFocusItem } from "../../Applications/News/NewsContext";
 import { radioTuneStation } from "../../Applications/RadioScanner/RadioScannerContext";
+import { BROADCAST_STATIONS } from "../../Applications/RadioScanner/stationGrouping";
+import { radioTunerTuneStation } from "../../Applications/RadioTuner/RadioTunerContext";
 import { setDateTimeFromUtc } from "../../Applications/TimeMachine/setVirtualClock";
 import { tvTuneChannel } from "../../Applications/TV/TVContext";
 import { virtualUtcMs } from "../MediaStream/virtualClock";
@@ -37,7 +39,11 @@ import {
 	type TriggerEvent,
 } from "./playlistEngine";
 import { loadPlaylist, playlistIdFromSearch } from "./loadPlaylist";
-import { PERMISSION_DENIED, PLAYLIST_APP_IDS, playlistAppMeta } from "./playlistApps";
+import {
+	PERMISSION_DENIED,
+	playlistAppMeta,
+	playlistFocusAppId,
+} from "./playlistApps";
 import { PlaylistContext, type PlaylistContextValue } from "./PlaylistContext";
 import { playlistMergeAppData } from "./playlistStoreActions";
 import type { PlaylistApp, PlaylistDefinition } from "./playlistTypes";
@@ -54,7 +60,15 @@ type Dispatch = (action: ActionMessage) => void;
 const FOCUS_DISPATCHERS: Record<PlaylistApp | "browser", (d: Dispatch, itemId: string) => void> =
 	{
 		tv: (d, itemId) => d(tvTuneChannel(itemId)),
-		radio: (d, itemId) => d(radioTuneStation(itemId)),
+		// The radio catalog spans two apps post-split: broadcast stations tune
+		// the Radio Tuner, comm-traffic stations the Radio Scanner — matching
+		// playlistFocusAppId's app choice.
+		radio: (d, itemId) =>
+			d(
+				BROADCAST_STATIONS.has(itemId.toUpperCase())
+					? radioTunerTuneStation(itemId)
+					: radioTuneStation(itemId),
+			),
 		news: (d, itemId) => d(newsFocusItem(Number(itemId))),
 		flights: (d, itemId) => d(flightTrackerFocusFlight(itemId)),
 		browser: (d, url) => d(browserNavigate(url)),
@@ -110,7 +124,7 @@ export const PlaylistProvider: FC<{ children: ReactNode }> = ({ children }) => {
 	// Open the owning app (unless disabled — disable wins) and tune it.
 	const applyFocus = useCallback(
 		(e: Extract<TriggerEvent, { kind: "focus" }>): void => {
-			const appId = PLAYLIST_APP_IDS[e.app];
+			const appId = playlistFocusAppId(e.app, e.itemId);
 			if (snapshotRef.current.disabledApps.has(appId)) return;
 			dispatch({ type: "ClassicyAppOpen", app: { id: appId, ...playlistAppMeta(appId) } });
 			FOCUS_DISPATCHERS[e.app](dispatch, e.itemId);
@@ -217,12 +231,12 @@ export const PlaylistProvider: FC<{ children: ReactNode }> = ({ children }) => {
 
 	// --- State: locked-focus reconciliation ----------------------------------
 	// Each participating app publishes its current selection into its store
-	// data (contract: TV.currentChannel, RadioScanner.activeStation,
+	// data (contract: TV.currentChannel, RadioScanner/RadioTuner.activeStation,
 	// News.openDocuments, FlightTracker.focusedFlight).
 	useEffect(() => {
 		if (!definition) return;
 		for (const [app, itemId] of snapshot.lockedFocus) {
-			const appId = PLAYLIST_APP_IDS[app];
+			const appId = playlistFocusAppId(app, itemId);
 			const data = apps[appId]?.data ?? {};
 			const current =
 				app === "tv"

--- a/packages/frontend/src/Providers/Playlist/playlistApps.ts
+++ b/packages/frontend/src/Providers/Playlist/playlistApps.ts
@@ -1,6 +1,7 @@
 // Mapping between playlist media catalogs and the desktop apps that own them,
 // plus name/icon metadata for programmatic open/close dispatches.
 import { ClassicyIcons } from "classicy";
+import { BROADCAST_STATIONS } from "../../Applications/RadioScanner/stationGrouping";
 import type { PlaylistApp } from "./playlistTypes";
 
 export const PLAYLIST_APP_IDS: Record<PlaylistApp, string> = {
@@ -10,6 +11,19 @@ export const PLAYLIST_APP_IDS: Record<PlaylistApp, string> = {
 	flights: "FlightTracker.app",
 };
 
+/**
+ * The app a focus entry actually opens. The "radio" catalog is split across
+ * two desktop apps: continuous broadcast stations (WCBS/WINS) live in the
+ * Radio Tuner, every other station in the Radio Scanner. Station slugs match
+ * case-insensitively, same as the apps' own tune commands.
+ */
+export function playlistFocusAppId(app: PlaylistApp, itemId: string): string {
+	if (app === "radio" && BROADCAST_STATIONS.has(itemId.toUpperCase())) {
+		return "RadioTuner.app";
+	}
+	return PLAYLIST_APP_IDS[app];
+}
+
 export const PERMISSION_DENIED = "You don't have permission to open this app.";
 
 // Names mirror each component's `appName` so menu entries created by an
@@ -17,6 +31,7 @@ export const PERMISSION_DENIED = "You don't have permission to open this app.";
 const APP_NAMES: Record<string, string> = {
 	"TV.app": "TV",
 	"RadioScanner.app": "Radio Scanner",
+	"RadioTuner.app": "Radio Tuner",
 	"News.app": "News",
 	"FlightTracker.app": "Flight Tracker",
 	"Browser.app": "Browser",
@@ -30,6 +45,7 @@ const APP_NAMES: Record<string, string> = {
 const APP_ICON_KEYS: Record<string, string> = {
 	"TV.app": "epg",
 	"RadioScanner.app": "radio",
+	"RadioTuner.app": "radio",
 	"News.app": "news",
 	"FlightTracker.app": "flightTracker",
 	"Browser.app": "internetExplorer",

--- a/packages/frontend/src/appManifests.test.ts
+++ b/packages/frontend/src/appManifests.test.ts
@@ -11,6 +11,7 @@ import "./Applications/FlightTracker/flightMapSettings";
 import "./Applications/FlightTracker/flightTrackerCommands";
 import "./Applications/Browser/BrowserContext";
 import "./Applications/RadioScanner/RadioScannerContext";
+import "./Applications/RadioTuner/RadioTunerContext";
 import "./Applications/Weather/weatherSettings";
 import "./Applications/TimeMachine/timeMachineSettings";
 import "./Applications/Feedback/FeedbackContext";
@@ -44,6 +45,12 @@ const CASES: Array<[string, string[], string[], boolean]> = [
 		"RadioScanner.app",
 		["ClassicyAppRadioScanner"],
 		["ClassicyAppRadioScannerTuneStation", "ClassicyAppRadioScannerSetSettings"],
+		true,
+	],
+	[
+		"RadioTuner.app",
+		["ClassicyAppRadioTuner"],
+		["ClassicyAppRadioTunerTuneStation", "ClassicyAppRadioTunerSetSettings"],
 		true,
 	],
 	[

--- a/packages/frontend/src/data/provenance.test.ts
+++ b/packages/frontend/src/data/provenance.test.ts
@@ -9,6 +9,7 @@ const EXPECTED_IDS = [
 	"Newsgroups.app",
 	"PagerDecoder.app",
 	"RadioScanner.app",
+	"RadioTuner.app",
 	"TV.app",
 	"Weather.app",
 ];
@@ -16,7 +17,7 @@ const EXPECTED_IDS = [
 const PLACEHOLDER = /\b(TBD|TODO|FIXME|XXX)\b/;
 
 describe("APP_PROVENANCE", () => {
-	it("covers exactly the nine in-scope apps", () => {
+	it("covers exactly the ten in-scope apps", () => {
 		expect([...PROVENANCE_APP_IDS].sort()).toEqual(EXPECTED_IDS);
 		expect(Object.keys(APP_PROVENANCE).sort()).toEqual(EXPECTED_IDS);
 	});
@@ -63,6 +64,7 @@ describe("APP_PROVENANCE", () => {
 			"News.app",
 			"TV.app",
 			"RadioScanner.app",
+			"RadioTuner.app",
 			"Browser.app",
 		]) {
 			expect(APP_PROVENANCE[id].method?.length ?? 0).toBeGreaterThan(0);

--- a/packages/frontend/src/data/provenance.ts
+++ b/packages/frontend/src/data/provenance.ts
@@ -56,13 +56,32 @@ export const APP_PROVENANCE: Record<string, AppProvenance> = {
 	"RadioScanner.app": {
 		appName: "Radio Scanner",
 		blurb:
-			"Air-traffic control, military and commercial radio from the morning of September 11, 2001.",
+			"Air-traffic control and military radio traffic from the morning of September 11, 2001.",
 		sources: [
 			{
 				name: "Rutgers Law Review — “A New Type of War”",
 				url: "https://www.rutgerslawreview.com/a-new-type-of-war/",
 				feeds: "The Rutgers channel — FAA and NORAD audio published with the monograph.",
 			},
+			{
+				name: "Internet Archive",
+				url: "https://archive.org/details/911datasets",
+				feeds:
+					"The remaining clips — the ATC and NORAD channels (atc, NEADS/NORAD, Langley, FAA, ATCSCC, ZNY, ZBW, ZOB, ZDC) and the per-flight channels (AA11, UA175, AA77, UA93, DL1989, GOFER06).",
+				note: "From a NIST release or uploaded directly to the Archive.",
+			},
+		],
+		method: [
+			"Captions are machine transcriptions (whisper.cpp), not official transcripts — treat wording as approximate.",
+			"Audio is loudness-normalized from the archived originals; the originals are retained unmodified.",
+		],
+	},
+
+	"RadioTuner.app": {
+		appName: "Radio Tuner",
+		blurb:
+			"Full-run live broadcast radio from September 11, 2001, replayed continuously in step with the virtual clock.",
+		sources: [
 			{
 				name: "Audacy",
 				url: "https://www.audacy.com/1010wins",
@@ -72,13 +91,6 @@ export const APP_PROVENANCE: Record<string, AppProvenance> = {
 				name: "WCBS Audio Archives",
 				url: "https://www.audacy.com/wcbs880",
 				feeds: "WCBS Newsradio 880 coverage.",
-			},
-			{
-				name: "Internet Archive",
-				url: "https://archive.org/details/911datasets",
-				feeds:
-					"The remaining clips — the ATC and NORAD channels (atc, NEADS/NORAD, Langley, FAA, ATCSCC, ZNY, ZBW, ZOB, ZDC) and the per-flight channels (AA11, UA175, AA77, UA93, DL1989, GOFER06).",
-				note: "From a NIST release or uploaded directly to the Archive.",
 			},
 		],
 		method: [


### PR DESCRIPTION
## Summary

The Radio Scanner housed both full-run live radio broadcasts (WCBS, 1010 WINS) and short comm-traffic clips. This adds a new **Radio Tuner** app that owns the continuous broadcasts; the Radio Scanner keeps the comm clips.

- **One partition seam:** `BROADCAST_STATIONS` in `stationGrouping.ts` — both apps filter the shared mp3 stream with it, so a station can never appear in both. Future long-form stations go in the Tuner by adding their slugs there.
- **Radio Tuner** (`RadioTuner.app`): visually the scanner's sibling — station strip with on-air lights, now-playing list, waveform/CC player, identical Settings window — minus the clip machinery (no Coming Up/Previous, no All Traffic, no focused-clip player). Own `ClassicyAppRadioTuner` action namespace, manifest, and About/provenance entry (Audacy/WCBS citations moved here).
- **Shared chrome, not a fork:** the ~240-line Settings window is extracted into `RadioSettingsWindow.tsx`, used by both apps; the Tuner imports StationPlayer/NowPlayingList/settings helpers from the scanner folder.
- **Scanner cleanup:** drops the now-dead continuous-station special cases; a persisted `activeStation` of WCBS/WINS falls back to the first station.
- **Playlists route across the split:** a `radio` focus entry with a broadcast slug opens/tunes the Tuner (`playlistFocusAppId`) instead of leaving the scanner retrying a station that no longer exists. Note: existing playlists disabling `RadioScanner.app` do not disable the Tuner — disable entries carry raw appIds.
- **Drive-by fix:** scanner manifest declared `mutedItems` as `string[]`; the reducer stores numeric media-item ids (was a dev-mode console.warn on every mute).

Mobile's iPod Radio screen deliberately still lists all stations. The Tuner reuses the radio app icon for now — no distinct icon asset exists yet.

## Test plan

- [x] `vitest run` — 252 files / 2,358 tests passing (new: `RadioTuner.test.tsx`, `RadioTunerContext.test.ts`; updated: scanner split assertions, `appManifests`, `appWiring`, `provenance` pinned registries)
- [x] `tsc -b` clean
- [x] `eslint .` — 0 errors
- [x] `vite build` production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)