### PR TITLE
fix(catalogue): sort mp3_items paging, which was silently skipping rows

### DIFF
--- a/packages/tools/video-grabber/tests/test_catalogue_paging.py
+++ b/packages/tools/video-grabber/tests/test_catalogue_paging.py
@@ -1,0 +1,51 @@
+"""Paging over mp3_items, which several flows do while updating what they page.
+
+The bug this guards: identify-parties reported 755 rows processed and left 119
+of them untouched, having done ~119 others twice. LIMIT/OFFSET with no ORDER BY
+has no defined order, and an UPDATE moves a row's physical position, so writing
+while paging reshuffles the pages still to come.
+"""
+from types import SimpleNamespace
+
+from video_grabber.catalogue.flows import _PAGE, _page_mp3_items
+
+
+class FakeClient:
+    """Records the params of each request and serves fixed pages."""
+
+    def __init__(self, pages):
+        self.pages = pages
+        self.calls = []
+
+    def get(self, url, params=None, headers=None):
+        self.calls.append(params)
+        page = self.pages.pop(0) if self.pages else []
+        return SimpleNamespace(
+            raise_for_status=lambda: None, json=lambda: {"data": page}
+        )
+
+
+def _cfg():
+    # `directus_api_token` is what get_directus_token reads; the shorter name is
+    # a different field and leaves the fake unauthenticated.
+    return SimpleNamespace(directus_url="http://d", directus_api_token="t")
+
+
+def test_every_page_is_ordered():
+    """Without this, a flow that writes as it reads silently skips rows."""
+    client = FakeClient([[{"id": i} for i in range(_PAGE)], [{"id": 9}]])
+    list(_page_mp3_items(_cfg(), "id", client=client))
+    assert len(client.calls) == 2
+    assert all(c["sort"] == "id" for c in client.calls)
+
+
+def test_offsets_advance_by_a_full_page():
+    client = FakeClient([[{"id": i} for i in range(_PAGE)], [{"id": 9}]])
+    list(_page_mp3_items(_cfg(), "id", client=client))
+    assert [c["offset"] for c in client.calls] == [0, _PAGE]
+
+
+def test_a_short_page_ends_the_walk():
+    client = FakeClient([[{"id": 1}]])
+    assert [r["id"] for r in _page_mp3_items(_cfg(), "id", client=client)] == [1]
+    assert len(client.calls) == 1

--- a/packages/tools/video-grabber/video_grabber/catalogue/flows.py
+++ b/packages/tools/video-grabber/video_grabber/catalogue/flows.py
@@ -40,12 +40,25 @@ def probe_duration(url: str) -> int | None:
 
 
 def _page_mp3_items(cfg: Config, fields: str, *, client=httpx):
-    """Yield every mp3_items row, following offsets until a short page."""
+    """Yield every mp3_items row, following offsets until a short page.
+
+    `sort` is not optional. LIMIT/OFFSET without an ORDER BY has no defined row
+    order, and callers of this walk the corpus *while updating the rows they
+    walk* — in Postgres an update writes a new tuple, moving the row's physical
+    position, which reshuffles what the next page returns. Rows drift backwards
+    past the offset and are read twice; others drift forwards and are never read
+    at all.
+
+    That is not hypothetical: identify-parties reported 755 rows processed and
+    left 119 of them untouched, having done ~119 others twice, because the
+    counter counts iterations rather than distinct rows. A read-only pass cannot
+    reproduce it — the scan has to be the writer.
+    """
     offset = 0
     while True:
         r = client.get(
             f"{cfg.directus_url}/items/mp3_items",
-            params={"fields": fields, "limit": _PAGE, "offset": offset},
+            params={"fields": fields, "limit": _PAGE, "offset": offset, "sort": "id"},
             headers=_auth_headers(cfg),
         )
         r.raise_for_status()


### PR DESCRIPTION
The full identify-parties run over the corpus reported:

```
identify-parties: 755 identified (144 with Commission sources), 3 skipped, 25 broadcast (excluded), 0 failed
```

…and left **119 of those rows untouched**, having processed ~119 others twice. Verified against the database with `Cache-Control: no-store`, so it is not a stale read:

```
rows with parties: 755 | schema 2: 636 | other: {None: 119}
```

Nothing looked wrong because the counter counts *iterations*, not distinct rows.

## Cause

`_page_mp3_items` walks LIMIT/OFFSET with **no ORDER BY**. That has no defined row order — and its callers walk the corpus *while updating the rows they walk*. In Postgres an update writes a new tuple, moving the row's physical position, which reshuffles what the next page returns. Rows drift backwards past the offset and are read twice; others drift forwards and are never read at all.

## Why this wasn't caught before

The same symptom appeared during the schema-1 run (flow counters not reconciling with the DB census). It was investigated, and the paging hypothesis was **disproved** by counting distinct URLs across a pass and finding no duplicates and no misses.

That experiment was correct but ran on the wrong workload: it was a **read-only** pass. With no writes there is no tuple movement, so the order is incidentally stable and the bug cannot appear. The scan has to be the writer.

## Fix

Adds `sort: id` to the pager, plus a test asserting every page requests it. This fixes every caller, not just parties — `backfill-mp3-catalogue` and `link-mp3-subtitles` walk the same generator.

613 passed, 8 skipped; `ruff check` clean.

After this rolls, re-running `identify-parties` **without** `force` picks up exactly the 119 stragglers, since `parties.schema_version` is the idempotency marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)