### PR TITLE
feat(radio): round-2 stations — WOR, KOH, WAMU/NPR, BBC Radio 4

### DIFF
--- a/packages/frontend/src/Applications/RadioScanner/stationGrouping.ts
+++ b/packages/frontend/src/Applications/RadioScanner/stationGrouping.ts
@@ -213,6 +213,10 @@ export const BROADCAST_STATIONS = new Set([
 	"WIBX",
 	"WBAP",
 	"KQRS",
+	"WOR",
+	"KOH",
+	"WAMU",
+	"BBC-R4",
 ]);
 
 /** Stations pinned to the front of the strip regardless of online state. */

--- a/packages/tools/radio-ingest/ingest_job.py
+++ b/packages/tools/radio-ingest/ingest_job.py
@@ -96,7 +96,7 @@ def ensure_item(entry, source_id):
         "start_date": entry["start_date"],
         "end_date": entry["end_date"],
         "calc_duration": entry["calc_duration"],
-        "timezone": TZ_LABEL.get(entry["source_slug"], "EDT"),
+        "timezone": entry.get("timezone") or TZ_LABEL.get(entry["source_slug"], "EDT"),
         "url": url,
         "format": "mp3",
         "approved": 1,

--- a/packages/tools/radio-ingest/ingest_manifest2.json
+++ b/packages/tools/radio-ingest/ingest_manifest2.json
@@ -1,0 +1,110 @@
+[
+ {
+  "source_slug": "WOR",
+  "file": "WOR-AM_2001-09-11_ET0848.mp3",
+  "bucket_key": "audio/radio/WOR/WOR-AM_2001-09-11_ET0848.mp3",
+  "title": "WOR 710",
+  "full_title": "WOR 710 New York \u2014 Sept 11, 8:48-10:50 AM ET (archive.org)",
+  "start_date": "2001-09-11T12:48:34",
+  "end_date": "2001-09-11T14:50:36",
+  "calc_duration": 7322,
+  "timezone": "EDT",
+  "note": "south tower collapse live at ~4230s"
+ },
+ {
+  "source_slug": "KOH",
+  "file": "KOH-AM_2001-09-11_ET0849.mp3",
+  "bucket_key": "audio/radio/KOH/KOH-AM_2001-09-11_ET0849.mp3",
+  "title": "News Talk 780 KOH",
+  "full_title": "KOH 780 Reno \u2014 Sept 11, ~8:49-11:01 AM ET, ABC feed + local (archive.org)",
+  "start_date": "2001-09-11T12:49:00",
+  "end_date": "2001-09-11T15:01:29",
+  "calc_duration": 7950,
+  "timezone": "PDT",
+  "note": "start +/-90s; content-bounded"
+ },
+ {
+  "source_slug": "BBC-R4",
+  "file": "BBC-R4_World-Tonight_2001-09-11_ET1700.mp3",
+  "bucket_key": "audio/radio/BBC-R4/BBC-R4_World-Tonight_2001-09-11_ET1700.mp3",
+  "title": "BBC Radio 4",
+  "full_title": "BBC Radio 4 \u2014 The World Tonight special edition, Sept 11, 10 PM UK / 5 PM ET",
+  "start_date": "2001-09-11T21:00:00",
+  "end_date": "2001-09-11T22:05:57",
+  "calc_duration": 3957,
+  "timezone": "BST",
+  "note": "program open verified"
+ },
+ {
+  "source_slug": "WAMU",
+  "file": "WAMU-NPR_2001-09-11_evening-a_ET1907.mp3",
+  "bucket_key": "audio/radio/WAMU/WAMU-NPR_2001-09-11_evening-a_ET1907.mp3",
+  "title": "WAMU 88.5 / NPR",
+  "full_title": "WAMU-NPR \u2014 Sept 11 evening coverage part 1, 7:07-8:22 PM ET (archive.org)",
+  "start_date": "2001-09-11T23:07:00",
+  "end_date": "2001-09-12T00:22:38",
+  "calc_duration": 4538,
+  "timezone": "EDT",
+  "note": "continuous into part 2"
+ },
+ {
+  "source_slug": "WAMU",
+  "file": "WAMU-NPR_2001-09-11_evening-b_ET2022.mp3",
+  "bucket_key": "audio/radio/WAMU/WAMU-NPR_2001-09-11_evening-b_ET2022.mp3",
+  "title": "WAMU 88.5 / NPR",
+  "full_title": "WAMU-NPR \u2014 Sept 11 evening coverage part 2 incl. Bush address, 8:22-9:03 PM ET",
+  "start_date": "2001-09-12T00:22:36",
+  "end_date": "2001-09-12T01:03:36",
+  "calc_duration": 2460,
+  "timezone": "EDT",
+  "note": "Bush 8:30 PM address anchors this file"
+ },
+ {
+  "source_slug": "WABC",
+  "file": "WABC-AM_2001-09-11_hole-patch_ET1050.mp3",
+  "bucket_key": "audio/radio/WABC/WABC-AM_2001-09-11_hole-patch_ET1050.mp3",
+  "title": "77 WABC New York",
+  "full_title": "WABC 770 \u2014 Sept 11, 10:50-10:59 AM ET patch (archive.org aircheck)",
+  "start_date": "2001-09-11T14:50:20",
+  "end_date": "2001-09-11T14:59:30",
+  "calc_duration": 550,
+  "timezone": "EDT",
+  "note": "fills the 10:50-11:00 hole; aligned via 11:00 ABC hourly open"
+ },
+ {
+  "source_slug": "WCBS",
+  "file": "WCBS-AM_2001-09-11_gap-patch_ET172710.mp3",
+  "bucket_key": "audio/radio/WCBS/WCBS-AM_2001-09-11_gap-patch_ET172710.mp3",
+  "title": "WCBS Newsradio 880",
+  "full_title": "WCBS 880 \u2014 Sept 11, 5:27-5:30 PM ET patch (official release)",
+  "start_date": "2001-09-11T21:27:10",
+  "end_date": "2001-09-11T21:30:50",
+  "calc_duration": 220,
+  "timezone": "EDT",
+  "note": "fills the 4-min radiotapes gap; WTC7 anchor proven segment"
+ },
+ {
+  "source_slug": "WCBS",
+  "file": "WCBS-AM_2001-09-12_morning_ET0716.mp3",
+  "bucket_key": "audio/radio/WCBS/WCBS-AM_2001-09-12_morning_ET0716.mp3",
+  "title": "WCBS Newsradio 880",
+  "full_title": "WCBS 880 \u2014 Sept 12 morning-after coverage, 7:16-9:18 AM ET (official release)",
+  "start_date": "2001-09-12T11:16:00",
+  "end_date": "2001-09-12T13:18:09",
+  "calc_duration": 7329,
+  "timezone": "EDT",
+  "note": "new coverage"
+ },
+ {
+  "source_slug": "WCBS",
+  "file": "WCBS-AM_2001-09-12_afternoon_ET1405.mp3",
+  "bucket_key": "audio/radio/WCBS/WCBS-AM_2001-09-12_afternoon_ET1405.mp3",
+  "title": "WCBS Newsradio 880",
+  "full_title": "WCBS 880 \u2014 Sept 12 afternoon coverage, 2:05-3:16 PM ET (official release)",
+  "start_date": "2001-09-12T18:05:00",
+  "end_date": "2001-09-12T19:16:34",
+  "calc_duration": 4294,
+  "timezone": "EDT",
+  "note": "new coverage"
+ }
+]

--- a/packages/tools/radio-ingest/ingest_manifest2.py
+++ b/packages/tools/radio-ingest/ingest_manifest2.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Round-2 ingest manifest: archive.org finds, anchor-verified 2026-08-16."""
+import json
+import os
+import subprocess
+from datetime import datetime, timedelta, timezone
+
+EDT = timezone(timedelta(hours=-4))
+HERE = os.path.dirname(os.path.abspath(__file__))
+STAGING = os.path.join(HERE, "staging2")
+
+
+def dur(path):
+    r = subprocess.run(
+        ["ffprobe", "-v", "quiet", "-print_format", "json", "-show_format", path],
+        capture_output=True, text=True,
+    )
+    return float(json.loads(r.stdout)["format"]["duration"])
+
+
+def et(day, h, m, s=0):
+    return datetime(2001, 9, day, h, m, s, tzinfo=EDT)
+
+
+def naive_utc(dt):
+    return dt.astimezone(timezone.utc).replace(tzinfo=None).isoformat(sep="T", timespec="seconds")
+
+
+ENTRIES = [
+    # slug, filename, start, tz label, title, full_title, note
+    ("WOR", "WOR-AM_2001-09-11_ET0848.mp3", et(11, 8, 48, 34), "EDT",
+     "WOR 710", "WOR 710 New York — Sept 11, 8:48-10:50 AM ET (archive.org)",
+     "south tower collapse live at ~4230s"),
+    ("KOH", "KOH-AM_2001-09-11_ET0849.mp3", et(11, 8, 49, 0), "PDT",
+     "News Talk 780 KOH", "KOH 780 Reno — Sept 11, ~8:49-11:01 AM ET, ABC feed + local (archive.org)",
+     "start +/-90s; content-bounded"),
+    ("BBC-R4", "BBC-R4_World-Tonight_2001-09-11_ET1700.mp3", et(11, 17, 0, 0), "BST",
+     "BBC Radio 4", "BBC Radio 4 — The World Tonight special edition, Sept 11, 10 PM UK / 5 PM ET",
+     "program open verified"),
+    ("WAMU", "WAMU-NPR_2001-09-11_evening-a_ET1907.mp3", et(11, 19, 7, 0), "EDT",
+     "WAMU 88.5 / NPR", "WAMU-NPR — Sept 11 evening coverage part 1, 7:07-8:22 PM ET (archive.org)",
+     "continuous into part 2"),
+    ("WAMU", "WAMU-NPR_2001-09-11_evening-b_ET2022.mp3", et(11, 20, 22, 36), "EDT",
+     "WAMU 88.5 / NPR", "WAMU-NPR — Sept 11 evening coverage part 2 incl. Bush address, 8:22-9:03 PM ET",
+     "Bush 8:30 PM address anchors this file"),
+    ("WABC", "WABC-AM_2001-09-11_hole-patch_ET1050.mp3", et(11, 10, 50, 20), "EDT",
+     "77 WABC New York", "WABC 770 — Sept 11, 10:50-10:59 AM ET patch (archive.org aircheck)",
+     "fills the 10:50-11:00 hole; aligned via 11:00 ABC hourly open"),
+    ("WCBS", "WCBS-AM_2001-09-11_gap-patch_ET172710.mp3", et(11, 17, 27, 10), "EDT",
+     "WCBS Newsradio 880", "WCBS 880 — Sept 11, 5:27-5:30 PM ET patch (official release)",
+     "fills the 4-min radiotapes gap; WTC7 anchor proven segment"),
+    ("WCBS", "WCBS-AM_2001-09-12_morning_ET0716.mp3", et(12, 7, 16, 0), "EDT",
+     "WCBS Newsradio 880", "WCBS 880 — Sept 12 morning-after coverage, 7:16-9:18 AM ET (official release)",
+     "new coverage"),
+    ("WCBS", "WCBS-AM_2001-09-12_afternoon_ET1405.mp3", et(12, 14, 5, 0), "EDT",
+     "WCBS Newsradio 880", "WCBS 880 — Sept 12 afternoon coverage, 2:05-3:16 PM ET (official release)",
+     "new coverage"),
+]
+
+entries = []
+for slug, fname, start, tz, title, full, note in ENTRIES:
+    path = os.path.join(STAGING, fname)
+    d = dur(path)
+    entries.append({
+        "source_slug": slug,
+        "file": fname,
+        "bucket_key": f"audio/radio/{slug}/{fname}",
+        "title": title,
+        "full_title": full,
+        "start_date": naive_utc(start),
+        "end_date": naive_utc(start + timedelta(seconds=d)),
+        "calc_duration": round(d),
+        "timezone": tz,
+        "note": note,
+    })
+
+out = os.path.join(HERE, "ingest_manifest2.json")
+json.dump(entries, open(out, "w"), indent=1)
+print(f"{len(entries)} entries, {sum(e['calc_duration'] for e in entries)/3600:.1f} h")
+for e in entries:
+    print(f"{e['source_slug']:7s} {e['start_date']}Z +{e['calc_duration']:>5}s  {e['file']}")


### PR DESCRIPTION
## What

Second batch of anchor-verified 9/11 broadcast recordings for the Radio Tuner, all found on archive.org:

- **WOR 710 New York** — 8:48:34-10:50 AM ET (South Tower collapse live at the computed offset)
- **KOH 780 Reno** — ~8:49-11:01 AM ET, ABC feed + local (start ±90s, same bar as KQRS in round 1)
- **WAMU 88.5 / NPR** — evening block 7:07-9:03 PM ET in two contiguous files; Bush's 8:30 PM address lands at the exact predicted offset
- **BBC Radio 4** — The World Tonight special edition, 10 PM UK / 5 PM ET

Plus three patches that ride under existing stations (no slug changes): the WABC 10:50-11:00 hole patch (aligned via the 11:00 ABC hourly open in a second aircheck of the same station), the WCBS 5:27 PM 4-minute gap patch, and two new WCBS **September 12** blocks (7:16-9:18 AM, 2:05-3:16 PM) recovered from the station's lost official release, WTC7-collapse-anchored to the second.

## Rejected after verification

Howard Stern "COMPLETE BROADCAST" (commercials stripped: 6.38 h of tape for ~8 h of air — drift proves it) and WFAN "(Full)" (stitched from YouTube parts, ~4 min drift by 10:24).

## Testing

RadioScanner + RadioTuner suites: 198 passed. Ingest runs as the same one-off in-cluster job pattern as round 1 (`packages/tools/radio-ingest/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)