### PR TITLE
feat(parties): curated tag column, and indexes for the tag search

### DIFF
--- a/packages/backend/seed.mjs
+++ b/packages/backend/seed.mjs
@@ -497,6 +497,24 @@ async function ensurePublicReadAccess(token) {
   }
 }
 
+// mp3_items.tags is a namespaced search index built by video-grabber's
+// identify-parties flow (see packages/tools/video-grabber/docs/party-identification.md).
+// Two query shapes reach it and they need different indexes — indexing for one
+// does nothing for the other:
+//   * Directus REST `filter[tags][_contains]=facility:zbw` compiles to a
+//     LIKE '%…%' over the serialized json, which only a trigram index helps.
+//   * `@> '["facility:zbw"]'` containment from SQL needs a jsonb GIN index.
+// At the corpus's present size (~780 rows) the planner will pick a sequential
+// scan regardless; these matter if the tag index ever backs a user-facing
+// search, and cost nothing to carry until then.
+const TAG_INDEX_SQL = `
+  CREATE EXTENSION IF NOT EXISTS pg_trgm;
+  CREATE INDEX IF NOT EXISTS idx_mp3_items_tags_trgm
+    ON mp3_items USING gin ((tags::text) gin_trgm_ops);
+  CREATE INDEX IF NOT EXISTS idx_mp3_items_tags_jsonb
+    ON mp3_items USING gin ((tags::jsonb) jsonb_path_ops);
+`;
+
 // createStreamerIndexes indexes the per-table time lookups the streamer's init/seek
 // queries run. usenet already has its own (source, start_date) index (see
 // createCollections); the video/news/mp3/pager tables are filtered by
@@ -515,6 +533,7 @@ function createStreamerIndexes() {
     CREATE INDEX IF NOT EXISTS idx_pager_items_approved_start ON pager_items (approved, start_date);
   `);
   psql(CHAT_INDEX_SQL);
+  psql(TAG_INDEX_SQL);
 }
 
 async function createRelations(token) {

--- a/packages/tools/video-grabber/docs/party-identification.md
+++ b/packages/tools/video-grabber/docs/party-identification.md
@@ -89,6 +89,39 @@ on. The parties block keeps the distinction.
 Callsigns are normalised so `American 11`, `AAL11` and `AA 11` collapse to
 `aircraft:aal11`. Military callsigns keep their own prefix (`gofer6`) — the goal
 is collapsing spellings, not forcing everything into an airline scheme.
+Facilities resolve the same way through `vocab.FACILITY_ALIASES`, so `Boston`,
+`Boston Center` and `ZBW` are one tag.
+
+### Curated tags
+
+`mp3_items.tags` is **derived and readonly in the admin UI**; it is rebuilt from
+scratch on every run. Hand-added tags go in **`tags_curated`**, which the flow
+reads and never writes, and merges into `tags`.
+
+Two columns rather than one, because the obvious single-column merge is wrong:
+folding each new derived set into whatever `tags` already held would let derived
+tags only ever accumulate. A facility the model stops identifying — or one the
+gate starts rejecting — would linger in the index forever with nothing able to
+retract it, so re-running would entrench old mistakes instead of correcting them.
+Rebuilding `tags` wholesale keeps derivation authoritative for itself; keeping
+human input in its own column keeps it safe from that rebuild.
+
+Curated values are stored verbatim — not slugged, not namespaced — since a
+curator may need vocabulary this module has never heard of.
+
+### Indexes
+
+`tags` carries two GIN indexes, because two query shapes reach it and indexing
+for one does nothing for the other:
+
+| Query | Index |
+|---|---|
+| Directus `filter[tags][_contains]=…` → `LIKE '%…%'` | `idx_mp3_items_tags_trgm` (pg_trgm) |
+| `@> '["facility:zbw"]'` from SQL | `idx_mp3_items_tags_jsonb` (jsonb_path_ops) |
+
+Both are declared in `packages/backend/seed.mjs`'s `TAG_INDEX_SQL`. At the
+corpus's present size the planner picks a sequential scan anyway; they matter if
+the tag index ever backs a user-facing search.
 
 ## Operating it
 

--- a/packages/tools/video-grabber/tests/test_parties_tags.py
+++ b/packages/tools/video-grabber/tests/test_parties_tags.py
@@ -150,3 +150,48 @@ def test_resolution_is_index_only_and_does_not_touch_the_record():
     parties = {"participants": [{"facility": "Boston"}]}
     build_tags(parties)
     assert parties["participants"][0]["facility"] == "Boston"
+
+
+# --- curated merge --------------------------------------------------------
+
+def test_curated_tags_are_preserved_alongside_derived_ones():
+    tags = build_tags(FULL, curated=["collection:team-8", "note:check-timestamp"])
+    assert "collection:team-8" in tags and "note:check-timestamp" in tags
+    assert "facility:indianapolis-center" in tags   # derived ones still there
+
+
+def test_a_retracted_derived_tag_does_not_survive_a_rerun():
+    """Why curated tags need their own column rather than merging into `tags`.
+
+    Merging the new derived set into whatever `tags` already held would let
+    derived tags only ever accumulate: a facility the model stops identifying,
+    or one the gate now rejects, would linger forever with nothing able to
+    retract it. Re-running would entrench old mistakes instead of fixing them.
+    """
+    before = build_tags({"participants": [{"facility": "NEADS", "role": "military"}]})
+    assert "facility:neads" in before
+    # Next run: the gate rejected NEADS, so it is simply absent from the input.
+    after = build_tags({"participants": [{"facility": None, "role": "military"}]},
+                       curated=["note:keep-me"])
+    assert "facility:neads" not in after
+    assert "note:keep-me" in after
+
+
+def test_curated_tags_need_not_use_a_known_namespace():
+    # A curator may need vocabulary this module has never heard of.
+    assert "anything at all" in build_tags({}, curated=["anything at all"])
+
+
+def test_blank_curated_entries_are_dropped():
+    assert build_tags({}, curated=["", "   ", None]) == []
+
+
+def test_curated_and_derived_duplicates_collapse():
+    tags = build_tags(FULL, curated=["facility:neads"])
+    assert tags.count("facility:neads") == 1
+
+
+def test_a_curator_may_assert_various_even_though_derivation_may_not():
+    assert "facility:various" in build_tags({}, curated=["facility:various"])
+    assert "facility:various" not in build_tags(
+        {"participants": [{"facility": "various", "role": "atc"}]})

--- a/packages/tools/video-grabber/video_grabber/parties/flows.py
+++ b/packages/tools/video-grabber/video_grabber/parties/flows.py
@@ -78,7 +78,9 @@ def identify_parties_flow(limit: int | None = None, force: bool = False,
     complete = anthropic_completer(cfg, model=cfg.parties_model, max_tokens=PARTIES_MAX_TOKENS)
 
     done = skipped = failed = broadcast = enriched = 0
-    for row in _page_mp3_items(cfg, "id,url,subtitles,calc_duration,parties"):
+    for row in _page_mp3_items(
+        cfg, "id,url,subtitles,calc_duration,parties,tags_curated"
+    ):
         if limit is not None and done >= limit:
             break
         key = key_from_url(row["url"])
@@ -141,7 +143,10 @@ def identify_parties_flow(limit: int | None = None, force: bool = False,
             cleaned["gate_reasons"] = reasons
             logger.info("identify-parties: %s gated: %s", key, reasons)
 
-        tags = build_tags(cleaned)
+        # `tags` is rebuilt from scratch every run so the model can retract a
+        # tag it no longer supports; `tags_curated` is the human column the
+        # flow reads and never writes, so hand-added tags survive regardless.
+        tags = build_tags(cleaned, row.get("tags_curated") or [])
 
         if dry_run:
             logger.info("DRY RUN %s -> %s | tags=%s", key, cleaned, tags)

--- a/packages/tools/video-grabber/video_grabber/parties/tags.py
+++ b/packages/tools/video-grabber/video_grabber/parties/tags.py
@@ -20,6 +20,7 @@ on; the parties block keeps the distinction for anyone who needs it.
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 
 from video_grabber.parties.spoken import spoken_to_digits
 from video_grabber.parties.vocab import (
@@ -64,9 +65,25 @@ def normalize_callsign(callsign: str) -> str:
     return f"{_AIRLINE_PREFIX.get(prefix, prefix)}{digits}"
 
 
-def build_tags(parties: dict) -> list[str]:
-    """Every tag implied by an identified parties block, sorted and deduped."""
-    tags: set[str] = set()
+def build_tags(parties: dict, curated: Iterable[str] = ()) -> list[str]:
+    """Every tag implied by an identified parties block, sorted and deduped.
+
+    `curated` is merged in verbatim. It exists because the obvious way to
+    preserve hand-added tags — merging the new derived set into whatever `tags`
+    already held — is wrong: derived tags could then only ever accumulate. A
+    facility the model stops identifying, or one removed because the gate now
+    rejects it, would linger in the index forever with nothing able to retract
+    it. Re-running would silently entrench old mistakes.
+
+    So the derived set is always rebuilt from scratch and is authoritative for
+    itself, and human additions live in their own column (`tags_curated`) that
+    the flow reads but never writes. Nothing a curator types can be clobbered,
+    and nothing the model retracts can survive.
+
+    Curated values are taken as given — not slugged, not namespaced — since a
+    curator may need vocabulary this module has never heard of.
+    """
+    tags: set[str] = {t.strip() for t in curated if t and t.strip()}
 
     if parties.get("tier"):
         tags.add(f"tier:{slugify(parties['tier'])}")
@@ -110,6 +127,8 @@ def build_tags(parties: dict) -> list[str]:
             tags.add(f"topic:{topic}")
 
     # 'various' is the tape tier's placeholder for "many counterparties"; it is
-    # not a facility and must never become one.
-    tags.discard("facility:various")
+    # not a facility and must never become one. A curator who types it anyway
+    # means it, so this only removes what derivation produced.
+    if "facility:various" not in curated:
+        tags.discard("facility:various")
     return sorted(tags)


### PR DESCRIPTION
Two things, both about `mp3_items.tags` being a derived column that people will reasonably want to edit.

## Curated tags get their own column

`tags` is now **readonly in the Directus UI** and rebuilt from scratch each run. Hand-added tags live in **`tags_curated`**, which the flow reads and never writes, and merges in.

**Why two columns and not a merge into one.** The obvious version — fold each new derived set into whatever `tags` already held — is wrong in a way that only shows up later: derived tags could then *only ever accumulate*. A facility the model stops identifying, or one the gate starts rejecting, would linger in the index forever with nothing able to retract it. Re-running would entrench old mistakes instead of correcting them.

Rebuilding `tags` wholesale keeps derivation authoritative for itself; a separate human column keeps hand input safe from that rebuild. There's a test pinning the retraction property.

The readonly flag matters as much as the column: the `tags` interface renders editable chips, so without it a curator's edit *looks* accepted and then silently vanishes on the next run.

Curated values are stored verbatim — not slugged, not namespaced — since a curator may need vocabulary this module has never heard of.

## Indexes

Two query shapes reach `tags`, and indexing for one does nothing for the other:

| Query | Index |
|---|---|
| Directus `filter[tags][_contains]=x` → `LIKE '%x%'` | `idx_mp3_items_tags_trgm` (pg_trgm) |
| `@> '["x"]'` from SQL | `idx_mp3_items_tags_jsonb` (jsonb_path_ops) |

Declared in `seed.mjs`'s `TAG_INDEX_SQL` beside the existing streamer indexes. **Being honest about sizing:** at ~780 rows the planner picks a sequential scan regardless — these matter if the tag index ever backs a user-facing search, and cost nothing to carry until then.

Noticed while looking: **`idx_mp3_items_approved_start` is missing from `mp3_items`**, though `createStreamerIndexes()` declares it and the sibling tables have it. That one is load-bearing for the streamer's windowed queries, and it's included in the DDL to apply.

## Applying it

Production DDL is blocked for me, and `seed.mjs` must not be run against the live database (it bulk-imports media). The statements to run:

```sh
kubectl -n rt911 exec deploy/rt911-db -- psql -U directus -d directus -v ON_ERROR_STOP=1 -c "
CREATE EXTENSION IF NOT EXISTS pg_trgm;
CREATE INDEX IF NOT EXISTS idx_mp3_items_tags_trgm ON mp3_items USING gin ((tags::text) gin_trgm_ops);
CREATE INDEX IF NOT EXISTS idx_mp3_items_tags_jsonb ON mp3_items USING gin ((tags::jsonb) jsonb_path_ops);
CREATE INDEX IF NOT EXISTS idx_mp3_items_approved_start ON mp3_items (approved, start_date);
ANALYZE mp3_items;"
```

The Directus side (`tags_curated` created, `tags` set readonly) is already applied — those went through the API, not psql.

630 passed, 8 skipped; `ruff check` clean; `seed.mjs` parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)