### PR TITLE
fix(parties): classify audio/radio/ as broadcast

### DIFF
--- a/packages/tools/video-grabber/docs/party-identification.md
+++ b/packages/tools/video-grabber/docs/party-identification.md
@@ -136,9 +136,18 @@ identify-parties  dry_run=false
 identify-parties  dry_run=false  force=true
 ```
 
-WINS and WCBS are excluded by an **affirmative allow-list** (`MEDIA_KIND`), never
-a deny-list: a deny-list that fails to load silently re-admits news radio and
-produces confident nonsense about a broadcast that has no counterparty.
+Radio broadcasts are excluded by an **affirmative allow-list** (`MEDIA_KIND`),
+never a deny-list: a deny-list that fails to load silently re-admits news radio
+and produces confident nonsense about a broadcast that has no counterparty.
+That covers `wins1010`, `wcbs`, and `radio` — the last standing for every AM/FM
+station under `audio/radio/`, since `media_kind` keys on the first segment below
+`audio/` rather than the station.
+
+**List a folder even when the answer is "skip it."** An unlisted folder is also
+skipped, so a deliberate exclusion and an unexamined one behave identically and
+report nothing. 31 station recordings sat outside the pipeline unnoticed for
+exactly that reason — they never appeared in a failure count because they were
+never counted at all.
 
 `PARTIES_MAX_TOKENS` is 5000 and the headroom is deliberate — `max_tokens` caps
 thinking and text together, and a budget consumed entirely by thinking returns an

--- a/packages/tools/video-grabber/tests/test_parties_identify.py
+++ b/packages/tools/video-grabber/tests/test_parties_identify.py
@@ -38,6 +38,23 @@ def test_atc_folders_are_conversation():
     assert should_identify("audio/AA77/0812 aa77 taxi.mp3") is True
 
 
+@pytest.mark.parametrize("station", [
+    "BBC-R4", "KFI", "KOH", "KQRS", "WABC", "WAMU",
+    "WBAP", "WCBS", "WIBX", "WINS", "WKXW", "WOR",
+])
+def test_every_station_under_radio_is_classified_broadcast(station):
+    """AM/FM station broadcasts, and the classification must be recorded.
+
+    These 31 rows were skipped for two months by falling through as
+    unclassified, which looks identical to a decision. Asserting BROADCAST
+    rather than `should_identify is False` is the point: the weaker assertion
+    would pass again if someone removed the entry.
+    """
+    key = f"audio/radio/{station}/{station}-AM_2001-09-11_ET0900.mp3"
+    assert media_kind(key) == BROADCAST
+    assert should_identify(key) is False
+
+
 def test_unknown_folder_is_skipped_not_identified():
     # Fail-closed: a folder nobody classified must not be identified by default.
     assert media_kind("audio/brand_new_collection/x.mp3") is None

--- a/packages/tools/video-grabber/video_grabber/parties/identify.py
+++ b/packages/tools/video-grabber/video_grabber/parties/identify.py
@@ -67,7 +67,13 @@ MEDIA_KIND: dict[str, str] = {
     "ZOB": CONVERSATION, "faa_atc": CONVERSATION, "fdny_dispatch": CONVERSATION,
     "rutgers_audiograph": CONVERSATION,
     # News radio: a broadcast has no counterparty. Excluded by decision.
-    "wins1010": BROADCAST, "wcbs": BROADCAST,
+    # `radio` covers every station under audio/radio/ (BBC-R4, KFI, KOH, KQRS,
+    # WABC, WAMU, WBAP, WCBS, WIBX, WINS, WKXW, WOR) because media_kind keys on
+    # the first segment under audio/, not the station. It is listed explicitly
+    # rather than left to fall through: an unlisted folder is also skipped, so
+    # "we decided these are broadcasts" and "nobody has looked at this folder"
+    # would otherwise be indistinguishable — which is how 31 rows sat unnoticed.
+    "wins1010": BROADCAST, "wcbs": BROADCAST, "radio": BROADCAST,
 }
 
 


### PR DESCRIPTION
31 rows under `audio/radio/` — AM/FM station recordings from BBC-R4, KFI, KOH, KQRS, WABC, WAMU, WBAP, WCBS, WIBX, WINS, WKXW and WOR — were absent from `MEDIA_KIND`, so `media_kind()` returned `None` and `identify-parties` skipped them.

Skipping was the **right outcome** — a broadcast has no counterparty, which is exactly why `wins1010` and `wcbs` are already excluded. But it happened for the **wrong reason**, and that distinction has teeth:

> An unlisted folder is skipped exactly like a folder listed as `BROADCAST`. A decision and an oversight are indistinguishable from the outside.

These rows never appeared in a failure count, a skipped count, or anywhere else — they were never counted at all. They surfaced only because a corpus census returned **814 rows where I expected 783**.

One entry covers all twelve stations, since `media_kind` keys on the first path segment below `audio/`, which is `radio` for every one of them.

The tests assert `media_kind(key) == BROADCAST` rather than the weaker `should_identify(key) is False` — the weaker form would pass again if someone deleted the entry, which is the failure this is fixing.

642 passed, 8 skipped; `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)