### PR TITLE
feat(playlists): split Radio Stations and Radio Traffic in the editor

### DIFF
--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.tsx
@@ -186,6 +186,7 @@ function PlaylistEditorContent() {
 								{ label: "All Media", types: Object.values(MEDIA_FILE_TYPES) },
 								{ label: "TV Channels", types: [MEDIA_FILE_TYPES.tv] },
 								{ label: "Radio Stations", types: [MEDIA_FILE_TYPES.radio] },
+							{ label: "Radio Traffic", types: [MEDIA_FILE_TYPES.radioTraffic] },
 								{ label: "News", types: [MEDIA_FILE_TYPES.news] },
 								{ label: "Flights", types: [MEDIA_FILE_TYPES.flight] },
 							]

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditorMain.test.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditorMain.test.tsx
@@ -55,13 +55,14 @@ describe("PlaylistEditorMain", () => {
 		render(<PlaylistEditorMain state={state()} edit={vi.fn()} {...zoomProps} />);
 		// Media is the initially active tab; each media app gets its own
 		// disclosure, open by default, with a per-section hint when empty.
-		for (const label of ["TV Channels", "Radio Stations", "News", "Flights"]) {
+		for (const label of ["TV Channels", "Radio Stations", "Radio Traffic", "News", "Flights"]) {
 			expect(
 				screen.getByRole("button", { name: new RegExp(label) }).getAttribute("aria-expanded"),
 			).toBe("true");
 		}
 		expect(screen.getByText(/No TV channels yet/i)).not.toBeNull();
 		expect(screen.getByText(/No radio stations yet/i)).not.toBeNull();
+		expect(screen.getByText(/No radio traffic yet/i)).not.toBeNull();
 	});
 
 	it("renders TV media entries as logo cards and radio entries as tree rows", () => {
@@ -73,6 +74,7 @@ describe("PlaylistEditorMain", () => {
 					entries: [
 						{ uid: "e1", entry: { kind: "media", app: "tv", itemId: "cnn" } },
 						{ uid: "e2", entry: { kind: "media", app: "radio", itemId: "wnyc" } },
+						{ uid: "e3", entry: { kind: "media", app: "radio", itemId: "WINS" } },
 					],
 				})}
 				edit={edit}
@@ -89,8 +91,16 @@ describe("PlaylistEditorMain", () => {
 		screen.getByRole("button", { name: "Remove CNN" }).click();
 		expect(edit).toHaveBeenCalledWith("p1", { type: "removeEntry", uid: "e1" });
 
-		// Radio: still the tree-row treatment for now.
+		// Radio: still the tree-row treatment for now — and split by station
+		// kind: WINS (a BROADCAST_STATIONS member) sits under Radio Stations,
+		// wnyc (traffic) under Radio Traffic.
 		expect(screen.getByText(/RADIO · wnyc/)).not.toBeNull();
+		expect(screen.getByText(/RADIO · WINS/)).not.toBeNull();
+		const stationsSection = screen
+			.getByRole("button", { name: /Radio Stations/ })
+			.closest(".classicyDisclosure");
+		expect(stationsSection?.textContent).toContain("WINS");
+		expect(stationsSection?.textContent).not.toContain("wnyc");
 	});
 
 	it("routes an entry removal through the injected dispatcher", async () => {

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditorMain.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditorMain.tsx
@@ -2,6 +2,7 @@ import { ClassicyControlLabel, ClassicySplitView, ClassicyTabs, ClassicyTree, ty
 import type { ReactNode } from "react";
 import { Disclosure } from "../../Components/Disclosure/Disclosure";
 import type { MediaEntry, PlaylistApp, PlaylistEntry } from "../../Providers/Playlist/playlistTypes";
+import { BROADCAST_STATIONS } from "../RadioScanner/stationGrouping";
 import { type EditorAction, type EditorEntry, type EditorState, utcIsoToDisplayWallClock } from "./editorState";
 import { MediaTvRow, type TvEditorEntry } from "./MediaTvRow";
 import { PlaylistTimeline } from "./PlaylistTimeline";
@@ -11,12 +12,44 @@ const KIND_BRANCHES: [PlaylistEntry["kind"], string][] = [
 	["file", "Files"], ["jump", "Jumps"], ["browser", "Browser"],
 ];
 
-// The Media tab's per-app disclosure sections, in broadcast-dial order.
-const MEDIA_SECTIONS: [PlaylistApp, string, string][] = [
-	["tv", "TV Channels", "No TV channels yet."],
-	["radio", "Radio Stations", "No radio stations yet."],
-	["news", "News", "No news stories yet."],
-	["flights", "Flights", "No flights yet."],
+// The Media tab's disclosure sections, in broadcast-dial order. Radio is one
+// playlist app but two product apps, split by BROADCAST_STATIONS the same way
+// the Radio Tuner and Radio Scanner partition the shared mp3 stream — so it
+// gets two sections here, keyed by the entry's station rather than app alone.
+type MediaSection = {
+	key: string;
+	app: PlaylistApp;
+	label: string;
+	emptyHint: string;
+	match: (e: EditorEntry & { entry: MediaEntry }) => boolean;
+};
+
+const isBroadcastStation = (e: { entry: MediaEntry }) =>
+	BROADCAST_STATIONS.has(e.entry.itemId.toUpperCase());
+
+const MEDIA_SECTIONS: MediaSection[] = [
+	{
+		key: "tv", app: "tv", label: "TV Channels", emptyHint: "No TV channels yet.",
+		match: (e) => e.entry.app === "tv",
+	},
+	{
+		key: "radio", app: "radio", label: "Radio Stations",
+		emptyHint: "No radio stations yet.",
+		match: (e) => e.entry.app === "radio" && isBroadcastStation(e),
+	},
+	{
+		key: "radio-traffic", app: "radio", label: "Radio Traffic",
+		emptyHint: "No radio traffic yet.",
+		match: (e) => e.entry.app === "radio" && !isBroadcastStation(e),
+	},
+	{
+		key: "news", app: "news", label: "News", emptyHint: "No news stories yet.",
+		match: (e) => e.entry.app === "news",
+	},
+	{
+		key: "flights", app: "flights", label: "Flights", emptyHint: "No flights yet.",
+		match: (e) => e.entry.app === "flights",
+	},
 ];
 
 function entrySummary(e: EditorEntry): string {
@@ -92,8 +125,8 @@ export function PlaylistEditorMain({
 	);
 	const mediaTab = (
 		<div className="playlistMediaSections">
-			{MEDIA_SECTIONS.map(([app, label, emptyHint]) => {
-				const entries = mediaEntries.filter((e) => e.entry.app === app);
+			{MEDIA_SECTIONS.map(({ key, app, label, emptyHint, match }) => {
+				const entries = mediaEntries.filter(match);
 				let body: ReactNode;
 				if (entries.length === 0) {
 					body = <ClassicyControlLabel label={emptyHint} />;
@@ -110,7 +143,7 @@ export function PlaylistEditorMain({
 					body = <ClassicyTree nodes={treeNodes(entries)} />;
 				}
 				return (
-					<Disclosure key={app} label={label} defaultOpen>
+					<Disclosure key={key} label={label} defaultOpen>
 						{body}
 					</Disclosure>
 				);

--- a/packages/frontend/src/Applications/PlaylistEditor/directusVolume.test.ts
+++ b/packages/frontend/src/Applications/PlaylistEditor/directusVolume.test.ts
@@ -43,7 +43,7 @@ const fetchFn = vi.fn(async (url: string) => {
 const volume = () =>
 	createDirectusVolume({
 		tvSlugs: () => ["ABC", "CNN"],
-		radioSlugs: () => ["FDNY-Manhattan"],
+		radioSlugs: () => ["WINS", "FDNY-Manhattan"],
 		fetchFn: fetchFn as unknown as typeof fetch,
 	});
 
@@ -54,10 +54,35 @@ beforeEach(() => {
 afterEach(() => vi.clearAllMocks());
 
 describe("createDirectusVolume", () => {
-	it("lists the four top folders without fetching", async () => {
+	it("lists the five top folders without fetching", async () => {
 		const entries = await volume().list([]);
-		expect(entries.map((e: typeof entries[number]) => e.name)).toEqual(["TV Channels", "Radio Stations", "News", "Flights"]);
+		expect(entries.map((e: typeof entries[number]) => e.name)).toEqual([
+			"TV Channels", "Radio Stations", "Radio Traffic", "News", "Flights",
+		]);
 		expect(fetchFn).not.toHaveBeenCalled();
+	});
+
+	it("splits radio slugs into broadcast stations and traffic by BROADCAST_STATIONS", async () => {
+		const stations = await volume().list(["Radio Stations"]);
+		expect(stations.map((e: typeof stations[number]) => e.name)).toEqual([
+			"Select All", "WINS",
+		]);
+		expect(stations[1]).toMatchObject({
+			fileType: MEDIA_FILE_TYPES.radio, meta: { app: "radio", itemId: "WINS" },
+		});
+
+		const traffic = await volume().list(["Radio Traffic"]);
+		expect(traffic.map((e: typeof traffic[number]) => e.name)).toEqual([
+			"Select All", "FDNY-Manhattan",
+		]);
+		expect(traffic[0]).toMatchObject({
+			name: "Select All", fileType: MEDIA_FILE_TYPES.radioTraffic,
+			meta: { selectAllPaths: [["Radio Traffic"]] },
+		});
+		expect(traffic[1]).toMatchObject({
+			fileType: MEDIA_FILE_TYPES.radioTraffic,
+			meta: { app: "radio", itemId: "FDNY-Manhattan" },
+		});
 	});
 
 	it("lists TV channels from the injected slugs with playlist meta", async () => {

--- a/packages/frontend/src/Applications/PlaylistEditor/directusVolume.ts
+++ b/packages/frontend/src/Applications/PlaylistEditor/directusVolume.ts
@@ -5,11 +5,13 @@ import {
 	OBSERVER_FLIGHTS,
 	PRESIDENTIAL_FLIGHTS,
 } from "../FlightTracker/notableFlights";
+import { BROADCAST_STATIONS } from "../RadioScanner/stationGrouping";
 import { directusGet } from "./directusQueue";
 
 export const MEDIA_FILE_TYPES = {
 	tv: "tv-channel",
 	radio: "radio-station",
+	radioTraffic: "radio-traffic",
 	news: "news-document",
 	flight: "flight",
 } as const;
@@ -112,6 +114,7 @@ export function createDirectusVolume(
 			return [
 				folder("tv", "TV Channels"),
 				folder("radio", "Radio Stations"),
+				folder("radio-traffic", "Radio Traffic"),
 				folder("news", "News"),
 				folder("flights", "Flights"),
 			];
@@ -125,12 +128,31 @@ export function createDirectusVolume(
 			return withSelectAll(items, "select-all-tv", MEDIA_FILE_TYPES.tv, path);
 		}
 
+		// Radio splits the way the two apps split the shared mp3 stream: full-run
+		// broadcast stations (the Radio Tuner's catalogue, BROADCAST_STATIONS)
+		// versus short comm traffic (everything else — the Radio Scanner's side).
+		// Both kinds address playlist entries as app:"radio"; playlistApps.ts
+		// re-derives which app a slug belongs to from the same set.
 		if (path[0] === "Radio Stations") {
-			const items = radioSlugs().map((slug) => ({
-				id: `radio-${slug}`, name: slug, kind: "file" as const,
-				fileType: MEDIA_FILE_TYPES.radio, meta: { app: "radio", itemId: slug },
-			}));
+			const items = radioSlugs()
+				.filter((slug) => BROADCAST_STATIONS.has(slug.toUpperCase()))
+				.map((slug) => ({
+					id: `radio-${slug}`, name: slug, kind: "file" as const,
+					fileType: MEDIA_FILE_TYPES.radio, meta: { app: "radio", itemId: slug },
+				}));
 			return withSelectAll(items, "select-all-radio", MEDIA_FILE_TYPES.radio, path);
+		}
+
+		if (path[0] === "Radio Traffic") {
+			const items = radioSlugs()
+				.filter((slug) => !BROADCAST_STATIONS.has(slug.toUpperCase()))
+				.map((slug) => ({
+					id: `radio-${slug}`, name: slug, kind: "file" as const,
+					fileType: MEDIA_FILE_TYPES.radioTraffic, meta: { app: "radio", itemId: slug },
+				}));
+			return withSelectAll(
+				items, "select-all-radio-traffic", MEDIA_FILE_TYPES.radioTraffic, path,
+			);
 		}
 
 		if (path[0] === "News" && path.length === 1) {


### PR DESCRIPTION
## What

The Playlist Editor now distinguishes the two radio products everywhere media is picked or listed:

- **Add Media dialog**: a separate "Radio Traffic" folder beside "Radio Stations", each with its own Select All; a new `radio-traffic` fileType with its own filter row ("All Media" derives from `Object.values(MEDIA_FILE_TYPES)`, so it includes the new type automatically — no allow-list gap).
- **Media panel**: the radio disclosure splits into "Radio Stations" and "Radio Traffic" sections, via match predicates on the section table.

## How

Both surfaces partition by `BROADCAST_STATIONS` — the same set the Radio Tuner and Radio Scanner use to divide the shared mp3 stream, and the same membership `playlistApps.ts` already uses to route playlist entries to the right app. Entries keep `app: "radio"` in both branches, so stored playlists and the playlist engine are unaffected; this is purely a picker/panel presentation split.

## Testing

- `directusVolume.test.ts`: five top folders; slugs split into the right folders with the right fileTypes and Select All entries
- `PlaylistEditorMain.test.tsx`: both sections render with hints; a WINS entry lands under Radio Stations while traffic (wnyc) stays out of it
- Playlist Editor suite: 236 passed; `tsc -b` clean; lint warnings all pre-existing in untouched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)