### PR TITLE
feat(playlists): list playlists in a Platinum table

### DIFF
--- a/packages/frontend/e2e/tests/playlist-editor.spec.ts
+++ b/packages/frontend/e2e/tests/playlist-editor.spec.ts
@@ -60,10 +60,11 @@ test("signed-in teacher creates and saves a playlist", async ({ page }) => {
 
 	await page.goto("/");
 	await page.getByRole("button", { name: "Playlists" }).dblclick();
-	// The list window's heading, specifically: "My Playlists" is also the text
+	// Scoped to the list window's own content: "My Playlists" is also the text
 	// of the Window menu's item for that window, so a bare getByText is
-	// ambiguous now that the app has a Window menu.
-	const listHeading = page.getByRole("heading", { name: "My Playlists" });
+	// ambiguous now that the app has a Window menu. (It is a control label
+	// beside the playlists table now, not a heading.)
+	const listHeading = page.locator(".playlistList").getByText("My Playlists");
 	await expect(listHeading).toBeVisible();
 
 	await page.getByRole("button", { name: "New", exact: true }).click();

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.scss
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.scss
@@ -261,3 +261,45 @@
 		image-rendering: pixelated;
 	}
 }
+/* ── Main window: the playlists list ──────────────────────────────────────
+   A Platinum list box (the Drive Setup control panel's shape) over the shared
+   ClassicyTable, with the control buttons in a row beneath it. */
+.playlistList {
+	display: flex;
+	flex-direction: column;
+	gap: var(--window-padding-size);
+	padding: var(--window-padding-size);
+	font-family: var(--ui-font, sans-serif);
+	font-size: var(--ui-font-size, 12px);
+}
+
+/* ClassicyTable supplies the list-view chrome and its own scroll container;
+   this frame adds the inset border and the height that makes the table scroll
+   internally instead of growing the window. */
+.playlistListTable {
+	display: flex;
+	flex-direction: column;
+	border: var(--box-border-size, 2px) inset var(--color-black, #000);
+	background: var(--color-system-01);
+	min-height: calc(var(--window-control-size) * 8);
+	max-height: 320px;
+
+	.classicyTableContainer {
+		flex: 1;
+		min-height: 0;
+	}
+}
+
+.playlistListActions,
+.playlistDeleteConfirm {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: var(--window-padding-size);
+}
+
+.playlistListError {
+	margin: 0;
+	color: var(--color-error);
+}

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistList.test.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistList.test.tsx
@@ -38,8 +38,11 @@ vi.mock("./PlaylistEditorProvider", () => ({
 
 import { PlaylistList } from "./PlaylistList";
 
+// Midday UTC on purpose: the Modified column renders a real local timestamp,
+// so a midnight fixture would land on the previous day in any negative-offset
+// zone and make the assertions below timezone-dependent.
 const rows = [
-	{ id: "p1", title: "Lesson One", status: "draft", date_updated: "2026-07-16T00:00:00Z", user_created: "u1" },
+	{ id: "p1", title: "Lesson One", status: "draft", date_updated: "2026-07-16T12:00:00Z", user_created: "u1" },
 	{ id: "p2", title: "Lesson Two", status: "published", date_updated: null, user_created: "u1" },
 ];
 
@@ -156,6 +159,64 @@ describe("PlaylistList", () => {
 		expect(screen.queryByRole("button", { name: "Copy Link" })).toBeNull();
 		fireEvent.click(screen.getByText("Lesson Two"));
 		expect(screen.getByRole("button", { name: "Copy Link" })).not.toBeNull();
+	});
+
+	// The list is a Platinum table (the Drive Setup control panel's list view),
+	// not a bare row of buttons: name, status and last-modified are columns.
+	it("renders the playlists as a table with name, status and modified columns", async () => {
+		render(<PlaylistList meId="u1" onOpen={() => {}} />);
+		await screen.findByText("Lesson One");
+		// Matched loosely: the sorted column's header also carries a sort-arrow
+		// image whose alt text joins its accessible name.
+		for (const header of [/^Name/, /^Status/, /^Date Modified/]) {
+			expect(screen.getByRole("columnheader", { name: header })).not.toBeNull();
+		}
+		expect(
+			screen.getByRole("columnheader", { name: /^Date Modified/ }).getAttribute("aria-sort"),
+		).toBe("descending");
+		expect(screen.getAllByRole("row").length).toBeGreaterThan(rows.length);
+	});
+
+	it("shows the status readably and the modified date as a real local timestamp", async () => {
+		render(<PlaylistList meId="u1" onOpen={() => {}} />);
+		expect(await screen.findByText("Draft")).not.toBeNull();
+		expect(screen.getByText("Published")).not.toBeNull();
+		// Whatever the runner's zone, a midday-UTC instant stays on its own day.
+		expect(screen.getByText(/2026/)).not.toBeNull();
+		expect(screen.queryByText("2026-07-16T12:00:00Z")).toBeNull();
+		// A playlist that has never been saved has no date to show.
+		expect(screen.getByText("—")).not.toBeNull();
+	});
+
+	// The headline gesture of this window: double-click opens, exactly as the
+	// Open button does, so the two can never drift apart.
+	it("opens a playlist on double-click", async () => {
+		const record = { ...rows[0], definition: { version: 1, mode: "restrict", entries: [] } };
+		api.getPlaylist.mockResolvedValue(record);
+		const onOpen = vi.fn();
+		render(<PlaylistList meId="u1" onOpen={onOpen} />);
+		fireEvent.doubleClick(await screen.findByText("Lesson One"));
+		await waitFor(() => expect(onOpen).toHaveBeenCalledWith(record));
+		expect(api.getPlaylist).toHaveBeenCalledWith("p1");
+	});
+
+	it("reports a failed open from a double-click instead of failing silently", async () => {
+		api.getPlaylist.mockRejectedValue(new Error("nope"));
+		const onOpen = vi.fn();
+		render(<PlaylistList meId="u1" onOpen={onOpen} />);
+		fireEvent.doubleClick(await screen.findByText("Lesson One"));
+		await waitFor(() =>
+			expect(document.querySelector(".playlistListError")).not.toBeNull(),
+		);
+		expect(onOpen).not.toHaveBeenCalled();
+	});
+
+	it("tells a teacher with no playlists that the list is empty", async () => {
+		api.listMine.mockResolvedValue([]);
+		render(<PlaylistList meId="u1" onOpen={() => {}} />);
+		expect(await screen.findByText("No playlists yet.")).not.toBeNull();
+		// The table chrome stays put so the window does not collapse to nothing.
+		expect(screen.getByRole("columnheader", { name: "Name" })).not.toBeNull();
 	});
 
 	it("calls auth refresh when listMine rejects with AuthRequiredError", async () => {

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistList.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistList.tsx
@@ -1,4 +1,9 @@
-import { ClassicyButton } from "classicy";
+import {
+	ClassicyButton,
+	ClassicyControlLabel,
+	ClassicyTable,
+	type ClassicyTableColumn,
+} from "classicy";
 import { useCallback, useEffect, useState } from "react";
 import {
 	createPlaylist,
@@ -14,6 +19,53 @@ import { useAuth } from "../../Providers/Auth/AuthContext";
 import { usePlaylistEditor } from "./PlaylistEditorProvider";
 
 const EMPTY_DEFINITION = { version: 1 as const, mode: "annotate" as const, entries: [] };
+
+/** Directus stores the workflow state lowercase ("draft"); show it as a word. */
+function formatStatus(status: string): string {
+	return status ? status[0].toUpperCase() + status.slice(1) : "";
+}
+
+/**
+ * When the playlist was last saved, in the reader's own timezone.
+ *
+ * Deliberately NOT routed through the virtual clock: every other date in this
+ * product is a September 2001 instant, but this one is real wall-clock time —
+ * when the teacher last edited the document — so it is formatted like any
+ * ordinary file's modification date. An em dash marks a playlist Directus has
+ * never stamped.
+ */
+function formatModified(iso: string | null): string {
+	if (!iso) return "—";
+	const at = new Date(iso);
+	if (Number.isNaN(at.getTime())) return "—";
+	return at.toLocaleString(undefined, {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+		hour: "numeric",
+		minute: "2-digit",
+	});
+}
+
+const COLUMNS: ClassicyTableColumn<PlaylistSummary>[] = [
+	{ id: "title", title: "Name", accessor: (r) => r.title, width: 190 },
+	{
+		id: "status",
+		title: "Status",
+		accessor: (r) => r.status,
+		render: (r) => formatStatus(r.status),
+		width: 90,
+	},
+	{
+		id: "date_updated",
+		title: "Date Modified",
+		// Sort on the raw ISO, not the rendered text: lexicographic order over
+		// ISO instants is chronological, "Jul 16, 2026" is not.
+		accessor: (r) => r.date_updated ?? "",
+		render: (r) => formatModified(r.date_updated),
+		width: 150,
+	},
+];
 
 export function PlaylistList({
 	meId,
@@ -66,28 +118,37 @@ export function PlaylistList({
 		});
 	};
 
+	// One code path for every "open this playlist" gesture — the Open button,
+	// a double-click, and Enter on the selected row — so they cannot drift.
+	const openById = (id: string) =>
+		run(async () => {
+			onOpen(await getPlaylist(id));
+		})();
+
 	return (
 		<div className="playlistList">
-			<h1>My Playlists</h1>
+			<ClassicyControlLabel label="My Playlists" />
 			{error && <p className="playlistListError">{error}</p>}
-			<ul className="playlistListRows">
-				{rowsState.map((r) => (
-					<li key={r.id}>
-						<button
-							type="button"
-							className={r.id === selectedId ? "playlistRowSelected" : undefined}
-							onClick={() => {
-								setSelectedId(r.id);
-								setConfirmingDelete(false);
-							}}
-						>
-							{r.title}
-							<span className="playlistRowStatus">{r.status}</span>
-							<span className="playlistRowDate">{r.date_updated ?? ""}</span>
-						</button>
-					</li>
-				))}
-			</ul>
+			<div className="playlistListTable">
+				<ClassicyTable
+					columns={COLUMNS}
+					rows={rowsState}
+					getRowId={(r) => r.id}
+					selectionMode="single"
+					selected={selectedId ? [selectedId] : []}
+					onSelectionChange={(ids) => {
+						setSelectedId(ids[0] ?? null);
+						setConfirmingDelete(false);
+					}}
+					onActivateRow={openById}
+					defaultSort={{ columnId: "date_updated", desc: true }}
+				/>
+				{/* The table keeps its header so an empty account still shows the
+				    window's shape rather than a blank box. */}
+				{rowsState.length === 0 && (
+					<ClassicyControlLabel label="No playlists yet." />
+				)}
+			</div>
 			{confirmingDelete && selected && (
 				<div className="playlistDeleteConfirm">
 					<span>{`Delete "${selected.title}"? This cannot be undone.`}</span>
@@ -129,9 +190,9 @@ export function PlaylistList({
 				</ClassicyButton>
 				<ClassicyButton
 					disabled={!selected}
-					onClickFunc={run(async () => {
-						if (selected) onOpen(await getPlaylist(selected.id));
-					})}
+					onClickFunc={() => {
+						if (selected) openById(selected.id);
+					}}
 				>
 					Open
 				</ClassicyButton>


### PR DESCRIPTION
The Playlists main window now shows its playlists in a table list, in the shape of the Drive Setup control panel's main window, with the control buttons underneath — and double-clicking a playlist opens it.

## Before

The list was a bare `<ul>` of `<button>`s with title, status and a raw ISO date crammed onto one line — and it had **no styles at all** (not a single `.playlistList` rule existed), so it rendered as unstyled browser-default HTML.

## Change

- **`ClassicyTable`** replaces the list — the same Platinum list view Drive Setup's hand-rolled `<table>` imitates, but the real component, so it brings sortable + resizable columns, a sticky header, and HIG list-box keyboard behaviour along with it. Columns: **Name**, **Status**, **Date Modified**.
- **Double-click opens**, through `ClassicyTable`'s `onActivateRow` (which covers Enter on the selected row too). It calls the same `openById` the Open button uses, so the three gestures can't drift apart.
- **Frame + buttons** — an inset border and bounded height around the table so long lists scroll internally rather than growing the window, matching Drive Setup's list box; the existing control-button row stays beneath it.

Two smaller fixes the table made obvious:

- **Date Modified** renders as a real local timestamp instead of a raw ISO string — and deliberately *not* through the virtual clock. Every other date in this product is a September 2001 instant, but a playlist's modified time is genuine wall-clock time, so it's formatted like any ordinary file's. It sorts on the ISO value, because lexicographic order over ISO instants is chronological and `Jul 16, 2026` is not.
- **Empty state** — an account with no playlists gets "No playlists yet." beneath the table header rather than an empty box.

Status renders capitalised (`draft` → "Draft"); sorting still uses the raw value.

## Testing

Five new tests: the three columns render with the default sort marked `aria-sort="descending"`; status and date formatting (including the `—` for a never-saved playlist); double-click opens; a failed open from a double-click surfaces the error instead of failing silently; and the empty state keeps its table header. Existing selection, delete-confirm and refresh tests pass unchanged.

`PlaylistEditor` suite green (25 files, 241 tests) against this branch's merge base; full frontend suite green at 2432 before rebasing; `tsc -b` and `eslint` clean; `vite build` compiles the new SCSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)