### PR TITLE
feat(desktop): Getting Started shortcut for the HyperCard guide

### DIFF
--- a/packages/frontend/src/Desktop.tsx
+++ b/packages/frontend/src/Desktop.tsx
@@ -2,6 +2,7 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import {
 	ClassicyButton,
 	ClassicyDesktop,
+	ClassicyIcons,
 	ClassicyWindowFrame,
 	useAppManagerDispatch,
 } from "classicy";
@@ -18,6 +19,13 @@ import {
 	PAGE_SHORTCUT_DISPOSITION,
 	pageShortcutIcon,
 } from "./data/pageShortcuts";
+import {
+	GETTING_STARTED_ICON_ID,
+	GETTING_STARTED_NAME,
+	GETTING_STARTED_PATH,
+	HYPERCARD_APP_ID,
+	HYPERCARD_OPEN_FILE_EVENT,
+} from "./data/stackShortcuts";
 import { RoomControlBridge } from "./Providers/Playlist/RoomControlBridge";
 import { Alerts } from "./Applications/Alerts/Alerts";
 import { AlertsManager } from "./Applications/Alerts/AlertsManager";
@@ -118,6 +126,42 @@ function PageShortcutIcons() {
 	return null;
 }
 
+/**
+ * The Getting Started guide, as a desktop shortcut to the stack living at the
+ * Macintosh HD root. Registered here as well as in DefaultFileSystem for the
+ * same reason as the page shortcuts above: a synced filesystem may never
+ * receive a new default-tree entry, while icon registration re-runs on mount.
+ *
+ * Opening it takes the same route Finder does — the kernel's generic
+ * `*OpenFile` handler appends the path to HyperCard.app's `data.openFiles` and
+ * launches it, and HyperCard fetches and validates the document from there. So
+ * double-clicking the desktop icon and double-clicking the file in Finder are
+ * the same operation, not two implementations of it.
+ */
+function GettingStartedIcon() {
+	const dispatch = useAppManagerDispatch();
+	useEffect(() => {
+		dispatch({
+			type: "ClassicyDesktopIconAdd",
+			app: {
+				id: GETTING_STARTED_ICON_ID,
+				name: GETTING_STARTED_NAME,
+				icon: ClassicyIcons.system.files.document,
+			},
+			kind: "shortcut",
+			// The icon id is not a registered app; without this the double-click
+			// would also dispatch ClassicyDesktopIconOpen and conjure one.
+			noLaunch: true,
+			event: HYPERCARD_OPEN_FILE_EVENT,
+			eventData: {
+				app: { id: HYPERCARD_APP_ID },
+				path: GETTING_STARTED_PATH,
+			},
+		});
+	}, [dispatch]);
+	return null;
+}
+
 /** The desktop branch: the Mac OS 8 desktop and every desktop app. */
 export default function Desktop() {
 	return (
@@ -125,6 +169,7 @@ export default function Desktop() {
 			preBootScreen={(powerOn) => <PreBootAbout powerOn={powerOn} />}
 		>
 			<PageShortcutIcons />
+			<GettingStartedIcon />
 			<Alerts />
 			<AlertsManager />
 			<HyperCardClockBridge />

--- a/packages/frontend/src/data/DefaultFileSystem.ts
+++ b/packages/frontend/src/data/DefaultFileSystem.ts
@@ -6,6 +6,7 @@ import {
 import {newspaperEntries} from "./NewspaperFiles";
 import {pageShortcutEntries} from "./pageShortcuts";
 import {photoEntries} from "./PhotoFiles"
+import {GETTING_STARTED_FILE} from "./stackShortcuts";
 import {voicesOf911Entries} from "./VideoFiles";
 
 // HyperCard stack documents ship in public/stacks/ and are served by the
@@ -33,7 +34,12 @@ export const DefaultFileSystem: ClassicyFileSystemTree = {
 		// The interactive user-guide tour, served from public/stacks/. Finder
 		// routes Stack-type files to HyperCard via its handlesFileTypes
 		// registration — double-clicking this opens the guide in HyperCard.
-		"Getting Started.stack": {
+		//
+		// Keyed off the shared constant because the desktop shortcut addresses
+		// this same file by path (see stackShortcuts.ts): renaming the entry
+		// here without updating that path would leave the icon pointing at
+		// nothing, and a shortcut that resolves to nothing fails silently.
+		[GETTING_STARTED_FILE]: {
 			_type: ClassicyFileSystemEntryFileType.Stack,
 			_mimeType: "application/json",
 			_icon: ClassicyIcons.system.files.document,

--- a/packages/frontend/src/data/stackShortcuts.test.ts
+++ b/packages/frontend/src/data/stackShortcuts.test.ts
@@ -1,0 +1,34 @@
+import { ClassicyFileSystemEntryFileType } from "classicy";
+import { describe, expect, it } from "vitest";
+import { DefaultFileSystem } from "./DefaultFileSystem";
+import {
+	GETTING_STARTED_FILE,
+	GETTING_STARTED_NAME,
+	GETTING_STARTED_PATH,
+	STACK_DRIVE,
+} from "./stackShortcuts";
+
+describe("Getting Started desktop shortcut", () => {
+	it("addresses a file that actually exists in the default tree", () => {
+		// The whole failure mode this guards: the shortcut resolves a path, and a
+		// path that resolves to nothing does nothing — no error, no window, no
+		// clue. Renaming the Finder entry without the constant would do exactly
+		// that.
+		const entry = DefaultFileSystem[STACK_DRIVE][GETTING_STARTED_FILE];
+		expect(entry).toBeDefined();
+		expect(entry._type).toBe(ClassicyFileSystemEntryFileType.Stack);
+	});
+
+	it("builds a colon-separated path, not a slash-separated one", () => {
+		// Classicy file-system paths follow the classic Mac convention and
+		// ClassicyFileSystem.pathArray splits on ':'. A slash would be treated as
+		// part of a single segment and resolve to nothing.
+		expect(GETTING_STARTED_PATH).toBe(`${STACK_DRIVE}:${GETTING_STARTED_FILE}`);
+		expect(GETTING_STARTED_PATH).not.toContain("/");
+	});
+
+	it("labels the icon without the file extension", () => {
+		expect(GETTING_STARTED_NAME).toBe("Getting Started");
+		expect(GETTING_STARTED_FILE).toBe(`${GETTING_STARTED_NAME}.stack`);
+	});
+});

--- a/packages/frontend/src/data/stackShortcuts.ts
+++ b/packages/frontend/src/data/stackShortcuts.ts
@@ -1,0 +1,40 @@
+/**
+ * HyperCard stacks that also get a desktop icon — the single source of truth
+ * shared by the desktop shortcut (Desktop.tsx) and the Finder drive-root entry
+ * (DefaultFileSystem.ts).
+ *
+ * Both surfaces exist for the same reason the CMS page shortcuts have both (see
+ * pageShortcuts.ts): rt911 runs `defaultFileSystemMode="exclusive"` and syncs
+ * each signed-in user's tree to Directus, so a new default-tree entry may never
+ * reach someone who already has a synced filesystem. Icon registration re-runs
+ * on every mount and has no such gap. The two must therefore always agree on
+ * what the shortcut points at, which is what this module guarantees.
+ */
+
+/** Drive the shortcut resolves within. */
+export const STACK_DRIVE = "Macintosh HD";
+
+/** Filename of the guide stack at the drive root. */
+export const GETTING_STARTED_FILE = "Getting Started.stack";
+
+/** Label on the desktop icon — the document name without its extension. */
+export const GETTING_STARTED_NAME = "Getting Started";
+
+export const GETTING_STARTED_ICON_ID = "shortcut_getting_started";
+
+/**
+ * Classicy file-system paths are **colon**-separated, not slash-separated —
+ * the classic Mac convention, and what `ClassicyFileSystem.pathArray` splits on.
+ * A slash here would resolve to nothing and the icon would silently do nothing.
+ */
+export const GETTING_STARTED_PATH = `${STACK_DRIVE}:${GETTING_STARTED_FILE}`;
+
+/**
+ * Opening a stack means handing its path to HyperCard, which fetches and
+ * validates the document and then opens it. The kernel's generic `*OpenFile`
+ * handler appends the path to `HyperCard.app`'s `data.openFiles` and launches
+ * the app — the same route Finder takes when the stack is double-clicked, so
+ * the desktop icon and the Finder entry behave identically.
+ */
+export const HYPERCARD_APP_ID = "HyperCard.app";
+export const HYPERCARD_OPEN_FILE_EVENT = "ClassicyAppHyperCardOpenFile";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 18.1.2
       classicy:
         specifier: latest
-        version: 0.75.0(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/dlv@1.1.5)(@types/react@19.2.18)(immer@11.1.16)(react-dom@19.2.8(react@19.2.8))(react-player@3.4.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zustand@5.0.14(@types/react@19.2.18)(immer@11.1.16)(react@19.2.8))
+        version: 0.75.1(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/dlv@1.1.5)(@types/react@19.2.18)(immer@11.1.16)(react-dom@19.2.8(react@19.2.8))(react-player@3.4.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zustand@5.0.14(@types/react@19.2.18)(immer@11.1.16)(react@19.2.8))
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -1035,8 +1035,8 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
-  classicy@0.75.0:
-    resolution: {integrity: sha512-NBWyOprFV6ZRgWtp0NnXPWND4KMJo58W3u+8BMQSWO9SPl263e33GOxHE18h0GLgwALyccaj5r+r5V8mTu1fFA==}
+  classicy@0.75.1:
+    resolution: {integrity: sha512-7mwX5pl+Y5sE8WXBNRzth1luLKUpOySr1Kew+5oM63ZvpnAkFE7gnrTWmqcl6W6PtSwCtFMpuXa6SERpxl459g==}
     peerDependencies:
       '@tanstack/react-table': ^8.21.3
       immer: ^11.1.8
@@ -3462,7 +3462,7 @@ snapshots:
       readdirp: 5.0.0
     optional: true
 
-  classicy@0.75.0(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/dlv@1.1.5)(@types/react@19.2.18)(immer@11.1.16)(react-dom@19.2.8(react@19.2.8))(react-player@3.4.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zustand@5.0.14(@types/react@19.2.18)(immer@11.1.16)(react@19.2.8)):
+  classicy@0.75.1(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/dlv@1.1.5)(@types/react@19.2.18)(immer@11.1.16)(react-dom@19.2.8(react@19.2.8))(react-player@3.4.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zustand@5.0.14(@types/react@19.2.18)(immer@11.1.16)(react@19.2.8)):
     dependencies:
       '@analytics/google-tag-manager': 0.6.0
       '@noble/hashes': 2.3.0


### PR DESCRIPTION
Adds a desktop icon named **Getting Started** that opens the user-guide stack at the Macintosh HD root.

## How it opens

The shortcut dispatches **the same action Finder does** rather than reimplementing the open:

```
ClassicyAppHyperCardOpenFile  { app: { id: "HyperCard.app" }, path: "Macintosh HD:Getting Started.stack" }
```

The kernel's generic `*OpenFile` handler appends the path to `HyperCard.app`'s `data.openFiles` and launches it; HyperCard fetches and validates the document from there. Double-clicking the desktop icon and double-clicking the file in Finder are one operation, not two that can drift.

## Two ways this silently fails if you get it wrong

**Paths are colon-separated.** Classicy follows the classic Mac convention and `ClassicyFileSystem.pathArray` splits on `:`. `Macintosh HD/Getting Started.stack` would be read as a single segment, resolve to nothing, and the double-click would do *nothing at all* — no error, no window. There's a test asserting the path contains no slash.

**`noLaunch: true` is required.** The icon id isn't a registered app, so without it the double-click would also fire `ClassicyDesktopIconOpen` and conjure a phantom app. Same reason the CMS page shortcuts set it.

## Shared source of truth

Name, filename and path live in `data/stackShortcuts.ts`. `DefaultFileSystem` is now keyed off the constant instead of a duplicated `"Getting Started.stack"` literal — renaming the Finder entry alone would otherwise leave the icon addressing a file that no longer exists.

Registering on **both** surfaces follows `pageShortcuts.ts`'s reasoning: rt911 runs `defaultFileSystemMode="exclusive"` and syncs each signed-in user's tree to Directus, so a new default-tree entry may never reach someone who already has a synced filesystem, while icon registration re-runs on every mount.

## Testing

254 test files / 2,419 tests pass; `tsc -b` and `eslint` clean. Three new tests cover the failure modes: the path resolves to a real `Stack`-type entry, it's colon-separated with no slash, and the icon label drops the `.stack` extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)