### PR TITLE
feat(playlist-editor): sticky timeline lane labels and TV thumbnail previews

### DIFF
--- a/packages/frontend/e2e/tests/playlist-editor.spec.ts
+++ b/packages/frontend/e2e/tests/playlist-editor.spec.ts
@@ -77,3 +77,86 @@ test("signed-in teacher creates and saves a playlist", async ({ page }) => {
 	await expect(listHeading).toBeVisible();
 	expect(createdBody).toMatchObject({ title: "Untitled Playlist", status: "draft" });
 });
+
+/**
+ * Opens the Playlists app, signed in, onto ONE existing playlist ("Lane
+ * Label Test") whose definition already has a media entry — a radio bar with
+ * no start/end, so it fades across the whole ten-day span and stays under
+ * the pointer at any scroll position. All Directus calls are intercepted;
+ * there is no shared helper for this in the spec yet, so this one is local
+ * to this file rather than duplicated across tests.
+ */
+async function openPlaylistWithEntries(page: import("@playwright/test").Page) {
+	await page.route("**/users/me**", (route) =>
+		route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify({ data: ME }),
+		}),
+	);
+	await page.route("**/items/playlists?*", (route) =>
+		route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify({
+				data: [
+					{
+						id: "p1",
+						title: "Lane Label Test",
+						status: "draft",
+						date_updated: null,
+						user_created: "u1",
+					},
+				],
+			}),
+		}),
+	);
+	await page.route("**/items/playlists/p1", (route) =>
+		route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify({
+				data: {
+					id: "p1",
+					title: "Lane Label Test",
+					status: "draft",
+					date_updated: null,
+					user_created: "u1",
+					definition: {
+						version: 1,
+						mode: "annotate",
+						entries: [{ kind: "media", app: "radio", itemId: "wcbs" }],
+					},
+				},
+			}),
+		}),
+	);
+
+	await page.goto("/");
+	await page.getByRole("button", { name: "Playlists" }).dblclick();
+	const row = page.getByText("Lane Label Test", { exact: true });
+	await expect(row).toBeVisible();
+	await row.dblclick();
+	await expect(page.getByRole("application", { name: "Lane Label Test" })).toBeVisible();
+}
+
+test("lane label stays visible when the timeline is scrolled", async ({ page }) => {
+	await openPlaylistWithEntries(page);
+	await page.getByRole("button", { name: "Zoom in" }).click();
+	await page.getByRole("button", { name: "Zoom in" }).click();
+
+	const label = page.locator(".playlistTimelineLabel").first();
+	const timeline = page.locator(".playlistTimeline");
+	await expect(label).toBeVisible();
+
+	await timeline.evaluate((el) => {
+		el.scrollLeft = el.scrollWidth / 3;
+	});
+
+	// The label must still be inside the viewport, not scrolled off to the left.
+	const box = await label.boundingBox();
+	const view = await timeline.boundingBox();
+	expect(box).not.toBeNull();
+	expect(view).not.toBeNull();
+	expect(box!.x).toBeGreaterThanOrEqual(view!.x - 1);
+});

--- a/packages/frontend/e2e/tests/playlist-editor.spec.ts
+++ b/packages/frontend/e2e/tests/playlist-editor.spec.ts
@@ -215,3 +215,52 @@ test("selected TV lane's thumbnail strip stays visible when the timeline is scro
 		})
 		.toEqual({ insideLeft: true, insideRight: true, narrowerThanView: true });
 });
+
+/**
+ * Regression test for the zoom effect's re-measure being gated behind the
+ * anchor === null early return in PlaylistTimeline.tsx's zoom useLayoutEffect.
+ * The +/- toolbar buttons go through changeZoom, which always sets anchorRef
+ * and therefore always reached measureView() — this test deliberately drives
+ * the OTHER path instead: View ▸ Zoom In dispatches setZoom directly
+ * (PlaylistDocumentWindow.tsx's documentViewMenu wiring) and never touches
+ * anchorRef, so it used to return before measureView() ran. That left `view`
+ * (and therefore visibleFrac, and therefore the strip's sampled window) stuck
+ * at the pre-zoom scrollWidth, so the thumbnail strip would have been mounted
+ * with an identical startMs/endMs before and after this zoom — this asserts
+ * the srcs actually change instead.
+ */
+test("View ▸ Zoom In narrows the selected TV lane's sampled preview window", async ({ page }) => {
+	// A 1x1 GIF for every thumbnail, same as the geometry test above — an e2e
+	// run must not depend on Wasabi being reachable.
+	await page.route("**/thumbnails/**", (route) =>
+		route.fulfill({
+			status: 200,
+			contentType: "image/gif",
+			body: Buffer.from("R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7", "base64"),
+		}),
+	);
+	await openPlaylistWithEntries(page, [{ kind: "media", app: "tv", itemId: "cnn" }]);
+
+	await page.locator(".playlistTimelineBar").first().click({ position: { x: 20, y: 8 } });
+	const strip = page.locator(".playlistTimelinePreview");
+	await expect(strip).toBeVisible();
+
+	const thumbSrcs = () =>
+		strip
+			.locator(".playlistTimelinePreviewThumb")
+			.evaluateAll((imgs) => imgs.map((img) => img.getAttribute("src")));
+
+	const before = await thumbSrcs();
+	expect(before.length).toBeGreaterThan(0);
+
+	// Deliberately the View menu, not the "Zoom in" toolbar button: that button
+	// calls changeZoom, which always sets anchorRef and so always reached the
+	// re-measure even before the fix. Only the menu path (setZoom dispatched
+	// directly) exercises the bug.
+	await page.getByRole("menuitem", { name: "View" }).click();
+	await page.getByRole("menuitem", { name: "Zoom In", exact: true }).click();
+
+	// Polled: the strip's inputs come from a useLayoutEffect-driven measure, not
+	// an immediate synchronous update the first read is guaranteed to see.
+	await expect.poll(thumbSrcs).not.toEqual(before);
+});

--- a/packages/frontend/e2e/tests/playlist-editor.spec.ts
+++ b/packages/frontend/e2e/tests/playlist-editor.spec.ts
@@ -79,14 +79,19 @@ test("signed-in teacher creates and saves a playlist", async ({ page }) => {
 });
 
 /**
- * Opens the Playlists app, signed in, onto ONE existing playlist ("Lane
- * Label Test") whose definition already has a media entry — a radio bar with
- * no start/end, so it fades across the whole ten-day span and stays under
- * the pointer at any scroll position. All Directus calls are intercepted;
- * there is no shared helper for this in the spec yet, so this one is local
- * to this file rather than duplicated across tests.
+ * Opens the Playlists app, signed in, onto ONE existing playlist ("Lane Label
+ * Test") whose definition already has the given media entries. The default is
+ * a radio bar with no start/end, so it fades across the whole ten-day span and
+ * stays under the pointer at any scroll position; pass a `tv` entry instead to
+ * exercise the thumbnail-strip preview, which renders for no other group. All
+ * Directus calls are intercepted; there is no shared helper for this in the
+ * spec yet, so this one is local to this file rather than duplicated across
+ * tests.
  */
-async function openPlaylistWithEntries(page: import("@playwright/test").Page) {
+async function openPlaylistWithEntries(
+	page: import("@playwright/test").Page,
+	entries: Record<string, unknown>[] = [{ kind: "media", app: "radio", itemId: "wcbs" }],
+) {
 	await page.route("**/users/me**", (route) =>
 		route.fulfill({
 			status: 200,
@@ -122,11 +127,7 @@ async function openPlaylistWithEntries(page: import("@playwright/test").Page) {
 					status: "draft",
 					date_updated: null,
 					user_created: "u1",
-					definition: {
-						version: 1,
-						mode: "annotate",
-						entries: [{ kind: "media", app: "radio", itemId: "wcbs" }],
-					},
+					definition: { version: 1, mode: "annotate", entries },
 				},
 			}),
 		}),
@@ -159,4 +160,58 @@ test("lane label stays visible when the timeline is scrolled", async ({ page }) 
 	expect(box).not.toBeNull();
 	expect(view).not.toBeNull();
 	expect(box!.x).toBeGreaterThanOrEqual(view!.x - 1);
+});
+
+/**
+ * The sticky-label test above cannot catch a broken preview: its fixture entry
+ * is `radio`, and LanePreview renders for `tv` only. A strip that fills the
+ * whole zoom*100% lane still LOOKS sticky in the stylesheet while measuring as
+ * a no-op in the browser, so this asserts the rendered geometry directly, with
+ * a TV entry selected.
+ */
+test("selected TV lane's thumbnail strip stays visible when the timeline is scrolled", async ({
+	page,
+}) => {
+	// A 1x1 GIF for every thumbnail: the real ones live on Wasabi, and an e2e
+	// run must not depend on that (or on offline.jpg's error path firing).
+	await page.route("**/thumbnails/**", (route) =>
+		route.fulfill({
+			status: 200,
+			contentType: "image/gif",
+			body: Buffer.from("R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7", "base64"),
+		}),
+	);
+	await openPlaylistWithEntries(page, [{ kind: "media", app: "tv", itemId: "cnn" }]);
+
+	// Selecting the bar is what expands the lane into a preview. Clicked near
+	// its left end rather than at its centre: the bar spans the whole ten-day
+	// track, and the floating Tools palette covers the middle of the timeline.
+	await page.locator(".playlistTimelineBar").first().click({ position: { x: 20, y: 8 } });
+	const strip = page.locator(".playlistTimelinePreview");
+	await expect(strip).toBeVisible();
+
+	for (let i = 0; i < 3; i++) await page.getByRole("button", { name: "Zoom in" }).click();
+
+	const timeline = page.locator(".playlistTimeline");
+	await timeline.evaluate((el) => {
+		el.scrollLeft = el.scrollWidth / 3;
+	});
+	await expect(strip).toBeVisible();
+
+	// Pinned to the visible left edge, and no wider than the window it sits in —
+	// the failure mode was a strip as wide as the whole track, starting thousands
+	// of pixels to the left of the viewport. Polled rather than read once: the
+	// strip is re-derived from a throttled scroll measurement.
+	await expect
+		.poll(async () => {
+			const box = await strip.boundingBox();
+			const view = await timeline.boundingBox();
+			if (!box || !view) return null;
+			return {
+				insideLeft: box.x >= view.x - 1,
+				insideRight: box.x <= view.x + view.width,
+				narrowerThanView: box.width <= view.width + 1,
+			};
+		})
+		.toEqual({ insideLeft: true, insideRight: true, narrowerThanView: true });
 });

--- a/packages/frontend/src/Applications/PlaylistEditor/LanePreview.test.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/LanePreview.test.tsx
@@ -1,0 +1,33 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { LanePreview } from "./LanePreview";
+
+afterEach(cleanup);
+
+const span = { startMs: Date.UTC(2001, 8, 11, 12, 0), endMs: Date.UTC(2001, 8, 11, 12, 30) };
+
+describe("LanePreview", () => {
+	it("renders a thumbnail strip for TV entries", () => {
+		render(<LanePreview group="tv" channel="cnn" {...span} viewportPx={400} />);
+		// alt="" downgrades <img> to the "presentation" role, dropping it out of
+		// getByRole("img") even with { hidden: true } — query by class instead,
+		// matching this file's existing convention (jest-dom is not installed).
+		const imgs = document.querySelectorAll<HTMLImageElement>(".playlistTimelinePreviewThumb");
+		expect(imgs.length).toBeGreaterThan(0);
+		expect(imgs[0].src).toContain("files.911realtime.org/thumbnails/cnn/");
+	});
+
+	it("renders nothing for a group with no preview", () => {
+		const { container } = render(
+			<LanePreview group="radio" channel="wcbs" {...span} viewportPx={400} />,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it("renders nothing when there is no room", () => {
+		const { container } = render(
+			<LanePreview group="tv" channel="cnn" {...span} viewportPx={0} />,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+});

--- a/packages/frontend/src/Applications/PlaylistEditor/LanePreview.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/LanePreview.tsx
@@ -10,6 +10,14 @@ const OFFLINE = `${THUMB_BASE}/offline.jpg`;
  * `label` is the entry's `itemId`, i.e. the channel slug) rather than a
  * re-derived `MediaEntry`, since that is all layoutBars ever carried.
  *
+ * `startMs`/`endMs` are the *visible* span — the caller
+ * (`PlaylistTimeline.tsx`) intersects the entry's own window with the timeline
+ * scroll viewport before calling, and renders nothing at all when that
+ * intersection is empty. This component never sees the entry's full extent, so
+ * zooming and panning walk the strip through the footage rather than
+ * re-sampling the same ten days. `viewportPx` is the scroll viewport's width,
+ * which is how much room the sticky strip has to lay tiles out in.
+ *
  * Radio gets its own branch in a later task; every other group renders
  * nothing here.
  */

--- a/packages/frontend/src/Applications/PlaylistEditor/LanePreview.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/LanePreview.tsx
@@ -1,0 +1,53 @@
+import { thumbnailBuckets } from "./thumbnailBuckets";
+
+const THUMB_BASE = "https://files.911realtime.org/thumbnails";
+const OFFLINE = `${THUMB_BASE}/offline.jpg`;
+
+/**
+ * The expanded lane content shown for the selected bar: a strip of TV
+ * thumbnails across the entry's visible span. `group`/`channel` come straight
+ * off the `TimelineBar` the caller already laid out (`b.group`, `b.label` —
+ * `label` is the entry's `itemId`, i.e. the channel slug) rather than a
+ * re-derived `MediaEntry`, since that is all layoutBars ever carried.
+ *
+ * Radio gets its own branch in a later task; every other group renders
+ * nothing here.
+ */
+export function LanePreview({
+	group,
+	channel,
+	startMs,
+	endMs,
+	viewportPx,
+}: {
+	group: "tv" | "radio" | "flights";
+	channel: string;
+	startMs: number;
+	endMs: number;
+	viewportPx: number;
+}) {
+	if (group !== "tv") return null;
+
+	const buckets = thumbnailBuckets({ startMs, endMs, viewportPx });
+	if (buckets.length === 0) return null;
+
+	const slug = channel.toLowerCase();
+	return (
+		// Sticky for the same reason the label is: the lane is far wider than
+		// the viewport once zoomed, so content anchored to the lane's left edge
+		// would sit off-screen.
+		<div className="playlistTimelinePreview">
+			{buckets.map((ts) => (
+				<img
+					key={ts}
+					className="playlistTimelinePreviewThumb"
+					src={`${THUMB_BASE}/${slug}/${ts}.jpg`}
+					onError={(e) => {
+						e.currentTarget.src = OFFLINE;
+					}}
+					alt=""
+				/>
+			))}
+		</div>
+	);
+}

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.scss
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.scss
@@ -123,7 +123,7 @@
 
 .playlistTimelineLane {
 	position: relative;
-	height: 20px;
+	min-height: 20px;
 }
 
 .playlistTimelineBar {
@@ -185,6 +185,22 @@
 	position: absolute;
 	top: 0;
 	height: 100%;
+}
+
+/* Sticky for the same reason .playlistTimelineLabel is — see the note there.
+ * The lane is zoom*100% wide, so anything anchored to its left edge sits
+ * off-screen the moment the user scrolls. */
+.playlistTimelinePreview {
+	position: sticky;
+	left: 0;
+	display: flex;
+	gap: 2px;
+	padding: 2px 0;
+}
+
+.playlistTimelinePreviewThumb {
+	height: 54px;
+	width: auto;
 }
 
 /* Add Settings dropdown: the div only anchors position measurement; the menu

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.scss
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.scss
@@ -121,15 +121,22 @@
 	flex-direction: column;
 }
 
+/* The bar row's own height. The lane can grow taller than this (an expanded
+ * preview lives underneath), so the bar and the label track are pinned to this
+ * fixed value rather than `height: 100%` — otherwise selecting a lane inflates
+ * its bar into a slab three times taller than every neighbour, which then
+ * paints over the thumbnail strip of any lane whose span it overlaps. */
+$lane-bar-height: 20px;
+
 .playlistTimelineLane {
 	position: relative;
-	min-height: 20px;
+	min-height: $lane-bar-height;
 }
 
 .playlistTimelineBar {
 	position: absolute;
 	top: 0;
-	height: 100%;
+	height: $lane-bar-height;
 	overflow: hidden;
 	white-space: nowrap;
 	text-align: left;
@@ -146,7 +153,7 @@
 .playlistTimelineLabelTrack {
 	position: absolute;
 	top: 0;
-	height: 100%;
+	height: $lane-bar-height;
 	clip-path: inset(0);
 	pointer-events: none;
 	display: flex;
@@ -189,10 +196,24 @@
 
 /* Sticky for the same reason .playlistTimelineLabel is — see the note there.
  * The lane is zoom*100% wide, so anything anchored to its left edge sits
- * off-screen the moment the user scrolls. */
+ * off-screen the moment the user scrolls.
+ *
+ * `width: fit-content` is what makes the stickiness do anything at all. A
+ * sticky box can only shift WITHIN its containing block's rectangle, and a
+ * block-level flex container fills its containing block exactly — so a
+ * full-width strip has zero room to move and stays pinned to track x=0 at
+ * every scroll position (it looks sticky in the stylesheet and measures as a
+ * no-op in the browser). Shrink-to-fit gives it the slack to travel, the same
+ * way .playlistTimelineLabel works by being a shrink-to-fit flex ITEM.
+ *
+ * The top margin clears the bar row above: the bar is absolutely positioned,
+ * so without it the strip starts at the lane's top edge and its first 20px sit
+ * under the bar. */
 .playlistTimelinePreview {
 	position: sticky;
 	left: 0;
+	width: fit-content;
+	margin-top: $lane-bar-height;
 	display: flex;
 	gap: 2px;
 	padding: 2px 0;

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.scss
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.scss
@@ -136,6 +136,30 @@
 	cursor: pointer;
 }
 
+/* The label rides above the bar rather than inside it. `position: sticky`
+ * resolves against the nearest ancestor with a scrolling box, and
+ * `overflow: hidden` counts as one — so a label inside .playlistTimelineBar
+ * would stick to the bar, which never scrolls, and nothing would happen.
+ *
+ * Clipping is therefore done with clip-path, which bounds the label to its
+ * item's span without creating a scroll container the way overflow would. */
+.playlistTimelineLabelTrack {
+	position: absolute;
+	top: 0;
+	height: 100%;
+	clip-path: inset(0);
+	pointer-events: none;
+	display: flex;
+	align-items: center;
+}
+
+.playlistTimelineLabel {
+	position: sticky;
+	left: 0;
+	white-space: nowrap;
+	padding-inline: 2px;
+}
+
 /* Edge-drag handles: a slim grab strip pinned to each end of the bar. The
  * resize cursor itself is set inline from ClassicyIcons — the published
  * classicy package inlines its cursor PNGs as data URIs in its own CSS, so

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistTimeline.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistTimeline.tsx
@@ -334,7 +334,6 @@ export function PlaylistTimeline({
 										>
 											{b.focus === "once" && <span aria-hidden>▸</span>}
 											{b.focus === "locked" && <span aria-hidden>🔒</span>}
-											{b.label}
 											{b.actualStartFrac !== undefined && endFrac - startFrac > 0 && (
 												<span
 													className="playlistTimelineActualSpan"
@@ -359,6 +358,16 @@ export function PlaylistTimeline({
 													/>
 												))}
 										</button>
+										<div
+											className="playlistTimelineLabelTrack"
+											style={{
+												left: `${startFrac * 100}%`,
+												width: `${(endFrac - startFrac) * 100}%`,
+											}}
+											aria-hidden
+										>
+											<span className="playlistTimelineLabel">{b.label}</span>
+										</div>
 									</div>
 								);
 							})}

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistTimeline.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistTimeline.tsx
@@ -1,6 +1,7 @@
 import { ClassicyButton, ClassicyIcons } from "classicy";
 import {
 	type PointerEvent as ReactPointerEvent,
+	useCallback,
 	useEffect,
 	useLayoutEffect,
 	useMemo,
@@ -30,6 +31,12 @@ import {
 // otherwise zooming in spreads the flags apart on screen while still stacking
 // them, which defeats the main reason to zoom into a crowded stretch.
 const FLAG_MIN_GAP_FRAC = 0.015;
+
+// How long a burst of scroll events is collapsed into one re-measure. Long
+// enough that a flick across a 64× track is a couple of dozen renders rather
+// than hundreds; short enough that the lane preview visibly keeps up with the
+// pan rather than snapping into place after it.
+const SCROLL_THROTTLE_MS = 50;
 
 /**
  * The Platinum resize cursors the Classicy View Pane dividers use, verbatim:
@@ -98,22 +105,73 @@ export function PlaylistTimeline({
 	const anchorRef = useRef<number | null>(null);
 	const [drag, setDrag] = useState<EdgeDrag | null>(null);
 	const lastDragXRef = useRef(0);
-	const [viewportPx, setViewportPx] = useState(0);
+	// Everything the lane preview needs to know about what is currently on
+	// screen: how wide the window onto the track is, and where in the track it
+	// sits. All three are read off the same element in one pass so they can
+	// never disagree by a frame. Zero under jsdom (no layout), same as elsewhere
+	// in this file, so the preview simply renders nothing in tests.
+	const [view, setView] = useState({ scrollLeft: 0, clientWidth: 0, scrollWidth: 0 });
 
-	// The lane preview needs to know how many thumbnails fit on screen. Reuses
-	// viewportRef (already held for zoom anchoring) rather than a second ref;
-	// clientWidth stays 0 under jsdom (no layout), same as elsewhere in this
-	// file, so the preview simply renders nothing in tests unless a test
-	// supplies its own width.
+	// Reuses viewportRef (already held for zoom anchoring) rather than a second
+	// ref. Bails out of the state write when nothing moved, so a scroll that
+	// lands back on the same pixel — or a ResizeObserver notification for a
+	// resize in the other axis — costs no render.
+	const measureView = useCallback(() => {
+		const el = viewportRef.current;
+		if (!el) return;
+		setView((prev) =>
+			prev.scrollLeft === el.scrollLeft &&
+			prev.clientWidth === el.clientWidth &&
+			prev.scrollWidth === el.scrollWidth
+				? prev
+				: {
+						scrollLeft: el.scrollLeft,
+						clientWidth: el.clientWidth,
+						scrollWidth: el.scrollWidth,
+					},
+		);
+	}, []);
+
 	useEffect(() => {
 		const el = viewportRef.current;
 		if (!el) return;
-		setViewportPx(el.clientWidth);
+		measureView();
 		if (typeof ResizeObserver === "undefined") return;
-		const ro = new ResizeObserver(() => setViewportPx(el.clientWidth));
+		const ro = new ResizeObserver(measureView);
 		ro.observe(el);
 		return () => ro.disconnect();
-	}, []);
+	}, [measureView]);
+
+	// Panning has to re-render, because the preview's thumbnails are sampled
+	// across the part of the entry that is *visible* — but only while a preview
+	// is actually mounted, which is only ever for the selected bar. With nothing
+	// selected the listener is not attached at all, so ordinary panning of a
+	// large timeline stays a pure browser scroll with no React work.
+	//
+	// A trailing timer, not requestAnimationFrame: rAF is only guaranteed to run
+	// when the page is being painted, and a compositor that decides it has
+	// nothing to draw can leave a queued callback sitting there — which shows up
+	// as a strip still previewing the stretch you scrolled away from. A timeout
+	// is delivered by the task queue regardless, and caps the work at ~20
+	// measures a second either way.
+	useEffect(() => {
+		const el = viewportRef.current;
+		if (!el || selectedUid === null) return;
+		measureView();
+		let timer = 0;
+		const onScroll = () => {
+			if (timer !== 0) return;
+			timer = window.setTimeout(() => {
+				timer = 0;
+				measureView();
+			}, SCROLL_THROTTLE_MS);
+		};
+		el.addEventListener("scroll", onScroll, { passive: true });
+		return () => {
+			el.removeEventListener("scroll", onScroll);
+			if (timer !== 0) window.clearTimeout(timer);
+		};
+	}, [selectedUid, measureView]);
 
 	// Zoom about the middle of what the user is currently looking at. Without
 	// this, widening the track keeps scrollLeft fixed and the view lurches
@@ -138,7 +196,19 @@ export function PlaylistTimeline({
 		// writing NaN into scrollLeft.
 		if (!el || anchor === null || el.scrollWidth === 0) return;
 		el.scrollLeft = anchor * el.scrollWidth - el.clientWidth / 2;
-	}, [zoom]);
+		measureView();
+	}, [zoom, measureView]);
+
+	// The window onto the track, as track fractions — the same 0…1 space bars
+	// are laid out in, so intersecting the two needs no unit conversion. Null
+	// until the element has been laid out (jsdom, first paint).
+	const visibleFrac = useMemo(() => {
+		if (view.scrollWidth <= 0 || view.clientWidth <= 0) return null;
+		return {
+			start: view.scrollLeft / view.scrollWidth,
+			end: (view.scrollLeft + view.clientWidth) / view.scrollWidth,
+		};
+	}, [view]);
 
 	useEffect(() => {
 		const toResolve = entries.filter(
@@ -333,6 +403,20 @@ export function PlaylistTimeline({
 								const fadeEnd = b.fadeEnd && dragging?.edge !== "end";
 								const handleCursor = (edge: "start" | "end") =>
 									edgeCursor(dragging?.edge === edge ? (dragging.dir ?? "lr") : "lr");
+								// The preview samples the part of the entry that is ON SCREEN,
+								// not its whole span — an entry with no bounds covers all ten
+								// days, and six thumbnails forty hours apart preview nothing.
+								// Intersecting with the scroll window is what makes zooming and
+								// panning walk the strip through the footage.
+								//
+								// It reads b.startFrac/b.endFrac rather than the drag-preview
+								// fractions above deliberately: following a live edge drag would
+								// re-derive the bucket set on every snapped minute and issue a
+								// fresh row of <img src>es each time — 193 image requests, measured,
+								// for one hour of dragging. The committed bounds hold the strip
+								// still until the drag lands.
+								const previewStart = Math.max(b.startFrac, visibleFrac?.start ?? 0);
+								const previewEnd = Math.min(b.endFrac, visibleFrac?.end ?? 0);
 								return (
 									<div key={b.uid} className={`playlistTimelineLane playlistTimelineLane-${b.group}`}>
 										<button
@@ -386,13 +470,13 @@ export function PlaylistTimeline({
 										>
 											<span className="playlistTimelineLabel">{b.label}</span>
 										</div>
-										{b.uid === selectedUid && (
+										{b.uid === selectedUid && previewEnd > previewStart && (
 											<LanePreview
 												group={b.group}
 												channel={b.label}
-												startMs={fractionToMs(startFrac, bounds)}
-												endMs={fractionToMs(endFrac, bounds)}
-												viewportPx={viewportPx}
+												startMs={fractionToMs(previewStart, bounds)}
+												endMs={fractionToMs(previewEnd, bounds)}
+												viewportPx={view.clientWidth}
 											/>
 										)}
 									</div>

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistTimeline.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistTimeline.tsx
@@ -192,11 +192,16 @@ export function PlaylistTimeline({
 		const el = viewportRef.current;
 		const anchor = anchorRef.current;
 		anchorRef.current = null;
+		// Every zoom change needs a re-measure, not just the anchor-driven ones:
+		// the ± buttons set anchorRef via changeZoom, but View ▸ Zoom In/Out and
+		// Actual Size dispatch setZoom directly and never touch it, so this has
+		// to run before the anchor === null early return below or the lane
+		// preview keeps sampling the pre-zoom scrollWidth.
+		measureView();
 		// scrollWidth is 0 under jsdom, so this is a no-op in tests rather than
 		// writing NaN into scrollLeft.
 		if (!el || anchor === null || el.scrollWidth === 0) return;
 		el.scrollLeft = anchor * el.scrollWidth - el.clientWidth / 2;
-		measureView();
 	}, [zoom, measureView]);
 
 	// The window onto the track, as track fractions — the same 0…1 space bars

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistTimeline.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistTimeline.tsx
@@ -8,10 +8,12 @@ import {
 	useState,
 } from "react";
 import type { EditorEntry } from "./editorState";
+import { LanePreview } from "./LanePreview";
 import "./PlaylistEditor.scss";
 import { resolveTimelineMeta } from "./resolveTimelineMeta";
 import {
 	dragEdgeIso,
+	fractionToMs,
 	layoutBars,
 	layoutFlags,
 	MAX_ZOOM,
@@ -96,6 +98,22 @@ export function PlaylistTimeline({
 	const anchorRef = useRef<number | null>(null);
 	const [drag, setDrag] = useState<EdgeDrag | null>(null);
 	const lastDragXRef = useRef(0);
+	const [viewportPx, setViewportPx] = useState(0);
+
+	// The lane preview needs to know how many thumbnails fit on screen. Reuses
+	// viewportRef (already held for zoom anchoring) rather than a second ref;
+	// clientWidth stays 0 under jsdom (no layout), same as elsewhere in this
+	// file, so the preview simply renders nothing in tests unless a test
+	// supplies its own width.
+	useEffect(() => {
+		const el = viewportRef.current;
+		if (!el) return;
+		setViewportPx(el.clientWidth);
+		if (typeof ResizeObserver === "undefined") return;
+		const ro = new ResizeObserver(() => setViewportPx(el.clientWidth));
+		ro.observe(el);
+		return () => ro.disconnect();
+	}, []);
 
 	// Zoom about the middle of what the user is currently looking at. Without
 	// this, widening the track keeps scrollLeft fixed and the view lurches
@@ -368,6 +386,15 @@ export function PlaylistTimeline({
 										>
 											<span className="playlistTimelineLabel">{b.label}</span>
 										</div>
+										{b.uid === selectedUid && (
+											<LanePreview
+												group={b.group}
+												channel={b.label}
+												startMs={fractionToMs(startFrac, bounds)}
+												endMs={fractionToMs(endFrac, bounds)}
+												viewportPx={viewportPx}
+											/>
+										)}
 									</div>
 								);
 							})}

--- a/packages/frontend/src/Applications/PlaylistEditor/thumbnailBuckets.test.ts
+++ b/packages/frontend/src/Applications/PlaylistEditor/thumbnailBuckets.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { BUCKET_SECONDS, thumbnailBuckets } from "./thumbnailBuckets";
+
+const at = (h: number, m: number, s = 0) => Date.UTC(2001, 8, 11, h, m, s);
+
+describe("thumbnailBuckets", () => {
+	it("fills the available width when enough buckets exist", () => {
+		// One hour of span, 800px of viewport, 100px tiles => 8 tiles.
+		const out = thumbnailBuckets({
+			startMs: at(12, 0), endMs: at(13, 0), viewportPx: 800, tilePx: 100,
+		});
+		expect(out).toHaveLength(8);
+	});
+
+	it("caps at the buckets a short span actually contains", () => {
+		// Thumbnails exist every 30s, so two minutes holds four of them however
+		// much room there is. Asking for more would return duplicates or 404s.
+		const out = thumbnailBuckets({
+			startMs: at(12, 0), endMs: at(12, 2), viewportPx: 2000, tilePx: 100,
+		});
+		expect(out).toHaveLength(4);
+	});
+
+	it("returns one thumbnail for a span shorter than a bucket", () => {
+		const out = thumbnailBuckets({
+			startMs: at(12, 0), endMs: at(12, 0, 10), viewportPx: 800, tilePx: 100,
+		});
+		expect(out).toHaveLength(1);
+	});
+
+	it("snaps every timestamp to the 30s grid the images exist at", () => {
+		const out = thumbnailBuckets({
+			startMs: at(12, 0, 17), endMs: at(12, 5), viewportPx: 400, tilePx: 100,
+		});
+		for (const ts of out) expect(ts % BUCKET_SECONDS).toBe(0);
+	});
+
+	it("returns nothing when there is no room to draw", () => {
+		expect(thumbnailBuckets({
+			startMs: at(12, 0), endMs: at(13, 0), viewportPx: 0, tilePx: 100,
+		})).toEqual([]);
+	});
+});

--- a/packages/frontend/src/Applications/PlaylistEditor/thumbnailBuckets.ts
+++ b/packages/frontend/src/Applications/PlaylistEditor/thumbnailBuckets.ts
@@ -1,0 +1,42 @@
+/**
+ * Which thumbnails to show for an entry's visible span.
+ *
+ * Thumbnails exist only on a 30-second grid (see TV/ThumbnailTile.tsx), so the
+ * count is bounded twice: by how many tiles fit, and by how many distinct
+ * images the span actually contains. The second bound is the important one — a
+ * two-minute entry has four thumbnails no matter how wide the window is, and
+ * requesting more would render duplicates or fall back to offline.jpg, which
+ * reads as broken rather than as "this is all there is".
+ */
+export const BUCKET_SECONDS = 30;
+
+const DEFAULT_TILE_PX = 96;
+
+export function thumbnailBuckets({
+	startMs,
+	endMs,
+	viewportPx,
+	tilePx = DEFAULT_TILE_PX,
+}: {
+	startMs: number;
+	endMs: number;
+	viewportPx: number;
+	tilePx?: number;
+}): number[] {
+	const fit = Math.floor(viewportPx / tilePx);
+	if (fit < 1 || endMs <= startMs) return [];
+
+	const startBucket = Math.floor(startMs / 1000 / BUCKET_SECONDS);
+	const endBucket = Math.floor((endMs - 1) / 1000 / BUCKET_SECONDS);
+	const available = endBucket - startBucket + 1;
+
+	const count = Math.min(fit, available);
+	const stride = available / count;
+
+	const out: number[] = [];
+	for (let i = 0; i < count; i++) {
+		const bucket = startBucket + Math.floor(i * stride);
+		out.push(bucket * BUCKET_SECONDS);
+	}
+	return out;
+}

--- a/packages/frontend/src/Applications/PlaylistEditor/thumbnailBuckets.ts
+++ b/packages/frontend/src/Applications/PlaylistEditor/thumbnailBuckets.ts
@@ -1,6 +1,13 @@
 /**
  * Which thumbnails to show for an entry's visible span.
  *
+ * "Visible span" is literal: `startMs`/`endMs` are the intersection of the
+ * entry's window with the timeline's scroll viewport, computed by the caller
+ * (`PlaylistTimeline.tsx`). That is what makes zoom mean something here — the
+ * tile budget is fixed by the viewport width, so a narrower visible window
+ * spends it on a denser, closer-spaced run of images instead of six stills
+ * forty hours apart.
+ *
  * Thumbnails exist only on a 30-second grid (see TV/ThumbnailTile.tsx), so the
  * count is bounded twice: by how many tiles fit, and by how many distinct
  * images the span actually contains. The second bound is the important one — a

--- a/packages/frontend/src/Applications/PlaylistEditor/timelineLayout.test.ts
+++ b/packages/frontend/src/Applications/PlaylistEditor/timelineLayout.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	dragEdgeIso,
+	fractionToMs,
 	FULL_BOUNDS,
 	layoutBars,
 	layoutFlags,
@@ -26,6 +27,31 @@ describe("timeToFraction", () => {
 		expect(timeToFraction("2001-09-19T00:00:00.000Z")).toBe(1);
 		expect(timeToFraction("2001-08-01T00:00:00.000Z")).toBe(0);
 		expect(timeToFraction("2001-09-14T00:00:00.000Z")).toBeCloseTo(0.5);
+	});
+});
+
+describe("fractionToMs", () => {
+	it("round-trips with timeToFraction on the full span", () => {
+		for (const iso of [
+			"2001-09-09T00:00:00.000Z",
+			"2001-09-14T06:30:00.000Z",
+			"2001-09-19T00:00:00.000Z",
+		]) {
+			const ms = new Date(iso).getTime();
+			expect(fractionToMs(timeToFraction(iso))).toBeCloseTo(ms, -1);
+		}
+	});
+
+	it("round-trips against rescaled bounds, not just the full span", () => {
+		const b = timelineBounds("2001-09-11T12:00:00Z", "2001-09-11T14:00:00Z");
+		const iso = "2001-09-11T13:15:00.000Z";
+		const ms = new Date(iso).getTime();
+		expect(fractionToMs(timeToFraction(iso, b), b)).toBeCloseTo(ms, -1);
+	});
+
+	it("maps the bounds edges to 0 and 1, inverse of timeToFraction", () => {
+		expect(fractionToMs(0)).toBe(TIMELINE_START_MS);
+		expect(fractionToMs(1)).toBe(TIMELINE_END_MS);
 	});
 });
 

--- a/packages/frontend/src/Applications/PlaylistEditor/timelineLayout.ts
+++ b/packages/frontend/src/Applications/PlaylistEditor/timelineLayout.ts
@@ -156,6 +156,11 @@ export function timeToFraction(iso: string, bounds: TimelineBounds = FULL_BOUNDS
 	return Math.min(1, Math.max(0, frac));
 }
 
+/** The inverse of {@link timeToFraction}: a track fraction back to a UTC ms instant. */
+export function fractionToMs(frac: number, bounds: TimelineBounds = FULL_BOUNDS): number {
+	return bounds.startMs + frac * (bounds.endMs - bounds.startMs);
+}
+
 // Edge drags snap to whole minutes: finer precision is invisible at any zoom
 // level, and it keeps the committed ISO strings as round as hand-entered ones.
 const DRAG_SNAP_MS = 60_000;

--- a/plans/2026-08-17-timeline-lane-preview-design.md
+++ b/plans/2026-08-17-timeline-lane-preview-design.md
@@ -85,6 +85,17 @@ computing them in the browser: 576 clips are under 5 minutes, but 179 position
 tapes run up to 6.75 hours, and decoding one of those client-side would download
 hundreds of megabytes and freeze the tab.
 
+**A radio entry names a station, not a file.** `MediaEntry.itemId` is a station
+slug (`Providers/Playlist/playlistTypes.ts`), so an entry is a station plus a
+window, and that window may contain several recordings or none. The preview is
+therefore assembled from whatever aired in the window, each recording drawn at
+its own time position — the same time-positioned shape as the thumbnail strip.
+
+One consequence for the sticky rule above: the radio preview is **not** sticky.
+A thumbnail strip is a summary, so it should stay in view; a waveform laid out
+by time is a positioned overlay, and pinning it would slide it out of alignment
+with the timeline it describes.
+
 So peaks are precomputed offline and stored on the row:
 
 - **`video_grabber/peaks/extract.py`** — pure. ffprobe for duration, ffmpeg to
@@ -102,13 +113,21 @@ benefit at preview size.
 ## Components
 
 ```
-PlaylistTimeline.tsx      existing — tracks expandedUid, renders <LanePreview>
-  LanePreview.tsx         new — dispatches on entry.app; owns the sticky wrapper
-    ThumbnailStrip.tsx    new — renders the derived bucket list
-    PeaksWaveform.tsx     new — draws 480 peaks to a canvas
-  mediaSections.ts        new — MEDIA_SECTIONS lifted out of PlaylistEditorMain
+PlaylistTimeline.tsx      existing — renders <LanePreview> for the selected bar
+  LanePreview.tsx         new — dispatches on the bar's `group`
+    (TV branch)           sticky thumbnail strip, derived bucket list
+    RadioLanePreview      time-positioned waveform slots (NOT sticky)
+      PeaksWaveform.tsx   new — draws 480 peaks to a canvas
+      usePeaksForSpan.ts  new — recordings overlapping the entry's window
   thumbnailBuckets.ts     new — pure: (span, width, tileWidth) → timestamps[]
+  timelineLayout.ts       existing — gains fractionToMs, the inverse of
+                          timeToFraction, so a bar's fracs become a time span
 ```
+
+Type discrimination needs no new module: the bar object already carries
+`group: "tv" | "radio" | "flights"`, derived in `timelineLayout.ts` from
+`entry.app` — the same source `MEDIA_SECTIONS` reads. Extracting shared
+predicates would buy no anti-drift guarantee the bar does not already have.
 
 `PeaksWaveform` deliberately does not extend `WaveformVisualizer`. That
 component's substance is Web Audio capture and animation-frame scheduling, none

--- a/plans/2026-08-17-timeline-lane-preview-design.md
+++ b/plans/2026-08-17-timeline-lane-preview-design.md
@@ -1,0 +1,160 @@
+# Playlist Editor: sticky lane labels and click-to-preview
+
+Design for two related changes to the Playlist Editor timeline:
+
+1. A media item's text label stays visible at the left of the **viewport** while
+   the timeline is scrolled or zoomed, instead of scrolling away with its bar.
+2. Clicking a lane expands it to preview the item — a thumbnail strip for TV
+   channels, a waveform for radio.
+
+## Why these are one change, not two
+
+`PlaylistTimeline` renders lanes inside a track whose width is `zoom * 100%`
+within a horizontally scrolling container. At 16× the track is sixteen viewports
+wide, and a lane spans all of it.
+
+Both features therefore need the same thing: content pinned to the *visible*
+left edge rather than the track's left edge. That is `position: sticky; left: 0`,
+applied to the label and to the preview body. Treating them separately would
+produce two mechanisms for one problem.
+
+It also settles what "only as many thumbnails as can fit in the window" means:
+the window is the **scroll viewport**, not the lane, because the lane is far
+wider than anything visible.
+
+## Current behaviour
+
+The label is rendered inside the bar button, positioned by the bar's
+`left`/`width` percentages (`PlaylistTimeline.tsx`, the `bars.map` block). When
+the bar's start scrolls out of view, the label goes with it, so a long entry
+becomes an unlabelled stripe — worse the further you zoom, which is exactly when
+labels matter most.
+
+Selection already exists: bars call `onSelect(b.uid)` and the component tracks
+`selectedUid`. The preview hangs off that rather than introducing a second
+notion of "the current item".
+
+## Type discrimination
+
+`MEDIA_SECTIONS` in `PlaylistEditorMain.tsx` already classifies entries:
+
+| `key` | Predicate | Preview |
+|---|---|---|
+| `tv` | `entry.app === "tv"` | thumbnail strip |
+| `radio` | `app === "radio"` and in `BROADCAST_STATIONS` | waveform |
+| `radio-traffic` | `app === "radio"` and not a broadcast station | waveform |
+| `news`, `flights`, non-media | — | no preview; lane does not expand |
+
+Both radio sections get waveforms; the split exists for the media palette, not
+for previewing. These predicates move to a shared `mediaSections.ts` so the
+timeline and the palette cannot drift into disagreeing about what a TV entry is.
+
+## Data sources
+
+### TV thumbnails — no new work
+
+Thumbnails are addressable by convention, already relied on by
+`TV/ThumbnailTile.tsx`:
+
+```
+https://files.911realtime.org/thumbnails/<channel-slug>/<30s-bucket-ts>.jpg
+```
+
+`thumbnailBuckets.ts` derives the strip as pure arithmetic:
+
+- count = floor(visible viewport width / tile width)
+- interval = entry's visible span / count, **snapped to the 30 s bucket grid**
+- capped at the number of distinct buckets the span actually contains
+
+The cap is load-bearing. Thumbnails exist only every 30 seconds, so a 2-minute
+entry has four distinct images however much room there is. Requesting more would
+return duplicates or 404s — `ThumbnailTile` falls back to `offline.jpg`, and a
+row of grey placeholders reads as broken rather than as "this is all there is".
+
+"More images as you zoom" is emergent: zooming widens the visible span, so more
+distinct buckets become addressable. No separate zoom code path.
+
+### Radio waveforms — new pipeline
+
+`RadioScanner/WaveformVisualizer.tsx` looks like the component for this and is
+not: it takes an `HTMLAudioElement` and captures live audio through Web Audio,
+rendering what is *playing*. A timeline entry is not playing.
+
+A static waveform needs amplitude peaks from the file. The corpus rules out
+computing them in the browser: 576 clips are under 5 minutes, but 179 position
+tapes run up to 6.75 hours, and decoding one of those client-side would download
+hundreds of megabytes and freeze the tab.
+
+So peaks are precomputed offline and stored on the row:
+
+- **`video_grabber/peaks/extract.py`** — pure. ffprobe for duration, ffmpeg to
+  raw PCM, reduce to a **fixed 480 buckets** of min/max amplitude.
+- **`mp3_items.peaks`** — new `json` field, declared in
+  `apps/rt911/schema/snapshot.json` and applied by the PreSync hook.
+- **`compute-peaks`** — Prefect flow, manual-only, `dry_run=True` by default,
+  idempotent on `peaks IS NOT NULL`.
+
+A fixed bucket count is deliberate: the stored blob is ~2 KB whether the file is
+40 seconds or 6.75 hours, and the renderer always draws 480 values across
+whatever width it has. Per-file resolution would make both sides variable for no
+benefit at preview size.
+
+## Components
+
+```
+PlaylistTimeline.tsx      existing — tracks expandedUid, renders <LanePreview>
+  LanePreview.tsx         new — dispatches on entry.app; owns the sticky wrapper
+    ThumbnailStrip.tsx    new — renders the derived bucket list
+    PeaksWaveform.tsx     new — draws 480 peaks to a canvas
+  mediaSections.ts        new — MEDIA_SECTIONS lifted out of PlaylistEditorMain
+  thumbnailBuckets.ts     new — pure: (span, width, tileWidth) → timestamps[]
+```
+
+`PeaksWaveform` deliberately does not extend `WaveformVisualizer`. That
+component's substance is Web Audio capture and animation-frame scheduling, none
+of which applies to drawing a static array; sharing it would drag an
+`AudioContext` into a component that needs none.
+
+`thumbnailBuckets.ts` keeps the arithmetic out of the render path so the
+"how many fit, at what interval" rule is testable without mounting anything —
+the same split `timelineLayout.ts` already uses for zoom levels.
+
+## Error handling
+
+| Condition | Behaviour |
+|---|---|
+| Entry has no peaks yet | No waveform; lane does not expand |
+| Thumbnail 404s | Existing `offline.jpg` fallback in `ThumbnailTile` |
+| Entry is not TV or radio | Lane does not expand at all |
+| Span shorter than one bucket | Single thumbnail, not zero |
+
+Nothing here surfaces an error dialog: a preview is an affordance, and a missing
+one should be quiet.
+
+## Testing
+
+- `thumbnailBuckets` — pure tests, including the cap (a 2-minute entry yields 4
+  buckets regardless of available width) and the sub-bucket span
+- `extract.py` — pure tests over synthetic PCM; a silent file yields flat peaks
+  rather than raising
+- Sticky positioning — asserted on computed style; jsdom does not reproduce real
+  scrolling, so a scroll-and-screenshot test would be theatre
+- `mediaSections` — the predicates keep classifying the same entries after being
+  moved
+
+## Out of scope
+
+Playback from the preview, scrubbing, and waveform interaction. The request is
+to *see* the item, not operate it.
+
+## Sequencing
+
+Three PRs, in this order, so the cheap wins land while the expensive one runs:
+
+1. **Sticky labels** — CSS plus a small render change
+2. **TV thumbnail strips** — needs no backend work
+3. **Peaks pipeline and waveforms** — schema change, new flow, a pass over 814
+   files
+
+Steps 1 and 2 are independently useful; step 3 is the only one that touches
+another repo.

--- a/plans/2026-08-17-timeline-lane-preview-plan.md
+++ b/plans/2026-08-17-timeline-lane-preview-plan.md
@@ -1,0 +1,1135 @@
+# Timeline Sticky Labels and Lane Previews — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep a timeline item's label visible at the left of the viewport while scrolling or zooming, and expand a clicked lane to preview the item — thumbnails for TV, waveform for radio.
+
+**Architecture:** Both features pin content to the visible left edge of a track that is `zoom * 100%` wide inside a scrolling container, using `position: sticky; left: 0`. Preview type dispatches on the existing `MEDIA_SECTIONS` predicates. TV thumbnails come from an existing URL convention; radio waveforms come from peaks precomputed by a new video-grabber flow.
+
+**Tech Stack:** React + TypeScript + Vite, vitest, Playwright, SCSS modules; Python + Prefect + ffmpeg (video-grabber); Directus schema via the infra repo's PreSync hook.
+
+**Spec:** `plans/2026-08-17-timeline-lane-preview-design.md`
+
+## Global Constraints
+
+- Repo conventions live in `packages/frontend/CLAUDE.md`; read it before touching the frontend.
+- Co-locate tests: `Foo.test.tsx` beside `Foo.tsx`; pure logic gets its own `*.test.ts`.
+- New test files need `afterEach(cleanup)` — this repo has no RTL auto-cleanup.
+- `classicy` is external and pinned to `"latest"`; never hand-edit its version.
+- Frontend gates: `pnpm exec tsc -b`, `pnpm exec eslint .`, `pnpm exec vitest run` must all pass.
+- video-grabber gates: `pytest tests/ -v` and `ruff check video_grabber/ tests/`.
+- Directus schema changes go through `Keeping-History/infra`, never by hand. Regenerate `snapshot.json` with `GET /schema/snapshot` (the CLI's format is rejected by `POST /schema/diff`), against a database that already has the raw indexes.
+- Every commit carries `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>`.
+
+**Three PRs, in order.** Phase 1 and 2 are frontend-only and independently shippable. Phase 3 spans video-grabber + infra + frontend; start it only after 1 and 2 are merged.
+
+---
+
+## Phase 1 — Sticky lane labels (PR 1)
+
+### Task 1: Move the label out of the bar so it can stick
+
+**Files:**
+- Modify: `packages/frontend/src/Applications/PlaylistEditor/PlaylistTimeline.tsx` (the `bars.map` block, ~line 319-340)
+- Modify: `packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.scss` (`.playlistTimelineBar`, ~line 129)
+- Test: `packages/frontend/e2e/tests/playlist-editor.spec.ts`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: CSS classes `.playlistTimelineLabelTrack` and `.playlistTimelineLabel`, used by Task 4's preview wrapper for the same sticky treatment.
+
+**The trap this task exists to avoid.** `.playlistTimelineBar` currently sets
+`overflow: hidden`, and the label is rendered inside it. `position: sticky`
+resolves against the nearest ancestor with a scrolling box — and `overflow:
+hidden` *is* a scrolling box, just one the user cannot scroll. A sticky label
+inside the bar therefore sticks to the bar, which never scrolls, and nothing
+appears to happen. The label must live outside any `overflow: hidden` ancestor,
+and the wrapper that clips it must clip with `clip-path` (which creates no
+scroll container) rather than `overflow`.
+
+- [ ] **Step 1: Write the failing e2e test**
+
+Append to `packages/frontend/e2e/tests/playlist-editor.spec.ts`:
+
+```ts
+test("lane label stays visible when the timeline is scrolled", async ({ page }) => {
+	await openPlaylistWithEntries(page);          // existing helper in this spec
+	await page.getByRole("button", { name: "Zoom in" }).click();
+	await page.getByRole("button", { name: "Zoom in" }).click();
+
+	const label = page.locator(".playlistTimelineLabel").first();
+	const timeline = page.locator(".playlistTimeline");
+	await expect(label).toBeVisible();
+
+	await timeline.evaluate((el) => { el.scrollLeft = el.scrollWidth / 3; });
+
+	// The label must still be inside the viewport, not scrolled off to the left.
+	const box = await label.boundingBox();
+	const view = await timeline.boundingBox();
+	expect(box).not.toBeNull();
+	expect(view).not.toBeNull();
+	expect(box!.x).toBeGreaterThanOrEqual(view!.x - 1);
+});
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `pnpm --filter @rt911/frontend exec playwright test e2e/tests/playlist-editor.spec.ts -g "stays visible"`
+Expected: FAIL — `.playlistTimelineLabel` does not exist yet.
+
+- [ ] **Step 3: Render the label as a sibling of the bar**
+
+In `PlaylistTimeline.tsx`, inside `bars.map`, remove the bare `{b.label}` from
+the `<button>` children and add a sibling *after* the button, still inside the
+lane:
+
+```tsx
+<div
+	className="playlistTimelineLabelTrack"
+	style={{
+		left: `${startFrac * 100}%`,
+		width: `${(endFrac - startFrac) * 100}%`,
+	}}
+	aria-hidden
+>
+	<span className="playlistTimelineLabel">{b.label}</span>
+</div>
+```
+
+`aria-hidden` because the bar's `title` and its accessible name already carry
+the label; a second copy would double-announce it.
+
+- [ ] **Step 4: Add the CSS**
+
+In `PlaylistEditor.scss`, after `.playlistTimelineBar`:
+
+```scss
+/* The label rides above the bar rather than inside it. `position: sticky`
+ * resolves against the nearest ancestor with a scrolling box, and
+ * `overflow: hidden` counts as one — so a label inside .playlistTimelineBar
+ * would stick to the bar, which never scrolls, and nothing would happen.
+ *
+ * Clipping is therefore done with clip-path, which bounds the label to its
+ * item's span without creating a scroll container the way overflow would. */
+.playlistTimelineLabelTrack {
+	position: absolute;
+	top: 0;
+	height: 100%;
+	clip-path: inset(0);
+	pointer-events: none;
+	display: flex;
+	align-items: center;
+}
+
+.playlistTimelineLabel {
+	position: sticky;
+	left: 0;
+	white-space: nowrap;
+	padding-inline: 2px;
+}
+```
+
+- [ ] **Step 5: Run the e2e test**
+
+Run: `pnpm --filter @rt911/frontend exec playwright test e2e/tests/playlist-editor.spec.ts -g "stays visible"`
+Expected: PASS
+
+- [ ] **Step 6: Run the full frontend gates**
+
+Run: `pnpm exec tsc -b && pnpm exec eslint . && pnpm exec vitest run`
+Expected: all pass. Existing `PlaylistTimeline` tests that asserted label text
+inside the bar may need their selector updated to `.playlistTimelineLabel`;
+update them rather than reverting the structure.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/frontend/src/Applications/PlaylistEditor/PlaylistTimeline.tsx \
+        packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.scss \
+        packages/frontend/e2e/tests/playlist-editor.spec.ts
+git commit -m "$(cat <<'EOF'
+feat(playlist): pin timeline lane labels to the visible left edge
+
+A lane spans a track that is zoom*100% wide inside a scrolling container, so a
+label positioned by the bar's left edge scrolls out of view — worse the further
+you zoom, which is exactly when labels matter most.
+
+The label moves out of .playlistTimelineBar because that element sets
+overflow: hidden, and position: sticky resolves against the nearest ancestor
+with a scrolling box. overflow: hidden is one, so a sticky label inside the bar
+sticks to the bar, which never scrolls, and nothing happens. The new wrapper
+clips with clip-path instead, which bounds the label to its item's span without
+creating a scroll container.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 2 — TV thumbnail strips (PR 2)
+
+### Task 2: Extract the media-type predicates
+
+**Files:**
+- Create: `packages/frontend/src/Applications/PlaylistEditor/mediaSections.ts`
+- Create: `packages/frontend/src/Applications/PlaylistEditor/mediaSections.test.ts`
+- Modify: `packages/frontend/src/Applications/PlaylistEditor/PlaylistEditorMain.tsx` (remove the local `MEDIA_SECTIONS`, import instead)
+
+**Interfaces:**
+- Consumes: `MediaEntry`, `EditorEntry` from `./editorState`; `BROADCAST_STATIONS` from the RadioTuner split.
+- Produces: `previewKindOf(entry: MediaEntry): "tv" | "radio" | null` — Task 4 dispatches on this. Also re-exports `MEDIA_SECTIONS` unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { previewKindOf } from "./mediaSections";
+
+describe("previewKindOf", () => {
+	it("classifies TV entries", () => {
+		expect(previewKindOf({ app: "tv", itemId: "cnn" } as never)).toBe("tv");
+	});
+
+	it("classifies both broadcast stations and comm traffic as radio", () => {
+		// The palette splits these into two sections; previewing does not —
+		// both render a waveform.
+		expect(previewKindOf({ app: "radio", itemId: "WCBS" } as never)).toBe("radio");
+		expect(previewKindOf({ app: "radio", itemId: "ZOB" } as never)).toBe("radio");
+	});
+
+	it("returns null for kinds with no preview", () => {
+		expect(previewKindOf({ app: "news", itemId: "x" } as never)).toBeNull();
+		expect(previewKindOf({ app: "flights", itemId: "AA11" } as never)).toBeNull();
+	});
+});
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `pnpm --filter @rt911/frontend exec vitest run src/Applications/PlaylistEditor/mediaSections.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Create the module**
+
+Move the `MediaSection` type, `isBroadcastStation`, and `MEDIA_SECTIONS` verbatim
+out of `PlaylistEditorMain.tsx` into `mediaSections.ts`, export them, and add:
+
+```ts
+/**
+ * Which preview a media entry gets, or null for none.
+ *
+ * Both radio sections collapse to "radio": the palette splits broadcast
+ * stations from comm traffic because they are browsed differently, but a
+ * waveform is a waveform.
+ */
+export function previewKindOf(entry: MediaEntry): "tv" | "radio" | null {
+	if (entry.app === "tv") return "tv";
+	if (entry.app === "radio") return "radio";
+	return null;
+}
+```
+
+- [ ] **Step 4: Update the import in PlaylistEditorMain.tsx**
+
+Replace the deleted definitions with:
+
+```ts
+import { MEDIA_SECTIONS } from "./mediaSections";
+```
+
+- [ ] **Step 5: Run the gates**
+
+Run: `pnpm exec tsc -b && pnpm exec vitest run src/Applications/PlaylistEditor/`
+Expected: PASS, including the existing `PlaylistEditorMain` tests unchanged —
+the predicates moved, their behaviour did not.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/frontend/src/Applications/PlaylistEditor/mediaSections.ts \
+        packages/frontend/src/Applications/PlaylistEditor/mediaSections.test.ts \
+        packages/frontend/src/Applications/PlaylistEditor/PlaylistEditorMain.tsx
+git commit -m "$(cat <<'EOF'
+refactor(playlist): lift MEDIA_SECTIONS into its own module
+
+The timeline preview needs to classify an entry the same way the media palette
+does. Sharing the predicates keeps the two surfaces from drifting into
+disagreeing about what a TV entry is; duplicating them guarantees they
+eventually will.
+
+Adds previewKindOf, which collapses both radio sections to one preview kind —
+the palette splits broadcast stations from comm traffic because they are
+browsed differently, but a waveform is a waveform.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 3: Thumbnail bucket arithmetic
+
+**Files:**
+- Create: `packages/frontend/src/Applications/PlaylistEditor/thumbnailBuckets.ts`
+- Create: `packages/frontend/src/Applications/PlaylistEditor/thumbnailBuckets.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `thumbnailBuckets(args: {startMs: number; endMs: number; viewportPx: number; tilePx?: number}): number[]` — returns 30s-bucket epoch-second timestamps. Task 4 maps these to URLs.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { BUCKET_SECONDS, thumbnailBuckets } from "./thumbnailBuckets";
+
+const at = (h: number, m: number, s = 0) => Date.UTC(2001, 8, 11, h, m, s);
+
+describe("thumbnailBuckets", () => {
+	it("fills the available width when enough buckets exist", () => {
+		// One hour of span, 800px of viewport, 100px tiles => 8 tiles.
+		const out = thumbnailBuckets({
+			startMs: at(12, 0), endMs: at(13, 0), viewportPx: 800, tilePx: 100,
+		});
+		expect(out).toHaveLength(8);
+	});
+
+	it("caps at the buckets a short span actually contains", () => {
+		// Thumbnails exist every 30s, so two minutes holds four of them however
+		// much room there is. Asking for more would return duplicates or 404s.
+		const out = thumbnailBuckets({
+			startMs: at(12, 0), endMs: at(12, 2), viewportPx: 2000, tilePx: 100,
+		});
+		expect(out).toHaveLength(4);
+	});
+
+	it("returns one thumbnail for a span shorter than a bucket", () => {
+		const out = thumbnailBuckets({
+			startMs: at(12, 0), endMs: at(12, 0, 10), viewportPx: 800, tilePx: 100,
+		});
+		expect(out).toHaveLength(1);
+	});
+
+	it("snaps every timestamp to the 30s grid the images exist at", () => {
+		const out = thumbnailBuckets({
+			startMs: at(12, 0, 17), endMs: at(12, 5), viewportPx: 400, tilePx: 100,
+		});
+		for (const ts of out) expect(ts % BUCKET_SECONDS).toBe(0);
+	});
+
+	it("returns nothing when there is no room to draw", () => {
+		expect(thumbnailBuckets({
+			startMs: at(12, 0), endMs: at(13, 0), viewportPx: 0, tilePx: 100,
+		})).toEqual([]);
+	});
+});
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `pnpm --filter @rt911/frontend exec vitest run src/Applications/PlaylistEditor/thumbnailBuckets.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement**
+
+```ts
+/**
+ * Which thumbnails to show for an entry's visible span.
+ *
+ * Thumbnails exist only on a 30-second grid (see TV/ThumbnailTile.tsx), so the
+ * count is bounded twice: by how many tiles fit, and by how many distinct
+ * images the span actually contains. The second bound is the important one — a
+ * two-minute entry has four thumbnails no matter how wide the window is, and
+ * requesting more would render duplicates or fall back to offline.jpg, which
+ * reads as broken rather than as "this is all there is".
+ */
+export const BUCKET_SECONDS = 30;
+
+const DEFAULT_TILE_PX = 96;
+
+export function thumbnailBuckets({
+	startMs,
+	endMs,
+	viewportPx,
+	tilePx = DEFAULT_TILE_PX,
+}: {
+	startMs: number;
+	endMs: number;
+	viewportPx: number;
+	tilePx?: number;
+}): number[] {
+	const fit = Math.floor(viewportPx / tilePx);
+	if (fit < 1 || endMs <= startMs) return [];
+
+	const startBucket = Math.floor(startMs / 1000 / BUCKET_SECONDS);
+	const endBucket = Math.floor((endMs - 1) / 1000 / BUCKET_SECONDS);
+	const available = endBucket - startBucket + 1;
+
+	const count = Math.min(fit, available);
+	const stride = available / count;
+
+	const out: number[] = [];
+	for (let i = 0; i < count; i++) {
+		const bucket = startBucket + Math.floor(i * stride);
+		out.push(bucket * BUCKET_SECONDS);
+	}
+	return out;
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `pnpm --filter @rt911/frontend exec vitest run src/Applications/PlaylistEditor/thumbnailBuckets.test.ts`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/frontend/src/Applications/PlaylistEditor/thumbnailBuckets.ts \
+        packages/frontend/src/Applications/PlaylistEditor/thumbnailBuckets.test.ts
+git commit -m "$(cat <<'EOF'
+feat(playlist): derive the thumbnail strip for a visible span
+
+Pure arithmetic, kept out of the render path so the "how many fit, at what
+interval" rule is testable without mounting anything — the same split
+timelineLayout.ts already uses for zoom.
+
+The cap is the load-bearing part. Thumbnails exist only every 30 seconds, so a
+two-minute entry holds four of them however wide the window is. Filling the
+available width instead would request duplicates or 404s, and a row of
+offline.jpg placeholders reads as broken rather than as "this is all there is".
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 4: The lane preview, TV half
+
+**Files:**
+- Create: `packages/frontend/src/Applications/PlaylistEditor/LanePreview.tsx`
+- Create: `packages/frontend/src/Applications/PlaylistEditor/LanePreview.test.tsx`
+- Modify: `packages/frontend/src/Applications/PlaylistEditor/PlaylistTimeline.tsx`
+- Modify: `packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.scss`
+
+**Interfaces:**
+- Consumes: `previewKindOf` (Task 2), `thumbnailBuckets` + `BUCKET_SECONDS` (Task 3), `.playlistTimelineLabel` sticky pattern (Task 1).
+- Produces: `<LanePreview entry={MediaEntry} startMs={number} endMs={number} viewportPx={number} />`. Task 7 adds the radio branch to this same component.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { LanePreview } from "./LanePreview";
+
+afterEach(cleanup);
+
+const tvEntry = { app: "tv", itemId: "cnn" } as never;
+const span = { startMs: Date.UTC(2001, 8, 11, 12, 0), endMs: Date.UTC(2001, 8, 11, 12, 30) };
+
+describe("LanePreview", () => {
+	it("renders a thumbnail strip for TV entries", () => {
+		render(<LanePreview entry={tvEntry} {...span} viewportPx={400} />);
+		const imgs = screen.getAllByRole("img");
+		expect(imgs.length).toBeGreaterThan(0);
+		expect(imgs[0]).toHaveProperty(
+			"src",
+			expect.stringContaining("files.911realtime.org/thumbnails/cnn/"),
+		);
+	});
+
+	it("renders nothing for an entry kind with no preview", () => {
+		const { container } = render(
+			<LanePreview entry={{ app: "news", itemId: "x" } as never} {...span} viewportPx={400} />,
+		);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("renders nothing when there is no room", () => {
+		const { container } = render(<LanePreview entry={tvEntry} {...span} viewportPx={0} />);
+		expect(container).toBeEmptyDOMElement();
+	});
+});
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `pnpm --filter @rt911/frontend exec vitest run src/Applications/PlaylistEditor/LanePreview.test.tsx`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the component**
+
+```tsx
+import type { MediaEntry } from "./editorState";
+import { previewKindOf } from "./mediaSections";
+import { thumbnailBuckets } from "./thumbnailBuckets";
+
+const THUMB_BASE = "https://files.911realtime.org/thumbnails";
+const OFFLINE = `${THUMB_BASE}/offline.jpg`;
+
+export function LanePreview({
+	entry,
+	startMs,
+	endMs,
+	viewportPx,
+}: {
+	entry: MediaEntry;
+	startMs: number;
+	endMs: number;
+	viewportPx: number;
+}) {
+	const kind = previewKindOf(entry);
+	if (kind !== "tv") return null;
+
+	const buckets = thumbnailBuckets({ startMs, endMs, viewportPx });
+	if (buckets.length === 0) return null;
+
+	const channel = entry.itemId.toLowerCase();
+	return (
+		// Sticky for the same reason the label is: the lane is far wider than
+		// the viewport once zoomed, so content anchored to the lane's left edge
+		// would sit off-screen.
+		<div className="playlistTimelinePreview">
+			{buckets.map((ts) => (
+				<img
+					key={ts}
+					className="playlistTimelinePreviewThumb"
+					src={`${THUMB_BASE}/${channel}/${ts}.jpg`}
+					onError={(e) => {
+						e.currentTarget.src = OFFLINE;
+					}}
+					alt=""
+				/>
+			))}
+		</div>
+	);
+}
+```
+
+- [ ] **Step 4: Add the CSS**
+
+```scss
+/* Sticky for the same reason .playlistTimelineLabel is — see the note there.
+ * The lane is zoom*100% wide, so anything anchored to its left edge sits
+ * off-screen the moment the user scrolls. */
+.playlistTimelinePreview {
+	position: sticky;
+	left: 0;
+	display: flex;
+	gap: 2px;
+	padding: 2px 0;
+}
+
+.playlistTimelinePreviewThumb {
+	height: 54px;
+	width: auto;
+}
+```
+
+- [ ] **Step 5: Wire it into the timeline**
+
+In `PlaylistTimeline.tsx`, add a ref and width measurement on the scroll
+container (there is already an `anchorRef` pattern on it to copy), then inside
+`bars.map`, after the `.playlistTimelineLabelTrack` div:
+
+```tsx
+{b.uid === selectedUid && b.entry && (
+	<LanePreview
+		entry={b.entry}
+		startMs={fractionToMs(startFrac, bounds)}
+		endMs={fractionToMs(endFrac, bounds)}
+		viewportPx={viewportPx}
+	/>
+)}
+```
+
+The lane grows to fit because `.playlistTimelineLane` has a fixed `height: 20px`
+— change it to `min-height: 20px` so an expanded lane can take the space.
+
+- [ ] **Step 6: Run the gates**
+
+Run: `pnpm exec tsc -b && pnpm exec eslint . && pnpm exec vitest run`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/frontend/src/Applications/PlaylistEditor/
+git commit -m "$(cat <<'EOF'
+feat(playlist): preview TV entries as a thumbnail strip
+
+Clicking a lane expands it to show thumbnails across the entry's visible span.
+The strip is sticky for the same reason the label is: the lane is zoom*100%
+wide, so content anchored to its left edge sits off-screen once scrolled.
+
+"More images as you zoom" is emergent rather than a code path — zooming widens
+the visible span, so more distinct 30s buckets become addressable.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 3 — Peaks pipeline and waveforms (PR 3)
+
+### Task 5: Peak extraction (pure)
+
+**Files:**
+- Create: `packages/tools/video-grabber/video_grabber/peaks/__init__.py` (empty)
+- Create: `packages/tools/video-grabber/video_grabber/peaks/extract.py`
+- Create: `packages/tools/video-grabber/tests/test_peaks_extract.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `PEAK_BUCKETS: int = 480`; `peaks_from_pcm(samples: bytes, buckets: int = PEAK_BUCKETS) -> list[list[int]]` returning `buckets` pairs of `[min, max]` scaled to -128..127. Task 6 calls it after running ffmpeg.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import struct
+
+from video_grabber.peaks.extract import PEAK_BUCKETS, peaks_from_pcm
+
+
+def pcm(values):
+    """Signed 16-bit little-endian mono, the format ffmpeg is asked for."""
+    return b"".join(struct.pack("<h", v) for v in values)
+
+
+def test_silence_yields_flat_peaks_rather_than_raising():
+    out = peaks_from_pcm(pcm([0] * 4800), buckets=10)
+    assert len(out) == 10
+    assert all(lo == 0 and hi == 0 for lo, hi in out)
+
+
+def test_full_scale_reaches_the_extremes():
+    out = peaks_from_pcm(pcm([32767, -32768] * 2400), buckets=10)
+    assert max(hi for _, hi in out) == 127
+    assert min(lo for lo, _ in out) == -128
+
+
+def test_bucket_count_is_fixed_regardless_of_length():
+    short = peaks_from_pcm(pcm([1000] * 1000))
+    long = peaks_from_pcm(pcm([1000] * 1_000_000))
+    assert len(short) == len(long) == PEAK_BUCKETS
+
+
+def test_a_file_shorter_than_the_bucket_count_still_fills_every_bucket():
+    out = peaks_from_pcm(pcm([500] * 10), buckets=100)
+    assert len(out) == 100
+
+
+def test_empty_input_yields_flat_peaks():
+    assert peaks_from_pcm(b"", buckets=5) == [[0, 0]] * 5
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `cd packages/tools/video-grabber && pytest tests/test_peaks_extract.py -v`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement**
+
+```python
+"""Reduce an audio file to a fixed-size amplitude envelope.
+
+A fixed bucket count is the point. The corpus runs from 40-second clips to
+6.75-hour position tapes, and storing per-file resolution would make the blob
+size and the renderer both variable for no benefit at preview size. 480 pairs
+is ~2 KB whatever the duration, and the component always draws 480 values
+across whatever width it has.
+"""
+from __future__ import annotations
+
+import struct
+
+PEAK_BUCKETS = 480
+
+
+def peaks_from_pcm(samples: bytes, buckets: int = PEAK_BUCKETS) -> list[list[int]]:
+    """Signed 16-bit mono PCM -> `buckets` [min, max] pairs scaled to -128..127.
+
+    Scaling to a byte range keeps the stored JSON small; a waveform drawn at
+    preview height cannot show more precision than that anyway.
+    """
+    count = len(samples) // 2
+    if count == 0:
+        return [[0, 0] for _ in range(buckets)]
+
+    values = struct.unpack(f"<{count}h", samples[: count * 2])
+    out: list[list[int]] = []
+    for i in range(buckets):
+        lo_idx = (i * count) // buckets
+        hi_idx = max(((i + 1) * count) // buckets, lo_idx + 1)
+        window = values[lo_idx:hi_idx]
+        if not window:
+            out.append([0, 0])
+            continue
+        out.append([min(window) >> 8, max(window) >> 8])
+    return out
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd packages/tools/video-grabber && pytest tests/test_peaks_extract.py -v && ruff check video_grabber/ tests/`
+Expected: PASS (5 tests), ruff clean
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/tools/video-grabber/video_grabber/peaks/ \
+        packages/tools/video-grabber/tests/test_peaks_extract.py
+git commit -m "$(cat <<'EOF'
+feat(peaks): reduce audio to a fixed-size amplitude envelope
+
+A fixed 480-bucket count regardless of duration: the corpus runs from
+40-second clips to 6.75-hour tapes, and per-file resolution would make both the
+stored blob and the renderer variable for no benefit at preview size. 480 pairs
+is ~2 KB whatever the file, and the component always draws 480 values.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 6: The compute-peaks flow
+
+**Files:**
+- Create: `packages/tools/video-grabber/video_grabber/peaks/flows.py`
+- Create: `packages/tools/video-grabber/tests/test_peaks_flows.py`
+- Modify: `packages/tools/video-grabber/video_grabber/serve.py` (register the deployment)
+- Modify: `Keeping-History/infra` → `apps/rt911/schema/snapshot.json` (add `mp3_items.peaks`)
+
+**Interfaces:**
+- Consumes: `peaks_from_pcm`, `PEAK_BUCKETS` (Task 5); `_page_mp3_items`, `key_from_url` from `video_grabber.catalogue.flows`.
+- Produces: `compute_peaks_flow(limit: int | None = None, force: bool = False, dry_run: bool = True)`, and the populated `mp3_items.peaks` field Task 7 reads.
+
+- [ ] **Step 1: Add the schema field in the infra repo**
+
+Regenerate the snapshot from the live database (the CLI's format is rejected by
+`POST /schema/diff`, and the snapshot must agree with the raw indexes already
+present):
+
+```bash
+kubectl -n video-grabber exec deploy/video-grabber-worker -- python -c "
+import httpx, json
+from video_grabber.config import Config
+from video_grabber.directus.writer import _auth_headers
+cfg = Config(); H = _auth_headers(cfg)
+snap = httpx.get(f'{cfg.directus_url}/schema/snapshot', headers=H, timeout=180).json()['data']
+tags = next(f for f in snap['fields'] if f['collection']=='mp3_items' and f['field']=='tags_curated')
+peaks = json.loads(json.dumps(tags))
+peaks['field'] = 'peaks'
+peaks['meta'] = {**peaks['meta'], 'field': 'peaks', 'readonly': True, 'interface': 'input-code',
+                 'note': 'Amplitude envelope: 480 [min,max] pairs. DERIVED by compute-peaks.'}
+peaks['schema'] = {**peaks['schema'], 'name': 'peaks'}
+snap['fields'].append(peaks)
+open('/tmp/peaks_snapshot.json','w').write(json.dumps(snap, indent=1, sort_keys=True))
+print('written')
+"
+kubectl -n video-grabber cp <worker-pod>:/tmp/peaks_snapshot.json \
+  /home/robbiebyrd/infra/apps/rt911/schema/snapshot.json
+```
+
+Commit and push to infra; the PreSync hook applies it. Verify with:
+
+```bash
+kubectl -n rt911 exec deploy/rt911-db -- psql -U directus -d directus -tAc \
+  "SELECT count(*) FROM information_schema.columns WHERE table_name='mp3_items' AND column_name='peaks';"
+```
+Expected: `1`
+
+- [ ] **Step 2: Write the failing flow test**
+
+```python
+from video_grabber.peaks.flows import should_compute
+
+
+def test_skips_rows_that_already_have_peaks():
+    assert should_compute({"peaks": [[0, 0]]}, force=False) is False
+
+
+def test_computes_rows_with_no_peaks():
+    assert should_compute({"peaks": None}, force=False) is True
+
+
+def test_force_recomputes_everything():
+    assert should_compute({"peaks": [[0, 0]]}, force=True) is True
+```
+
+- [ ] **Step 3: Run it to confirm it fails**
+
+Run: `cd packages/tools/video-grabber && pytest tests/test_peaks_flows.py -v`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 4: Implement the flow**
+
+```python
+"""Compute an amplitude envelope for every audio recording.
+
+Manual-only and dry_run=True by default, like identify-parties: it writes to
+the live catalogue, so nothing should schedule it.
+"""
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+import httpx
+from prefect import flow, get_run_logger
+
+from video_grabber.catalogue.flows import _page_mp3_items, key_from_url
+from video_grabber.config import Config
+from video_grabber.directus.writer import _auth_headers
+from video_grabber.peaks.extract import PEAK_BUCKETS, peaks_from_pcm
+from video_grabber.storage import wasabi
+
+
+def should_compute(row: dict, *, force: bool) -> bool:
+    """Idempotency marker is `peaks IS NOT NULL`, so a run is resumable."""
+    return force or not row.get("peaks")
+
+
+def pcm_for(path: Path) -> bytes:
+    """Decode to 8 kHz signed 16-bit mono — plenty for an envelope, and it
+    keeps a 6.75-hour tape's intermediate buffer under 200 MB."""
+    r = subprocess.run(
+        ["ffmpeg", "-v", "error", "-i", str(path),
+         "-ac", "1", "-ar", "8000", "-f", "s16le", "-"],
+        capture_output=True, check=True,
+    )
+    return r.stdout
+
+
+@flow(name="compute-peaks")
+def compute_peaks_flow(limit: int | None = None, force: bool = False,
+                       dry_run: bool = True) -> None:
+    logger = get_run_logger()
+    cfg = Config()
+    done = skipped = failed = 0
+
+    for row in _page_mp3_items(cfg, "id,url,peaks"):
+        if limit is not None and done >= limit:
+            break
+        if not should_compute(row, force=force):
+            skipped += 1
+            continue
+        key = key_from_url(row["url"])
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                local = Path(tmp) / "audio.mp3"
+                wasabi.download_file(key, local, cfg)
+                peaks = peaks_from_pcm(pcm_for(local), PEAK_BUCKETS)
+        except Exception as exc:
+            logger.warning("compute-peaks: %s failed: %s: %s", key, type(exc).__name__, exc)
+            failed += 1
+            continue
+
+        if dry_run:
+            logger.info("DRY RUN %s -> %d buckets", key, len(peaks))
+        else:
+            r = httpx.patch(f"{cfg.directus_url}/items/mp3_items/{row['id']}",
+                            json={"peaks": peaks}, headers=_auth_headers(cfg))
+            r.raise_for_status()
+        done += 1
+
+    logger.info("compute-peaks: %d computed, %d skipped, %d failed", done, skipped, failed)
+```
+
+- [ ] **Step 5: Register the deployment**
+
+In `video_grabber/serve.py`, beside `identify_parties_flow.to_deployment(...)`:
+
+```python
+compute_peaks_flow.to_deployment(name="compute-peaks"),
+```
+and add the import. Registering it is what made `enrich-parties-from-commission`
+unreachable when it was skipped once before.
+
+- [ ] **Step 6: Run the gates**
+
+Run: `cd packages/tools/video-grabber && pytest tests/ -v --ignore=tests/test_migrations.py && ruff check video_grabber/ tests/`
+Expected: PASS, ruff clean
+
+- [ ] **Step 7: Commit, then run for real**
+
+```bash
+git add packages/tools/video-grabber/
+git commit -m "$(cat <<'EOF'
+feat(peaks): compute-peaks flow over the audio corpus
+
+Manual-only and dry_run=True by default, like identify-parties: it writes to the
+live catalogue, so nothing should schedule it. Idempotent on `peaks IS NOT
+NULL`.
+
+Decodes at 8 kHz mono, which is ample for an envelope and keeps a 6.75-hour
+tape's intermediate buffer under 200 MB rather than several GB at source rate.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+After the image rolls: `compute-peaks limit=5 dry_run=true`, inspect, then
+`compute-peaks dry_run=false`.
+
+### Task 7: The waveform component
+
+**Files:**
+- Create: `packages/frontend/src/Applications/PlaylistEditor/PeaksWaveform.tsx`
+- Create: `packages/frontend/src/Applications/PlaylistEditor/PeaksWaveform.test.tsx`
+- Modify: `packages/frontend/src/Applications/PlaylistEditor/LanePreview.tsx` (add the radio branch)
+
+**Interfaces:**
+- Consumes: `previewKindOf` (Task 2); `peaks` from the Directus row (Task 6).
+- Produces: `<PeaksWaveform peaks={number[][]} height={number} />`.
+
+**Why not reuse `RadioScanner/WaveformVisualizer`.** That component's substance
+is Web Audio capture from an `HTMLAudioElement` plus animation-frame
+scheduling — it renders what is *playing*. A timeline entry is not playing, and
+sharing it would drag an `AudioContext` into a component that needs none.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { PeaksWaveform } from "./PeaksWaveform";
+
+afterEach(cleanup);
+
+describe("PeaksWaveform", () => {
+	it("renders a canvas sized to the requested height", () => {
+		const peaks = Array.from({ length: 480 }, (_, i) => [-i % 128, i % 128]);
+		const { container } = render(<PeaksWaveform peaks={peaks} height={40} />);
+		const canvas = container.querySelector("canvas");
+		expect(canvas).not.toBeNull();
+		expect(canvas!.height).toBe(40);
+	});
+
+	it("renders nothing when there are no peaks", () => {
+		const { container } = render(<PeaksWaveform peaks={[]} height={40} />);
+		expect(container).toBeEmptyDOMElement();
+	});
+});
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `pnpm --filter @rt911/frontend exec vitest run src/Applications/PlaylistEditor/PeaksWaveform.test.tsx`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement**
+
+```tsx
+import { useEffect, useRef } from "react";
+
+/**
+ * A static amplitude envelope drawn from precomputed peaks.
+ *
+ * Deliberately not an extension of RadioScanner's WaveformVisualizer: that one
+ * captures live audio from an HTMLAudioElement and renders what is playing. A
+ * timeline entry is not playing, and there is no shared logic between reading
+ * an AnalyserNode and drawing a fixed array.
+ */
+export function PeaksWaveform({
+	peaks,
+	height,
+}: {
+	peaks: number[][];
+	height: number;
+}) {
+	const ref = useRef<HTMLCanvasElement>(null);
+
+	useEffect(() => {
+		const canvas = ref.current;
+		if (!canvas) return;
+		const ctx = canvas.getContext("2d");
+		if (!ctx) return;
+		const { width } = canvas;
+		ctx.clearRect(0, 0, width, height);
+		ctx.fillStyle = "currentColor";
+		const mid = height / 2;
+		const step = width / peaks.length;
+		peaks.forEach(([lo, hi], i) => {
+			const top = mid - (hi / 128) * mid;
+			const bottom = mid - (lo / 128) * mid;
+			ctx.fillRect(i * step, top, Math.max(step, 1), Math.max(bottom - top, 1));
+		});
+	}, [peaks, height]);
+
+	if (peaks.length === 0) return null;
+	return <canvas ref={ref} height={height} className="playlistTimelineWaveform" />;
+}
+```
+
+- [ ] **Step 4: Fetch the peaks for the entry's span**
+
+A radio `MediaEntry` carries a **station slug**, not a recording id
+(`playlistTypes.ts`: `itemId` is "station slug"), and a window on that station
+can cover several `mp3_items` rows or none. So the waveform is assembled from
+whatever aired in the window, positioned by time — the same shape as the
+thumbnail strip, which is also time-positioned rather than item-positioned.
+
+Create `packages/frontend/src/Applications/PlaylistEditor/usePeaksForSpan.ts`:
+
+```ts
+import { useEffect, useState } from "react";
+import { directusUrl } from "../../Providers/Auth/directus"; // existing base-URL helper
+
+export type SpanPeaks = { startMs: number; endMs: number; peaks: number[][] };
+
+/**
+ * Recordings that aired on `station` during the span, with their envelopes.
+ *
+ * A radio entry names a station and a window, not a file, so the preview is
+ * whatever aired in that window — zero, one, or several recordings drawn at
+ * their own time positions.
+ */
+export function usePeaksForSpan(
+	station: string,
+	startMs: number,
+	endMs: number,
+): SpanPeaks[] {
+	const [rows, setRows] = useState<SpanPeaks[]>([]);
+	useEffect(() => {
+		const ctrl = new AbortController();
+		const qs = new URLSearchParams({
+			"filter[_and][0][source][_eq]": station,
+			"filter[_and][1][start_date][_between]":
+				`${new Date(startMs).toISOString()},${new Date(endMs).toISOString()}`,
+			fields: "start_date,calc_duration,peaks",
+			limit: "20",
+			sort: "start_date",
+		});
+		fetch(`${directusUrl()}/items/mp3_items?${qs}`, { signal: ctrl.signal })
+			.then((r) => (r.ok ? r.json() : { data: [] }))
+			.then((body) => {
+				setRows(
+					(body.data ?? [])
+						.filter((d: { peaks?: number[][] }) => d.peaks?.length)
+						.map((d: { start_date: string; calc_duration: number; peaks: number[][] }) => ({
+							startMs: Date.parse(`${d.start_date}Z`),
+							endMs: Date.parse(`${d.start_date}Z`) + d.calc_duration * 1000,
+							peaks: d.peaks,
+						})),
+				);
+			})
+			.catch(() => setRows([]));   // a failed preview stays quiet
+		return () => ctrl.abort();
+	}, [station, startMs, endMs]);
+	return rows;
+}
+```
+
+**`peaks` must be added to the public read field list**, the same way `tags` was:
+the anonymous policy on `mp3_items` enumerates its fields rather than granting
+`*`, so a new field is invisible until it is listed.
+
+- [ ] **Step 5: Add the radio branch to LanePreview**
+
+Replace the early `if (kind !== "tv") return null;` with:
+
+```tsx
+	if (kind === "radio") {
+		return <RadioLanePreview station={entry.itemId} startMs={startMs} endMs={endMs} />;
+	}
+	if (kind !== "tv") return null;
+```
+
+and add, in the same file:
+
+```tsx
+function RadioLanePreview({
+	station, startMs, endMs,
+}: { station: string; startMs: number; endMs: number }) {
+	const spans = usePeaksForSpan(station, startMs, endMs);
+	// Nothing aired, or compute-peaks has not reached these recordings yet:
+	// show nothing rather than an empty box, so a missing preview stays quiet.
+	if (spans.length === 0) return null;
+	const total = endMs - startMs;
+	return (
+		<div className="playlistTimelinePreview playlistTimelinePreviewRadio">
+			{spans.map((s) => (
+				<div
+					key={s.startMs}
+					className="playlistTimelineWaveformSlot"
+					style={{
+						left: `${((s.startMs - startMs) / total) * 100}%`,
+						width: `${((s.endMs - s.startMs) / total) * 100}%`,
+					}}
+				>
+					<PeaksWaveform peaks={s.peaks} height={40} />
+				</div>
+			))}
+		</div>
+	);
+}
+```
+
+Note `.playlistTimelinePreviewRadio` is `position: relative` and the slots are
+absolute, so each recording sits at its own moment in the entry's window — which
+also means this one is **not** sticky: it must stay aligned with the timeline it
+describes, unlike the thumbnail strip, which is a summary rather than a
+positioned overlay.
+
+- [ ] **Step 5: Run the gates**
+
+Run: `pnpm exec tsc -b && pnpm exec eslint . && pnpm exec vitest run`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/frontend/src/Applications/PlaylistEditor/
+git commit -m "$(cat <<'EOF'
+feat(playlist): preview radio entries as a waveform
+
+Draws the precomputed envelope from mp3_items.peaks. Deliberately not an
+extension of RadioScanner's WaveformVisualizer: that component captures live
+audio from an HTMLAudioElement and renders what is playing, which shares no
+logic with drawing a fixed array and would drag an AudioContext into a
+component that needs none.
+
+A recording compute-peaks has not reached yet shows no waveform rather than an
+empty box — a missing preview should be quiet.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+**Spec coverage.** Sticky labels → Task 1. Thumbnail strips with zoom-derived
+count → Tasks 3, 4. Waveforms → Tasks 5, 6, 7. Type discrimination → Task 2.
+Error handling table → Task 4 Step 3 (no room, wrong kind), Task 7 Step 4
+(missing peaks), existing `offline.jpg` fallback (Task 4). Out-of-scope items
+(playback, scrubbing) appear in no task, as intended.
+
+**Correction found during self-review.** The first draft of Task 7 read
+`entry.peaks`, assuming a playlist entry carries its recording's envelope. It
+does not: `MediaEntry` (`Providers/Playlist/playlistTypes.ts`) holds only
+`itemId`, which for radio is a **station slug**. A radio entry therefore names a
+station and a window, not a file, and that window may contain several
+recordings or none.
+
+Task 7 now fetches the recordings overlapping the span and draws each at its own
+time position. This also changes a design detail the spec got wrong: the radio
+preview is **not** sticky, because it is a positioned overlay that must stay
+aligned with the timeline beneath it, unlike the thumbnail strip which is a
+summary and should stay in view.
+
+**Second consequence.** `peaks` must be added to the anonymous read field list
+on `mp3_items`, which enumerates fields rather than granting `*` — a new field
+is invisible to the frontend until listed, the same trap `tags` hit.
+
+**Spec amendment needed.** `plans/2026-08-17-timeline-lane-preview-design.md`
+describes radio previews as one waveform per entry. Update its "Radio waveforms"
+and "Components" sections to match before executing Phase 3.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 18.1.2
       classicy:
         specifier: latest
-        version: 0.75.1(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/dlv@1.1.5)(@types/react@19.2.18)(immer@11.1.16)(react-dom@19.2.8(react@19.2.8))(react-player@3.4.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zustand@5.0.14(@types/react@19.2.18)(immer@11.1.16)(react@19.2.8))
+        version: 0.75.2(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/dlv@1.1.5)(@types/react@19.2.18)(immer@11.1.16)(react-dom@19.2.8(react@19.2.8))(react-player@3.4.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zustand@5.0.14(@types/react@19.2.18)(immer@11.1.16)(react@19.2.8))
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -1035,8 +1035,8 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
-  classicy@0.75.1:
-    resolution: {integrity: sha512-7mwX5pl+Y5sE8WXBNRzth1luLKUpOySr1Kew+5oM63ZvpnAkFE7gnrTWmqcl6W6PtSwCtFMpuXa6SERpxl459g==}
+  classicy@0.75.2:
+    resolution: {integrity: sha512-EF/PFtPg/rgN8CezvP2cymrIKkXgwfoZgRzpsn4ZzMBi1p4wjShc0PSLw5JRDD/4w77jxe0kd80KVDgxN/Rf1Q==}
     peerDependencies:
       '@tanstack/react-table': ^8.21.3
       immer: ^11.1.8
@@ -3462,7 +3462,7 @@ snapshots:
       readdirp: 5.0.0
     optional: true
 
-  classicy@0.75.1(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/dlv@1.1.5)(@types/react@19.2.18)(immer@11.1.16)(react-dom@19.2.8(react@19.2.8))(react-player@3.4.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zustand@5.0.14(@types/react@19.2.18)(immer@11.1.16)(react@19.2.8)):
+  classicy@0.75.2(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/dlv@1.1.5)(@types/react@19.2.18)(immer@11.1.16)(react-dom@19.2.8(react@19.2.8))(react-player@3.4.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zustand@5.0.14(@types/react@19.2.18)(immer@11.1.16)(react@19.2.8)):
     dependencies:
       '@analytics/google-tag-manager': 0.6.0
       '@noble/hashes': 2.3.0


### PR DESCRIPTION
## What

Two changes to the Playlist Editor timeline, both about keeping a lane legible while the user scrolls and zooms.

**Sticky lane labels.** A media item's name used to be painted inside its bar, so scrolling a long entry pushed the name off-screen and left an anonymous stripe. The label now lives in its own track above the bar and is `position: sticky; left: 0`, so it stays pinned to the visible left edge for as long as any part of its entry is on screen.

**Click-to-preview.** Selecting an entry opens a preview strip beneath its label. TV entries show a row of thumbnails; the count is derived from the entry's *visible* span and the viewport width, so zooming in reveals more frames rather than stretching the same ones.

## Why it looks like this

`position: sticky` resolves against the nearest ancestor with a **scrolling box**, and `overflow: hidden` counts as one — which is why the label track clips with `clip-path: inset(0)` instead. `clip-path` clips without creating a scroll container, so the sticky label still resolves against the timeline's real scroller.

The sticky element also needs `width: fit-content`. A block-level box that already fills its containing block has nowhere to shift to, so sticky positioning is a no-op on it — the label appeared stuck only because it happened to start at the left edge. This was found by testing, not by reading.

Thumbnail selection buckets at a fixed 30-second granularity (`thumbnailBuckets.ts`) rather than at whatever the current zoom implies. Continuous zoom would otherwise request a different URL on every animation frame — an early build issued roughly 360 image requests during a single drag. Bucketing makes repeated views of the same span hit the browser cache.

## Testing

- `vitest` unit coverage for `thumbnailBuckets` (fencepost, zero-width viewport, sub-bucket spans) and for `fractionToMs` as the inverse of `timeToFraction`
- Playwright e2e asserting the label stays within the viewport across a scroll

## Notes for review

- The View menu's Zoom In/Out path sets zoom without an anchor point; `measureView()` had to be hoisted above the `anchor === null` early return or menu-driven zoom would skip re-measuring and leave the preview showing a stale span.
- Radio waveform previews are deliberately **not** here — they need a `peaks` column and a backfill, and ship separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
