### PR TITLE
feat(playlist-editor): waveform previews for radio timeline entries

### DIFF
--- a/packages/frontend/src/Applications/PlaylistEditor/LanePreview.test.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/LanePreview.test.tsx
@@ -1,24 +1,55 @@
-import { cleanup, render, waitFor } from "@testing-library/react";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { enqueue } from "./directusQueue";
 import { LanePreview } from "./LanePreview";
+import { FULL_BOUNDS } from "./timelineLayout";
 
 afterEach(() => {
 	cleanup();
 	vi.unstubAllGlobals();
 });
 
-const span = { startMs: Date.UTC(2001, 8, 11, 12, 0), endMs: Date.UTC(2001, 8, 11, 12, 30) };
+/** The entry's own committed window: half an hour on 11 September. */
+const ENTRY_START = Date.UTC(2001, 8, 11, 12, 0);
+const ENTRY_END = Date.UTC(2001, 8, 11, 12, 30);
+
+/**
+ * A viewport showing only that half hour of the ten-day track — i.e. deeply
+ * zoomed in, which is where a slot laid out against the VISIBLE span instead of
+ * the track lands somewhere else entirely.
+ */
+const props = {
+	visibleStartMs: ENTRY_START,
+	visibleEndMs: ENTRY_END,
+	viewportPx: 400,
+	entryStartMs: ENTRY_START,
+	entryEndMs: ENTRY_END,
+	bounds: FULL_BOUNDS,
+};
+
+const TRACK_MS = FULL_BOUNDS.endMs - FULL_BOUNDS.startMs;
 
 function stubFetchJson(data: unknown) {
-	vi.stubGlobal(
-		"fetch",
-		vi.fn(async () => ({ ok: true, json: async () => ({ data }) }) as Response),
-	);
+	const spy = vi.fn(async () => ({ ok: true, json: async () => ({ data }) }) as Response);
+	vi.stubGlobal("fetch", spy);
+	return spy;
+}
+
+/**
+ * Let every queued Directus call settle and its state update flush.
+ * `directusGet` serializes on a module-global promise chain, so enqueuing a
+ * no-op behind the pending request is a deterministic "everything before me has
+ * finished" — no timers, no arbitrary microtask counting.
+ */
+async function drainDirectusQueue() {
+	await act(async () => {
+		await enqueue(async () => undefined);
+	});
 }
 
 describe("LanePreview", () => {
 	it("renders a thumbnail strip for TV entries", () => {
-		render(<LanePreview group="tv" channel="cnn" {...span} viewportPx={400} />);
+		render(<LanePreview group="tv" channel="cnn" {...props} />);
 		// alt="" downgrades <img> to the "presentation" role, dropping it out of
 		// getByRole("img") even with { hidden: true } — query by class instead,
 		// matching this file's existing convention (jest-dom is not installed).
@@ -28,36 +59,37 @@ describe("LanePreview", () => {
 	});
 
 	it("renders nothing for a group with no preview", () => {
-		const { container } = render(
-			<LanePreview group="flights" channel="AA11" {...span} viewportPx={400} />,
-		);
+		const { container } = render(<LanePreview group="flights" channel="AA11" {...props} />);
 		expect(container.firstChild).toBeNull();
 	});
 
 	it("renders nothing when there is no room", () => {
-		const { container } = render(
-			<LanePreview group="tv" channel="cnn" {...span} viewportPx={0} />,
-		);
+		const { container } = render(<LanePreview group="tv" channel="cnn" {...props} viewportPx={0} />);
 		expect(container.firstChild).toBeNull();
 	});
 
-	it("renders nothing for radio when nothing aired in the span", () => {
-		stubFetchJson([]);
-		const { container } = render(
-			<LanePreview group="radio" channel="WCBS" {...span} viewportPx={400} />,
-		);
+	it("renders nothing for radio when nothing aired in the entry's window", async () => {
+		const spy = stubFetchJson([]);
+		const { container } = render(<LanePreview group="radio" channel="WCBS" {...props} />);
+
+		// Asserting straight after render would pass no matter what the stub
+		// returned — no state update from the fetch can have flushed yet. The
+		// assertion is only worth anything once the request has SETTLED.
+		await waitFor(() => expect(spy).toHaveBeenCalled());
+		await drainDirectusQueue();
+
+		expect(container.querySelector(".playlistTimelinePreviewRadio")).toBeNull();
+		expect(container.querySelector(".playlistTimelineWaveformSlot")).toBeNull();
 		expect(container.firstChild).toBeNull();
 	});
 
-	it("renders a non-sticky waveform slot per recording that aired in the span", async () => {
+	it("positions each waveform slot against the timeline bounds, not the visible span", async () => {
 		stubFetchJson([
 			{ start_date: "2001-09-11T12:05:00", calc_duration: 60, peaks: [[-5, 5]] },
 			// no peaks yet — compute-peaks hasn't reached this row — dropped
 			{ start_date: "2001-09-11T12:10:00", calc_duration: 60, peaks: [] },
 		]);
-		const { container } = render(
-			<LanePreview group="radio" channel="WCBS" {...span} viewportPx={400} />,
-		);
+		const { container } = render(<LanePreview group="radio" channel="WCBS" {...props} />);
 
 		await waitFor(() =>
 			expect(container.querySelectorAll(".playlistTimelineWaveformSlot")).toHaveLength(1),
@@ -67,13 +99,60 @@ describe("LanePreview", () => {
 		// PlaylistEditor.scss and is keyed off this class — jsdom doesn't apply
 		// external stylesheets, so this asserts the class is present rather than
 		// the computed position.
-		const wrapper = container.querySelector(".playlistTimelinePreviewRadio");
-		expect(wrapper).not.toBeNull();
+		expect(container.querySelector(".playlistTimelinePreviewRadio")).not.toBeNull();
 
 		const slot = container.querySelector<HTMLElement>(".playlistTimelineWaveformSlot")!;
-		// Recording starts 5min into a 30min span → left = 5/30 ≈ 16.67%.
-		expect(slot.style.left).toBe(`${(5 / 30) * 100}%`);
-		expect(slot.style.width).toBe(`${(1 / 30) * 100}%`);
+		// The containing block is the lane, which spans the WHOLE zoomed track —
+		// so a percentage here is a fraction of the ten-day bounds, worked out
+		// from first principles rather than from the layout helper under test.
+		const recordingStart = Date.UTC(2001, 8, 11, 12, 5);
+		const expectedLeft = ((recordingStart - FULL_BOUNDS.startMs) / TRACK_MS) * 100;
+		const expectedWidth = (60_000 / TRACK_MS) * 100;
+		expect(parseFloat(slot.style.left)).toBeCloseTo(expectedLeft, 6);
+		expect(parseFloat(slot.style.width)).toBeCloseTo(expectedWidth, 6);
+
+		// …and emphatically NOT the visible-span fractions the strip used to
+		// compute (5/30 and 1/30 of the half-hour window), which at this zoom
+		// would paint the recording about 1.7 days into the track.
+		expect(parseFloat(slot.style.left)).not.toBeCloseTo((5 / 30) * 100, 2);
+		expect(parseFloat(slot.style.width)).not.toBeCloseTo((1 / 30) * 100, 2);
+
 		expect(slot.querySelector("canvas")).not.toBeNull();
+	});
+
+	it("does not refetch when the visible span moves under an unchanged entry", async () => {
+		const spy = stubFetchJson([
+			{ start_date: "2001-09-11T12:05:00", calc_duration: 60, peaks: [[-5, 5]] },
+		]);
+		const { container, rerender } = render(<LanePreview group="radio" channel="WCBS" {...props} />);
+		await waitFor(() =>
+			expect(container.querySelectorAll(".playlistTimelineWaveformSlot")).toHaveLength(1),
+		);
+		expect(spy).toHaveBeenCalledTimes(1);
+
+		// A pan: the scroll viewport now covers a different stretch of track, but
+		// the SELECTED ENTRY has not changed. Before the fix this was the fetch
+		// key, so a three-second pan fired ~60 unabortable Directus requests.
+		for (const shift of [60_000, 120_000, 180_000]) {
+			rerender(
+				<LanePreview
+					group="radio"
+					channel="WCBS"
+					{...props}
+					visibleStartMs={ENTRY_START + shift}
+					visibleEndMs={ENTRY_END + shift}
+					viewportPx={400 + shift / 60_000}
+				/>,
+			);
+		}
+		await drainDirectusQueue();
+		expect(spy).toHaveBeenCalledTimes(1);
+
+		// Control: the entry's own window IS a fetch key, so committing an edge
+		// drag still refetches — proving the assertion above can fail.
+		rerender(
+			<LanePreview group="radio" channel="WCBS" {...props} entryEndMs={ENTRY_END + 600_000} />,
+		);
+		await waitFor(() => expect(spy).toHaveBeenCalledTimes(2));
 	});
 });

--- a/packages/frontend/src/Applications/PlaylistEditor/LanePreview.test.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/LanePreview.test.tsx
@@ -1,10 +1,20 @@
-import { cleanup, render } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { LanePreview } from "./LanePreview";
 
-afterEach(cleanup);
+afterEach(() => {
+	cleanup();
+	vi.unstubAllGlobals();
+});
 
 const span = { startMs: Date.UTC(2001, 8, 11, 12, 0), endMs: Date.UTC(2001, 8, 11, 12, 30) };
+
+function stubFetchJson(data: unknown) {
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(async () => ({ ok: true, json: async () => ({ data }) }) as Response),
+	);
+}
 
 describe("LanePreview", () => {
 	it("renders a thumbnail strip for TV entries", () => {
@@ -19,7 +29,7 @@ describe("LanePreview", () => {
 
 	it("renders nothing for a group with no preview", () => {
 		const { container } = render(
-			<LanePreview group="radio" channel="wcbs" {...span} viewportPx={400} />,
+			<LanePreview group="flights" channel="AA11" {...span} viewportPx={400} />,
 		);
 		expect(container.firstChild).toBeNull();
 	});
@@ -29,5 +39,41 @@ describe("LanePreview", () => {
 			<LanePreview group="tv" channel="cnn" {...span} viewportPx={0} />,
 		);
 		expect(container.firstChild).toBeNull();
+	});
+
+	it("renders nothing for radio when nothing aired in the span", () => {
+		stubFetchJson([]);
+		const { container } = render(
+			<LanePreview group="radio" channel="WCBS" {...span} viewportPx={400} />,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it("renders a non-sticky waveform slot per recording that aired in the span", async () => {
+		stubFetchJson([
+			{ start_date: "2001-09-11T12:05:00", calc_duration: 60, peaks: [[-5, 5]] },
+			// no peaks yet — compute-peaks hasn't reached this row — dropped
+			{ start_date: "2001-09-11T12:10:00", calc_duration: 60, peaks: [] },
+		]);
+		const { container } = render(
+			<LanePreview group="radio" channel="WCBS" {...span} viewportPx={400} />,
+		);
+
+		await waitFor(() =>
+			expect(container.querySelectorAll(".playlistTimelineWaveformSlot")).toHaveLength(1),
+		);
+
+		// The non-sticky CSS rule (position: relative) lives in
+		// PlaylistEditor.scss and is keyed off this class — jsdom doesn't apply
+		// external stylesheets, so this asserts the class is present rather than
+		// the computed position.
+		const wrapper = container.querySelector(".playlistTimelinePreviewRadio");
+		expect(wrapper).not.toBeNull();
+
+		const slot = container.querySelector<HTMLElement>(".playlistTimelineWaveformSlot")!;
+		// Recording starts 5min into a 30min span → left = 5/30 ≈ 16.67%.
+		expect(slot.style.left).toBe(`${(5 / 30) * 100}%`);
+		expect(slot.style.width).toBe(`${(1 / 30) * 100}%`);
+		expect(slot.querySelector("canvas")).not.toBeNull();
 	});
 });

--- a/packages/frontend/src/Applications/PlaylistEditor/LanePreview.test.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/LanePreview.test.tsx
@@ -85,9 +85,9 @@ describe("LanePreview", () => {
 
 	it("positions each waveform slot against the timeline bounds, not the visible span", async () => {
 		stubFetchJson([
-			{ start_date: "2001-09-11T12:05:00", calc_duration: 60, peaks: [[-5, 5]] },
+			{ id: 11, start_date: "2001-09-11T12:05:00", calc_duration: 60, peaks: [[-5, 5]] },
 			// no peaks yet — compute-peaks hasn't reached this row — dropped
-			{ start_date: "2001-09-11T12:10:00", calc_duration: 60, peaks: [] },
+			{ id: 12, start_date: "2001-09-11T12:10:00", calc_duration: 60, peaks: [] },
 		]);
 		const { container } = render(<LanePreview group="radio" channel="WCBS" {...props} />);
 
@@ -120,9 +120,55 @@ describe("LanePreview", () => {
 		expect(slot.querySelector("canvas")).not.toBeNull();
 	});
 
+	it("draws every recording that shares a start time, once each, across a refetch", async () => {
+		// `(station, start_date)` is NOT unique in production: 20 collision groups
+		// across the corpus, 17 of them with differing durations. `UA93 @
+		// 2001-09-11T13:34:00` is three rows (451/452/453) of 26 s, 86 s and 52 s.
+		// Keyed on the start instant, the three slots are indistinguishable to
+		// React's reconciler.
+		const rows = [
+			// Ends at 12:01, so it drops out of the window in the second pass
+			// below — an edge drag that moves the entry's start past it.
+			{ id: 300, start_date: "2001-09-11T12:00:00", calc_duration: 60, peaks: [[-1, 1]] },
+			{ id: 451, start_date: "2001-09-11T12:05:00", calc_duration: 26, peaks: [[-5, 5]] },
+			{ id: 452, start_date: "2001-09-11T12:05:00", calc_duration: 86, peaks: [[-6, 6]] },
+			{ id: 453, start_date: "2001-09-11T12:05:00", calc_duration: 52, peaks: [[-7, 7]] },
+		];
+		stubFetchJson(rows);
+		const { container, rerender } = render(<LanePreview group="radio" channel="UA93" {...props} />);
+
+		// Each slot's width IS its recording's duration (as a fraction of the
+		// ten-day track), so distinct durations make a lost or duplicated slot
+		// legible rather than hiding behind three identical boxes.
+		const slotDurationsSec = () =>
+			[...container.querySelectorAll<HTMLElement>(".playlistTimelineWaveformSlot")].map(
+				(s) => Math.round((parseFloat(s.style.width) / 100) * TRACK_MS) / 1000,
+			);
+
+		await waitFor(() => expect(slotDurationsSec()).toEqual([60, 26, 86, 52]));
+
+		// Commit an edge drag that starts the entry after the 12:00 recording. The
+		// refetch returns the same rows; overlappingSpans drops the first. That
+		// breaks the reconciler's lockstep at index 0, which is exactly where a
+		// non-unique key stops being a warning and starts producing wrong DOM:
+		// React cannot match the surviving duplicates to their previous fibers, so
+		// the stale ones are neither reused nor deleted and the list ends up
+		// [26, 86, 26, 86, 52] — the same audio painted twice.
+		rerender(
+			<LanePreview
+				group="radio"
+				channel="UA93"
+				{...props}
+				entryStartMs={Date.UTC(2001, 8, 11, 12, 3)}
+			/>,
+		);
+		await drainDirectusQueue();
+		expect(slotDurationsSec()).toEqual([26, 86, 52]);
+	});
+
 	it("does not refetch when the visible span moves under an unchanged entry", async () => {
 		const spy = stubFetchJson([
-			{ start_date: "2001-09-11T12:05:00", calc_duration: 60, peaks: [[-5, 5]] },
+			{ id: 11, start_date: "2001-09-11T12:05:00", calc_duration: 60, peaks: [[-5, 5]] },
 		]);
 		const { container, rerender } = render(<LanePreview group="radio" channel="WCBS" {...props} />);
 		await waitFor(() =>

--- a/packages/frontend/src/Applications/PlaylistEditor/LanePreview.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/LanePreview.tsx
@@ -1,14 +1,17 @@
+import { PeaksWaveform } from "./PeaksWaveform";
 import { thumbnailBuckets } from "./thumbnailBuckets";
+import { usePeaksForSpan } from "./usePeaksForSpan";
 
 const THUMB_BASE = "https://files.911realtime.org/thumbnails";
 const OFFLINE = `${THUMB_BASE}/offline.jpg`;
 
 /**
  * The expanded lane content shown for the selected bar: a strip of TV
- * thumbnails across the entry's visible span. `group`/`channel` come straight
- * off the `TimelineBar` the caller already laid out (`b.group`, `b.label` —
- * `label` is the entry's `itemId`, i.e. the channel slug) rather than a
- * re-derived `MediaEntry`, since that is all layoutBars ever carried.
+ * thumbnails, or a radio waveform, across the entry's visible span.
+ * `group`/`channel` come straight off the `TimelineBar` the caller already
+ * laid out (`b.group`, `b.label` — `label` is the entry's `itemId`, i.e. the
+ * channel/station slug) rather than a re-derived `MediaEntry`, since that is
+ * all layoutBars ever carried.
  *
  * `startMs`/`endMs` are the *visible* span — the caller
  * (`PlaylistTimeline.tsx`) intersects the entry's own window with the timeline
@@ -16,10 +19,9 @@ const OFFLINE = `${THUMB_BASE}/offline.jpg`;
  * intersection is empty. This component never sees the entry's full extent, so
  * zooming and panning walk the strip through the footage rather than
  * re-sampling the same ten days. `viewportPx` is the scroll viewport's width,
- * which is how much room the sticky strip has to lay tiles out in.
+ * which is how much room the sticky TV strip has to lay tiles out in.
  *
- * Radio gets its own branch in a later task; every other group renders
- * nothing here.
+ * `flights` renders nothing here.
  */
 export function LanePreview({
 	group,
@@ -34,6 +36,9 @@ export function LanePreview({
 	endMs: number;
 	viewportPx: number;
 }) {
+	if (group === "radio") {
+		return <RadioLanePreview station={channel} startMs={startMs} endMs={endMs} />;
+	}
 	if (group !== "tv") return null;
 
 	const buckets = thumbnailBuckets({ startMs, endMs, viewportPx });
@@ -55,6 +60,51 @@ export function LanePreview({
 					}}
 					alt=""
 				/>
+			))}
+		</div>
+	);
+}
+
+/**
+ * A radio entry names a station and a time window, not a single recording
+ * (`playlistTypes.ts`: a `MediaEntry`'s `itemId` is a station slug for radio).
+ * The window can span several `mp3_items` rows or none, so the preview is
+ * assembled from whatever aired in it, each drawn at its own time position —
+ * the same shape as the TV thumbnail strip above, which is also
+ * time-positioned rather than item-positioned.
+ *
+ * Unlike that strip, this preview is `position: relative`, not sticky: it is
+ * a time-positioned overlay whose slots must stay aligned with the timeline
+ * beneath them as the user scrolls, rather than a summary that should stay in
+ * view.
+ */
+function RadioLanePreview({
+	station,
+	startMs,
+	endMs,
+}: {
+	station: string;
+	startMs: number;
+	endMs: number;
+}) {
+	const spans = usePeaksForSpan(station, startMs, endMs);
+	// Nothing aired, or compute-peaks has not reached these recordings yet:
+	// show nothing rather than an empty box, so a missing preview stays quiet.
+	if (spans.length === 0) return null;
+	const total = endMs - startMs;
+	return (
+		<div className="playlistTimelinePreview playlistTimelinePreviewRadio">
+			{spans.map((s) => (
+				<div
+					key={s.startMs}
+					className="playlistTimelineWaveformSlot"
+					style={{
+						left: `${((s.startMs - startMs) / total) * 100}%`,
+						width: `${((s.endMs - s.startMs) / total) * 100}%`,
+					}}
+				>
+					<PeaksWaveform peaks={s.peaks} height={40} />
+				</div>
 			))}
 		</div>
 	);

--- a/packages/frontend/src/Applications/PlaylistEditor/LanePreview.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/LanePreview.tsx
@@ -133,7 +133,11 @@ function RadioLanePreview({
 				const rightFrac = msToFraction(s.endMs, bounds);
 				return (
 					<div
-						key={s.startMs}
+						// The row id, never the start instant: `(station,
+						// start_date)` is not unique in production, and two
+						// recordings sharing a key make the reconciler duplicate or
+						// omit slots the next time the row set changes.
+						key={s.id}
 						className="playlistTimelineWaveformSlot"
 						style={{
 							left: `${leftFrac * 100}%`,

--- a/packages/frontend/src/Applications/PlaylistEditor/LanePreview.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/LanePreview.tsx
@@ -1,47 +1,79 @@
 import { PeaksWaveform } from "./PeaksWaveform";
 import { thumbnailBuckets } from "./thumbnailBuckets";
+import { msToFraction, type TimelineBounds } from "./timelineLayout";
 import { usePeaksForSpan } from "./usePeaksForSpan";
 
 const THUMB_BASE = "https://files.911realtime.org/thumbnails";
 const OFFLINE = `${THUMB_BASE}/offline.jpg`;
 
+/** Matches `.playlistTimelinePreviewRadio`'s height in PlaylistEditor.scss. */
+const WAVEFORM_HEIGHT = 40;
+
 /**
  * The expanded lane content shown for the selected bar: a strip of TV
- * thumbnails, or a radio waveform, across the entry's visible span.
+ * thumbnails, or a radio waveform.
  * `group`/`channel` come straight off the `TimelineBar` the caller already
  * laid out (`b.group`, `b.label` — `label` is the entry's `itemId`, i.e. the
  * channel/station slug) rather than a re-derived `MediaEntry`, since that is
  * all layoutBars ever carried.
  *
- * `startMs`/`endMs` are the *visible* span — the caller
- * (`PlaylistTimeline.tsx`) intersects the entry's own window with the timeline
- * scroll viewport before calling, and renders nothing at all when that
- * intersection is empty. This component never sees the entry's full extent, so
- * zooming and panning walk the strip through the footage rather than
- * re-sampling the same ten days. `viewportPx` is the scroll viewport's width,
- * which is how much room the sticky TV strip has to lay tiles out in.
+ * The two branches want different spans, and conflating them is the bug this
+ * component was rewritten around:
+ *
+ * - **TV** is a sticky *summary* strip, so it takes the VISIBLE span —
+ *   `visibleStartMs`/`visibleEndMs`, the entry's window intersected with the
+ *   scroll viewport by the caller (`PlaylistTimeline.tsx`). Zooming and panning
+ *   walk the strip through the footage rather than re-sampling the same ten
+ *   days. `viewportPx` is the scroll viewport's width, which is how much room
+ *   the strip has to lay tiles out in. It renders nothing when the intersection
+ *   is empty.
+ * - **Radio** is a *time-positioned overlay* that has to stay aligned with the
+ *   footage beneath it, so it ignores the visible span entirely: it fetches on
+ *   the entry's own committed window (`entryStartMs`/`entryEndMs`) and lays its
+ *   slots out as fractions of `bounds`, the same space `.playlistTimelineBar`
+ *   is positioned in. The lane is `position: relative` and spans the whole
+ *   zoomed track, so a percentage on an absolutely-positioned child is already
+ *   track-relative — measuring against the viewport instead put a 12:05
+ *   recording a day and a half into a ten-day track at high zoom.
  *
  * `flights` renders nothing here.
  */
 export function LanePreview({
 	group,
 	channel,
-	startMs,
-	endMs,
+	visibleStartMs,
+	visibleEndMs,
 	viewportPx,
+	entryStartMs,
+	entryEndMs,
+	bounds,
 }: {
 	group: "tv" | "radio" | "flights";
 	channel: string;
-	startMs: number;
-	endMs: number;
+	visibleStartMs: number;
+	visibleEndMs: number;
 	viewportPx: number;
+	entryStartMs: number;
+	entryEndMs: number;
+	bounds: TimelineBounds;
 }) {
 	if (group === "radio") {
-		return <RadioLanePreview station={channel} startMs={startMs} endMs={endMs} />;
+		return (
+			<RadioLanePreview
+				station={channel}
+				startMs={entryStartMs}
+				endMs={entryEndMs}
+				bounds={bounds}
+			/>
+		);
 	}
 	if (group !== "tv") return null;
 
-	const buckets = thumbnailBuckets({ startMs, endMs, viewportPx });
+	const buckets = thumbnailBuckets({
+		startMs: visibleStartMs,
+		endMs: visibleEndMs,
+		viewportPx,
+	});
 	if (buckets.length === 0) return null;
 
 	const slug = channel.toLowerCase();
@@ -69,43 +101,49 @@ export function LanePreview({
  * A radio entry names a station and a time window, not a single recording
  * (`playlistTypes.ts`: a `MediaEntry`'s `itemId` is a station slug for radio).
  * The window can span several `mp3_items` rows or none, so the preview is
- * assembled from whatever aired in it, each drawn at its own time position —
- * the same shape as the TV thumbnail strip above, which is also
- * time-positioned rather than item-positioned.
+ * assembled from whatever aired in it, each drawn at its own time position.
  *
- * Unlike that strip, this preview is `position: relative`, not sticky: it is
- * a time-positioned overlay whose slots must stay aligned with the timeline
- * beneath them as the user scrolls, rather than a summary that should stay in
- * view.
+ * Each slot is positioned against the TIMELINE BOUNDS, not against the entry's
+ * window or the viewport, because that is the space its containing block is
+ * laid out in. A recording that starts before the window and runs into it draws
+ * at its true extent rather than being clipped to the window — the envelope
+ * maps to the whole recording, so trimming the box would misalign the drawing
+ * from the audio it depicts. `.playlistTimelinePreviewRadio` clips at the track
+ * edge instead.
  */
 function RadioLanePreview({
 	station,
 	startMs,
 	endMs,
+	bounds,
 }: {
 	station: string;
 	startMs: number;
 	endMs: number;
+	bounds: TimelineBounds;
 }) {
 	const spans = usePeaksForSpan(station, startMs, endMs);
 	// Nothing aired, or compute-peaks has not reached these recordings yet:
 	// show nothing rather than an empty box, so a missing preview stays quiet.
 	if (spans.length === 0) return null;
-	const total = endMs - startMs;
 	return (
 		<div className="playlistTimelinePreview playlistTimelinePreviewRadio">
-			{spans.map((s) => (
-				<div
-					key={s.startMs}
-					className="playlistTimelineWaveformSlot"
-					style={{
-						left: `${((s.startMs - startMs) / total) * 100}%`,
-						width: `${((s.endMs - s.startMs) / total) * 100}%`,
-					}}
-				>
-					<PeaksWaveform peaks={s.peaks} height={40} />
-				</div>
-			))}
+			{spans.map((s) => {
+				const leftFrac = msToFraction(s.startMs, bounds);
+				const rightFrac = msToFraction(s.endMs, bounds);
+				return (
+					<div
+						key={s.startMs}
+						className="playlistTimelineWaveformSlot"
+						style={{
+							left: `${leftFrac * 100}%`,
+							width: `${(rightFrac - leftFrac) * 100}%`,
+						}}
+					>
+						<PeaksWaveform peaks={s.peaks} height={WAVEFORM_HEIGHT} />
+					</div>
+				);
+			})}
 		</div>
 	);
 }

--- a/packages/frontend/src/Applications/PlaylistEditor/PeaksWaveform.test.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PeaksWaveform.test.tsx
@@ -1,0 +1,22 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { PeaksWaveform } from "./PeaksWaveform";
+
+afterEach(cleanup);
+
+describe("PeaksWaveform", () => {
+	it("renders a canvas sized to the requested height", () => {
+		const peaks = Array.from({ length: 480 }, (_, i) => [-i % 128, i % 128]);
+		const { container } = render(<PeaksWaveform peaks={peaks} height={40} />);
+		const canvas = container.querySelector("canvas");
+		expect(canvas).not.toBeNull();
+		expect(canvas!.height).toBe(40);
+	});
+
+	it("renders nothing when there are no peaks", () => {
+		const { container } = render(<PeaksWaveform peaks={[]} height={40} />);
+		// No jest-dom in this repo: assert absence directly rather than via
+		// toBeEmptyDOMElement.
+		expect(container.firstChild).toBeNull();
+	});
+});

--- a/packages/frontend/src/Applications/PlaylistEditor/PeaksWaveform.test.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PeaksWaveform.test.tsx
@@ -1,13 +1,70 @@
-import { cleanup, render } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { PeaksWaveform } from "./PeaksWaveform";
 
-afterEach(cleanup);
+afterEach(() => {
+	cleanup();
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+	// `clientWidth` lives on Element.prototype; the stub below shadows it with
+	// an own property on HTMLCanvasElement.prototype, which has to come back off
+	// or it leaks into every other file in the run.
+	Reflect.deleteProperty(HTMLCanvasElement.prototype, "clientWidth");
+});
+
+type Rect = [number, number, number, number];
+
+/**
+ * jsdom has no canvas 2D context at all, so the drawing path is unreachable
+ * without one. This records just enough of it to assert what got drawn and in
+ * what color.
+ */
+function fakeContext() {
+	const rects: Rect[] = [];
+	const ctx = {
+		fillStyle: "#000000",
+		clearRect: vi.fn(),
+		fillRect: (...r: Rect) => {
+			rects.push(r);
+		},
+	};
+	vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+		ctx as unknown as CanvasRenderingContext2D,
+	);
+	return { ctx, rects };
+}
+
+/** Stand in for layout: jsdom lays nothing out, so clientWidth is always 0. */
+function stubClientWidth(width: () => number) {
+	Object.defineProperty(HTMLCanvasElement.prototype, "clientWidth", {
+		configurable: true,
+		get: width,
+	});
+}
+
+/** A ResizeObserver whose callback the test can fire on demand. */
+function controllableResizeObserver() {
+	const callbacks: (() => void)[] = [];
+	class Stub {
+		constructor(cb: () => void) {
+			callbacks.push(cb);
+		}
+		observe() {}
+		unobserve() {}
+		disconnect() {}
+	}
+	vi.stubGlobal("ResizeObserver", Stub);
+	return () => {
+		for (const cb of callbacks) cb();
+	};
+}
+
+const peaks = Array.from({ length: 8 }, (_, i) => [-(i + 1) * 8, (i + 1) * 8]);
 
 describe("PeaksWaveform", () => {
 	it("renders a canvas sized to the requested height", () => {
-		const peaks = Array.from({ length: 480 }, (_, i) => [-i % 128, i % 128]);
-		const { container } = render(<PeaksWaveform peaks={peaks} height={40} />);
+		const tall = Array.from({ length: 480 }, (_, i) => [-i % 128, i % 128]);
+		const { container } = render(<PeaksWaveform peaks={tall} height={40} />);
 		const canvas = container.querySelector("canvas");
 		expect(canvas).not.toBeNull();
 		expect(canvas!.height).toBe(40);
@@ -18,5 +75,55 @@ describe("PeaksWaveform", () => {
 		// No jest-dom in this repo: assert absence directly rather than via
 		// toBeEmptyDOMElement.
 		expect(container.firstChild).toBeNull();
+	});
+
+	it("sizes the bitmap to the laid-out width instead of the 300px default", () => {
+		fakeContext();
+		stubClientWidth(() => 137);
+		const { container } = render(<PeaksWaveform peaks={peaks} height={40} />);
+		const canvas = container.querySelector("canvas")!;
+		expect(canvas.width).toBe(137);
+	});
+
+	it("fills with a real color, not the unparseable currentColor keyword", () => {
+		const { ctx, rects } = fakeContext();
+		stubClientWidth(() => 120);
+		render(<PeaksWaveform peaks={peaks} height={40} />);
+		// Assigning "currentColor" to a canvas fillStyle is silently ignored, so
+		// the old code drew every waveform in the #000000 default.
+		expect(ctx.fillStyle).not.toBe("currentColor");
+		expect(ctx.fillStyle).toMatch(/^(#|rgb)/);
+		expect(rects).toHaveLength(peaks.length);
+		// One column per peak pair, spread across the laid-out width.
+		expect(rects[0][0]).toBe(0);
+		expect(rects[rects.length - 1][0]).toBeCloseTo((120 / peaks.length) * (peaks.length - 1), 6);
+	});
+
+	it("resizes and redraws its bitmap when the slot's width changes", () => {
+		const { rects } = fakeContext();
+		let width = 40;
+		stubClientWidth(() => width);
+		const fireResize = controllableResizeObserver();
+
+		const { container } = render(<PeaksWaveform peaks={peaks} height={40} />);
+		const canvas = container.querySelector("canvas")!;
+		expect(canvas.width).toBe(40);
+		const drawnAtFirstWidth = rects.length;
+
+		// Zooming in widens the slot; without the observer the bitmap would keep
+		// its first resolution and CSS would upscale it.
+		width = 800;
+		act(() => fireResize());
+		expect(canvas.width).toBe(800);
+		expect(rects.length).toBe(drawnAtFirstWidth * 2);
+		expect(rects[rects.length - 1][0]).toBeCloseTo((800 / peaks.length) * (peaks.length - 1), 6);
+	});
+
+	it("draws nothing while the slot has no measurable width", () => {
+		const { ctx, rects } = fakeContext();
+		stubClientWidth(() => 0);
+		render(<PeaksWaveform peaks={peaks} height={40} />);
+		expect(rects).toHaveLength(0);
+		expect(ctx.clearRect).not.toHaveBeenCalled();
 	});
 });

--- a/packages/frontend/src/Applications/PlaylistEditor/PeaksWaveform.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PeaksWaveform.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * A static amplitude envelope drawn from precomputed peaks.
+ *
+ * Deliberately not an extension of RadioScanner's WaveformVisualizer: that one
+ * captures live audio from an HTMLAudioElement and renders what is playing. A
+ * timeline entry is not playing, and there is no shared logic between reading
+ * an AnalyserNode and drawing a fixed array.
+ *
+ * `peaks` is `mp3_items.peaks`: an array of `[min, max]` pairs scaled to
+ * -128..127 (matching the compute-peaks pipeline's int8 range).
+ */
+export function PeaksWaveform({
+	peaks,
+	height,
+}: {
+	peaks: number[][];
+	height: number;
+}) {
+	const ref = useRef<HTMLCanvasElement>(null);
+
+	useEffect(() => {
+		const canvas = ref.current;
+		if (!canvas) return;
+		const ctx = canvas.getContext("2d");
+		// jsdom (unit tests) has no canvas 2D context; nothing to draw there.
+		if (!ctx) return;
+		const { width } = canvas;
+		ctx.clearRect(0, 0, width, height);
+		ctx.fillStyle = "currentColor";
+		const mid = height / 2;
+		const step = width / peaks.length;
+		peaks.forEach(([lo, hi], i) => {
+			const top = mid - (hi / 128) * mid;
+			const bottom = mid - (lo / 128) * mid;
+			ctx.fillRect(i * step, top, Math.max(step, 1), Math.max(bottom - top, 1));
+		});
+	}, [peaks, height]);
+
+	if (peaks.length === 0) return null;
+	return <canvas ref={ref} height={height} className="playlistTimelineWaveform" />;
+}

--- a/packages/frontend/src/Applications/PlaylistEditor/PeaksWaveform.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PeaksWaveform.tsx
@@ -23,21 +23,49 @@ export function PeaksWaveform({
 	useEffect(() => {
 		const canvas = ref.current;
 		if (!canvas) return;
-		const ctx = canvas.getContext("2d");
-		// jsdom (unit tests) has no canvas 2D context; nothing to draw there.
-		if (!ctx) return;
-		const { width } = canvas;
-		ctx.clearRect(0, 0, width, height);
-		ctx.fillStyle = "currentColor";
-		const mid = height / 2;
-		const step = width / peaks.length;
-		peaks.forEach(([lo, hi], i) => {
-			const top = mid - (hi / 128) * mid;
-			const bottom = mid - (lo / 128) * mid;
-			ctx.fillRect(i * step, top, Math.max(step, 1), Math.max(bottom - top, 1));
-		});
+
+		const draw = () => {
+			const ctx = canvas.getContext("2d");
+			// jsdom (unit tests) has no canvas 2D context; nothing to draw there.
+			if (!ctx) return;
+			// The bitmap has to be sized from layout every time. The slot this
+			// canvas fills is a TIME SPAN of the track, so its CSS width ranges
+			// from a couple of pixels to hundreds and changes on every zoom step;
+			// leaving the bitmap at the 300px default just hands CSS the job of
+			// squashing or upscaling one fixed drawing into whatever box it got.
+			const width = Math.round(canvas.clientWidth);
+			if (width < 1) return;
+			// Assigning either dimension resets the bitmap (and its context
+			// state), so both are set before anything is drawn.
+			if (canvas.width !== width) canvas.width = width;
+			if (canvas.height !== height) canvas.height = height;
+			ctx.clearRect(0, 0, width, height);
+			// NOT "currentColor": that is a CSS keyword, not a color a canvas
+			// context can parse, so per spec the assignment is dropped silently
+			// and fillStyle stays #000000 — invisible on a dark lane. Resolve the
+			// inherited color to a real value first.
+			ctx.fillStyle = getComputedStyle(canvas).color || "#000000";
+			const mid = height / 2;
+			const step = width / peaks.length;
+			peaks.forEach(([lo, hi], i) => {
+				const top = mid - (hi / 128) * mid;
+				const bottom = mid - (lo / 128) * mid;
+				ctx.fillRect(i * step, top, Math.max(step, 1), Math.max(bottom - top, 1));
+			});
+		};
+
+		draw();
+		// Redrawing on resize is not optional here: the slot's width follows the
+		// zoom level, and without this the envelope would keep whatever bitmap
+		// resolution it was first laid out at.
+		if (typeof ResizeObserver === "undefined") return;
+		const ro = new ResizeObserver(draw);
+		ro.observe(canvas);
+		return () => ro.disconnect();
 	}, [peaks, height]);
 
 	if (peaks.length === 0) return null;
+	// The height attribute is set here as well as in the effect so the element
+	// has a sane intrinsic aspect before it has ever been laid out.
 	return <canvas ref={ref} height={height} className="playlistTimelineWaveform" />;
 }

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.scss
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.scss
@@ -237,6 +237,12 @@ $lane-bar-height: 20px;
 	// the canvas has an explicit pixel height, and stretching it to a
 	// differently-sized CSS box would distort the drawn envelope.
 	height: 40px;
+	// Undoes .playlistTimelinePreview's `padding: 2px 0`. There is no global
+	// `box-sizing: border-box` in this app, so that padding is ADDED to the
+	// 40px: the padding box becomes 44px, the slot's `height: 100%` resolves
+	// against it, and the 40px canvas bitmap gets upscaled ~10% vertically —
+	// exactly the distortion the height above exists to prevent.
+	padding: 0;
 	margin-top: $lane-bar-height;
 	// The slots are positioned in TRACK time, and a recording can overrun the
 	// timeline bounds at either end (it is drawn at its true extent so the

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.scss
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.scss
@@ -224,6 +224,37 @@ $lane-bar-height: 20px;
 	width: auto;
 }
 
+/* The radio preview is a time-positioned overlay, not a summary strip: each
+ * recording sits at its own moment within the entry's window, so — unlike
+ * .playlistTimelinePreview above — this one is `position: relative` and must
+ * NOT be sticky. Sticky would decouple the slots from the timeline positions
+ * they are meant to align with as the user scrolls. */
+.playlistTimelinePreviewRadio {
+	position: relative;
+	left: 0;
+	width: 100%;
+	// Matches the `height={40}` passed to PeaksWaveform (RadioLanePreview):
+	// the canvas has an explicit pixel height, and stretching it to a
+	// differently-sized CSS box would distort the drawn envelope.
+	height: 40px;
+	margin-top: $lane-bar-height;
+}
+
+.playlistTimelineWaveformSlot {
+	position: absolute;
+	top: 0;
+	height: 100%;
+	overflow: hidden;
+}
+
+.playlistTimelineWaveform {
+	display: block;
+	width: 100%;
+	height: 100%;
+	/* fillStyle: "currentColor" in PeaksWaveform picks up whatever text color
+	 * this inherits from the lane — no override needed here. */
+}
+
 /* Add Settings dropdown: the div only anchors position measurement; the menu
  * itself is a ClassicyContextualMenu (position: fixed), because the palette
  * window's overflow: hidden clips anything absolutely positioned inside it. */

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.scss
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.scss
@@ -238,6 +238,11 @@ $lane-bar-height: 20px;
 	// differently-sized CSS box would distort the drawn envelope.
 	height: 40px;
 	margin-top: $lane-bar-height;
+	// The slots are positioned in TRACK time, and a recording can overrun the
+	// timeline bounds at either end (it is drawn at its true extent so the
+	// envelope stays aligned with the audio it depicts). Clip at the track edge
+	// rather than letting a slot paint into the scroll overflow.
+	overflow: hidden;
 }
 
 .playlistTimelineWaveformSlot {
@@ -251,8 +256,12 @@ $lane-bar-height: 20px;
 	display: block;
 	width: 100%;
 	height: 100%;
-	/* fillStyle: "currentColor" in PeaksWaveform picks up whatever text color
-	 * this inherits from the lane — no override needed here. */
+	/* PeaksWaveform resolves the drawing color with getComputedStyle().color,
+	 * so the envelope follows whatever `color` this element inherits from the
+	 * lane — set one here if the waveform ever needs its own. It cannot be done
+	 * by assigning "currentColor" to the canvas fillStyle: that is a CSS
+	 * keyword, not a color a canvas context parses, and the assignment is
+	 * dropped silently, leaving everything painted #000. */
 }
 
 /* Add Settings dropdown: the div only anchors position measurement; the menu

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistTimeline.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistTimeline.tsx
@@ -408,13 +408,16 @@ export function PlaylistTimeline({
 								const fadeEnd = b.fadeEnd && dragging?.edge !== "end";
 								const handleCursor = (edge: "start" | "end") =>
 									edgeCursor(dragging?.edge === edge ? (dragging.dir ?? "lr") : "lr");
-								// The preview samples the part of the entry that is ON SCREEN,
+								// The TV strip samples the part of the entry that is ON SCREEN,
 								// not its whole span — an entry with no bounds covers all ten
 								// days, and six thumbnails forty hours apart preview nothing.
 								// Intersecting with the scroll window is what makes zooming and
-								// panning walk the strip through the footage.
+								// panning walk the strip through the footage. The radio waveform
+								// wants the opposite (see LanePreview): it is positioned in track
+								// space, so it takes the entry's committed window and `bounds`
+								// below and ignores these two entirely.
 								//
-								// It reads b.startFrac/b.endFrac rather than the drag-preview
+								// Both read b.startFrac/b.endFrac rather than the drag-preview
 								// fractions above deliberately: following a live edge drag would
 								// re-derive the bucket set on every snapped minute and issue a
 								// fresh row of <img src>es each time — 193 image requests, measured,
@@ -475,13 +478,16 @@ export function PlaylistTimeline({
 										>
 											<span className="playlistTimelineLabel">{b.label}</span>
 										</div>
-										{b.uid === selectedUid && previewEnd > previewStart && (
+										{b.uid === selectedUid && (
 											<LanePreview
 												group={b.group}
 												channel={b.label}
-												startMs={fractionToMs(previewStart, bounds)}
-												endMs={fractionToMs(previewEnd, bounds)}
+												visibleStartMs={fractionToMs(previewStart, bounds)}
+												visibleEndMs={fractionToMs(previewEnd, bounds)}
 												viewportPx={view.clientWidth}
+												entryStartMs={fractionToMs(b.startFrac, bounds)}
+												entryEndMs={fractionToMs(b.endFrac, bounds)}
+												bounds={bounds}
 											/>
 										)}
 									</div>

--- a/packages/frontend/src/Applications/PlaylistEditor/timelineLayout.ts
+++ b/packages/frontend/src/Applications/PlaylistEditor/timelineLayout.ts
@@ -151,9 +151,22 @@ export function rulerLabels(zoom: number, bounds: TimelineBounds = FULL_BOUNDS):
 	});
 }
 
+/**
+ * A UTC instant as a fraction of the timeline bounds, UNCLAMPED.
+ *
+ * Anything laid out as a percentage inside the track is in this space — the
+ * track is `zoom * 100%` wide and every child positions against it, so a
+ * fraction here is the one unit that stays meaningful at every zoom level.
+ * Unclamped because a *span* (a recording overlapping the bounds, say) has to
+ * keep its true width: clamping one end would silently stretch or squash it.
+ * {@link timeToFraction} clamps, because a bar's own bounds are meant to.
+ */
+export function msToFraction(ms: number, bounds: TimelineBounds = FULL_BOUNDS): number {
+	return (ms - bounds.startMs) / (bounds.endMs - bounds.startMs);
+}
+
 export function timeToFraction(iso: string, bounds: TimelineBounds = FULL_BOUNDS): number {
-	const frac = (playlistUtcMs(iso) - bounds.startMs) / (bounds.endMs - bounds.startMs);
-	return Math.min(1, Math.max(0, frac));
+	return Math.min(1, Math.max(0, msToFraction(playlistUtcMs(iso), bounds)));
 }
 
 /** The inverse of {@link timeToFraction}: a track fraction back to a UTC ms instant. */

--- a/packages/frontend/src/Applications/PlaylistEditor/usePeaksForSpan.test.ts
+++ b/packages/frontend/src/Applications/PlaylistEditor/usePeaksForSpan.test.ts
@@ -14,13 +14,9 @@ describe("usePeaksForSpan", () => {
 		const fetchFn = vi.fn(async () =>
 			jsonResponse({
 				data: [
-					{
-						start_date: "2001-09-11T12:00:00",
-						calc_duration: 30,
-						peaks: [[-10, 10]],
-					},
+					{ id: 901, start_date: "2001-09-11T12:00:00", calc_duration: 30, peaks: [[-10, 10]] },
 					// no peaks yet (compute-peaks hasn't reached this row) — dropped
-					{ start_date: "2001-09-11T12:01:00", calc_duration: 20, peaks: [] },
+					{ id: 902, start_date: "2001-09-11T12:01:00", calc_duration: 20, peaks: [] },
 				],
 			}),
 		);
@@ -31,10 +27,16 @@ describe("usePeaksForSpan", () => {
 
 		await waitFor(() => expect(result.current).toHaveLength(1));
 		expect(result.current[0]).toEqual({
+			id: 901,
 			startMs: WINDOW_START,
 			endMs: WINDOW_START + 30_000,
 			peaks: [[-10, 10]],
 		});
+		// The row id is what keys the rendered slot, so the query has to ask for
+		// it — without the projection every span would arrive id-less.
+		expect(decodeURIComponent(String((fetchFn.mock.calls[0] as unknown[])[0]))).toContain(
+			"fields=id,start_date,calc_duration,peaks",
+		);
 	});
 
 	it("includes a recording that started before the window and runs into it", async () => {
@@ -45,9 +47,9 @@ describe("usePeaksForSpan", () => {
 		const fetchFn = vi.fn(async () =>
 			jsonResponse({
 				data: [
-					{ start_date: "2001-09-11T11:50:00", calc_duration: 1800, peaks: [[-3, 3]] },
+					{ id: 903, start_date: "2001-09-11T11:50:00", calc_duration: 1800, peaks: [[-3, 3]] },
 					// Ends five minutes before the window opens: no overlap, dropped.
-					{ start_date: "2001-09-11T11:50:00", calc_duration: 300, peaks: [[-9, 9]] },
+					{ id: 904, start_date: "2001-09-11T11:50:00", calc_duration: 300, peaks: [[-9, 9]] },
 				],
 			}),
 		);
@@ -112,24 +114,32 @@ describe("overlappingSpans", () => {
 	it("keeps a row that straddles either edge and drops one that misses entirely", () => {
 		const rows = [
 			// straddles the start
-			{ start_date: "2001-09-11T11:50:00", calc_duration: 1800, peaks: [[-1, 1]] },
+			{ id: 905, start_date: "2001-09-11T11:50:00", calc_duration: 1800, peaks: [[-1, 1]] },
 			// straddles the end
-			{ start_date: "2001-09-11T12:25:00", calc_duration: 1800, peaks: [[-2, 2]] },
+			{ id: 906, start_date: "2001-09-11T12:25:00", calc_duration: 1800, peaks: [[-2, 2]] },
 			// wholly before
-			{ start_date: "2001-09-11T11:00:00", calc_duration: 60, peaks: [[-3, 3]] },
+			{ id: 907, start_date: "2001-09-11T11:00:00", calc_duration: 60, peaks: [[-3, 3]] },
 			// wholly after
-			{ start_date: "2001-09-11T13:00:00", calc_duration: 60, peaks: [[-4, 4]] },
+			{ id: 908, start_date: "2001-09-11T13:00:00", calc_duration: 60, peaks: [[-4, 4]] },
 		];
 		expect(overlappingSpans(rows, WINDOW_START, WINDOW_END).map((s) => s.peaks[0][1])).toEqual([
 			1, 2,
 		]);
 	});
 
+	it("drops a row with no id, since the id is the slot's only unique key", () => {
+		const rows = [
+			{ start_date: "2001-09-11T12:05:00", calc_duration: 10, peaks: [[-1, 1]] },
+			{ id: 920, start_date: "2001-09-11T12:05:00", calc_duration: 20, peaks: [[-2, 2]] },
+		];
+		expect(overlappingSpans(rows, WINDOW_START, WINDOW_END).map((s) => s.id)).toEqual([920]);
+	});
+
 	it("drops rows with no usable duration rather than emitting a zero-width slot", () => {
 		const rows = [
-			{ start_date: "2001-09-11T12:05:00", peaks: [[-1, 1]] },
-			{ start_date: "2001-09-11T12:06:00", calc_duration: 0, peaks: [[-2, 2]] },
-			{ start_date: "2001-09-11T12:07:00", calc_duration: 10, peaks: [[-3, 3]] },
+			{ id: 909, start_date: "2001-09-11T12:05:00", peaks: [[-1, 1]] },
+			{ id: 910, start_date: "2001-09-11T12:06:00", calc_duration: 0, peaks: [[-2, 2]] },
+			{ id: 911, start_date: "2001-09-11T12:07:00", calc_duration: 10, peaks: [[-3, 3]] },
 		];
 		const spans = overlappingSpans(rows, WINDOW_START, WINDOW_END);
 		expect(spans).toHaveLength(1);

--- a/packages/frontend/src/Applications/PlaylistEditor/usePeaksForSpan.test.ts
+++ b/packages/frontend/src/Applications/PlaylistEditor/usePeaksForSpan.test.ts
@@ -1,10 +1,13 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { usePeaksForSpan } from "./usePeaksForSpan";
+import { overlappingSpans, usePeaksForSpan } from "./usePeaksForSpan";
 
 function jsonResponse(data: unknown, ok = true): Response {
 	return { ok, json: async () => data } as Response;
 }
+
+const WINDOW_START = Date.UTC(2001, 8, 11, 12, 0);
+const WINDOW_END = Date.UTC(2001, 8, 11, 12, 30);
 
 describe("usePeaksForSpan", () => {
 	it("returns recordings that have peaks, positioned by their own start/duration", async () => {
@@ -23,49 +26,113 @@ describe("usePeaksForSpan", () => {
 		);
 
 		const { result } = renderHook(() =>
-			usePeaksForSpan(
-				"WCBS",
-				Date.UTC(2001, 8, 11, 12, 0),
-				Date.UTC(2001, 8, 11, 12, 30),
-				fetchFn as unknown as typeof fetch,
-			),
+			usePeaksForSpan("WCBS", WINDOW_START, WINDOW_END, fetchFn as unknown as typeof fetch),
 		);
 
 		await waitFor(() => expect(result.current).toHaveLength(1));
 		expect(result.current[0]).toEqual({
-			startMs: Date.UTC(2001, 8, 11, 12, 0),
-			endMs: Date.UTC(2001, 8, 11, 12, 0) + 30_000,
+			startMs: WINDOW_START,
+			endMs: WINDOW_START + 30_000,
 			peaks: [[-10, 10]],
 		});
+	});
+
+	it("includes a recording that started before the window and runs into it", async () => {
+		// 30 minutes of WCBS starting at 11:50 — its START is outside a
+		// 12:00–12:30 window, so a `start_date BETWEEN` predicate alone drops it
+		// and the preview comes up blank exactly when you have zoomed in far
+		// enough to care.
+		const fetchFn = vi.fn(async () =>
+			jsonResponse({
+				data: [
+					{ start_date: "2001-09-11T11:50:00", calc_duration: 1800, peaks: [[-3, 3]] },
+					// Ends five minutes before the window opens: no overlap, dropped.
+					{ start_date: "2001-09-11T11:50:00", calc_duration: 300, peaks: [[-9, 9]] },
+				],
+			}),
+		);
+
+		const { result } = renderHook(() =>
+			usePeaksForSpan("WCBS", WINDOW_START, WINDOW_END, fetchFn as unknown as typeof fetch),
+		);
+
+		await waitFor(() => expect(result.current).toHaveLength(1));
+		expect(result.current[0].startMs).toBe(Date.UTC(2001, 8, 11, 11, 50));
+
+		// The server-side half of the predicate has to reach back far enough for
+		// that row to be returned at all: `end_date` is not readable anonymously,
+		// so the overlap is completed client-side over a lookback window.
+		const query = decodeURIComponent(String((fetchFn.mock.calls[0] as unknown[])[0]));
+		const between = /filter\[start_date\]\[_between\]=([^&]+)/.exec(query)?.[1];
+		expect(between).toBeDefined();
+		const [lowerBound, upperBound] = between!.split(",");
+		expect(Date.parse(lowerBound)).toBeLessThanOrEqual(Date.UTC(2001, 8, 11, 11, 50));
+		expect(Date.parse(upperBound)).toBe(WINDOW_END);
 	});
 
 	it("filters by the station's source slug", async () => {
 		const fetchFn = vi.fn(async () => jsonResponse({ data: [] }));
 		renderHook(() =>
-			usePeaksForSpan(
-				"WCBS",
-				Date.UTC(2001, 8, 11, 12, 0),
-				Date.UTC(2001, 8, 11, 12, 30),
-				fetchFn as unknown as typeof fetch,
-			),
+			usePeaksForSpan("NEADS/NORAD", WINDOW_START, WINDOW_END, fetchFn as unknown as typeof fetch),
 		);
 		await waitFor(() => expect(fetchFn).toHaveBeenCalled());
 		const url = String((fetchFn.mock.calls[0] as unknown[])[0]);
 		expect(url).toContain("/items/mp3_items?");
-		expect(decodeURIComponent(url)).toContain("filter[source][slug][_eq]=WCBS");
+		// The slash in the slug must be escaped, not concatenated into the query.
+		expect(url).toContain("NEADS%2FNORAD");
+		expect(decodeURIComponent(url)).toContain("filter[source][slug][_eq]=NEADS/NORAD");
 	});
 
 	it("stays quiet (empty) on a failed fetch", async () => {
 		const fetchFn = vi.fn(async () => jsonResponse({}, false));
 		const { result } = renderHook(() =>
-			usePeaksForSpan(
-				"WCBS",
-				Date.UTC(2001, 8, 11, 12, 0),
-				Date.UTC(2001, 8, 11, 12, 30),
-				fetchFn as unknown as typeof fetch,
-			),
+			usePeaksForSpan("WCBS", WINDOW_START, WINDOW_END, fetchFn as unknown as typeof fetch),
 		);
 		await waitFor(() => expect(fetchFn).toHaveBeenCalled());
 		expect(result.current).toEqual([]);
+	});
+
+	it("does not refetch when the caller passes a fresh fetch lambda each render", async () => {
+		const inner = vi.fn(async () => jsonResponse({ data: [] }));
+		const { rerender } = renderHook(() =>
+			// A new function identity on every render — the shape any inline
+			// `() => fetch(...)` caller has. Before the fix this sat in the effect's
+			// dependency array and refetched forever.
+			usePeaksForSpan("WCBS", WINDOW_START, WINDOW_END, (() =>
+				inner()) as unknown as typeof fetch),
+		);
+		await waitFor(() => expect(inner).toHaveBeenCalledTimes(1));
+		rerender();
+		rerender();
+		await waitFor(() => expect(inner).toHaveBeenCalledTimes(1));
+	});
+});
+
+describe("overlappingSpans", () => {
+	it("keeps a row that straddles either edge and drops one that misses entirely", () => {
+		const rows = [
+			// straddles the start
+			{ start_date: "2001-09-11T11:50:00", calc_duration: 1800, peaks: [[-1, 1]] },
+			// straddles the end
+			{ start_date: "2001-09-11T12:25:00", calc_duration: 1800, peaks: [[-2, 2]] },
+			// wholly before
+			{ start_date: "2001-09-11T11:00:00", calc_duration: 60, peaks: [[-3, 3]] },
+			// wholly after
+			{ start_date: "2001-09-11T13:00:00", calc_duration: 60, peaks: [[-4, 4]] },
+		];
+		expect(overlappingSpans(rows, WINDOW_START, WINDOW_END).map((s) => s.peaks[0][1])).toEqual([
+			1, 2,
+		]);
+	});
+
+	it("drops rows with no usable duration rather than emitting a zero-width slot", () => {
+		const rows = [
+			{ start_date: "2001-09-11T12:05:00", peaks: [[-1, 1]] },
+			{ start_date: "2001-09-11T12:06:00", calc_duration: 0, peaks: [[-2, 2]] },
+			{ start_date: "2001-09-11T12:07:00", calc_duration: 10, peaks: [[-3, 3]] },
+		];
+		const spans = overlappingSpans(rows, WINDOW_START, WINDOW_END);
+		expect(spans).toHaveLength(1);
+		expect(spans[0].endMs - spans[0].startMs).toBe(10_000);
 	});
 });

--- a/packages/frontend/src/Applications/PlaylistEditor/usePeaksForSpan.test.ts
+++ b/packages/frontend/src/Applications/PlaylistEditor/usePeaksForSpan.test.ts
@@ -1,0 +1,71 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { usePeaksForSpan } from "./usePeaksForSpan";
+
+function jsonResponse(data: unknown, ok = true): Response {
+	return { ok, json: async () => data } as Response;
+}
+
+describe("usePeaksForSpan", () => {
+	it("returns recordings that have peaks, positioned by their own start/duration", async () => {
+		const fetchFn = vi.fn(async () =>
+			jsonResponse({
+				data: [
+					{
+						start_date: "2001-09-11T12:00:00",
+						calc_duration: 30,
+						peaks: [[-10, 10]],
+					},
+					// no peaks yet (compute-peaks hasn't reached this row) — dropped
+					{ start_date: "2001-09-11T12:01:00", calc_duration: 20, peaks: [] },
+				],
+			}),
+		);
+
+		const { result } = renderHook(() =>
+			usePeaksForSpan(
+				"WCBS",
+				Date.UTC(2001, 8, 11, 12, 0),
+				Date.UTC(2001, 8, 11, 12, 30),
+				fetchFn as unknown as typeof fetch,
+			),
+		);
+
+		await waitFor(() => expect(result.current).toHaveLength(1));
+		expect(result.current[0]).toEqual({
+			startMs: Date.UTC(2001, 8, 11, 12, 0),
+			endMs: Date.UTC(2001, 8, 11, 12, 0) + 30_000,
+			peaks: [[-10, 10]],
+		});
+	});
+
+	it("filters by the station's source slug", async () => {
+		const fetchFn = vi.fn(async () => jsonResponse({ data: [] }));
+		renderHook(() =>
+			usePeaksForSpan(
+				"WCBS",
+				Date.UTC(2001, 8, 11, 12, 0),
+				Date.UTC(2001, 8, 11, 12, 30),
+				fetchFn as unknown as typeof fetch,
+			),
+		);
+		await waitFor(() => expect(fetchFn).toHaveBeenCalled());
+		const url = String((fetchFn.mock.calls[0] as unknown[])[0]);
+		expect(url).toContain("/items/mp3_items?");
+		expect(decodeURIComponent(url)).toContain("filter[source][slug][_eq]=WCBS");
+	});
+
+	it("stays quiet (empty) on a failed fetch", async () => {
+		const fetchFn = vi.fn(async () => jsonResponse({}, false));
+		const { result } = renderHook(() =>
+			usePeaksForSpan(
+				"WCBS",
+				Date.UTC(2001, 8, 11, 12, 0),
+				Date.UTC(2001, 8, 11, 12, 30),
+				fetchFn as unknown as typeof fetch,
+			),
+		);
+		await waitFor(() => expect(fetchFn).toHaveBeenCalled());
+		expect(result.current).toEqual([]);
+	});
+});

--- a/packages/frontend/src/Applications/PlaylistEditor/usePeaksForSpan.ts
+++ b/packages/frontend/src/Applications/PlaylistEditor/usePeaksForSpan.ts
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+import { directusGet } from "./directusQueue";
+
+export type SpanPeaks = { startMs: number; endMs: number; peaks: number[][] };
+
+interface Mp3ItemRow {
+	start_date?: string;
+	calc_duration?: number;
+	peaks?: number[][];
+}
+
+/** Parse a Directus/UTC datetime string to epoch ms (append Z when tz-less). */
+function toMs(value: string): number {
+	const s = /Z$|[+-]\d{2}:\d{2}$/.test(value) ? value : `${value}Z`;
+	return new Date(s).getTime();
+}
+
+/**
+ * Recordings that aired on `station` during the span, with their envelopes.
+ *
+ * A radio `MediaEntry` carries a station slug and a time window, not a
+ * recording id (`playlistTypes.ts`: `itemId` is "station slug"), and a window
+ * on that station can cover several `mp3_items` rows or none. So the preview
+ * is assembled from whatever aired in the window — zero, one, or several
+ * recordings, each drawn at its own time position — the same shape as the TV
+ * thumbnail strip, which is also time-positioned rather than item-positioned.
+ *
+ * `mp3_items.source` is a relation to the station; filtering on
+ * `source.slug` (not `source` itself) is required for the same reason
+ * `stationLogos.ts` projects `source.slug` rather than `source`.
+ */
+export function usePeaksForSpan(
+	station: string,
+	startMs: number,
+	endMs: number,
+	fetchFn: typeof fetch = fetch,
+): SpanPeaks[] {
+	const [rows, setRows] = useState<SpanPeaks[]>([]);
+
+	useEffect(() => {
+		let alive = true;
+		const qs = new URLSearchParams({
+			"filter[source][slug][_eq]": station,
+			"filter[start_date][_between]": `${new Date(startMs).toISOString()},${new Date(endMs).toISOString()}`,
+			fields: "start_date,calc_duration,peaks",
+			limit: "20",
+			sort: "start_date",
+		});
+		directusGet(`/items/mp3_items?${qs.toString()}`, fetchFn)
+			.then((data) => {
+				if (!alive) return;
+				setRows(
+					(data as Mp3ItemRow[])
+						.filter((d): d is Mp3ItemRow & { start_date: string; peaks: number[][] } =>
+							typeof d.start_date === "string" && Array.isArray(d.peaks) && d.peaks.length > 0,
+						)
+						.map((d) => {
+							const start = toMs(d.start_date);
+							return {
+								startMs: start,
+								endMs: start + (d.calc_duration ?? 0) * 1000,
+								peaks: d.peaks,
+							};
+						}),
+				);
+			})
+			.catch(() => {
+				// A failed preview stays quiet rather than surfacing an error state.
+				if (alive) setRows([]);
+			});
+		return () => {
+			alive = false;
+		};
+	}, [station, startMs, endMs, fetchFn]);
+
+	return rows;
+}

--- a/packages/frontend/src/Applications/PlaylistEditor/usePeaksForSpan.ts
+++ b/packages/frontend/src/Applications/PlaylistEditor/usePeaksForSpan.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { directusGet } from "./directusQueue";
 
 export type SpanPeaks = { startMs: number; endMs: number; peaks: number[][] };
@@ -9,10 +9,67 @@ interface Mp3ItemRow {
 	peaks?: number[][];
 }
 
+/**
+ * How far back of the window the query reaches to catch a recording that was
+ * already playing when the window opened.
+ *
+ * The overlap predicate we actually want is `start_date <= windowEnd AND
+ * end_date >= windowStart`, but `mp3_items.end_date` is not in the anonymous
+ * read policy (verified against production 2026-08-17: both projecting and
+ * filtering on it return FORBIDDEN), so the end has to be reconstructed from
+ * `start_date + calc_duration`. That can only be done client-side, which means
+ * the server-side half of the predicate has to be a lookback wide enough that
+ * no overlapping row is excluded before we see it. The longest recording in the
+ * corpus is ~8h20m (`aggregate[max]=calc_duration` = 29 880 s, same date), so
+ * twelve hours clears it with room to spare; {@link overlappingSpans} then
+ * applies the exact test to what comes back.
+ */
+const LOOKBACK_MS = 12 * 3_600_000;
+
+/**
+ * Row cap. Chosen to be unreachable rather than to truncate: the busiest
+ * station in the corpus has 82 rows and the whole `mp3_items` table has 588
+ * (production, 2026-08-17), so 200 cannot be hit by one station even over the
+ * full ten-day span — while still bounding the payload, which carries a peaks
+ * array per row (~340 KB for all 82 `atc` rows). A silent truncation would be
+ * indistinguishable from "nothing else aired", which is why the cap is set out
+ * of reach instead of being surfaced.
+ */
+const ROW_LIMIT = 200;
+
 /** Parse a Directus/UTC datetime string to epoch ms (append Z when tz-less). */
 function toMs(value: string): number {
 	const s = /Z$|[+-]\d{2}:\d{2}$/.test(value) ? value : `${value}Z`;
 	return new Date(s).getTime();
+}
+
+/**
+ * The rows that actually overlap `[windowStartMs, windowEndMs]`, as spans.
+ *
+ * Rows without an envelope are dropped: `peaks` is nullable and the backfill is
+ * still running, and a missing preview is meant to be quiet. Rows without a
+ * positive `calc_duration` are dropped for a different reason — with no
+ * `end_date` available there is nothing to reconstruct an extent from, and a
+ * zero-length span would render as a `width: 0%` slot: an invisible canvas that
+ * looks identical to having drawn nothing, but costs a DOM node and a draw.
+ */
+export function overlappingSpans(
+	rows: Mp3ItemRow[],
+	windowStartMs: number,
+	windowEndMs: number,
+): SpanPeaks[] {
+	const out: SpanPeaks[] = [];
+	for (const d of rows) {
+		if (typeof d.start_date !== "string") continue;
+		if (!Array.isArray(d.peaks) || d.peaks.length === 0) continue;
+		const duration = d.calc_duration;
+		if (typeof duration !== "number" || !(duration > 0)) continue;
+		const startMs = toMs(d.start_date);
+		const endMs = startMs + duration * 1000;
+		if (endMs < windowStartMs || startMs > windowEndMs) continue;
+		out.push({ startMs, endMs, peaks: d.peaks });
+	}
+	return out;
 }
 
 /**
@@ -24,6 +81,13 @@ function toMs(value: string): number {
  * is assembled from whatever aired in the window — zero, one, or several
  * recordings, each drawn at its own time position — the same shape as the TV
  * thumbnail strip, which is also time-positioned rather than item-positioned.
+ *
+ * The span is the entry's own COMMITTED window, never the scroll viewport's.
+ * Keying it on what is visible fired a fresh request per scroll frame, and
+ * `directusGet` has no abort — the queue is a module-global FIFO, so a pan
+ * parked ~60 unabortable requests in front of every other editor REST call.
+ * The entry's window changes on selection and on an edge-drag commit, which is
+ * exactly how often this should refetch.
  *
  * `mp3_items.source` is a relation to the station; filtering on
  * `source.slug` (not `source` itself) is required for the same reason
@@ -37,32 +101,30 @@ export function usePeaksForSpan(
 ): SpanPeaks[] {
 	const [rows, setRows] = useState<SpanPeaks[]>([]);
 
+	// Held in a ref, and deliberately NOT an effect dependency: callers pass an
+	// injected fetch for tests, and an inline lambda (or a stubbed global) is a
+	// new identity every render, which would refetch on every render forever.
+	// The effect below only ever reads it at fire time.
+	const fetchRef = useRef(fetchFn);
+	useEffect(() => {
+		fetchRef.current = fetchFn;
+	}, [fetchFn]);
+
 	useEffect(() => {
 		let alive = true;
 		const qs = new URLSearchParams({
 			"filter[source][slug][_eq]": station,
-			"filter[start_date][_between]": `${new Date(startMs).toISOString()},${new Date(endMs).toISOString()}`,
+			// URLSearchParams, never concatenation: a slug can contain a slash
+			// (`NEADS/NORAD`) or other URL-significant characters.
+			"filter[start_date][_between]": `${new Date(startMs - LOOKBACK_MS).toISOString()},${new Date(endMs).toISOString()}`,
 			fields: "start_date,calc_duration,peaks",
-			limit: "20",
+			limit: String(ROW_LIMIT),
 			sort: "start_date",
 		});
-		directusGet(`/items/mp3_items?${qs.toString()}`, fetchFn)
+		directusGet(`/items/mp3_items?${qs.toString()}`, fetchRef.current)
 			.then((data) => {
 				if (!alive) return;
-				setRows(
-					(data as Mp3ItemRow[])
-						.filter((d): d is Mp3ItemRow & { start_date: string; peaks: number[][] } =>
-							typeof d.start_date === "string" && Array.isArray(d.peaks) && d.peaks.length > 0,
-						)
-						.map((d) => {
-							const start = toMs(d.start_date);
-							return {
-								startMs: start,
-								endMs: start + (d.calc_duration ?? 0) * 1000,
-								peaks: d.peaks,
-							};
-						}),
-				);
+				setRows(overlappingSpans(data as Mp3ItemRow[], startMs, endMs));
 			})
 			.catch(() => {
 				// A failed preview stays quiet rather than surfacing an error state.
@@ -71,7 +133,7 @@ export function usePeaksForSpan(
 		return () => {
 			alive = false;
 		};
-	}, [station, startMs, endMs, fetchFn]);
+	}, [station, startMs, endMs]);
 
 	return rows;
 }

--- a/packages/frontend/src/Applications/PlaylistEditor/usePeaksForSpan.ts
+++ b/packages/frontend/src/Applications/PlaylistEditor/usePeaksForSpan.ts
@@ -1,9 +1,10 @@
 import { useEffect, useRef, useState } from "react";
 import { directusGet } from "./directusQueue";
 
-export type SpanPeaks = { startMs: number; endMs: number; peaks: number[][] };
+export type SpanPeaks = { id: number; startMs: number; endMs: number; peaks: number[][] };
 
 interface Mp3ItemRow {
+	id?: number;
 	start_date?: string;
 	calc_duration?: number;
 	peaks?: number[][];
@@ -20,7 +21,7 @@ interface Mp3ItemRow {
  * `start_date + calc_duration`. That can only be done client-side, which means
  * the server-side half of the predicate has to be a lookback wide enough that
  * no overlapping row is excluded before we see it. The longest recording in the
- * corpus is ~8h20m (`aggregate[max]=calc_duration` = 29 880 s, same date), so
+ * corpus is 8h18m (`aggregate[max]=calc_duration` = 29 880 s, same date), so
  * twelve hours clears it with room to spare; {@link overlappingSpans} then
  * applies the exact test to what comes back.
  */
@@ -28,12 +29,13 @@ const LOOKBACK_MS = 12 * 3_600_000;
 
 /**
  * Row cap. Chosen to be unreachable rather than to truncate: the busiest
- * station in the corpus has 82 rows and the whole `mp3_items` table has 588
- * (production, 2026-08-17), so 200 cannot be hit by one station even over the
- * full ten-day span — while still bounding the payload, which carries a peaks
- * array per row (~340 KB for all 82 `atc` rows). A silent truncation would be
- * indistinguishable from "nothing else aired", which is why the cap is set out
- * of reach instead of being surfaced.
+ * station in the corpus is `AA11` with 98 rows, and the whole `mp3_items` table
+ * has 814 — 588 of which are approved, i.e. visible to this anonymous read
+ * (production, 2026-08-17). So 200 cannot be hit by one station even over the
+ * full ten-day span, while still bounding the payload, which carries a peaks
+ * array per row (~4.1 KB of compact JSON each, ~400 KB for all 98 `AA11`
+ * rows). A silent truncation would be indistinguishable from "nothing else
+ * aired", which is why the cap is set out of reach instead of being surfaced.
  */
 const ROW_LIMIT = 200;
 
@@ -52,6 +54,17 @@ function toMs(value: string): number {
  * `end_date` available there is nothing to reconstruct an extent from, and a
  * zero-length span would render as a `width: 0%` slot: an invisible canvas that
  * looks identical to having drawn nothing, but costs a DOM node and a draw.
+ *
+ * Rows without a numeric `id` are dropped for a third reason: the id is the
+ * slot's React key, and it is the ONLY unique thing about a row here.
+ * `(source, start_date)` is not unique in production — 20 collision groups
+ * across the corpus, 17 of them with differing durations (`UA93 @ 13:34:00` is
+ * three recordings of 26 s, 86 s and 52 s) — so keying on the start instant
+ * hands the reconciler indistinguishable siblings, and the next refetch that
+ * changes the row set duplicates or omits them. `id` is projected explicitly
+ * below and is anonymously readable, so this guard should never fire; it is
+ * here so the uniqueness invariant is enforced where the span is built rather
+ * than assumed where it is drawn.
  */
 export function overlappingSpans(
 	rows: Mp3ItemRow[],
@@ -60,6 +73,7 @@ export function overlappingSpans(
 ): SpanPeaks[] {
 	const out: SpanPeaks[] = [];
 	for (const d of rows) {
+		if (typeof d.id !== "number") continue;
 		if (typeof d.start_date !== "string") continue;
 		if (!Array.isArray(d.peaks) || d.peaks.length === 0) continue;
 		const duration = d.calc_duration;
@@ -67,7 +81,7 @@ export function overlappingSpans(
 		const startMs = toMs(d.start_date);
 		const endMs = startMs + duration * 1000;
 		if (endMs < windowStartMs || startMs > windowEndMs) continue;
-		out.push({ startMs, endMs, peaks: d.peaks });
+		out.push({ id: d.id, startMs, endMs, peaks: d.peaks });
 	}
 	return out;
 }
@@ -117,7 +131,9 @@ export function usePeaksForSpan(
 			// URLSearchParams, never concatenation: a slug can contain a slash
 			// (`NEADS/NORAD`) or other URL-significant characters.
 			"filter[start_date][_between]": `${new Date(startMs - LOOKBACK_MS).toISOString()},${new Date(endMs).toISOString()}`,
-			fields: "start_date,calc_duration,peaks",
+			// `id` is not decoration: it is the only unique identity a row has
+			// here, and the slots' React key. See {@link overlappingSpans}.
+			fields: "id,start_date,calc_duration,peaks",
 			limit: String(ROW_LIMIT),
 			sort: "start_date",
 		});

--- a/packages/tools/video-grabber/CLAUDE.md
+++ b/packages/tools/video-grabber/CLAUDE.md
@@ -35,6 +35,15 @@ Also stitches per-channel continuous HLS streams + EPG guide JSON.
   narrative is admitted as a second source, with per-field provenance. See
   [`docs/party-identification.md`](docs/party-identification.md) — read it before
   changing the prompt or the gate, and do not weaken the gate to raise yield.
+- `video_grabber/peaks/` — a **sixth pipeline**: reduce every `audio/*.mp3` to a
+  fixed 480-bucket `[min, max]` amplitude envelope for the Playlist Editor's
+  timeline waveform, writing `mp3_items.peaks`. No state table — `peaks IS NOT
+  NULL` is the idempotency marker. One manual-only flow, `compute-peaks`
+  (`dry_run=True` by default). See [`docs/peaks.md`](docs/peaks.md) — read it
+  before touching the decode path: ffmpeg exits **0** on a truncated MP3, so
+  `check=True` alone does not make a stored envelope trustworthy and the
+  decoded-length guard is what keeps a partial decode from being written
+  permanently.
 - `k8s/` — deployment manifests (see Deploy below).
 - `tests/` — pytest. `test_migrations.py` needs a live Postgres; it **errors** (not
   fails) when none is reachable — that's an environment gap, not a regression.

--- a/packages/tools/video-grabber/CLAUDE.md
+++ b/packages/tools/video-grabber/CLAUDE.md
@@ -38,6 +38,8 @@ Also stitches per-channel continuous HLS streams + EPG guide JSON.
   `tags.py`/`vocab.py` derivation changes). See
   [`docs/party-identification.md`](docs/party-identification.md) — read it before
   changing the prompt or the gate, and do not weaken the gate to raise yield.
+  **`mp3_items.tags` is an m2m alias, not a column** — it cannot be set by PATCHing the
+  item, which is what the writer used to do when `tags` was a json array.
 - `video_grabber/peaks/` — a **sixth pipeline**: reduce every `audio/*.mp3` to a
   fixed 480-bucket `[min, max]` amplitude envelope for the Playlist Editor's
   timeline waveform, writing `mp3_items.peaks`. No state table — `peaks IS NOT
@@ -47,8 +49,6 @@ Also stitches per-channel continuous HLS streams + EPG guide JSON.
   `check=True` alone does not make a stored envelope trustworthy and the
   decoded-length guard is what keeps a partial decode from being written
   permanently.
-  **`mp3_items.tags` is an m2m alias, not a column** — it cannot be set by PATCHing the
-  item, which is what the writer used to do when `tags` was a json array.
 - `k8s/` — deployment manifests (see Deploy below).
 - `tests/` — pytest. `test_migrations.py` needs a live Postgres; it **errors** (not
   fails) when none is reachable — that's an environment gap, not a regression.

--- a/packages/tools/video-grabber/docs/peaks.md
+++ b/packages/tools/video-grabber/docs/peaks.md
@@ -1,0 +1,117 @@
+# Amplitude envelopes (`compute-peaks`)
+
+Populates `mp3_items.peaks`: a fixed-size amplitude envelope for every audio
+recording, so the Playlist Editor's timeline can draw a static waveform for a
+radio entry without downloading the audio.
+
+One Prefect flow, `compute-peaks`, manual-only and `dry_run=True` by default —
+like `identify-parties`, it writes to the live catalogue, so nothing schedules
+it.
+
+Code lives in [`video_grabber/peaks/`](../video_grabber/peaks/): `extract.py`
+(pure, no I/O) and `flows.py` (download, decode, guard, write). There is **no
+state table** — `peaks IS NOT NULL` is the idempotency marker, which is why a
+row that fails is left NULL and picked up by the next run. For the product
+rationale (why offline, why not sticky, why a station window can hold several
+recordings) see
+[`plans/2026-08-17-timeline-lane-preview-design.md`](../../../../plans/2026-08-17-timeline-lane-preview-design.md).
+
+---
+
+## The shape: 480 buckets, always
+
+`peaks_from_pcm` reduces the whole recording to **480 `[min, max]` pairs**,
+each scaled to `-128..127`, whatever its duration.
+
+- **Fixed count, not fixed resolution.** The corpus runs from 2-second clips to
+  an 8h18m (29 880 s) position tape. Per-file resolution would make both the
+  stored blob and the renderer variable for no visible benefit at preview size,
+  where the slot is a few pixels to a few hundred wide. At 480 pairs the blob is
+  ~4.1 KB of compact JSON (4 110 bytes measured) regardless.
+- **Byte-range scaling.** `>>` 8 in Python floors toward negative infinity, so
+  `-32768 >> 8 == -128` and `32767 >> 8 == 127` — the full signed-16-bit range
+  maps onto `-128..127` with no branch for negatives.
+- **8 kHz mono decode.** Plenty for a preview envelope, and it holds the largest
+  tape's PCM buffer to ~478 MB rather than ~5.3 GB at 44.1 kHz stereo.
+- **`array("h")`, not `struct.unpack`.** Unpacking would box ~239M samples as
+  Python ints. `array` keeps them as packed machine shorts and still slices.
+  Built from a `memoryview` slice so the source `bytes` is not copied twice.
+  Honest peak RSS on the largest tape is ~956 MB (source buffer + array), well
+  inside the worker's 8Gi limit.
+
+## A partial decode is a failure, not an envelope
+
+**This is the non-obvious part of the flow.** `check=True` on the ffmpeg call
+only catches a non-zero exit, and ffmpeg routinely **exits 0 on a truncated or
+damaged MP3** after emitting a short PCM prefix. Nothing downstream would
+notice: `peaks_from_pcm` stretches that prefix across all 480 buckets, and the
+frontend draws those 480 buckets across the row's full `calc_duration` extent —
+a waveform misaligned from the audio it claims to depict, stored as a success.
+A zero-length decode is worse still: 480 `[0, 0]` pairs are indistinguishable
+from a genuinely silent recording.
+
+Because `should_compute` treats any non-null `peaks` as done, neither is ever
+repaired by a normal re-run — only a `force=True` pass over the whole corpus
+would. So the check happens **before** the write:
+
+| Case | Outcome |
+|---|---|
+| Decoded length within tolerance of `calc_duration` | Written. |
+| Decoded length diverges beyond tolerance | `PartialDecodeError` → counted **failed**, `peaks` left NULL, next run retries. |
+| Zero-length decode | `PartialDecodeError`, regardless of `calc_duration`. |
+| `calc_duration` absent or non-positive | Accepted **unverified** (the zero-length rule still applies). |
+
+Tolerance is `max(1.5 s, 1 % of calc_duration)`. The floor covers
+`calc_duration` being whole seconds — `catalogue/flows.py:probe_duration` is
+`int(float(...))`, a truncation, so the stored value sits up to 1 s low before
+codec padding adds tens of ms. The 1 % term covers ffprobe estimating a
+duration from bitrate rather than a frame count, the one error that scales with
+length (~5 minutes of slack on the 8h18m tape). The bias is deliberate: a false
+rejection costs one recomputed row on the next run, a false acceptance is
+permanent.
+
+One blind spot worth knowing: if a file was already truncated when
+`probe_duration` ran, `calc_duration` describes the truncated file and matches
+the short decode. The guard catches damage that postdates the catalogue entry
+and headers whose frame count outlives the payload — not a file that has been
+short since ingest.
+
+`timeout=_FFMPEG_TIMEOUT_S` (20 minutes) covers the other direction: a stalled
+decode would otherwise sit forever with nothing raised. `TimeoutExpired` is an
+`Exception`, so the per-row handler counts it failed and the run continues.
+
+## Operating it
+
+```bash
+# dry run over a handful, printing bucket counts and writing nothing
+prefect deployment run compute-peaks/compute-peaks -p limit=5
+
+# apply, filling in every row whose peaks are still NULL
+prefect deployment run compute-peaks/compute-peaks -p dry_run=false
+
+# recompute everything (only needed if the bucket count or scaling changes)
+prefect deployment run compute-peaks/compute-peaks -p dry_run=false -p force=true
+```
+
+The run logs `N computed, N skipped, N failed`. **`failed` is the number to
+watch** — those rows have no envelope and will be retried next run; grep the
+logs for `compute-peaks: <key> failed:` to see whether it was a download, a
+decode, or a `PartialDecodeError`.
+
+Row order comes from `_page_mp3_items`, which sorts by `id` for the reason
+documented there: this flow updates the rows it walks, and LIMIT/OFFSET without
+an ORDER BY reshuffles the pages underneath it.
+
+## The consumer
+
+`packages/frontend/src/Applications/PlaylistEditor/usePeaksForSpan.ts` reads
+`peaks` anonymously alongside `id`, `start_date` and `calc_duration`, and
+`PeaksWaveform.tsx` draws the 480 pairs to a canvas. Two constraints that
+travel back to this pipeline:
+
+- **`peaks` is a Directus `json` field**, which in Directus 12 accepts only
+  `_null` / `_nnull` filters. The frontend cannot filter on envelope contents,
+  so a row with no envelope is simply dropped client-side.
+- **`(source, start_date)` is not unique** — 20 collision groups in the corpus,
+  17 with differing durations. The row `id` is the only unique identity a
+  recording has, which is why the frontend keys its slots on it.

--- a/packages/tools/video-grabber/tests/test_peaks_extract.py
+++ b/packages/tools/video-grabber/tests/test_peaks_extract.py
@@ -33,3 +33,25 @@ def test_a_file_shorter_than_the_bucket_count_still_fills_every_bucket():
 
 def test_empty_input_yields_flat_peaks():
     assert peaks_from_pcm(b"", buckets=5) == [[0, 0]] * 5
+
+
+def test_non_divisible_bucket_count_partitions_correctly():
+    """7 samples into 3 buckets doesn't divide evenly, and a ramp (rather
+    than a flat value) means a shifted window boundary changes the numbers
+    instead of silently passing.
+
+    Partition (lo_idx = i*7//3, hi_idx = max((i+1)*7//3, lo_idx+1)):
+      bucket 0: samples[0:2] = [0, 500]              -> >>8 = [0, 1]
+      bucket 1: samples[2:4] = [1000, 1500]          -> >>8 = [3, 5]
+      bucket 2: samples[4:7] = [2000, 2500, 3000]    -> >>8 = [7, 11]
+    """
+    out = peaks_from_pcm(pcm([0, 500, 1000, 1500, 2000, 2500, 3000]), buckets=3)
+    assert out == [[0, 1], [3, 5], [7, 11]]
+
+
+def test_odd_length_input_ignores_the_trailing_byte():
+    """A truncated final sample (odd total byte count) must not raise and
+    must not be read as a spurious extra sample."""
+    truncated = pcm([1000, -2000, 3000]) + b"\xff"
+    out = peaks_from_pcm(truncated, buckets=3)
+    assert out == [[3, 3], [-8, -8], [11, 11]]

--- a/packages/tools/video-grabber/tests/test_peaks_extract.py
+++ b/packages/tools/video-grabber/tests/test_peaks_extract.py
@@ -1,0 +1,35 @@
+import struct
+
+from video_grabber.peaks.extract import PEAK_BUCKETS, peaks_from_pcm
+
+
+def pcm(values):
+    """Signed 16-bit little-endian mono, the format ffmpeg is asked for."""
+    return b"".join(struct.pack("<h", v) for v in values)
+
+
+def test_silence_yields_flat_peaks_rather_than_raising():
+    out = peaks_from_pcm(pcm([0] * 4800), buckets=10)
+    assert len(out) == 10
+    assert all(lo == 0 and hi == 0 for lo, hi in out)
+
+
+def test_full_scale_reaches_the_extremes():
+    out = peaks_from_pcm(pcm([32767, -32768] * 2400), buckets=10)
+    assert max(hi for _, hi in out) == 127
+    assert min(lo for lo, _ in out) == -128
+
+
+def test_bucket_count_is_fixed_regardless_of_length():
+    short = peaks_from_pcm(pcm([1000] * 1000))
+    long = peaks_from_pcm(pcm([1000] * 1_000_000))
+    assert len(short) == len(long) == PEAK_BUCKETS
+
+
+def test_a_file_shorter_than_the_bucket_count_still_fills_every_bucket():
+    out = peaks_from_pcm(pcm([500] * 10), buckets=100)
+    assert len(out) == 100
+
+
+def test_empty_input_yields_flat_peaks():
+    assert peaks_from_pcm(b"", buckets=5) == [[0, 0]] * 5

--- a/packages/tools/video-grabber/tests/test_peaks_flows.py
+++ b/packages/tools/video-grabber/tests/test_peaks_flows.py
@@ -1,3 +1,9 @@
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+import video_grabber.peaks.flows as flows
 from video_grabber.peaks.flows import should_compute
 
 
@@ -15,3 +21,72 @@ def test_computes_rows_missing_the_key_entirely():
 
 def test_force_recomputes_everything():
     assert should_compute({"peaks": [[0, 0]]}, force=True) is True
+
+
+# --- compute_peaks_flow: mocked httpx, subprocess and Wasabi. No network,
+# no shelling out — `pcm_for`/`peaks_from_pcm`/`wasabi.download_file` are all
+# stubbed, so these exercise only the flow's own control flow: what it writes,
+# when it writes, and whether one bad row can stop the run.
+
+
+class FakeHttpx:
+    """Records every PATCH call instead of making one."""
+
+    def __init__(self):
+        self.calls = []
+
+    def patch(self, url, json, headers):
+        self.calls.append({"url": url, "json": json, "headers": headers})
+        return SimpleNamespace(raise_for_status=lambda: None)
+
+
+ROW = {"id": 1, "url": "https://files.911realtime.org/audio/foo.mp3", "peaks": None}
+
+
+@pytest.fixture
+def flow_env(monkeypatch):
+    """Stub every side-effecting collaborator `compute_peaks_flow` calls."""
+    monkeypatch.setattr(flows, "get_run_logger", lambda: logging.getLogger("test"))
+    monkeypatch.setattr(flows, "wasabi", SimpleNamespace(download_file=lambda *a, **k: None))
+    monkeypatch.setattr(flows, "pcm_for", lambda path: b"\x00\x00")
+    monkeypatch.setattr(flows, "peaks_from_pcm", lambda pcm, buckets: [[1, 2]] * buckets)
+    monkeypatch.setattr(flows, "_auth_headers", lambda cfg: {})
+    fake_httpx = FakeHttpx()
+    monkeypatch.setattr(flows, "httpx", fake_httpx)
+    return fake_httpx
+
+
+def test_dry_run_issues_zero_writes(monkeypatch, flow_env):
+    monkeypatch.setattr(flows, "_page_mp3_items", lambda cfg, fields: iter([ROW]))
+    flows.compute_peaks_flow.fn(dry_run=True)
+    assert flow_env.calls == []
+
+
+def test_patch_body_contains_only_the_peaks_key(monkeypatch, flow_env):
+    """A row PATCH must never be able to clobber any other column."""
+    monkeypatch.setattr(flows, "_page_mp3_items", lambda cfg, fields: iter([ROW]))
+    flows.compute_peaks_flow.fn(dry_run=False)
+    assert len(flow_env.calls) == 1
+    assert set(flow_env.calls[0]["json"].keys()) == {"peaks"}
+    assert flow_env.calls[0]["json"]["peaks"] == [[1, 2]] * flows.PEAK_BUCKETS
+
+
+def test_a_failing_row_is_counted_and_the_run_continues(monkeypatch, flow_env):
+    """The property the per-row try/except exists for: one bad recording
+    (download error, corrupt file, whatever) must not end the run."""
+    bad = {"id": 1, "url": "https://files.911realtime.org/audio/bad.mp3", "peaks": None}
+    good = {"id": 2, "url": "https://files.911realtime.org/audio/good.mp3", "peaks": None}
+
+    def flaky_download(key, dest, cfg):
+        if "bad" in key:
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(flows, "_page_mp3_items", lambda cfg, fields: iter([bad, good]))
+    monkeypatch.setattr(flows, "wasabi", SimpleNamespace(download_file=flaky_download))
+
+    flows.compute_peaks_flow.fn(dry_run=False)
+
+    # Only the surviving row gets written; the failed one is skipped, not
+    # raised, and the loop reaches the row after it.
+    assert len(flow_env.calls) == 1
+    assert flow_env.calls[0]["url"].endswith("/items/mp3_items/2")

--- a/packages/tools/video-grabber/tests/test_peaks_flows.py
+++ b/packages/tools/video-grabber/tests/test_peaks_flows.py
@@ -1,0 +1,17 @@
+from video_grabber.peaks.flows import should_compute
+
+
+def test_skips_rows_that_already_have_peaks():
+    assert should_compute({"peaks": [[0, 0]]}, force=False) is False
+
+
+def test_computes_rows_with_no_peaks():
+    assert should_compute({"peaks": None}, force=False) is True
+
+
+def test_computes_rows_missing_the_key_entirely():
+    assert should_compute({}, force=False) is True
+
+
+def test_force_recomputes_everything():
+    assert should_compute({"peaks": [[0, 0]]}, force=True) is True

--- a/packages/tools/video-grabber/tests/test_peaks_flows.py
+++ b/packages/tools/video-grabber/tests/test_peaks_flows.py
@@ -1,10 +1,12 @@
 import logging
+import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 import video_grabber.peaks.flows as flows
-from video_grabber.peaks.flows import should_compute
+from video_grabber.peaks.flows import PartialDecodeError, check_decode_length, should_compute
 
 
 def test_skips_rows_that_already_have_peaks():
@@ -21,6 +23,86 @@ def test_computes_rows_missing_the_key_entirely():
 
 def test_force_recomputes_everything():
     assert should_compute({"peaks": [[0, 0]]}, force=True) is True
+
+
+# --- pcm_for: the ffmpeg call itself. These drive `subprocess.run` rather
+# than stubbing `pcm_for` wholesale, because `check=True` and `timeout=` carry
+# the whole "one bad file cannot wedge an unattended run, and a failed decode
+# is never mistaken for audio" argument and are invisible to every test that
+# replaces the function.
+
+
+def test_the_decode_is_bounded_and_its_exit_status_checked():
+    seen = {}
+
+    def fake_run(cmd, **kwargs):
+        seen.update(cmd=cmd, kwargs=kwargs)
+        return SimpleNamespace(stdout=b"\x00\x00")
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(flows.subprocess, "run", fake_run)
+        assert flows.pcm_for(Path("clip.mp3")) == b"\x00\x00"
+
+    assert seen["kwargs"]["check"] is True
+    assert seen["kwargs"]["timeout"] == flows._FFMPEG_TIMEOUT_S
+    assert seen["cmd"][0] == "ffmpeg"
+
+
+def test_a_nonzero_exit_raises_instead_of_returning_the_partial_output(monkeypatch):
+    """ffmpeg failing mid-decode still leaves bytes on stdout. Without
+    check=True those bytes become an envelope for audio that never decoded."""
+    real_run = subprocess.run
+
+    def run_failing(cmd, **kwargs):
+        return real_run(["sh", "-c", "printf partial; exit 3"], **kwargs)
+
+    monkeypatch.setattr(flows.subprocess, "run", run_failing)
+    with pytest.raises(subprocess.CalledProcessError):
+        flows.pcm_for(Path("broken.mp3"))
+
+
+def test_a_hung_decode_is_cut_off_rather_than_blocking_the_run(monkeypatch):
+    """The timeout is what keeps one stalled file from wedging an unattended
+    run forever; nothing else in the flow can interrupt a blocked read."""
+    real_run = subprocess.run
+
+    def run_hanging(cmd, **kwargs):
+        return real_run(["sh", "-c", "sleep 5"], **kwargs)
+
+    monkeypatch.setattr(flows, "_FFMPEG_TIMEOUT_S", 0.3)
+    monkeypatch.setattr(flows.subprocess, "run", run_hanging)
+    with pytest.raises(subprocess.TimeoutExpired):
+        flows.pcm_for(Path("stalled.mp3"))
+
+
+# --- check_decode_length: a short decode must never become a stored envelope.
+
+
+def _pcm_of(seconds: float) -> bytes:
+    return b"\x00\x00" * int(seconds * flows._SAMPLE_RATE_HZ)
+
+
+def test_a_decode_matching_the_catalogued_duration_is_accepted():
+    # 0.4 s long: whole-second truncation in `calc_duration` plus codec
+    # padding, i.e. the normal case, not a defect.
+    check_decode_length(_pcm_of(60.4), 60)
+
+
+def test_a_short_decode_is_rejected():
+    with pytest.raises(PartialDecodeError):
+        check_decode_length(_pcm_of(12), 600)
+
+
+def test_an_empty_decode_is_rejected_even_with_no_duration_to_check_against():
+    """480 [0, 0] pairs are indistinguishable from a genuinely silent
+    recording, so this one cannot be waved through as unverifiable."""
+    with pytest.raises(PartialDecodeError):
+        check_decode_length(b"", None)
+
+
+def test_a_row_with_no_usable_duration_is_accepted_unverified():
+    for missing in (None, 0, -1):
+        check_decode_length(_pcm_of(3), missing)
 
 
 # --- compute_peaks_flow: mocked httpx, subprocess and Wasabi. No network,
@@ -40,6 +122,9 @@ class FakeHttpx:
         return SimpleNamespace(raise_for_status=lambda: None)
 
 
+# No `calc_duration`, so the decode-length check treats this row as
+# unverifiable and the stubbed 1-sample PCM is accepted — these tests are
+# about the flow's control flow, not the guard. The guard has its own below.
 ROW = {"id": 1, "url": "https://files.911realtime.org/audio/foo.mp3", "peaks": None}
 
 
@@ -90,3 +175,46 @@ def test_a_failing_row_is_counted_and_the_run_continues(monkeypatch, flow_env):
     # raised, and the loop reaches the row after it.
     assert len(flow_env.calls) == 1
     assert flow_env.calls[0]["url"].endswith("/items/mp3_items/2")
+
+
+def test_the_row_projection_carries_the_duration_the_guard_needs(monkeypatch, flow_env):
+    """`check_decode_length` reads `calc_duration` off the row. Drop it from
+    the projection and every row silently becomes unverifiable."""
+    seen = []
+
+    def spy_page(cfg, fields):
+        seen.append(fields)
+        return iter([])
+
+    monkeypatch.setattr(flows, "_page_mp3_items", spy_page)
+    flows.compute_peaks_flow.fn()
+    assert "calc_duration" in seen[0].split(",")
+
+
+def test_a_partial_decode_is_counted_as_failed_and_writes_nothing(monkeypatch, flow_env):
+    """The failure this guard exists for: ffmpeg exits 0 on a truncated MP3
+    after emitting a short prefix, and storing that prefix's envelope against
+    the row's full extent is permanent — `should_compute` never revisits a
+    non-null `peaks`."""
+    row = {"id": 9, "url": "https://files.911realtime.org/audio/truncated.mp3",
+           "peaks": None, "calc_duration": 600}
+    monkeypatch.setattr(flows, "_page_mp3_items", lambda cfg, fields: iter([row]))
+    monkeypatch.setattr(flows, "pcm_for", lambda path: _pcm_of(12))
+
+    flows.compute_peaks_flow.fn(dry_run=False)
+
+    assert flow_env.calls == []
+
+
+def test_a_full_decode_of_the_same_shape_is_still_written(monkeypatch, flow_env):
+    """Control for the test above: the guard must not simply reject everything
+    with a `calc_duration`."""
+    row = {"id": 9, "url": "https://files.911realtime.org/audio/whole.mp3",
+           "peaks": None, "calc_duration": 600}
+    monkeypatch.setattr(flows, "_page_mp3_items", lambda cfg, fields: iter([row]))
+    monkeypatch.setattr(flows, "pcm_for", lambda path: _pcm_of(600.4))
+
+    flows.compute_peaks_flow.fn(dry_run=False)
+
+    assert len(flow_env.calls) == 1
+    assert flow_env.calls[0]["url"].endswith("/items/mp3_items/9")

--- a/packages/tools/video-grabber/video_grabber/peaks/extract.py
+++ b/packages/tools/video-grabber/video_grabber/peaks/extract.py
@@ -23,20 +23,28 @@ def peaks_from_pcm(samples: bytes, buckets: int = PEAK_BUCKETS) -> list[list[int
     32767 >> 8 == 127 — the full signed 16-bit range maps onto -128..127
     without a separate branch for negative values.
 
-    The corpus's longest tape is 6.75 hours (~194 MB of 8 kHz mono PCM,
-    ~97M samples). `struct.unpack` would box every sample as a Python int in
-    a tuple — ~16x the raw byte size, multi-GB peak RSS on that one file.
-    `array("h", ...)` stores samples as packed machine shorts (~2x the raw
-    bytes) while still supporting the slicing the bucket loop below relies on.
-    `array` uses native byte order, unlike `struct`'s explicit `<h`, so a
-    big-endian host needs an explicit byteswap to preserve the little-endian
-    contract ffmpeg is asked for.
+    The corpus's longest tape is 6.75 hours: at 8 kHz mono that's ~194M
+    samples, ~389 MB of 16-bit PCM (2 bytes/sample — samples and bytes are
+    not the same number). `struct.unpack` would box every sample as a Python
+    int in a tuple — ~16x the raw byte size, multi-GB peak RSS on that one
+    file. `array("h")` stores samples as packed machine shorts (same 2
+    bytes/sample as the source) while still supporting the slicing the
+    bucket loop below relies on. Building it via `frombytes` off a
+    `memoryview` slice, rather than slicing the `bytes` object first, avoids
+    one full-size copy: a `bytes` slice copies, a `memoryview` slice does
+    not. The caller's PCM buffer (~389 MB for the largest tape) is still
+    live alongside the array's own copy while this runs, so the honest peak
+    is ~780 MB, not the "under 200 MB" an earlier version of this comment
+    claimed. `array` uses native byte order, unlike `struct`'s explicit
+    `<h`, so a big-endian host needs an explicit byteswap to preserve the
+    little-endian contract ffmpeg is asked for.
     """
     count = len(samples) // 2
     if count == 0:
         return [[0, 0] for _ in range(buckets)]
 
-    values = array("h", samples[: count * 2])
+    values = array("h")
+    values.frombytes(memoryview(samples)[: count * 2])
     if sys.byteorder == "big":
         values.byteswap()
     out: list[list[int]] = []

--- a/packages/tools/video-grabber/video_grabber/peaks/extract.py
+++ b/packages/tools/video-grabber/video_grabber/peaks/extract.py
@@ -1,10 +1,11 @@
 """Reduce an audio file to a fixed-size amplitude envelope.
 
-A fixed bucket count is the point. The corpus runs from 40-second clips to
-6.75-hour position tapes, and storing per-file resolution would make the blob
-size and the renderer both variable for no benefit at preview size. 480 pairs
-is ~2 KB whatever the duration, and the component always draws 480 values
-across whatever width it has.
+A fixed bucket count is the point. The corpus runs from two-second clips to
+8h18m position tapes, and storing per-file resolution would make the blob size
+and the renderer both variable for no benefit at preview size. 480 pairs is
+~4.1 KB whatever the duration (4 110 bytes of compact JSON, measured against
+production 2026-08-17), and the component always draws 480 values across
+whatever width it has.
 """
 from __future__ import annotations
 
@@ -23,18 +24,18 @@ def peaks_from_pcm(samples: bytes, buckets: int = PEAK_BUCKETS) -> list[list[int
     32767 >> 8 == 127 — the full signed 16-bit range maps onto -128..127
     without a separate branch for negative values.
 
-    The corpus's longest tape is 6.75 hours: at 8 kHz mono that's ~194M
-    samples, ~389 MB of 16-bit PCM (2 bytes/sample — samples and bytes are
-    not the same number). `struct.unpack` would box every sample as a Python
-    int in a tuple — ~16x the raw byte size, multi-GB peak RSS on that one
-    file. `array("h")` stores samples as packed machine shorts (same 2
+    The corpus's longest tape is 8h18m (29 880 s): at 8 kHz mono that's
+    ~239M samples, ~478 MB of 16-bit PCM (2 bytes/sample — samples and bytes
+    are not the same number). `struct.unpack` would box every sample as a
+    Python int in a tuple — ~16x the raw byte size, multi-GB peak RSS on that
+    one file. `array("h")` stores samples as packed machine shorts (same 2
     bytes/sample as the source) while still supporting the slicing the
     bucket loop below relies on. Building it via `frombytes` off a
     `memoryview` slice, rather than slicing the `bytes` object first, avoids
     one full-size copy: a `bytes` slice copies, a `memoryview` slice does
-    not. The caller's PCM buffer (~389 MB for the largest tape) is still
+    not. The caller's PCM buffer (~478 MB for the largest tape) is still
     live alongside the array's own copy while this runs, so the honest peak
-    is ~780 MB, not the "under 200 MB" an earlier version of this comment
+    is ~956 MB, not the "under 200 MB" an earlier version of this comment
     claimed. `array` uses native byte order, unlike `struct`'s explicit
     `<h`, so a big-endian host needs an explicit byteswap to preserve the
     little-endian contract ffmpeg is asked for.
@@ -50,10 +51,11 @@ def peaks_from_pcm(samples: bytes, buckets: int = PEAK_BUCKETS) -> list[list[int
     out: list[list[int]] = []
     for i in range(buckets):
         lo_idx = (i * count) // buckets
+        # The window is never empty: `count >= 1` here (count == 0 returned
+        # above), so lo_idx <= count - 1 and hi_idx >= lo_idx + 1. More buckets
+        # than samples just means consecutive buckets repeat a sample rather
+        # than yielding an empty slice.
         hi_idx = max(((i + 1) * count) // buckets, lo_idx + 1)
         window = values[lo_idx:hi_idx]
-        if not window:
-            out.append([0, 0])
-            continue
         out.append([min(window) >> 8, max(window) >> 8])
     return out

--- a/packages/tools/video-grabber/video_grabber/peaks/extract.py
+++ b/packages/tools/video-grabber/video_grabber/peaks/extract.py
@@ -8,7 +8,8 @@ across whatever width it has.
 """
 from __future__ import annotations
 
-import struct
+import sys
+from array import array
 
 PEAK_BUCKETS = 480
 
@@ -21,12 +22,23 @@ def peaks_from_pcm(samples: bytes, buckets: int = PEAK_BUCKETS) -> list[list[int
     floor-toward-negative-infinity shift in Python, so -32768 >> 8 == -128 and
     32767 >> 8 == 127 — the full signed 16-bit range maps onto -128..127
     without a separate branch for negative values.
+
+    The corpus's longest tape is 6.75 hours (~194 MB of 8 kHz mono PCM,
+    ~97M samples). `struct.unpack` would box every sample as a Python int in
+    a tuple — ~16x the raw byte size, multi-GB peak RSS on that one file.
+    `array("h", ...)` stores samples as packed machine shorts (~2x the raw
+    bytes) while still supporting the slicing the bucket loop below relies on.
+    `array` uses native byte order, unlike `struct`'s explicit `<h`, so a
+    big-endian host needs an explicit byteswap to preserve the little-endian
+    contract ffmpeg is asked for.
     """
     count = len(samples) // 2
     if count == 0:
         return [[0, 0] for _ in range(buckets)]
 
-    values = struct.unpack(f"<{count}h", samples[: count * 2])
+    values = array("h", samples[: count * 2])
+    if sys.byteorder == "big":
+        values.byteswap()
     out: list[list[int]] = []
     for i in range(buckets):
         lo_idx = (i * count) // buckets

--- a/packages/tools/video-grabber/video_grabber/peaks/extract.py
+++ b/packages/tools/video-grabber/video_grabber/peaks/extract.py
@@ -1,0 +1,39 @@
+"""Reduce an audio file to a fixed-size amplitude envelope.
+
+A fixed bucket count is the point. The corpus runs from 40-second clips to
+6.75-hour position tapes, and storing per-file resolution would make the blob
+size and the renderer both variable for no benefit at preview size. 480 pairs
+is ~2 KB whatever the duration, and the component always draws 480 values
+across whatever width it has.
+"""
+from __future__ import annotations
+
+import struct
+
+PEAK_BUCKETS = 480
+
+
+def peaks_from_pcm(samples: bytes, buckets: int = PEAK_BUCKETS) -> list[list[int]]:
+    """Signed 16-bit mono PCM -> `buckets` [min, max] pairs scaled to -128..127.
+
+    Scaling to a byte range keeps the stored JSON small; a waveform drawn at
+    preview height cannot show more precision than that anyway. `>>` 8 is a
+    floor-toward-negative-infinity shift in Python, so -32768 >> 8 == -128 and
+    32767 >> 8 == 127 — the full signed 16-bit range maps onto -128..127
+    without a separate branch for negative values.
+    """
+    count = len(samples) // 2
+    if count == 0:
+        return [[0, 0] for _ in range(buckets)]
+
+    values = struct.unpack(f"<{count}h", samples[: count * 2])
+    out: list[list[int]] = []
+    for i in range(buckets):
+        lo_idx = (i * count) // buckets
+        hi_idx = max(((i + 1) * count) // buckets, lo_idx + 1)
+        window = values[lo_idx:hi_idx]
+        if not window:
+            out.append([0, 0])
+            continue
+        out.append([min(window) >> 8, max(window) >> 8])
+    return out

--- a/packages/tools/video-grabber/video_grabber/peaks/flows.py
+++ b/packages/tools/video-grabber/video_grabber/peaks/flows.py
@@ -1,0 +1,85 @@
+"""Compute an amplitude envelope for every audio recording.
+
+Manual-only and dry_run=True by default, like identify-parties: it writes to
+the live catalogue, so nothing should schedule it.
+"""
+from pathlib import Path
+import subprocess
+import tempfile
+
+import httpx
+from prefect import flow, get_run_logger
+
+from video_grabber.catalogue.flows import _page_mp3_items, key_from_url
+from video_grabber.config import Config
+from video_grabber.directus.writer import _auth_headers
+from video_grabber.peaks.extract import PEAK_BUCKETS, peaks_from_pcm
+from video_grabber.storage import wasabi
+
+
+def should_compute(row: dict, *, force: bool) -> bool:
+    """Idempotency marker is `peaks IS NOT NULL`, so a run is resumable."""
+    return force or not row.get("peaks")
+
+
+def pcm_for(path: Path) -> bytes:
+    """Decode to 8 kHz signed 16-bit little-endian mono.
+
+    Plenty for an envelope drawn at preview size, and it keeps a 6.75-hour
+    tape's intermediate buffer under 200 MB rather than several GB at source
+    rate. `capture_output=True` uses `Popen.communicate()` internally, so
+    stdout is read incrementally alongside the process rather than after it
+    exits — the pipe can't fill and deadlock the way a naive
+    `stdout=PIPE` + `.wait()` would on a large decode.
+    """
+    result = subprocess.run(
+        ["ffmpeg", "-v", "error", "-i", str(path),
+         "-ac", "1", "-ar", "8000", "-f", "s16le", "-"],
+        capture_output=True, check=True,
+    )
+    return result.stdout
+
+
+@flow(name="compute-peaks")
+def compute_peaks_flow(limit: int | None = None, force: bool = False,
+                       dry_run: bool = True) -> None:
+    """Compute a 480-bucket amplitude envelope for every eligible mp3_items row.
+
+    Idempotency marker is `peaks IS NOT NULL`, so re-running picks up rows
+    left empty (new uploads, a prior failure) and skips ones already done;
+    pass force=True to recompute everything.
+    """
+    logger = get_run_logger()
+    cfg = Config()
+    done = skipped = failed = 0
+
+    for row in _page_mp3_items(cfg, "id,url,peaks"):
+        if limit is not None and done >= limit:
+            break
+        if not should_compute(row, force=force):
+            skipped += 1
+            continue
+
+        key = key_from_url(row["url"])
+        # One recording must not be able to end a run over hundreds of them —
+        # a bad download, an unreadable file, a corrupt tape — count it and
+        # move on, the way identify-parties does.
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                local = Path(tmp) / Path(key).name
+                wasabi.download_file(key, local, cfg)
+                peaks = peaks_from_pcm(pcm_for(local), PEAK_BUCKETS)
+        except Exception as exc:
+            logger.warning("compute-peaks: %s failed: %s: %s", key, type(exc).__name__, exc)
+            failed += 1
+            continue
+
+        if dry_run:
+            logger.info("DRY RUN %s -> %d buckets", key, len(peaks))
+        else:
+            r = httpx.patch(f"{cfg.directus_url}/items/mp3_items/{row['id']}",
+                            json={"peaks": peaks}, headers=_auth_headers(cfg))
+            r.raise_for_status()
+        done += 1
+
+    logger.info("compute-peaks: %d computed, %d skipped, %d failed", done, skipped, failed)

--- a/packages/tools/video-grabber/video_grabber/peaks/flows.py
+++ b/packages/tools/video-grabber/video_grabber/peaks/flows.py
@@ -22,20 +22,33 @@ def should_compute(row: dict, *, force: bool) -> bool:
     return force or not row.get("peaks")
 
 
+# 20 minutes. The longest tape is 6.75h, and ffmpeg decodes audio far faster
+# than realtime (minutes, not hours, even for the longest source) — this
+# leaves generous headroom over any real decode while still bounding a hang
+# on a corrupt/truncated file. `subprocess.TimeoutExpired` is a subclass of
+# `Exception`, so it's caught by compute_peaks_flow's per-row `except
+# Exception`: a timed-out row is counted as failed and the run continues,
+# rather than the whole unattended run wedging on one bad file forever.
+_FFMPEG_TIMEOUT_S = 20 * 60
+
+
 def pcm_for(path: Path) -> bytes:
     """Decode to 8 kHz signed 16-bit little-endian mono.
 
     Plenty for an envelope drawn at preview size, and it keeps a 6.75-hour
-    tape's intermediate buffer under 200 MB rather than several GB at source
-    rate. `capture_output=True` uses `Popen.communicate()` internally, so
-    stdout is read incrementally alongside the process rather than after it
-    exits — the pipe can't fill and deadlock the way a naive
-    `stdout=PIPE` + `.wait()` would on a large decode.
+    tape's PCM buffer to ~389 MB rather than several GB at source rate (e.g.
+    44.1 kHz stereo would be well over 4 GB for the same tape).
+    `capture_output=True` uses `Popen.communicate()` internally, so stdout is
+    read incrementally alongside the process rather than after it exits — the
+    pipe can't fill and deadlock the way a naive `stdout=PIPE` + `.wait()`
+    would on a large decode. `timeout=` guards a different failure mode: a
+    hung or stalled decode on a corrupt/truncated file would otherwise sit
+    forever with nothing raised and the per-row try/except never firing.
     """
     result = subprocess.run(
         ["ffmpeg", "-v", "error", "-i", str(path),
          "-ac", "1", "-ar", "8000", "-f", "s16le", "-"],
-        capture_output=True, check=True,
+        capture_output=True, check=True, timeout=_FFMPEG_TIMEOUT_S,
     )
     return result.stdout
 

--- a/packages/tools/video-grabber/video_grabber/peaks/flows.py
+++ b/packages/tools/video-grabber/video_grabber/peaks/flows.py
@@ -22,7 +22,7 @@ def should_compute(row: dict, *, force: bool) -> bool:
     return force or not row.get("peaks")
 
 
-# 20 minutes. The longest tape is 6.75h, and ffmpeg decodes audio far faster
+# 20 minutes. The longest tape is 8h18m, and ffmpeg decodes audio far faster
 # than realtime (minutes, not hours, even for the longest source) — this
 # leaves generous headroom over any real decode while still bounding a hang
 # on a corrupt/truncated file. `subprocess.TimeoutExpired` is a subclass of
@@ -32,12 +32,16 @@ def should_compute(row: dict, *, force: bool) -> bool:
 _FFMPEG_TIMEOUT_S = 20 * 60
 
 
+_SAMPLE_RATE_HZ = 8000
+_BYTES_PER_SAMPLE = 2  # s16le
+
+
 def pcm_for(path: Path) -> bytes:
     """Decode to 8 kHz signed 16-bit little-endian mono.
 
-    Plenty for an envelope drawn at preview size, and it keeps a 6.75-hour
-    tape's PCM buffer to ~389 MB rather than several GB at source rate (e.g.
-    44.1 kHz stereo would be well over 4 GB for the same tape).
+    Plenty for an envelope drawn at preview size, and it keeps the 8h18m
+    tape's PCM buffer to ~478 MB rather than several GB at source rate (e.g.
+    44.1 kHz stereo would be ~5.3 GB for the same tape).
     `capture_output=True` uses `Popen.communicate()` internally, so stdout is
     read incrementally alongside the process rather than after it exits — the
     pipe can't fill and deadlock the way a naive `stdout=PIPE` + `.wait()`
@@ -47,10 +51,79 @@ def pcm_for(path: Path) -> bytes:
     """
     result = subprocess.run(
         ["ffmpeg", "-v", "error", "-i", str(path),
-         "-ac", "1", "-ar", "8000", "-f", "s16le", "-"],
+         "-ac", "1", "-ar", str(_SAMPLE_RATE_HZ), "-f", "s16le", "-"],
         capture_output=True, check=True, timeout=_FFMPEG_TIMEOUT_S,
     )
     return result.stdout
+
+
+class PartialDecodeError(RuntimeError):
+    """ffmpeg produced less audio than the catalogue says the recording holds."""
+
+
+# Tolerance for the decoded-vs-catalogued length check below. It cannot be
+# exact, and the two terms cover two different sources of honest divergence:
+#
+# - The 1.5 s floor covers rounding and codec padding. `calc_duration` is
+#   whole seconds — `catalogue/flows.py:probe_duration` is `int(float(...))`,
+#   a TRUNCATION, so the stored value sits up to 1 s below the real duration
+#   before anything else — and MP3 encoder/decoder delay and padding add tens
+#   of ms on top. The shortest recording in the corpus is 2 s, so the floor
+#   has to stay small enough to still catch a truncated decode of one of
+#   those.
+# - The 1 % term covers ffprobe estimating a duration from the bitrate rather
+#   than reading a frame count, which is the one error that scales with
+#   length. On the 8h18m tape that is ~5 minutes of slack — still far tighter
+#   than any partial decode worth catching, and ~5 of the 480 buckets.
+#
+# The bias is deliberate: a false rejection costs one recomputed row on the
+# next run (logged, retried, cheap), while a false acceptance writes a
+# permanently misaligned envelope that `should_compute` will never revisit.
+_DURATION_TOLERANCE_S = 1.5
+_DURATION_TOLERANCE_FRACTION = 0.01
+
+
+def check_decode_length(pcm: bytes, calc_duration: object) -> None:
+    """Raise `PartialDecodeError` if the decode cannot be the whole recording.
+
+    `check=True` on the ffmpeg call only catches a non-zero exit, and ffmpeg
+    routinely exits 0 on a truncated or damaged MP3 after emitting a short PCM
+    prefix. `peaks_from_pcm` would then stretch that prefix across all 480
+    buckets and the frontend would draw it across the row's full
+    `calc_duration` extent: a waveform misaligned from the audio it claims to
+    depict, stored as a success. Because `should_compute` treats any non-null
+    `peaks` as done, only a `force=True` pass over the whole corpus would ever
+    repair it — so the check has to happen before the write, not after.
+
+    A zero-length decode is the worst case and is rejected unconditionally:
+    `peaks_from_pcm` turns it into 480 `[0, 0]` pairs, indistinguishable from a
+    genuinely silent recording, so there is no `calc_duration` to compare
+    against and nothing to gain from storing it.
+
+    Rows with an absent or non-positive `calc_duration` cannot be checked
+    beyond that. They are ACCEPTED rather than failed: the length is the only
+    evidence available, refusing them would drop real envelopes for rows whose
+    only defect is a missing catalogue field, and a re-run would keep refusing
+    them forever. The zero-length rule above still applies, which is the case
+    that would actually corrupt the display.
+
+    Note the one blind spot: if a file was already truncated when
+    `probe_duration` ran, `calc_duration` describes the truncated file and
+    matches the short decode. This catches damage that postdates the
+    catalogue entry, and MP3s whose header frame count outlives their payload
+    — not a file that has been short since ingest.
+    """
+    decoded_s = len(pcm) / _BYTES_PER_SAMPLE / _SAMPLE_RATE_HZ
+    if decoded_s <= 0:
+        raise PartialDecodeError("ffmpeg decoded 0 samples")
+    if not isinstance(calc_duration, (int, float)) or calc_duration <= 0:
+        return
+    tolerance = max(_DURATION_TOLERANCE_S, _DURATION_TOLERANCE_FRACTION * calc_duration)
+    if abs(decoded_s - calc_duration) > tolerance:
+        raise PartialDecodeError(
+            f"decoded {decoded_s:.1f}s but the catalogue says {calc_duration}s "
+            f"(tolerance {tolerance:.1f}s) — a partial decode, not an envelope"
+        )
 
 
 @flow(name="compute-peaks")
@@ -66,7 +139,9 @@ def compute_peaks_flow(limit: int | None = None, force: bool = False,
     cfg = Config()
     done = skipped = failed = 0
 
-    for row in _page_mp3_items(cfg, "id,url,peaks"):
+    # `calc_duration` is projected for `check_decode_length`, not for display:
+    # without it every row becomes unverifiable and the guard is silently dead.
+    for row in _page_mp3_items(cfg, "id,url,peaks,calc_duration"):
         if limit is not None and done >= limit:
             break
         if not should_compute(row, force=force):
@@ -75,13 +150,18 @@ def compute_peaks_flow(limit: int | None = None, force: bool = False,
 
         key = key_from_url(row["url"])
         # One recording must not be able to end a run over hundreds of them —
-        # a bad download, an unreadable file, a corrupt tape — count it and
-        # move on, the way identify-parties does.
+        # a bad download, an unreadable file, a corrupt tape, a partial decode
+        # — count it and move on, the way identify-parties does.
+        # `PartialDecodeError` lands here too, which is the point: a row whose
+        # envelope would be wrong is left NULL for a later run to retry rather
+        # than written and never revisited.
         try:
             with tempfile.TemporaryDirectory() as tmp:
                 local = Path(tmp) / Path(key).name
                 wasabi.download_file(key, local, cfg)
-                peaks = peaks_from_pcm(pcm_for(local), PEAK_BUCKETS)
+                pcm = pcm_for(local)
+                check_decode_length(pcm, row.get("calc_duration"))
+                peaks = peaks_from_pcm(pcm, PEAK_BUCKETS)
         except Exception as exc:
             logger.warning("compute-peaks: %s failed: %s: %s", key, type(exc).__name__, exc)
             failed += 1

--- a/packages/tools/video-grabber/video_grabber/serve.py
+++ b/packages/tools/video-grabber/video_grabber/serve.py
@@ -59,6 +59,7 @@ from video_grabber.catalogue.flows import (
     link_mp3_subtitles_flow,
 )
 from video_grabber.parties.flows import identify_parties_flow
+from video_grabber.peaks.flows import compute_peaks_flow
 from video_grabber.enhance.flows import (
     render_audition_flow,
     render_enhanced_corpus_flow,
@@ -327,6 +328,7 @@ def main() -> None:
         backfill_mp3_catalogue_flow.to_deployment(name="backfill-mp3-catalogue"),
         link_mp3_subtitles_flow.to_deployment(name="link-mp3-subtitles"),
         identify_parties_flow.to_deployment(name="identify-parties"),
+        compute_peaks_flow.to_deployment(name="compute-peaks"),
         render_audition_flow.to_deployment(name="render-audition"),
         render_enhanced_corpus_flow.to_deployment(name="render-enhanced-corpus"),
     )

--- a/plans/2026-08-17-timeline-lane-preview-design.md
+++ b/plans/2026-08-17-timeline-lane-preview-design.md
@@ -82,7 +82,7 @@ rendering what is *playing*. A timeline entry is not playing.
 
 A static waveform needs amplitude peaks from the file. The corpus rules out
 computing them in the browser: 576 clips are under 5 minutes, but 179 position
-tapes run up to 6.75 hours, and decoding one of those client-side would download
+tapes run up to 8h18m, and decoding one of those client-side would download
 hundreds of megabytes and freeze the tab.
 
 **A radio entry names a station, not a file.** `MediaEntry.itemId` is a station
@@ -105,10 +105,10 @@ So peaks are precomputed offline and stored on the row:
 - **`compute-peaks`** — Prefect flow, manual-only, `dry_run=True` by default,
   idempotent on `peaks IS NOT NULL`.
 
-A fixed bucket count is deliberate: the stored blob is ~2 KB whether the file is
-40 seconds or 6.75 hours, and the renderer always draws 480 values across
-whatever width it has. Per-file resolution would make both sides variable for no
-benefit at preview size.
+A fixed bucket count is deliberate: the stored blob is ~4.1 KB (4 110 bytes of
+compact JSON, measured) whether the file is two seconds or 8h18m, and the
+renderer always draws 480 values across whatever width it has. Per-file
+resolution would make both sides variable for no benefit at preview size.
 
 ## Components
 


### PR DESCRIPTION
Selecting a radio entry in the Playlist Editor timeline now draws the audio that actually aired in that window, as a waveform positioned under the moment it played. Follows #435, which added sticky lane labels and the TV thumbnail strip.

## Two halves

**Offline** — a new `compute-peaks` Prefect flow (`packages/tools/video-grabber/video_grabber/peaks/`) decodes each MP3 with ffmpeg to 8 kHz mono s16le PCM and reduces it to a fixed **480 `[min,max]` pairs** scaled to -128..127, stored in a new `mp3_items.peaks` json column.

**Frontend** — `usePeaksForSpan` fetches the envelopes overlapping the selected entry's window; `PeaksWaveform` draws each on a canvas.

## Why a fixed 480 buckets

Regardless of duration. That keeps every envelope about 4 KB whether the recording is a 40-second ATC clip or WRIF's 8h18m morning show, and lets the renderer always draw 480 values across whatever width it has. Computing this in the browser was never an option — decoding one of the long tapes client-side would pull hundreds of megabytes and freeze the tab.

## Positioned in track time, not viewport time

The radio preview is a time-positioned overlay, not a summary strip: the envelope at 13:00 sits under 13:00 on the timeline. That is the one property that makes a waveform worth showing, and it drives three decisions that look arbitrary otherwise:

- Slots are positioned as fractions of the **timeline bounds**, the way `.playlistTimelineBar` already is — not of the visible span. The containing lane spans the entire zoomed track, so visible-span fractions put a 12:05 recording roughly 1.7 days into a ten-day track at any zoom.
- The fetch keys on the entry's **committed** window rather than the visible one. A visible-span key changes on every 50 ms scroll measure — a three-second pan fired ~60 unabortable Directus requests that FIFO-blocked every other editor REST call behind them.
- A recording overlapping the window is drawn at its **full** extent, clipped only at the track edge. Truncating it to the entry would break the 1:1 mapping between envelope position and time.

The TV strip deliberately keeps its visible-span behaviour — it is a summary that should re-sample as you zoom. Only radio changed.

## Things that had to be worked out against live data

- **`end_date` is unusable.** It is `FORBIDDEN` to anonymous reads *and* null on 162 of 814 rows, so granting it would have produced a silently wrong predicate for a fifth of the corpus. The overlap test is a 12-hour server-side lookback on `start_date` plus an exact client-side `start + calc_duration` check. The lookback constant is sized off the longest recording (8h18m) and is commented as such.
- **`(station, start_date)` is not unique.** 20 collision groups among the 588 approved rows, 17 with differing durations — `UA93 @ 13:34:00` has three rows at 26 s, 86 s and 52 s. Slots key on `id`.
- **`fillStyle = "currentColor"` silently did nothing.** Not a parseable canvas color, so the assignment was dropped and every envelope drew black. Now reads `getComputedStyle(canvas).color`.

## Pipeline safety

ffmpeg exits 0 on a truncated MP3, so `check=True` alone would store a short prefix stretched across all 480 buckets — misaligned from the audio, recorded as a success, and permanent, since the flow treats any non-null `peaks` as done. The decode is now checked against `calc_duration` and a divergent one is counted as failed rather than written.

## Already applied to production

The schema landed via the infra repo's PreSync hook (Keeping-History/infra `94b7e6c`) — no one-off schema changes. The backfill has run: **814 computed, 0 skipped, 0 failed**; 814/814 rows and 588/588 approved rows carry an envelope. Anonymous read on `mp3_items.peaks` is granted, with the `approved = 1` row filter unchanged.

## Testing

Frontend 2470 passing, `tsc -b` and `eslint .` clean; video-grabber peaks suites 24 passing, `ruff` clean.

Every regression test here was verified to **fail** on the pre-fix code by temporary revert — three review rounds on this branch each turned up a test that passed whether or not the logic worked, so they were checked individually rather than assumed. The multi-recording case in particular had no coverage at all despite being the design's central premise.

One known cosmetic quirk, not a defect: WRIF (id 802) renders as a solid block. Its 62-second buckets genuinely sit near full scale — the station runs heavy broadcast limiting. Exactly 1 row of 814 is affected; KFI at a comparable 8 hours saturates 0%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
