### PR TITLE
feat(parties): store tags as a many-to-many, not a junction with the text inlined

### DIFF
--- a/packages/tools/video-grabber/CLAUDE.md
+++ b/packages/tools/video-grabber/CLAUDE.md
@@ -29,12 +29,17 @@ Also stitches per-channel continuous HLS streams + EPG guide JSON.
   `audio-original/` first (first-write-wins). See [`docs/normalization.md`](docs/normalization.md).
 - `video_grabber/parties/` — a **fifth pipeline**: identify who each `audio/*.mp3`
   recording's traffic is between and tag it for searching, writing `mp3_items.parties`
-  and `mp3_items.tags`. No state table — `parties.schema_version` is the idempotency
-  marker. Every name the model returns must appear in a document it was shown; where
-  the 9/11 Commission catalogued the same clip (`commission_clips.json`) their
-  narrative is admitted as a second source, with per-field provenance. See
+  and the `mp3_tags` / `mp3_items_tags` many-to-many. No state table —
+  `parties.schema_version` is the idempotency marker. Every name the model returns must
+  appear in a document it was shown; where the 9/11 Commission catalogued the same clip
+  (`commission_clips.json`) their narrative is admitted as a second source, with
+  per-field provenance. Two flows: `identify-parties` (calls the model) and
+  `rebuild-tags` (re-derives tags from stored `parties`, no inference — use it whenever
+  `tags.py`/`vocab.py` derivation changes). See
   [`docs/party-identification.md`](docs/party-identification.md) — read it before
   changing the prompt or the gate, and do not weaken the gate to raise yield.
+  **`mp3_items.tags` is an m2m alias, not a column** — it cannot be set by PATCHing the
+  item, which is what the writer used to do when `tags` was a json array.
 - `k8s/` — deployment manifests (see Deploy below).
 - `tests/` — pytest. `test_migrations.py` needs a live Postgres; it **errors** (not
   fails) when none is reachable — that's an environment gap, not a regression.

--- a/packages/tools/video-grabber/docs/party-identification.md
+++ b/packages/tools/video-grabber/docs/party-identification.md
@@ -1,9 +1,12 @@
 # Party identification and tagging
 
 Populates `mp3_items.parties` (who a recording's traffic is between, and what it
-is about) and `mp3_items.tags` (a flat, namespaced index for searching).
+is about) and the `mp3_tags` / `mp3_items_tags` many-to-many (a namespaced index
+for searching).
 
-One Prefect flow, `identify-parties`, manual-only and `dry_run=True` by default.
+Two Prefect flows, both manual-only and `dry_run=True` by default:
+`identify-parties` (calls the model) and `rebuild-tags` (re-derives tags from
+stored `parties`, no inference).
 
 ## The containment gate is the whole design
 
@@ -92,36 +95,65 @@ is collapsing spellings, not forcing everything into an airline scheme.
 Facilities resolve the same way through `vocab.FACILITY_ALIASES`, so `Boston`,
 `Boston Center` and `ZBW` are one tag.
 
+### How tags are stored
+
+A many-to-many, the same three-part shape `readme_articles` uses:
+
+| Collection | Rows | What it holds |
+|---|---|---|
+| `mp3_tags` | ~1,100 | The vocabulary: `tag`, `namespace`, `value`, `color`, `sort`. `tag` is unique. |
+| `mp3_items_tags` | ~8,200 | The junction: `mp3_items_id`, `mp3_tags_id`. |
+| `mp3_items.tags` | — | An **alias** (`list-m2m`) over the junction. |
+
+`mp3_items.tags` was previously a json array of strings, and before that the
+junction itself carried the tag text on every row — 8,192 rows repeating 1,131
+distinct tags, with the parent's `start_date` copied onto each. The text is now
+stored once and referenced.
+
+Two consequences worth knowing before touching the writer:
+
+- **You cannot set tags by PATCHing the item.** `tags` is an alias, not a
+  column; `PATCH /items/mp3_items/{id} {"tags": [...]}` does not do what it did
+  when `tags` was json. Persistence goes through `tag_store.py`.
+- **Time filtering goes through `mp3_items.start_date`.** The junction no longer
+  carries a copy, because it was identical to the parent's value on all 8,192
+  rows and the index belongs on the item.
+
+Vocabulary rows are created but never deleted. A retracted tag loses its
+junction rows and vanishes from every search, but the row is cheap and may be
+referenced again — and deleting it would discard any `color`/`sort` a curator
+set on it.
+
 ### Curated tags
 
-`mp3_items.tags` is **derived and readonly in the admin UI**; it is rebuilt from
-scratch on every run. Hand-added tags go in **`tags_curated`**, which the flow
-reads and never writes, and merges into `tags`.
+Derived tags are **rebuilt from scratch on every run**. Hand-added tags go in
+**`tags_curated`**, a json column on the item that the flow reads and never
+writes, and merges into the derived set.
 
-Two columns rather than one, because the obvious single-column merge is wrong:
-folding each new derived set into whatever `tags` already held would let derived
+Two places rather than one, because the obvious single-store merge is wrong:
+folding each new derived set into whatever was already there would let derived
 tags only ever accumulate. A facility the model stops identifying — or one the
 gate starts rejecting — would linger in the index forever with nothing able to
 retract it, so re-running would entrench old mistakes instead of correcting them.
-Rebuilding `tags` wholesale keeps derivation authoritative for itself; keeping
-human input in its own column keeps it safe from that rebuild.
+Rebuilding wholesale keeps derivation authoritative for itself; keeping human
+input in its own column keeps it safe from that rebuild.
 
 Curated values are stored verbatim — not slugged, not namespaced — since a
-curator may need vocabulary this module has never heard of.
+curator may need vocabulary this module has never heard of. `split_tag()`
+therefore has to cope with an un-namespaced tag, and records it as
+`namespace = NULL`.
 
-### Indexes
+### Re-deriving without inference
 
-`tags` carries two GIN indexes, because two query shapes reach it and indexing
-for one does nothing for the other:
+Tags are a pure function of `parties` plus `tags_curated`, so changing
+`tags.py` or `vocab.py` — a new facility alias, a topic added to the
+vocabulary, a callsign that normalises differently — makes every stored tag
+stale without making a single `parties` block wrong.
 
-| Query | Index |
-|---|---|
-| Directus `filter[tags][_contains]=…` → `LIKE '%…%'` | `idx_mp3_items_tags_trgm` (pg_trgm) |
-| `@> '["facility:zbw"]'` from SQL | `idx_mp3_items_tags_jsonb` (jsonb_path_ops) |
-
-Both are declared in `packages/backend/seed.mjs`'s `TAG_INDEX_SQL`. At the
-corpus's present size the planner picks a sequential scan anyway; they matter if
-the tag index ever backs a user-facing search.
+The **`rebuild-tags`** flow re-derives the whole corpus from stored `parties`.
+It reads no transcripts and calls no model, so correcting derivation costs
+nothing but the writes. `identify-parties` is only needed when the *parties*
+themselves must change.
 
 ## Operating it
 

--- a/packages/tools/video-grabber/tests/test_parties_tag_store.py
+++ b/packages/tools/video-grabber/tests/test_parties_tag_store.py
@@ -1,0 +1,149 @@
+"""Tests for persisting derived tags as a many-to-many.
+
+Mocks HTTP calls — no real Directus instance required.
+"""
+import httpx
+import respx
+
+from video_grabber.config import Config
+from video_grabber.parties.tag_store import (
+    ensure_tags,
+    load_vocabulary,
+    replace_item_tags,
+    sync_item_tags,
+)
+
+BASE = "http://directus:8055"
+
+
+def make_cfg():
+    cfg = Config()
+    cfg.directus_url = BASE
+    cfg.directus_api_token = "static-token-xyz"
+    return cfg
+
+
+@respx.mock
+def test_load_vocabulary_maps_tag_text_to_id():
+    respx.get(f"{BASE}/items/mp3_tags").mock(return_value=httpx.Response(200, json={
+        "data": [{"id": 3, "tag": "topic:wtc-impact"}, {"id": 8, "tag": "agency:faa"}],
+    }))
+    assert load_vocabulary(make_cfg()) == {"topic:wtc-impact": 3, "agency:faa": 8}
+
+
+@respx.mock
+def test_ensure_tags_creates_only_the_unknown_ones():
+    """A tag already in the vocabulary must not be inserted a second time.
+
+    This is the whole point of the restructure: 8192 taggings drew on 1131
+    distinct tags, so re-inserting a known tag per tagging is what produced the
+    duplication in the first place.
+    """
+    created = {}
+
+    def record(request):
+        created["body"] = request.content
+        return httpx.Response(200, json={"data": [{"id": 99, "tag": "topic:new-one"}]})
+
+    route = respx.post(f"{BASE}/items/mp3_tags").mock(side_effect=record)
+
+    vocab = {"agency:faa": 8}
+    records = [
+        {"tag": "agency:faa", "namespace": "agency", "value": "faa"},
+        {"tag": "topic:new-one", "namespace": "topic", "value": "new-one"},
+    ]
+    ids = ensure_tags(make_cfg(), records, vocab)
+
+    assert ids == [8, 99]
+    assert route.call_count == 1
+    # Only the unknown tag is posted, and the vocabulary is updated in place so
+    # the next item carrying it costs no insert at all.
+    assert b"topic:new-one" in created["body"]
+    assert b"agency:faa" not in created["body"]
+    assert vocab["topic:new-one"] == 99
+
+
+@respx.mock
+def test_ensure_tags_makes_no_request_when_every_tag_is_known():
+    route = respx.post(f"{BASE}/items/mp3_tags")
+    vocab = {"agency:faa": 8}
+    ids = ensure_tags(
+        make_cfg(), [{"tag": "agency:faa", "namespace": "agency", "value": "faa"}], vocab
+    )
+    assert ids == [8]
+    assert route.call_count == 0
+
+
+@respx.mock
+def test_replace_item_tags_deletes_the_previous_rows_then_inserts():
+    """Rebuilding must retract, not accumulate.
+
+    A tag the model no longer supports has to lose its junction row; without the
+    delete, re-running would only ever add, entrenching old mistakes.
+    """
+    respx.get(f"{BASE}/items/mp3_items_tags").mock(
+        return_value=httpx.Response(200, json={"data": [{"id": 11}, {"id": 12}]})
+    )
+    deleted, posted = {}, {}
+    respx.delete(f"{BASE}/items/mp3_items_tags").mock(
+        side_effect=lambda r: (deleted.setdefault("body", r.content),
+                               httpx.Response(200, json={"data": []}))[1]
+    )
+    respx.post(f"{BASE}/items/mp3_items_tags").mock(
+        side_effect=lambda r: (posted.setdefault("body", r.content),
+                               httpx.Response(200, json={"data": []}))[1]
+    )
+
+    replace_item_tags(make_cfg(), 7, [3, 8])
+
+    assert b"11" in deleted["body"] and b"12" in deleted["body"]
+    assert b'"mp3_items_id":7' in posted["body"].replace(b" ", b"")
+    assert b'"mp3_tags_id":3' in posted["body"].replace(b" ", b"")
+
+
+@respx.mock
+def test_replace_item_tags_skips_the_delete_when_there_is_nothing_to_remove():
+    respx.get(f"{BASE}/items/mp3_items_tags").mock(
+        return_value=httpx.Response(200, json={"data": []})
+    )
+    delete_route = respx.delete(f"{BASE}/items/mp3_items_tags")
+    respx.post(f"{BASE}/items/mp3_items_tags").mock(
+        return_value=httpx.Response(200, json={"data": []})
+    )
+
+    replace_item_tags(make_cfg(), 7, [3])
+    assert delete_route.call_count == 0
+
+
+@respx.mock
+def test_replace_item_tags_clears_an_item_whose_tags_all_went_away():
+    """An item that derives no tags must end up with none, not keep its old ones."""
+    respx.get(f"{BASE}/items/mp3_items_tags").mock(
+        return_value=httpx.Response(200, json={"data": [{"id": 11}]})
+    )
+    respx.delete(f"{BASE}/items/mp3_items_tags").mock(
+        return_value=httpx.Response(200, json={"data": []})
+    )
+    post_route = respx.post(f"{BASE}/items/mp3_items_tags")
+
+    replace_item_tags(make_cfg(), 7, [])
+    assert post_route.call_count == 0
+
+
+@respx.mock
+def test_sync_item_tags_returns_the_tag_count():
+    respx.post(f"{BASE}/items/mp3_tags").mock(
+        return_value=httpx.Response(200, json={"data": [{"id": 99, "tag": "topic:x"}]})
+    )
+    respx.get(f"{BASE}/items/mp3_items_tags").mock(
+        return_value=httpx.Response(200, json={"data": []})
+    )
+    respx.post(f"{BASE}/items/mp3_items_tags").mock(
+        return_value=httpx.Response(200, json={"data": []})
+    )
+    vocab = {"agency:faa": 8}
+    n = sync_item_tags(make_cfg(), 7, [
+        {"tag": "agency:faa", "namespace": "agency", "value": "faa"},
+        {"tag": "topic:x", "namespace": "topic", "value": "x"},
+    ], vocab)
+    assert n == 2

--- a/packages/tools/video-grabber/tests/test_parties_tags.py
+++ b/packages/tools/video-grabber/tests/test_parties_tags.py
@@ -1,5 +1,11 @@
 """Tag derivation: what a searcher can actually filter on."""
-from video_grabber.parties.tags import build_tags, normalize_callsign, slugify
+from video_grabber.parties.tags import (
+    build_tag_records,
+    build_tags,
+    normalize_callsign,
+    slugify,
+    split_tag,
+)
 from video_grabber.parties.vocab import agency_for, canonical_facility
 
 FULL = {
@@ -195,3 +201,25 @@ def test_a_curator_may_assert_various_even_though_derivation_may_not():
     assert "facility:various" in build_tags({}, curated=["facility:various"])
     assert "facility:various" not in build_tags(
         {"participants": [{"facility": "various", "role": "atc"}]})
+
+
+def test_split_tag_separates_namespace_from_value():
+    assert split_tag("topic:hijack-report") == ("topic", "hijack-report")
+
+
+def test_split_tag_keeps_a_value_containing_a_colon_intact():
+    """Splitting on every colon would truncate the value silently."""
+    assert split_tag("person:smith:jr") == ("person", "smith:jr")
+
+
+def test_split_tag_returns_no_namespace_for_a_bare_tag():
+    """Curated tags are taken verbatim, so an un-namespaced one must survive."""
+    assert split_tag("interesting") == (None, "interesting")
+
+
+def test_build_tag_records_reshapes_without_changing_the_derived_set():
+    """The vocabulary and the search index must not be able to disagree."""
+    records = build_tag_records(FULL)
+    assert [r["tag"] for r in records] == build_tags(FULL)
+    assert {"tag": "topic:hijack-report", "namespace": "topic",
+            "value": "hijack-report"} in records

--- a/packages/tools/video-grabber/video_grabber/parties/flows.py
+++ b/packages/tools/video-grabber/video_grabber/parties/flows.py
@@ -23,7 +23,8 @@ from video_grabber.parties.identify import (
     tier_for,
     validate_parties,
 )
-from video_grabber.parties.tags import build_tags
+from video_grabber.parties.tag_store import load_vocabulary, sync_item_tags
+from video_grabber.parties.tags import build_tag_records
 from video_grabber.storage import wasabi
 from video_grabber.transcript.summarize_flows import anthropic_completer
 
@@ -76,6 +77,9 @@ def identify_parties_flow(limit: int | None = None, force: bool = False,
     if not cfg.anthropic_api_key:
         raise RuntimeError("ANTHROPIC_API_KEY is not set")
     complete = anthropic_completer(cfg, model=cfg.parties_model, max_tokens=PARTIES_MAX_TOKENS)
+    # Read once for the whole run and updated in place as new tags appear; a
+    # per-row read would spend most of its requests re-fetching the same table.
+    vocab = {} if dry_run else load_vocabulary(cfg)
 
     done = skipped = failed = broadcast = enriched = 0
     for row in _page_mp3_items(
@@ -143,22 +147,69 @@ def identify_parties_flow(limit: int | None = None, force: bool = False,
             cleaned["gate_reasons"] = reasons
             logger.info("identify-parties: %s gated: %s", key, reasons)
 
-        # `tags` is rebuilt from scratch every run so the model can retract a
+        # Tags are rebuilt from scratch every run so the model can retract a
         # tag it no longer supports; `tags_curated` is the human column the
         # flow reads and never writes, so hand-added tags survive regardless.
-        tags = build_tags(cleaned, row.get("tags_curated") or [])
+        records = build_tag_records(cleaned, row.get("tags_curated") or [])
 
         if dry_run:
-            logger.info("DRY RUN %s -> %s | tags=%s", key, cleaned, tags)
+            logger.info("DRY RUN %s -> %s | tags=%s",
+                        key, cleaned, [r["tag"] for r in records])
         else:
+            # `parties` is a column on the item; the tags are a many-to-many and
+            # cannot ride along in this PATCH — `mp3_items.tags` is an alias over
+            # the junction, not a field that holds values.
             pr = httpx.patch(f"{cfg.directus_url}/items/mp3_items/{row['id']}",
-                             json={"parties": cleaned, "tags": tags},
+                             json={"parties": cleaned},
                              headers=_auth_headers(cfg))
             pr.raise_for_status()
+            sync_item_tags(cfg, row["id"], records, vocab)
         done += 1
 
     logger.info(
         "identify-parties: %d identified (%d with Commission sources), "
         "%d skipped, %d broadcast (excluded), %d failed",
         done, enriched, skipped, broadcast, failed,
+    )
+
+
+@flow(name="rebuild-tags")
+def rebuild_tags_flow(limit: int | None = None, dry_run: bool = True) -> None:
+    """Re-derive every row's tags from the `parties` it already carries.
+
+    Tags are a pure function of `parties` plus `tags_curated`, so a change to
+    the derivation — a new facility alias, a topic added to the vocabulary, a
+    callsign that now normalises differently — makes every stored tag stale
+    without making a single `parties` block wrong. Re-running `identify-parties`
+    would fix them, but only by paying for inference over the whole corpus to
+    reproduce answers already on disk.
+
+    This reads no transcripts and calls no model. It is also how the corpus was
+    moved onto the m2m shape: the junction is rebuilt from scratch, so a tag the
+    derivation no longer produces loses its rows rather than lingering.
+    """
+    logger = get_run_logger()
+    cfg = Config()
+    vocab = {} if dry_run else load_vocabulary(cfg)
+
+    done = skipped = tagged = 0
+    for row in _page_mp3_items(cfg, "id,parties,tags_curated"):
+        if limit is not None and done >= limit:
+            break
+        parties = row.get("parties")
+        if not parties:
+            skipped += 1
+            continue
+
+        records = build_tag_records(parties, row.get("tags_curated") or [])
+        if dry_run:
+            logger.info("DRY RUN %s -> %s", row["id"], [r["tag"] for r in records])
+        else:
+            tagged += sync_item_tags(cfg, row["id"], records, vocab)
+        done += 1
+
+    logger.info(
+        "rebuild-tags: %d rows re-derived, %d taggings written, %d without parties, "
+        "%d distinct tags in vocabulary",
+        done, tagged, skipped, len(vocab),
     )

--- a/packages/tools/video-grabber/video_grabber/parties/tag_store.py
+++ b/packages/tools/video-grabber/video_grabber/parties/tag_store.py
@@ -1,0 +1,111 @@
+"""Persist derived tags as a many-to-many, mirroring the readme_* collections.
+
+Three collections, the shape Directus expects of an m2m and the one
+`readme_articles` already uses here:
+
+    mp3_tags        vocabulary   one row per distinct tag
+    mp3_items_tags  junction     (mp3_items_id, mp3_tags_id)
+    mp3_items.tags  alias        list-m2m over the junction
+
+The previous shape wrote one `mp3_tags` row per *tagging* with the tag text
+inlined — 8192 rows repeating 1131 distinct tags, plus a `start_date` copied
+from the parent item on every row. Nothing could rename a tag, and the text was
+stored ~7x over. Time filtering never needed the copy either: it goes through
+`mp3_items.start_date`, which is where the index belongs.
+
+Vocabulary rows are created but never deleted here. A tag the model retracts
+loses its junction rows and so disappears from every search, but the row itself
+is cheap and may be referenced again on the next run; garbage-collecting it
+would also throw away any `color`/`sort` a curator had set on it.
+"""
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from video_grabber.config import Config
+from video_grabber.directus.writer import _auth_headers
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT = 60.0
+
+
+def load_vocabulary(cfg: Config) -> dict[str, int]:
+    """Every known tag as `{tag: id}`.
+
+    Read once per flow run rather than per row: the vocabulary is ~1100 rows
+    against ~800 items, so a lookup per item would spend most of its requests
+    re-reading the same table.
+    """
+    r = httpx.get(
+        f"{cfg.directus_url}/items/mp3_tags",
+        params={"fields": "id,tag", "limit": "-1"},
+        headers=_auth_headers(cfg), timeout=_TIMEOUT,
+    )
+    r.raise_for_status()
+    return {row["tag"]: row["id"] for row in r.json()["data"] if row.get("tag")}
+
+
+def ensure_tags(cfg: Config, records: list[dict], vocab: dict[str, int]) -> list[int]:
+    """Ids for `records`, creating any vocabulary row that does not exist yet.
+
+    `vocab` is updated in place, so a tag first seen on one item costs one
+    insert for the whole run rather than one per item that carries it.
+    """
+    missing = [r for r in records if r["tag"] not in vocab]
+    if missing:
+        resp = httpx.post(
+            f"{cfg.directus_url}/items/mp3_tags",
+            json=missing, headers=_auth_headers(cfg), timeout=_TIMEOUT,
+        )
+        resp.raise_for_status()
+        for row in resp.json()["data"]:
+            vocab[row["tag"]] = row["id"]
+    return [vocab[r["tag"]] for r in records]
+
+
+def replace_item_tags(cfg: Config, item_id: int, tag_ids: list[int]) -> None:
+    """Make the item's junction rows exactly `tag_ids`.
+
+    Delete-then-insert rather than a diff: the derived set is rebuilt from
+    scratch on every run anyway (see `build_tags`), so computing a minimal patch
+    would be more code for the same end state. Existing rows are read and
+    deleted by id rather than by filter because a filtered DELETE that silently
+    matches nothing and one that silently matches everything look identical in
+    the response.
+    """
+    headers = _auth_headers(cfg)
+    base = f"{cfg.directus_url}/items/mp3_items_tags"
+
+    existing = httpx.get(
+        base,
+        params={"fields": "id", "limit": "-1",
+                "filter[mp3_items_id][_eq]": str(item_id)},
+        headers=headers, timeout=_TIMEOUT,
+    )
+    existing.raise_for_status()
+    stale = [row["id"] for row in existing.json()["data"]]
+    if stale:
+        resp = httpx.request(
+            "DELETE", base, json=stale, headers=headers, timeout=_TIMEOUT,
+        )
+        resp.raise_for_status()
+
+    if tag_ids:
+        resp = httpx.post(
+            base,
+            json=[{"mp3_items_id": item_id, "mp3_tags_id": t} for t in tag_ids],
+            headers=headers, timeout=_TIMEOUT,
+        )
+        resp.raise_for_status()
+
+
+def sync_item_tags(
+    cfg: Config, item_id: int, records: list[dict], vocab: dict[str, int]
+) -> int:
+    """Point one item at exactly `records`. Returns how many tags it now carries."""
+    tag_ids = ensure_tags(cfg, records, vocab)
+    replace_item_tags(cfg, item_id, tag_ids)
+    return len(tag_ids)

--- a/packages/tools/video-grabber/video_grabber/parties/tags.py
+++ b/packages/tools/video-grabber/video_grabber/parties/tags.py
@@ -132,3 +132,28 @@ def build_tags(parties: dict, curated: Iterable[str] = ()) -> list[str]:
     if "facility:various" not in curated:
         tags.discard("facility:various")
     return sorted(tags)
+
+
+def split_tag(tag: str) -> tuple[str | None, str]:
+    """`topic:hijack-report` -> `("topic", "hijack-report")`.
+
+    A tag with no namespace returns `(None, tag)`. Derivation always namespaces,
+    but `curated` values are taken verbatim precisely so a curator can use
+    vocabulary this module has never heard of — including an un-namespaced one.
+    Splitting on the FIRST colon only, so a value containing one survives.
+    """
+    ns, sep, value = tag.partition(":")
+    return (ns, value) if sep else (None, tag)
+
+
+def build_tag_records(parties: dict, curated: Iterable[str] = ()) -> list[dict]:
+    """`build_tags` output as `{tag, namespace, value}` rows for the vocabulary.
+
+    Derivation stays in `build_tags` and this only reshapes it, so the tag a
+    search hits and the tag stored in the vocabulary cannot drift apart.
+    """
+    records = []
+    for tag in build_tags(parties, curated):
+        namespace, value = split_tag(tag)
+        records.append({"tag": tag, "namespace": namespace, "value": value})
+    return records

--- a/packages/tools/video-grabber/video_grabber/serve.py
+++ b/packages/tools/video-grabber/video_grabber/serve.py
@@ -58,7 +58,7 @@ from video_grabber.catalogue.flows import (
     backfill_mp3_catalogue_flow,
     link_mp3_subtitles_flow,
 )
-from video_grabber.parties.flows import identify_parties_flow
+from video_grabber.parties.flows import identify_parties_flow, rebuild_tags_flow
 from video_grabber.enhance.flows import (
     render_audition_flow,
     render_enhanced_corpus_flow,
@@ -327,6 +327,7 @@ def main() -> None:
         backfill_mp3_catalogue_flow.to_deployment(name="backfill-mp3-catalogue"),
         link_mp3_subtitles_flow.to_deployment(name="link-mp3-subtitles"),
         identify_parties_flow.to_deployment(name="identify-parties"),
+        rebuild_tags_flow.to_deployment(name="rebuild-tags"),
         render_audition_flow.to_deployment(name="render-audition"),
         render_enhanced_corpus_flow.to_deployment(name="render-enhanced-corpus"),
     )


### PR DESCRIPTION
`mp3_tags` was never a tag table. It held one row per *tagging* with the tag text copied in — 8,192 rows drawing on 1,131 distinct tags, plus the parent item's `start_date` duplicated onto every one of them. Nothing could rename a tag, nothing could carry a colour or a sort order, and the same ~259 KB of strings was stored roughly seven times over.

It is now the three-part shape `readme_articles` already uses:

| Collection | Rows | Holds |
|---|---|---|
| `mp3_tags` | 1,131 | The vocabulary — `tag` (unique), `namespace`, `value`, `color`, `sort` |
| `mp3_items_tags` | 8,192 | The junction — `mp3_items_id`, `mp3_tags_id` |
| `mp3_items.tags` | — | A `list-m2m` alias over it |

The junction drops `start_date`: it was identical to the parent's value on all 8,192 rows, and time filtering belongs on `mp3_items.start_date` where the index is.

## This also fixes a writer that was already broken

`flows.py` PATCHed `{"tags": [...]}` onto the item. That worked when `tags` was a json column and silently stopped meaning anything when it became a relational alias — the next non-dry run would have posted an array of strings at a field that resolves related primary keys. Persistence now goes through `tag_store.py`, which reads the vocabulary once per run and rebuilds each item's junction rows outright, so a tag the model retracts loses its rows instead of lingering.

## New: `rebuild-tags`

Tags are a pure function of `parties` plus `tags_curated`, so changing `tags.py` or `vocab.py` — a new facility alias, a topic added to the vocabulary, a callsign that normalises differently — makes every stored tag stale while leaving every `parties` block correct. `identify-parties` would fix them, but only by paying for inference over ~800 recordings to reproduce answers already on disk.

`rebuild-tags` re-derives the whole corpus from stored `parties`. No transcripts, no model calls.

## Already applied to production

The schema is declared in the infra repo (`850e341`) and has been applied: **vocabulary 1,131 rows, junction 8,192, all 1,131 tags distinct**. Anonymous reads verified for forward expansion, reverse lookup by tag, and namespace faceting, with the `approved = 1` gate moved to the junction — `topic:shootdown-authority` returns 9 taggings to the service policy and 4 to the public one.

Before deleting anything, the rebuild was proven lossless: re-deriving from `parties` reproduced the stored 8,192 `(item, tag)` pairs **set-identically** — 0 lost, 0 new.

## Two things a reviewer should know

**The production rebuild did not run this code.** The worker image predates this branch, so the repopulation used a script that called the image's own `build_tags` (unchanged by this PR) and wrote the vocabulary and junction directly. The derivation is therefore identical, and `build_tag_records` is tested to return exactly `build_tags`' output; but the *persistence* path in `tag_store.py` has only been exercised by its unit tests, not against production. The first real run will be the first exercise of `replace_item_tags`, which should be a no-op given the state already matches.

**Uniqueness is enforced in raw DDL, not in the Directus field metadata.** Declaring `is_unique` on `mp3_tags.tag` makes Directus drop the index under its own naming convention (`mp3_tags_tag_index`) while the raw DDL calls it `idx_mp3_tags_tag`, and every schema apply 500s. The two rules that keep those systems apart are now written into `schema/indexes.sql` in the infra repo.

## Testing

653 passed, 8 skipped (12 `test_migrations.py` errors are the documented no-Postgres environment gap); `ruff` clean. New coverage for `split_tag`, `build_tag_records`, and every function in `tag_store.py` — including that a known tag issues no insert, that rebuilding retracts rows rather than accumulating them, and that an item deriving no tags ends up with none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
