### PR TITLE
fix(backend): bounds-check DB pool size env vars (CodeQL)

### DIFF
--- a/packages/backend/cmd/server/main.go
+++ b/packages/backend/cmd/server/main.go
@@ -28,8 +28,8 @@ func main() {
 
 	dbURL := env("DATABASE_URL", "postgres://directus:directus@localhost:5432/directus")
 	pool, err := db.Connect(dbURL, db.PoolConfig{
-		MaxConns:          int32(envInt("DB_MAX_CONNS", 20)),
-		MinConns:          int32(envInt("DB_MIN_CONNS", 2)),
+		MaxConns:          envInt32("DB_MAX_CONNS", 20),
+		MinConns:          envInt32("DB_MIN_CONNS", 2),
 		MaxConnLifetime:   envDur("DB_MAX_CONN_LIFETIME", time.Hour),
 		MaxConnIdleTime:   envDur("DB_MAX_CONN_IDLE_TIME", 30*time.Minute),
 		HealthCheckPeriod: envDur("DB_HEALTH_CHECK_PERIOD", time.Minute),
@@ -424,6 +424,18 @@ func envInt(key string, fallback int) int {
 	if v := os.Getenv(key); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
 			return n
+		}
+	}
+	return fallback
+}
+
+// envInt32 reads key as an int32, falling back on an unset/empty/unparseable/
+// out-of-range value. ParseInt's bitSize=32 rejects anything that would
+// overflow int32 instead of silently truncating it, unlike int32(envInt(...)).
+func envInt32(key string, fallback int32) int32 {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 32); err == nil {
+			return int32(n)
 		}
 	}
 	return fallback


### PR DESCRIPTION
## Summary
Fixes CodeQL alerts #8 and #9 (`go/incorrect-integer-conversion`) in `packages/backend/cmd/server/main.go`.

`envInt` returns a platform-width `int`; `MaxConns`/`MinConns` were built with `int32(envInt(...))`, an unchecked narrowing conversion. A malformed `DB_MAX_CONNS`/`DB_MIN_CONNS` env value (e.g. an operator typo adding extra digits) would silently wrap into an unexpected — possibly negative — `int32` instead of falling back to the default, rather than erroring or clamping.

Added `envInt32`, matching the existing `envInt`/`envDur` naming convention, using `strconv.ParseInt(v, 10, 32)` — which rejects out-of-range values outright instead of truncating them — and switched both call sites to it.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all packages pass

Closes the CodeQL alerts referenced above once merged.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>