### PR TITLE
fix(playlist): repoint radio catalog's app id from RadioScanner.app to RadioTraffic.app

### DIFF
--- a/packages/frontend/src/Applications/PlaylistEditor/EntryForm.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/EntryForm.tsx
@@ -11,7 +11,7 @@ import type { EditorEntry } from "./editorState";
 import { listSettingsApps } from "./settingsRegistry";
 
 const KNOWN_APP_IDS = [
-	"TimeMachine.app", "TV.app", "RadioScanner.app", "News.app",
+	"TimeMachine.app", "TV.app", "RadioTraffic.app", "RadioTuner.app", "News.app",
 	"FlightTracker.app", "Browser.app", "PDFViewer.app", "Weather.app",
 ];
 

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistDocumentWindow.test.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistDocumentWindow.test.tsx
@@ -465,12 +465,12 @@ describe("PlaylistDocumentWindow", () => {
 			renderWindow();
 			const focus = item("control", "playlist_control_focus");
 			const radio = focus.menuChildren?.find(
-				(c) => c.id === "playlist_control_focus_RadioScanner.app",
+				(c) => c.id === "playlist_control_focus_RadioTraffic.app",
 			);
-			if (!radio) throw new Error("no RadioScanner focus item");
+			if (!radio) throw new Error("no RadioTraffic focus item");
 			act(() => radio.onClickFunc?.());
 			await waitFor(() =>
-				expect(roomApi.sendRoomFocus).toHaveBeenCalledWith("p1", "RadioScanner.app"),
+				expect(roomApi.sendRoomFocus).toHaveBeenCalledWith("p1", "RadioTraffic.app"),
 			);
 		});
 

--- a/packages/frontend/src/Applications/PlaylistEditor/playlistMenus.test.ts
+++ b/packages/frontend/src/Applications/PlaylistEditor/playlistMenus.test.ts
@@ -133,7 +133,7 @@ describe("documentControlMenu", () => {
 		const onFocusApp = vi.fn();
 		const focus = child(documentControlMenu({ ...noopControl, onFocusApp }), "playlist_control_focus");
 		expect(focus.menuChildren?.map((c) => c.title)).toEqual([
-			"TV", "Radio Scanner", "News", "Flight Tracker",
+			"TV", "Radio Traffic", "News", "Flight Tracker",
 		]);
 
 		focus.menuChildren?.[0].onClickFunc?.();

--- a/packages/frontend/src/Applications/PlaylistEditor/playlistMenus.ts
+++ b/packages/frontend/src/Applications/PlaylistEditor/playlistMenus.ts
@@ -221,7 +221,7 @@ export const PUSH_UPDATE_BALLOONS = {
  * APP_NAMES) — the same ids RoomControlBridge resolves on the student side. */
 export const FOCUS_APPS: { appId: string; name: string }[] = [
 	{ appId: "TV.app", name: "TV" },
-	{ appId: "RadioScanner.app", name: "Radio Scanner" },
+	{ appId: "RadioTraffic.app", name: "Radio Traffic" },
 	{ appId: "News.app", name: "News" },
 	{ appId: "FlightTracker.app", name: "Flight Tracker" },
 ];

--- a/packages/frontend/src/Providers/Playlist/PlaylistProvider.tsx
+++ b/packages/frontend/src/Providers/Playlist/PlaylistProvider.tsx
@@ -26,7 +26,6 @@ import { browserNavigate } from "../../Applications/Browser/BrowserContext";
 import { flightTrackerFocusFlight } from "../../Applications/FlightTracker/flightTrackerCommands";
 import { newsFocusItem } from "../../Applications/News/NewsContext";
 import { BROADCAST_STATIONS } from "../../Applications/radio-core/stationGrouping";
-import { radioTuneStation } from "../../Applications/radio-core/radioTuneStation";
 import { radioTunerTuneStation } from "../../Applications/RadioTuner/RadioTunerContext";
 import { setDateTimeFromUtc } from "../../Applications/TimeMachine/setVirtualClock";
 import { tvTuneChannel } from "../../Applications/TV/TVContext";
@@ -61,14 +60,16 @@ const FOCUS_DISPATCHERS: Record<PlaylistApp | "browser", (d: Dispatch, itemId: s
 	{
 		tv: (d, itemId) => d(tvTuneChannel(itemId)),
 		// The radio catalog spans two apps post-split: broadcast stations tune
-		// the Radio Tuner, comm-traffic stations the Radio Scanner — matching
-		// playlistFocusAppId's app choice.
-		radio: (d, itemId) =>
-			d(
-				BROADCAST_STATIONS.has(itemId.toUpperCase())
-					? radioTunerTuneStation(itemId)
-					: radioTuneStation(itemId),
-			),
+		// the Radio Tuner (matching playlistFocusAppId's app choice), which still
+		// has a single "current station" to tune. Comm/ATC traffic's successor,
+		// Radio Traffic, has no equivalent per-item focus target — it shows every
+		// LIVE/UPCOMING/PREVIOUS card at once rather than tuning one channel — so
+		// there is nothing to dispatch here yet. applyFocus's ClassicyAppOpen
+		// still opens the app; a real per-card focus (solo? scroll-to?) is a
+		// follow-up story, not something to invent here.
+		radio: (d, itemId) => {
+			if (BROADCAST_STATIONS.has(itemId.toUpperCase())) d(radioTunerTuneStation(itemId));
+		},
 		news: (d, itemId) => d(newsFocusItem(Number(itemId))),
 		flights: (d, itemId) => d(flightTrackerFocusFlight(itemId)),
 		browser: (d, url) => d(browserNavigate(url)),

--- a/packages/frontend/src/Providers/Playlist/parsePlaylist.ts
+++ b/packages/frontend/src/Providers/Playlist/parsePlaylist.ts
@@ -118,7 +118,7 @@ function parseEntry(raw: unknown, warn: (msg: string) => void): PlaylistEntry | 
 // PlaylistApp → owning desktop app id, needed for the disable-wins cross-check.
 const APP_IDS: Record<PlaylistApp, string> = {
 	tv: "TV.app",
-	radio: "RadioScanner.app",
+	radio: "RadioTraffic.app",
 	news: "News.app",
 	flights: "FlightTracker.app",
 };

--- a/packages/frontend/src/Providers/Playlist/playlistApps.ts
+++ b/packages/frontend/src/Providers/Playlist/playlistApps.ts
@@ -6,7 +6,7 @@ import type { PlaylistApp } from "./playlistTypes";
 
 export const PLAYLIST_APP_IDS: Record<PlaylistApp, string> = {
 	tv: "TV.app",
-	radio: "RadioScanner.app",
+	radio: "RadioTraffic.app",
 	news: "News.app",
 	flights: "FlightTracker.app",
 };
@@ -14,8 +14,9 @@ export const PLAYLIST_APP_IDS: Record<PlaylistApp, string> = {
 /**
  * The app a focus entry actually opens. The "radio" catalog is split across
  * two desktop apps: continuous broadcast stations (WCBS/WINS) live in the
- * Radio Tuner, every other station in the Radio Scanner. Station slugs match
- * case-insensitively, same as the apps' own tune commands.
+ * Radio Tuner, every other station — comm/ATC traffic — in Radio Traffic
+ * (RadioScanner's successor; see radio-core's own header comment). Station
+ * slugs match case-insensitively, same as the apps' own tune commands.
  */
 export function playlistFocusAppId(app: PlaylistApp, itemId: string): string {
 	if (app === "radio" && BROADCAST_STATIONS.has(itemId.toUpperCase())) {
@@ -30,7 +31,7 @@ export const PERMISSION_DENIED = "You don't have permission to open this app.";
 // open/close dispatch match the ones the app itself creates.
 const APP_NAMES: Record<string, string> = {
 	"TV.app": "TV",
-	"RadioScanner.app": "Radio Scanner",
+	"RadioTraffic.app": "Radio Traffic",
 	"RadioTuner.app": "Radio Tuner",
 	"News.app": "News",
 	"FlightTracker.app": "Flight Tracker",
@@ -44,7 +45,7 @@ const APP_NAMES: Record<string, string> = {
 // depending on import order.
 const APP_ICON_KEYS: Record<string, string> = {
 	"TV.app": "epg",
-	"RadioScanner.app": "radioScanner",
+	"RadioTraffic.app": "radioTraffic",
 	"RadioTuner.app": "radio",
 	"News.app": "news",
 	"FlightTracker.app": "flightTracker",


### PR DESCRIPTION
## Summary
- Story 020 (part of #488, just merged) deleted RadioScanner.tsx/RadioScannerContext.ts, but four call sites outside that story's file list still hard-coded `"RadioScanner.app"` as the target for the playlist "radio" catalog's non-broadcast-station focus entries — the majority of what Radio Traffic now owns.
- Result: any playlist scheduling a "radio" focus on a non-broadcast (comm/ATC) item was a **silent no-op** in production — the app never opened, no error surfaced to a teacher or student.
- Repoints `PLAYLIST_APP_IDS.radio`/`APP_NAMES`/`APP_ICON_KEYS` (playlistApps.ts), the disable-wins cross-check table (parsePlaylist.ts), the "Bring App to Front" live teacher control (playlistMenus.ts), and the "disable app" picker (EntryForm.tsx, now listing RadioTraffic.app and RadioTuner.app separately since one id used to cover both).
- Drops the dead `radioTuneStation()` dispatch for the comm-traffic case in PlaylistProvider.tsx — nothing has handled that action type since RadioScannerContext.ts was deleted (confirmed via grep). The app still opens via the existing `ClassicyAppOpen` dispatch; per-item focus (solo a card? scroll to it?) doesn't map cleanly onto RadioTraffic's card/lane model and is a follow-up story, not invented here.
- Two tests were pinning the broken id as expected behavior — updated to assert the fix, not reverted.

Not touched: `public/stacks/getting-started.stack.json`'s tutorial button still opens `"RadioScanner.app"` — pure content, a separate content-authoring fix.

## Test plan
- [x] `tsc -b` clean
- [x] `pnpm lint` clean (only pre-existing unrelated warnings)
- [x] `pnpm test` — 292 files / 3147 tests passing
- [x] Targeted `src/Providers/Playlist` + `src/Applications/PlaylistEditor` suites — 354 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111gnL3iJXzp6C7FADiE815