### PR TITLE
feat(flight-tracker): show every multi-selected flight's track

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ permissions:
 
 env:
   # Public backend URLs compiled into the frontend bundle.
-  FE_VITE_PROXY_PROTOCOL: "https:"
+  FE_VITE_PROXY_PROTOCOL: "wss:"
   FE_VITE_PROXY_HOST: "timemachine.911realtime.org"
   FE_VITE_PROXY_PORT: "443"
   FE_VITE_MEDIA_STREAM_URL: "wss://stream.911realtime.org/stream"

--- a/packages/frontend/src/Applications/FlightTracker/FlightMap.test.tsx
+++ b/packages/frontend/src/Applications/FlightTracker/FlightMap.test.tsx
@@ -49,6 +49,7 @@ const FakeMap = vi.hoisted(() => {
 			this.layers.push({ ...def, beforeId, __raw: def });
 		}
 		getLayer(id: string) { return this.layers.find((l) => l.id === id); }
+		removeLayer(id: string) { this.layers = this.layers.filter((l) => l.id !== id); }
 		repaints = 0;
 		triggerRepaint() { this.repaints++; }
 		setPaintProperty(layerId: string, name: string, value: unknown) {
@@ -1087,6 +1088,44 @@ describe("FlightMap", () => {
 		expect(tube.vertexCount).toBe(0);
 	});
 
+
+	it("adds/removes one plain 3D tube per OTHER multi-selected flight (issue #326)", () => {
+		const profile = [
+			{ lon: -74, lat: 40, alt_ft: 1_000, utc: "2001-09-11T12:00:00Z" },
+			{ lon: -73.5, lat: 40.5, alt_ft: 12_000, utc: "2001-09-11T12:01:00Z" },
+		];
+		const common = {
+			positions: [], basemapUrls: TEST_URLS, trackGeoJSON: null, nowMs: 0,
+			playing: false, onSelectFlight: () => {}, onClearSelection: () => {},
+			darkMap: false, mapStyle: "classic" as const, pinColor: "#3a3a3a",
+			notablePinColor: "#c0202a", observerPinColor: "#0f766e", anonPinColor: "#8b7d6b",
+			radarSweep: false, trailMultiplier: 1,
+		};
+		const { rerender } = render(<FlightMap {...common} secondaryTrackProfiles={[]} />);
+		const map = FakeMap.last!;
+		map.fire("load");
+		expect(map.layers.find((l) => l.id === "track-tube-3d-secondary-UA175")).toBeUndefined();
+
+		rerender(<FlightMap {...common} secondaryTrackProfiles={[{ flight: "UA175", profile }]} />);
+		const tube = map.layers.find((l) => l.id === "track-tube-3d-secondary-UA175")!
+			.__raw as import("./trackTubeLayer").TrackTube3DLayer;
+		expect(tube.vertexCount).toBeGreaterThan(0);
+
+		// A second flight joins the selection: its own tube is added, the first survives.
+		rerender(
+			<FlightMap {...common} secondaryTrackProfiles={[
+				{ flight: "UA175", profile },
+				{ flight: "AA77", profile },
+			]} />,
+		);
+		expect(map.layers.find((l) => l.id === "track-tube-3d-secondary-UA175")).toBeDefined();
+		expect(map.layers.find((l) => l.id === "track-tube-3d-secondary-AA77")).toBeDefined();
+
+		// Deselecting UA175 removes only its tube.
+		rerender(<FlightMap {...common} secondaryTrackProfiles={[{ flight: "AA77", profile }]} />);
+		expect(map.layers.find((l) => l.id === "track-tube-3d-secondary-UA175")).toBeUndefined();
+		expect(map.layers.find((l) => l.id === "track-tube-3d-secondary-AA77")).toBeDefined();
+	});
 
 	it("reports pitch-threshold crossings so the 3D toggle can follow the camera", () => {
 		const onPitchedChange = vi.fn();

--- a/packages/frontend/src/Applications/FlightTracker/FlightMap.test.tsx
+++ b/packages/frontend/src/Applications/FlightTracker/FlightMap.test.tsx
@@ -114,6 +114,14 @@ const FakeMap = vi.hoisted(() => {
 			disable: () => { this.dragPanDisabled = true; },
 			enable: () => { this.dragPanDisabled = false; },
 		};
+		// boxZoom is constructor-disabled only (issue #326) — stubbed with a
+		// spy, not wired into setCameraInteractive's toggle list, so a test can
+		// assert it's never re-enabled by a follow-lock cycle.
+		boxZoomEnableCalls = 0;
+		boxZoom = {
+			disable: () => {},
+			enable: () => { this.boxZoomEnableCalls++; },
+		};
 		canvasStyle: Record<string, string> = {};
 		getCanvas() { return { style: this.canvasStyle } as unknown as HTMLCanvasElement; }
 		easeToCalls: Record<string, unknown>[] = [];
@@ -1382,6 +1390,15 @@ describe("FlightMap", () => {
 					followFlight={null} cameraMode="track" />,
 			);
 			expect(map.dragPanDisabled).toBe(false);
+			// ...but never boxZoom (issue #326): it's disabled permanently at
+			// construction because it competes with shift-click multi-select, and
+			// re-enabling camera interactivity here must not undo that.
+			expect(map.boxZoomEnableCalls).toBe(0);
+		});
+
+		it("constructs the map with boxZoom disabled, so Shift+drag can't hijack shift-click multi-select (issue #326)", () => {
+			render(<FlightMap {...common} positions={[]} followFlight={null} cameraMode="track" />);
+			expect(FakeMap.last!.ctorOpts.boxZoom).toBe(false);
 		});
 
 		it("cockpit mode opens the pitch band and drives a steep heading-aligned view", () => {

--- a/packages/frontend/src/Applications/FlightTracker/FlightMap.tsx
+++ b/packages/frontend/src/Applications/FlightTracker/FlightMap.tsx
@@ -10,6 +10,7 @@ import { invertHex } from "./colorInvert";
 import {
 	type BasemapStyleId,
 	type BasemapUrls,
+	SECONDARY_TRACK_COLOR,
 	TRACK_LINE_COLOR,
 	TRACK_SHADOW_COLOR,
 	applyMapColors,
@@ -327,6 +328,10 @@ interface FlightMapProps {
 	// arrive pre-colored in trackGeoJSON, but the 3D tube colors its own
 	// vertices, so it needs the selected flight's palette (flightPhases.ts).
 	trackPalette?: PhasePalette;
+	// Every OTHER multi-selected flight's altitude profile (issue #326): each
+	// gets its own plain (unphased) 3D tube alongside the active one's above,
+	// mirroring trackGeoJSON's secondary 2D features.
+	secondaryTrackProfiles?: { flight: string; profile: AltitudeSample[] }[];
 	nowMs: number;
 	playing: boolean;
 	mapStyle: BasemapStyleId;
@@ -600,6 +605,7 @@ export const THREE_D_MAX_PITCH = 85;
 // can't flicker off mid-drag.
 export const THREE_D_MIN_PITCH = 10;
 const EMPTY_FC = { type: "FeatureCollection" as const, features: [] };
+const EMPTY_SECONDARY_TRACKS: { flight: string; profile: AltitudeSample[] }[] = [];
 const FRAME_MS = 66; // ~15 fps animation gate
 // Click hit-test slop (px). Dots are a small (3px) and gliding target, so an
 // exact-pixel hit-test misses easily; a click within this radius selects the
@@ -613,7 +619,7 @@ const REPLAY_TRAIL_STROKE_COLOR = "#ffffff";
 export const FlightMap: FC<FlightMapProps> = ({
 	ref: handleRef,
 	positions, seedPositions, basemapUrls, trackGeoJSON,
-	trackProfile = null, trackPalette, nowMs, playing,
+	trackProfile = null, trackPalette, secondaryTrackProfiles = EMPTY_SECONDARY_TRACKS, nowMs, playing,
 	mapStyle, darkMap, pinColor, notablePinColor, observerPinColor, anonPinColor, radarSweep, trailMultiplier,
 	// Warm-stone defaults mirror flightMapSettings.ts's DEFAULT_FLIGHT_MAP_SETTINGS
 	// so call sites that predate hero landmarks (or omit the setting) still get a
@@ -768,6 +774,10 @@ export const FlightMap: FC<FlightMapProps> = ({
 	const replayTrail3DRef = useRef<Planes3DLayer | null>(null);
 	// The selected flight's smooth 3D track tube.
 	const trackTubeRef = useRef<TrackTube3DLayer | null>(null);
+	// One plain (unphased) tube per OTHER multi-selected flight (issue #326),
+	// keyed by flight — added/removed as the selection changes, unlike the
+	// fixed-at-load layers above. Mirrors trackGeoJSON's secondary 2D features.
+	const secondaryTubesRef = useRef<Map<string, TrackTube3DLayer>>(new Map());
 	// Smooth live-trail ribbons (same class, translucent + flat-shaded).
 	const trailTubeRef = useRef<TrackTube3DLayer | null>(null);
 	// Alternating-frame gate for the ribbon rebuild (see the rAF loop).
@@ -794,6 +804,7 @@ export const FlightMap: FC<FlightMapProps> = ({
 		planes3DRef.current?.setVisible(custom3D);
 		replayTrail3DRef.current?.setVisible(custom3D);
 		trackTubeRef.current?.setVisible(custom3D);
+		for (const tube of secondaryTubesRef.current.values()) tube.setVisible(custom3D);
 		trailTubeRef.current?.setVisible(custom3D && !clusterRef.current);
 		// Pitched: the elevated geometry carries the track color, so the ground
 		// line darkens into its shadow; flat: it IS the track, full color.
@@ -1343,6 +1354,7 @@ export const FlightMap: FC<FlightMapProps> = ({
 			planes3DRef.current = null;
 			replayTrail3DRef.current = null;
 			trackTubeRef.current = null;
+			secondaryTubesRef.current = new Map();
 			trailTubeRef.current = null;
 			buildings3DRef.current = null;
 			mapRef.current = null;
@@ -1422,6 +1434,33 @@ export const FlightMap: FC<FlightMapProps> = ({
 		trackTubeRef.current?.setGeometry(buildTrackTube(trackProfile, undefined, trackPalette));
 		dirtyRef.current = true;
 	}, [trackProfile, trackPalette]);
+
+	// Add/remove/rebuild one plain 3D tube per OTHER multi-selected flight
+	// (issue #326), keyed by flight so an unrelated prop change doesn't tear
+	// down and recreate every tube. Radius/vertical-drop come per-frame from
+	// the rAF loop, same as the active tube.
+	useEffect(() => {
+		const map = mapRef.current;
+		if (!map || !loadedRef.current) return;
+		const wanted = new Set(secondaryTrackProfiles.map((t) => t.flight));
+		for (const [flight, tube] of secondaryTubesRef.current) {
+			if (wanted.has(flight)) continue;
+			if (map.getLayer(tube.id)) map.removeLayer(tube.id);
+			secondaryTubesRef.current.delete(flight);
+		}
+		for (const { flight, profile } of secondaryTrackProfiles) {
+			let tube = secondaryTubesRef.current.get(flight);
+			if (!tube) {
+				tube = new TrackTube3DLayer({ id: `track-tube-3d-secondary-${flight}` });
+				tube.setColor(SECONDARY_TRACK_COLOR);
+				tube.setVisible(pitchedRef.current);
+				secondaryTubesRef.current.set(flight, tube);
+				map.addLayer(tube);
+			}
+			tube.setGeometry(buildTrackTube(profile, undefined, undefined));
+		}
+		dirtyRef.current = true;
+	}, [secondaryTrackProfiles]);
 
 	// Re-theme / recolor live. setPaintProperty only — setStyle() would tear
 	// down the flights/trails/track sources and layers. Before "load" fires,
@@ -1680,6 +1719,10 @@ export const FlightMap: FC<FlightMapProps> = ({
 				// height is sizeKm*500 m, so drop by that plus the tube's own
 				// radius. Uniform-driven, so it tracks zoom with no rebuild.
 				trackTubeRef.current?.setVerticalDrop(sizeKm * 500 + tubeRadiusM);
+				for (const tube of secondaryTubesRef.current.values()) {
+					tube.setRadius(tubeRadiusM);
+					tube.setVerticalDrop(sizeKm * 500 + tubeRadiusM);
+				}
 				if (planes3DRef.current) {
 					// Per-airframe batches (issue #250 follow-up): each family
 					// draws its own model; unloaded families render the prism

--- a/packages/frontend/src/Applications/FlightTracker/FlightMap.tsx
+++ b/packages/frontend/src/Applications/FlightTracker/FlightMap.tsx
@@ -400,11 +400,19 @@ interface FlightMapProps {
 // Enable/disable every user camera handler in one place (the follow lock owns
 // the camera while active). Defensive against handlers a given build/mock may
 // not expose — only dragPan is guaranteed in the test harness.
+//
+// boxZoom is deliberately absent: MapLibre's default Shift+drag box-zoom
+// competes directly with shift-click multi-select (issue #310) — a click is
+// just a near-zero-distance drag, so boxZoom's handler can swallow the
+// gesture before the app's own click handler ever sees a clean shiftKey
+// click. It's disabled permanently at construction (`boxZoom: false`) and
+// must stay out of this list, or re-enabling camera interactivity here
+// (follow-unlock) would silently turn it back on.
 type MapHandler = { enable?: () => void; disable?: () => void };
 function setCameraInteractive(map: maplibregl.Map, on: boolean) {
 	const m = map as unknown as Record<string, MapHandler | undefined>;
 	for (const key of [
-		"dragPan", "dragRotate", "scrollZoom", "boxZoom",
+		"dragPan", "dragRotate", "scrollZoom",
 		"doubleClickZoom", "keyboard", "touchZoomRotate", "touchPitch",
 	]) {
 		const h = m[key];
@@ -830,6 +838,9 @@ export const FlightMap: FC<FlightMapProps> = ({
 			center: NA_CENTER,
 			zoom: NA_ZOOM,
 			attributionControl: false,
+			// MapLibre's default Shift+drag box-zoom would otherwise intercept
+			// shift-click multi-select (see setCameraInteractive's comment above).
+			boxZoom: false,
 			// Pitch is exclusively the 3D toggle's domain: with 3D off the map is
 			// hard-locked flat (right-drag still rotates bearing, never the z
 			// axis); with 3D on right-drag tilts freely across

--- a/packages/frontend/src/Applications/FlightTracker/FlightTracker.test.tsx
+++ b/packages/frontend/src/Applications/FlightTracker/FlightTracker.test.tsx
@@ -6,6 +6,7 @@ import {
 	type MediaStreamContextValue,
 } from "../../Providers/MediaStream/MediaStreamContext";
 import { DEFAULT_FLIGHT_MAP_SETTINGS } from "./flightMapSettings";
+import { SECONDARY_TRACK_COLOR } from "./flightMapStyle";
 
 // Mock the map (WebGL) — assert wiring, not rendering.
 const mapProps: Array<Record<string, unknown>> = [];
@@ -886,6 +887,60 @@ describe("FlightTracker", () => {
 			});
 			// The tool disarms after a selection.
 			expect(mapProps[mapProps.length - 1].selectMode).toBe("off");
+		});
+
+		it("a multi-selection (shift-click or area-select) draws every OTHER flight's track too, not just the active one (issue #326)", async () => {
+			const UA175_GEOMETRY = {
+				type: "LineString" as const,
+				coordinates: [[-73, 41], [-72, 42]] as [number, number][],
+			};
+			const UA175_PROFILE = [
+				{ lat: 41, lon: -73, alt_ft: 30000, utc: "2001-09-11T13:00:00.000Z" },
+				{ lat: 42, lon: -72, alt_ft: 31000, utc: "2001-09-11T13:05:00.000Z" },
+			];
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(async (url: string) => {
+					const u = String(url);
+					if (u.includes("/items/flight_tracks")) {
+						const flight = new URL(u).searchParams.get("filter[flight][_eq]");
+						if (flight !== "UA175") return { ok: true, json: async () => ({ data: [] }) };
+						return {
+							ok: true,
+							json: async () => ({
+								data: [{
+									flight: "UA175", flight_date: "2001-09-11", origin: null,
+									scheduled_dest: null, landed_at: null, diverted: false,
+									geometry: UA175_GEOMETRY, tail_number: null, aircraft_type: null,
+									details: null, wheels_off_utc: null, wheels_on_utc: null,
+								}],
+							}),
+						};
+					}
+					// flight_positions (altitude profile): only UA175 has data here.
+					const flight = new URL(u).searchParams.get("filter[flight][_eq]");
+					return {
+						ok: true,
+						json: async () => ({ data: flight === "UA175" ? UA175_PROFILE : [] }),
+					};
+				}),
+			);
+			renderWithContext({ flightPositions: [aa11, ua175], connected: true });
+			const onAreaSelect = mapProps[mapProps.length - 1].onAreaSelect as (f: string[]) => void;
+			// AA11 becomes active (index 0, no track data stubbed → no active
+			// feature); UA175 is the OTHER selected flight.
+			act(() => onAreaSelect(["AA11", "UA175"]));
+
+			await waitFor(() => {
+				const secondary = mapProps[mapProps.length - 1].secondaryTrackProfiles as
+					{ flight: string; profile: unknown[] }[];
+				expect(secondary).toEqual([{ flight: "UA175", profile: UA175_PROFILE }]);
+			});
+			const geoJSON = mapProps[mapProps.length - 1].trackGeoJSON as GeoJSON.FeatureCollection;
+			const secondaryFeature = geoJSON.features.find(
+				(f) => f.properties?.color === SECONDARY_TRACK_COLOR,
+			);
+			expect(secondaryFeature?.geometry).toEqual(UA175_GEOMETRY);
 		});
 
 		it("a persisted flight-list filter hides everything else", () => {

--- a/packages/frontend/src/Applications/FlightTracker/FlightTracker.test.tsx
+++ b/packages/frontend/src/Applications/FlightTracker/FlightTracker.test.tsx
@@ -943,6 +943,27 @@ describe("FlightTracker", () => {
 			expect(secondaryFeature?.geometry).toEqual(UA175_GEOMETRY);
 		});
 
+		it("shift-click (onToggleFlight) after a plain click builds a real 2-flight multi-selection (issue #310 integration)", () => {
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(async () => ({ ok: true, json: async () => ({ data: [] }) })),
+			);
+			renderWithContext({ flightPositions: [aa11, ua175], connected: true });
+
+			const onSelectFlight = mapProps.at(-1)!.onSelectFlight as (f: string) => void;
+			act(() => onSelectFlight("AA11"));
+			// A single selection: the multi-select dropdown is not shown at all.
+			expect(screen.queryByTestId("flight_detail_selection")).toBeNull();
+
+			const onToggleFlight = mapProps.at(-1)!.onToggleFlight as (f: string) => void;
+			act(() => onToggleFlight("UA175"));
+
+			const dd = screen.queryByTestId("flight_detail_selection") as HTMLSelectElement | null;
+			expect(dd).not.toBeNull();
+			const values = [...dd!.options].map((o) => o.value);
+			expect(values).toEqual(["AA11", "UA175"]);
+		});
+
 		it("a persisted flight-list filter hides everything else", () => {
 			mockAppData.current = { filterSettings: { flights: ["UA175"] } };
 			renderWithContext({ flightPositions: [aa11, ua175], connected: true });

--- a/packages/frontend/src/Applications/FlightTracker/FlightTracker.tsx
+++ b/packages/frontend/src/Applications/FlightTracker/FlightTracker.tsx
@@ -99,7 +99,9 @@ import {
 	type BasemapStyleId,
 	effectiveTone,
 	normalizeBasemapStyle,
+	SECONDARY_TRACK_COLOR,
 } from "./flightMapStyle";
+import { type SecondaryTrack, useMultiFlightTracks } from "./useMultiFlightTracks";
 import { toggleFlightSelection } from "./selectionToggle";
 
 // This app's own icon, registered into the shared registry at
@@ -718,6 +720,21 @@ export const FlightTracker: FC = () => {
 	// the other day's route — see useAltitudeProfile's doc comment.
 	const { profile } = useAltitudeProfile(selection, track?.flight_date ?? null);
 
+	// Every OTHER multi-selected flight (issue #326): the active one above
+	// keeps its richer phase-colored/profile-driven track, these get a plain
+	// track each so a shift-click or area-select multi-selection shows every
+	// flight's path, not just the one shown in the detail pane's dropdown.
+	// Memoized the same way `selection` is — multiSelected/activeFlightIdx
+	// only get fresh references on a genuine selection change.
+	const secondarySelections: TrackSelection[] = useMemo(
+		() =>
+			multiSelected
+				.filter((_, i) => i !== activeFlightIdx)
+				.map((p) => ({ flight: p.flight, startDate: p.start_date })),
+		[multiSelected, activeFlightIdx],
+	);
+	const secondaryTracks = useMultiFlightTracks(secondarySelections);
+
 	// Live fix for the selected flight (`selected` is a click-time snapshot; the
 	// streamed set updates each minute-bucket). Heading is the bearing of the
 	// track leg nearest that fix — no motion-buffer plumbing needed.
@@ -854,21 +871,59 @@ export const FlightTracker: FC = () => {
 		[profile],
 	);
 
+	// 3D counterpart of secondaryFeatures below: every OTHER multi-selected
+	// flight with a loaded altitude profile, for FlightMap's secondary tubes.
+	const secondaryTrackProfiles = useMemo(
+		() =>
+			[...secondaryTracks.values()]
+				.filter((t): t is SecondaryTrack & { profile: NonNullable<SecondaryTrack["profile"]> } =>
+					!!t.profile,
+				)
+				.map((t) => ({ flight: t.flight, profile: t.profile })),
+		[secondaryTracks],
+	);
+
+	// One plain feature per OTHER multi-selected flight, colored distinctly
+	// from the active track (issue #326) — appended to whichever branch below
+	// produces the active flight's own feature(s).
+	const secondaryFeatures = useMemo<GeoJSON.Feature[]>(
+		() =>
+			[...secondaryTracks.values()]
+				.filter((t): t is SecondaryTrack & { geometry: NonNullable<SecondaryTrack["geometry"]> } =>
+					!!t.geometry,
+				)
+				.map((t) => ({
+					type: "Feature" as const,
+					geometry: t.geometry,
+					properties: { color: SECONDARY_TRACK_COLOR },
+				})),
+		[secondaryTracks],
+	);
+
 	const trackGeoJSON: FeatureCollection | null = useMemo(() => {
-		if (!track?.geometry) return null;
+		if (!track?.geometry) {
+			return secondaryFeatures.length
+				? { type: "FeatureCollection", features: secondaryFeatures }
+				: null;
+		}
 		if (
 			selection && profile && profile.length >= 2
 			&& (isNotable(selection.flight) || hasEstimated)
 		) {
 			const features = buildTrackSegments(profile, phasePaletteFor(selection.flight));
-			if (features.length) return { type: "FeatureCollection", features };
+			if (features.length) {
+				return { type: "FeatureCollection", features: [...features, ...secondaryFeatures] };
+			}
 		}
 		// non-notable (or no profile yet): the decimated track as one plain feature.
 		return {
 			type: "FeatureCollection",
-			features: [{ type: "Feature", geometry: track.geometry, properties: {} }],
+			features: [
+				{ type: "Feature", geometry: track.geometry, properties: {} },
+				...secondaryFeatures,
+			],
 		};
-	}, [track?.geometry, selection, profile, hasEstimated]);
+	}, [track?.geometry, selection, profile, hasEstimated, secondaryFeatures]);
 
 	// Provenance legend: only meaningful once a track actually mixes radar and
 	// estimated stretches.
@@ -1252,6 +1307,7 @@ export const FlightTracker: FC = () => {
 								trackGeoJSON={trackGeoJSON}
 								trackProfile={profile}
 								trackPalette={phasePaletteFor(selection?.flight)}
+								secondaryTrackProfiles={secondaryTrackProfiles}
 								nowMs={nowMs}
 								playing={!paused}
 								mapStyle={settings.mapStyle}

--- a/packages/frontend/src/Applications/FlightTracker/flightMapStyle.ts
+++ b/packages/frontend/src/Applications/FlightTracker/flightMapStyle.ts
@@ -34,6 +34,11 @@ export const TRACK_LINE_COLOR = "#b22222";
 // as the tube's shadow. Flat views keep the full color — there the ground
 // line IS the track.
 export const TRACK_SHADOW_COLOR = "#591111";
+// Every OTHER multi-selected flight's track (the active one keeps the colors
+// above / phaseLineColorExpression) — a steel blue distinct from the phase
+// palettes' reds/greens/blues, the plain-track red, and the breadcrumb-trail
+// grays, so a listener can tell "selected, not detailed" from "just flying".
+export const SECONDARY_TRACK_COLOR = "#4f83cc";
 
 export function trailColor(mapStyle: BasemapStyleId, darkMap: boolean): string {
 	return TRAIL_COLORS[mapStyle][effectiveTone(mapStyle, darkMap)];

--- a/packages/frontend/src/Applications/FlightTracker/useMultiFlightTracks.test.ts
+++ b/packages/frontend/src/Applications/FlightTracker/useMultiFlightTracks.test.ts
@@ -1,0 +1,129 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { FlightTrack } from "./useFlightTrack";
+import { useMultiFlightTracks } from "./useMultiFlightTracks";
+
+const GEOMETRY = { type: "LineString" as const, coordinates: [[-73, 40], [-72, 41]] as [number, number][] };
+const SAMPLES = [
+	{ lat: 40, lon: -73, alt_ft: 0, utc: "2001-09-11T12:00:00.000Z" },
+	{ lat: 41, lon: -72, alt_ft: 5000, utc: "2001-09-11T12:05:00.000Z" },
+];
+
+function trackRow(flight: string): FlightTrack {
+	return {
+		flight, flight_date: "2001-09-11", origin: null, scheduled_dest: null, landed_at: null,
+		diverted: false, geometry: GEOMETRY, tail_number: null, aircraft_type: null,
+		details: null, wheels_off_utc: null, wheels_on_utc: null,
+	};
+}
+
+/** Routes by URL: flight_tracks -> the given rows, flight_positions -> SAMPLES. */
+function stubFetch(rowsFor: (flight: string) => FlightTrack[]) {
+	const fetchMock = vi.fn(async (url: string) => {
+		const u = String(url);
+		if (u.includes("/items/flight_tracks")) {
+			const flight = new URL(u).searchParams.get("filter[flight][_eq]") ?? "";
+			return { ok: true, json: async () => ({ data: rowsFor(flight) }) } as Response;
+		}
+		return { ok: true, json: async () => ({ data: SAMPLES }) } as Response;
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	return fetchMock;
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+describe("useMultiFlightTracks", () => {
+	it("returns an empty map for no selections without fetching", () => {
+		const fetchMock = stubFetch((f) => [trackRow(f)]);
+		const { result } = renderHook(
+			({ s }) => useMultiFlightTracks(s),
+			{ initialProps: { s: [] as { flight: string; startDate: string }[] } },
+		);
+		expect(result.current.size).toBe(0);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("fetches geometry and profile for every selection, keyed by flight", async () => {
+		stubFetch((f) => [trackRow(f)]);
+		const { result } = renderHook(
+			({ s }) => useMultiFlightTracks(s),
+			{
+				initialProps: {
+					s: [
+						{ flight: "UA175", startDate: "2001-09-11T12:03:00Z" },
+						{ flight: "AA77", startDate: "2001-09-11T12:03:00Z" },
+					],
+				},
+			},
+		);
+
+		await waitFor(() => expect(result.current.size).toBe(2));
+		expect(result.current.get("UA175")).toEqual({
+			flight: "UA175", geometry: GEOMETRY, profile: SAMPLES,
+		});
+		expect(result.current.get("AA77")).toEqual({
+			flight: "AA77", geometry: GEOMETRY, profile: SAMPLES,
+		});
+	});
+
+	it("caches by flight|date|hour across renders — a referentially-equal selection list doesn't refetch", async () => {
+		const fetchMock = stubFetch((f) => [trackRow(f)]);
+		const selections = [{ flight: "UA175", startDate: "2001-09-11T12:03:00Z" }];
+		const { result, rerender } = renderHook(
+			({ s }) => useMultiFlightTracks(s),
+			{ initialProps: { s: selections } },
+		);
+		await waitFor(() => expect(result.current.size).toBe(1));
+		expect(fetchMock).toHaveBeenCalledTimes(2); // one track + one profile fetch
+
+		// A NEW array with an equivalent (same flight|date|hour) selection still
+		// hits the hook's own cache, not the network.
+		rerender({ s: [{ flight: "UA175", startDate: "2001-09-11T12:03:30Z" }] });
+		await waitFor(() => expect(result.current.size).toBe(1));
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("skips a flight whose track fetch fails, without throwing or dropping the rest", async () => {
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+		const fetchMock = vi.fn(async (url: string) => {
+			const u = String(url);
+			if (u.includes("/items/flight_tracks")) {
+				if (u.includes("_eq%5D=BAD1")) return { ok: false, status: 500 } as Response;
+				return { ok: true, json: async () => ({ data: [trackRow("UA175")] }) } as Response;
+			}
+			return { ok: true, json: async () => ({ data: SAMPLES }) } as Response;
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const { result } = renderHook(
+			({ s }) => useMultiFlightTracks(s),
+			{
+				initialProps: {
+					s: [
+						{ flight: "BAD1", startDate: "2001-09-11T12:00:00Z" },
+						{ flight: "UA175", startDate: "2001-09-11T12:03:00Z" },
+					],
+				},
+			},
+		);
+
+		await waitFor(() => expect(result.current.size).toBe(1));
+		expect(result.current.has("BAD1")).toBe(false);
+		expect(result.current.get("UA175")?.geometry).toEqual(GEOMETRY);
+	});
+
+	it("clears the map when selections become empty", async () => {
+		stubFetch((f) => [trackRow(f)]);
+		const { result, rerender } = renderHook(
+			({ s }) => useMultiFlightTracks(s),
+			{ initialProps: { s: [{ flight: "UA175", startDate: "2001-09-11T12:03:00Z" }] } },
+		);
+		await waitFor(() => expect(result.current.size).toBe(1));
+		rerender({ s: [] });
+		expect(result.current.size).toBe(0);
+	});
+});

--- a/packages/frontend/src/Applications/FlightTracker/useMultiFlightTracks.ts
+++ b/packages/frontend/src/Applications/FlightTracker/useMultiFlightTracks.ts
@@ -1,0 +1,88 @@
+import { useEffect, useRef, useState } from "react";
+import type { AltitudeSample } from "./flightAltitude";
+import { flightDateOf } from "./flightDates";
+import { profileUrl } from "./useAltitudeProfile";
+import { type FlightTrack, pickLeg, trackUrl, type TrackSelection } from "./useFlightTrack";
+
+export interface SecondaryTrack {
+	flight: string;
+	geometry: FlightTrack["geometry"];
+	profile: AltitudeSample[] | null;
+}
+
+/**
+ * Plain (unphased) geometry + altitude profile for every multi-selected
+ * flight OTHER than the active one — the active flight keeps its own richer
+ * useFlightTrack/useAltitudeProfile pair (detail panel, phase coloring).
+ * This is what lets shift-click and the area-select tools show every
+ * selected flight's track on the map, not just the one shown in the detail
+ * pane's dropdown.
+ *
+ * Cached by flight|date|hour across renders, mirroring useFlightTrack's key
+ * (a multi-leg flight number resolves to different rows at different times
+ * of day). Profile is fetched using the track's OWN flight_date, the same
+ * authoritative-date pattern useAltitudeProfile uses for the active flight —
+ * no day-guessing needed since the track fetch already resolved it.
+ */
+export function useMultiFlightTracks(selections: TrackSelection[]): Map<string, SecondaryTrack> {
+	const [tracks, setTracks] = useState<Map<string, SecondaryTrack>>(new Map());
+	const cache = useRef<Map<string, SecondaryTrack>>(new Map());
+
+	useEffect(() => {
+		if (selections.length === 0) {
+			setTracks(new Map());
+			return;
+		}
+		const controller = new AbortController();
+
+		const fetchOne = async (
+			selection: TrackSelection,
+		): Promise<[string, SecondaryTrack] | null> => {
+			const date = flightDateOf(selection.startDate);
+			const atMs = Date.parse(selection.startDate);
+			const key = `${selection.flight}|${date}|${Number.isNaN(atMs) ? 0 : Math.floor(atMs / 3_600_000)}`;
+			const cached = cache.current.get(key);
+			if (cached) return [selection.flight, cached];
+
+			try {
+				const trackRes = await fetch(trackUrl(selection.flight, date), {
+					signal: controller.signal,
+				});
+				if (!trackRes.ok) throw new Error(`HTTP ${trackRes.status}`);
+				const trackJson = (await trackRes.json()) as { data: FlightTrack[] };
+				const row = pickLeg(trackJson.data, atMs);
+				if (!row) return null;
+
+				const profileRes = await fetch(profileUrl(selection.flight, row.flight_date), {
+					signal: controller.signal,
+				});
+				const profileJson = profileRes.ok
+					? ((await profileRes.json()) as { data: AltitudeSample[] })
+					: null;
+
+				const entry: SecondaryTrack = {
+					flight: selection.flight,
+					geometry: row.geometry,
+					profile: profileJson?.data?.length ? profileJson.data : null,
+				};
+				cache.current.set(key, entry);
+				return [selection.flight, entry];
+			} catch (err) {
+				if (controller.signal.aborted) return null;
+				console.warn("secondary flight track fetch failed:", err);
+				return null;
+			}
+		};
+
+		void Promise.all(selections.map(fetchOne)).then((results) => {
+			if (controller.signal.aborted) return;
+			setTracks(
+				new Map(results.filter((r): r is [string, SecondaryTrack] => r !== null)),
+			);
+		});
+
+		return () => controller.abort();
+	}, [selections]);
+
+	return tracks;
+}


### PR DESCRIPTION
## Summary
- Shift-click already toggled flights into the same `multiSelected` list the rectangle/circle area-select tools populate, and the detail panel's dropdown already rendered generically off that list (issue #310) — the panel side of multi-select already worked.
- The real gap: `useFlightTrack`/`useAltitudeProfile` only ever fetched the **active** selection, so only one track ever drew on the map regardless of how many flights were selected.
- New `useMultiFlightTracks` hook fetches plain (unphased) geometry + altitude profile for every OTHER multi-selected flight, cached by `flight|date|hour` like `useFlightTrack`. The active flight keeps its existing richer phase-colored/profile-driven track unchanged.
- Flat 2D: `trackGeoJSON` gains one plain feature per secondary flight, tagged with a new `SECONDARY_TRACK_COLOR` (steel blue) via the line-color expression's existing `properties.color` override.
- 3D/pitched: one additional `TrackTube3DLayer` per secondary flight, added/removed as the selection changes, radius/vertical-drop synced from the same per-frame math as the active tube.
- Also includes an unrelated one-line fix: the Browser app's TimeMachine proxy now builds with `wss:` instead of `https:` in production (port/host were already correct; the `/ws` path fallback was already correct in code, it just needed the right protocol to take that path).

## Test plan
- [x] `tsc -b` clean
- [x] `oxlint .` clean (no new warnings)
- [x] Full frontend suite: 3154/3154 passing, including new coverage:
  - `useMultiFlightTracks.test.ts` (fetch/cache/error/empty-selection behavior)
  - `FlightTracker.test.tsx`: multi-selection draws every other flight's track
  - `FlightMap.test.tsx`: secondary 3D tubes add/remove correctly as selection changes