### PR TITLE
feat(tv): persist grid selection as source slugs in the reducer

### DIFF
--- a/packages/frontend/src/Applications/RadioScanner/FocusedItemPlayer.test.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/FocusedItemPlayer.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { MediaItem } from "../../Providers/MediaStream/MediaStreamContext";
 import { FocusedItemPlayer } from "./FocusedItemPlayer";
@@ -122,5 +122,51 @@ describe("FocusedItemPlayer", () => {
 		expect(getByTestId("caption-overlay")).not.toBeNull();
 		const props = captionProps.current as { subtitlesUrl?: string } | null;
 		expect(props?.subtitlesUrl).toBe("clip.vtt");
+	});
+
+	it("tracks duration, advances on timeupdate, and seeks via the slider", () => {
+		const { container } = render(
+			<FocusedItemPlayer
+				item={item({})}
+				onDismiss={() => {}}
+				showWaveform={false}
+				vizMode="Wave"
+				onCycleVizMode={() => {}}
+				waveColors={null}
+				maxVolume={1}
+			/>,
+		);
+		const el = container.querySelector("audio") as HTMLAudioElement;
+		Object.defineProperty(el, "duration", { configurable: true, get: () => 200 });
+		const input = () => container.querySelector("input") as HTMLInputElement;
+
+		fireEvent.loadedMetadata(el);
+		expect(input().value).toBe("0");
+
+		el.currentTime = 50;
+		fireEvent.timeUpdate(el);
+		expect(input().value).toBe("0.25");
+
+		fireEvent.change(input(), { target: { value: "0.5" } });
+		expect(el.currentTime).toBe(100);
+	});
+
+	it("returns the button to Play when the clip ends", async () => {
+		const { container, findByText, getByText } = render(
+			<FocusedItemPlayer
+				item={item({})}
+				onDismiss={() => {}}
+				showWaveform={false}
+				vizMode="Wave"
+				onCycleVizMode={() => {}}
+				waveColors={null}
+				maxVolume={1}
+			/>,
+		);
+		// The mount effect calls play() (mocked to resolve) → button shows Pause.
+		await findByText("Pause");
+		const el = container.querySelector("audio") as HTMLAudioElement;
+		fireEvent.ended(el);
+		expect(getByText("Play")).not.toBeNull();
 	});
 });

--- a/packages/frontend/src/Applications/RadioScanner/FocusedItemPlayer.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/FocusedItemPlayer.tsx
@@ -13,6 +13,7 @@ import {
 } from "./radioScannerSettings";
 import styles from "./RadioScanner.module.scss";
 import { WaveformVisualizer } from "./WaveformVisualizer";
+import { RadioProgressBar } from "./RadioProgressBar";
 import { setAudioLevel } from "./audioCapture";
 
 interface FocusedItemPlayerProps {
@@ -43,6 +44,8 @@ export const FocusedItemPlayer: React.FC<FocusedItemPlayerProps> = ({
 	// Bumped in onLoadedMetadata so the waveform remounts once the element is
 	// actually ready — mirrors StationPlayer's readyVersions handling.
 	const [readyVersion, setReadyVersion] = useState(0);
+	const [currentTime, setCurrentTime] = useState(0);
+	const [duration, setDuration] = useState(0);
 
 	useEffect(() => {
 		const el = audioRef.current;
@@ -75,6 +78,14 @@ export const FocusedItemPlayer: React.FC<FocusedItemPlayerProps> = ({
 		}
 	};
 
+	const seekToPct = (pct: number) => {
+		const el = audioRef.current;
+		if (!el) return;
+		const seconds = pct * (el.duration || 0);
+		el.currentTime = seconds;
+		setCurrentTime(seconds);
+	};
+
 	return (
 		<div className={styles.rsFocusedPlayer}>
 			<div className={styles.rsFocusedHeader}>
@@ -87,7 +98,13 @@ export const FocusedItemPlayer: React.FC<FocusedItemPlayerProps> = ({
 				src={item.url}
 				crossOrigin="anonymous"
 				style={{ display: "none" }}
-				onLoadedMetadata={() => setReadyVersion((v) => v + 1)}
+				onLoadedMetadata={() => {
+					setReadyVersion((v) => v + 1);
+					setDuration(audioRef.current?.duration ?? 0);
+				}}
+				onDurationChange={() => setDuration(audioRef.current?.duration ?? 0)}
+				onTimeUpdate={() => setCurrentTime(audioRef.current?.currentTime ?? 0)}
+				onEnded={() => setPlaying(false)}
 			/>
 			{captionsOn && (
 				<CaptionOverlay
@@ -105,6 +122,11 @@ export const FocusedItemPlayer: React.FC<FocusedItemPlayerProps> = ({
 					colors={waveColors}
 				/>
 			)}
+			<RadioProgressBar
+				currentTime={currentTime}
+				duration={duration}
+				onSeekPct={seekToPct}
+			/>
 			<div className={styles.rsFocusedControls}>
 				<ClassicyButton buttonSize="small" onClickFunc={togglePlay}>
 					{playing ? "Pause" : "Play"}

--- a/packages/frontend/src/Applications/RadioScanner/RadioProgressBar.test.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/RadioProgressBar.test.tsx
@@ -1,0 +1,40 @@
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RadioProgressBar } from "./RadioProgressBar";
+
+afterEach(cleanup);
+
+describe("RadioProgressBar", () => {
+	it("derives the slider value from currentTime / duration", () => {
+		const { container } = render(
+			<RadioProgressBar currentTime={30} duration={120} onSeekPct={() => {}} />,
+		);
+		const input = container.querySelector("input") as HTMLInputElement;
+		expect(input.value).toBe("0.25");
+	});
+
+	it("shows 0 and does not divide by zero when duration is 0", () => {
+		const { container } = render(
+			<RadioProgressBar currentTime={5} duration={0} onSeekPct={() => {}} />,
+		);
+		const input = container.querySelector("input") as HTMLInputElement;
+		expect(input.value).toBe("0");
+	});
+
+	it("formats an elapsed / total readout", () => {
+		const { getByText } = render(
+			<RadioProgressBar currentTime={65} duration={125} onSeekPct={() => {}} />,
+		);
+		expect(getByText("0:01:05 / 0:02:05")).not.toBeNull();
+	});
+
+	it("reports the dragged fraction through onSeekPct", () => {
+		const onSeekPct = vi.fn();
+		const { container } = render(
+			<RadioProgressBar currentTime={0} duration={100} onSeekPct={onSeekPct} />,
+		);
+		const input = container.querySelector("input") as HTMLInputElement;
+		fireEvent.change(input, { target: { value: "0.5" } });
+		expect(onSeekPct).toHaveBeenCalledWith(0.5);
+	});
+});

--- a/packages/frontend/src/Applications/RadioScanner/RadioProgressBar.tsx
+++ b/packages/frontend/src/Applications/RadioScanner/RadioProgressBar.tsx
@@ -1,0 +1,36 @@
+import { timeFriendly } from "classicy";
+import type React from "react";
+import styles from "./RadioScanner.module.scss";
+
+interface RadioProgressBarProps {
+	currentTime: number;
+	duration: number;
+	onSeekPct: (pct: number) => void;
+}
+
+/**
+ * Seekable progress/duration slider for the RadioScanner focused player.
+ * Pure and props-only: the owning FocusedItemPlayer feeds it the audio
+ * element's currentTime/duration and turns onSeekPct back into a seek.
+ */
+export const RadioProgressBar: React.FC<RadioProgressBarProps> = ({
+	currentTime,
+	duration,
+	onSeekPct,
+}) => (
+	<div className={styles.rsFocusedProgress}>
+		<input
+			type="range"
+			className={styles.rsFocusedProgressBar}
+			min={0}
+			max={1}
+			step={0.001}
+			value={duration > 0 ? currentTime / duration : 0}
+			aria-label="Seek"
+			onChange={(e) => onSeekPct(Number.parseFloat(e.target.value))}
+		/>
+		<p className={styles.rsFocusedTime}>
+			{timeFriendly(currentTime)} / {timeFriendly(duration)}
+		</p>
+	</div>
+);

--- a/packages/frontend/src/Applications/RadioScanner/RadioScanner.module.scss
+++ b/packages/frontend/src/Applications/RadioScanner/RadioScanner.module.scss
@@ -356,6 +356,49 @@
   z-index: 9;
 }
 
+.rsFocusedProgress {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--window-padding-size) / 2);
+  z-index: 9;
+}
+
+.rsFocusedProgressBar {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--color-system-05);
+  cursor: pointer;
+
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--color-theme-01);
+    border: 1px solid var(--color-system-05);
+  }
+
+  &::-moz-range-thumb {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--color-theme-01);
+    border: 1px solid var(--color-system-05);
+  }
+}
+
+.rsFocusedTime {
+  font-family: var(--ui-font);
+  font-size: calc(var(--ui-font-size) * 0.75);
+  color: var(--color-theme-02);
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
 /* Scrim shown while the browser's autoplay policy is holding audio back —
    any click anywhere doubles as the unlock gesture, so the overlay needs no
    handler of its own. Sits above the display panels (z-index 9). */

--- a/packages/frontend/src/Applications/TV/TVContext.test.ts
+++ b/packages/frontend/src/Applications/TV/TVContext.test.ts
@@ -142,3 +142,36 @@ describe("classicyTVEventHandler — channel order", () => {
 		).toMatchObject({ channelOrder: [] });
 	});
 });
+
+describe("classicyTVEventHandler — grid selection (slug-based)", () => {
+	it("persists selectedChannels, mutedChannels and channelVolumes", () => {
+		const out = classicyTVEventHandler(storeWithApp(), {
+			type: "ClassicyAppTVSetGridState",
+			multiSelectMode: true,
+			selectedChannels: ["WABC", "WNBC"],
+			mutedChannels: ["WNBC"],
+			channelVolumes: { WABC: 0.5 },
+		});
+		expect(
+			out.System.Manager.Applications.apps["TV.app"].data,
+		).toMatchObject({
+			multiSelectMode: true,
+			selectedChannels: ["WABC", "WNBC"],
+			mutedChannels: ["WNBC"],
+			channelVolumes: { WABC: 0.5 },
+		});
+	});
+
+	it("preserves unrelated fields when writing grid state", () => {
+		const out = classicyTVEventHandler(storeWithApp({ currentChannel: "CNN" }), {
+			type: "ClassicyAppTVSetGridState",
+			multiSelectMode: false,
+			selectedChannels: [],
+			mutedChannels: [],
+			channelVolumes: {},
+		});
+		expect(
+			out.System.Manager.Applications.apps["TV.app"].data,
+		).toMatchObject({ currentChannel: "CNN", multiSelectMode: false, selectedChannels: [] });
+	});
+});

--- a/packages/frontend/src/Applications/TV/TVContext.ts
+++ b/packages/frontend/src/Applications/TV/TVContext.ts
@@ -138,9 +138,9 @@ export const classicyTVEventHandler = (
 			apps[appId].data = {
 				...appData,
 				multiSelectMode: action.multiSelectMode,
-				selectedPlayers: action.selectedPlayers,
-				mutedGridPlayers: action.mutedGridPlayers,
-				gridPlayerVolumes: action.gridPlayerVolumes,
+				selectedChannels: action.selectedChannels,
+				mutedChannels: action.mutedChannels,
+				channelVolumes: action.channelVolumes,
 			};
 			return ds;
 		// Channels the user has turned off in Settings. Stored as a blacklist of

--- a/plans/2026-07-22-radioscanner-focused-player-progress-design.md
+++ b/plans/2026-07-22-radioscanner-focused-player-progress-design.md
@@ -1,0 +1,89 @@
+# RadioScanner focused-player progress slider — design
+
+**Date:** 2026-07-22
+**Scope:** `packages/frontend/src/Applications/RadioScanner`
+
+## Goal
+
+Add a progress indicator to the RadioScanner **focused player** (`rsFocusedPlayer`, rendered
+by `FocusedItemPlayer.tsx`) so a user playing a single radio clip can see playback position and
+**scrub** to any point — a duration slider modeled on classicy's QuickTime Movie Player.
+
+## Context
+
+- `FocusedItemPlayer` wraps a plain hidden `<audio src={item.url}>` with local `playing` state
+  and a `togglePlay`. It plays a single clip from `0` on mount and is **independent of the
+  virtual clock**. Seeking is therefore just `audio.currentTime = …` — no `setDateTimeFromUtc`
+  seam is involved (Hard Rule #2 does not apply here).
+- Classicy already ships the reference implementation: `QuickTimeSeekBar` (a
+  `<input type="range">` bound to `currentTime / duration`, a `timeFriendly()` elapsed label, and
+  ±10s skip buttons) plus the `useQuickTimePlayback` hook that mirrors the media element's
+  native `timeupdate` event into React state. `QuickTimeSeekBar` and `timeFriendly` are both
+  exported from the `classicy` package.
+- `HTMLMediaElement.currentTime` is not reactive; progress UI must copy it into React state on
+  the element's `timeupdate` event or it will not re-render during playback.
+
+## Decisions
+
+- **Seekable** (drag to scrub), matching the QuickTime reference — not read-only.
+- **Bar + time readout, scanner-styled.** No ±10s skip buttons. Reuse classicy's `timeFriendly`
+  helper for formatting, but render our own scanner-native markup rather than reusing
+  `QuickTimeSeekBar`'s QuickTime chrome (its CSS classes would clash with the RadioScanner panel).
+
+## Components
+
+### New: `RadioProgressBar.tsx` (pure, presentational)
+
+Props:
+
+```ts
+interface RadioProgressBarProps {
+  currentTime: number;            // seconds
+  duration: number;               // seconds (0 when unknown)
+  onSeekPct: (pct: number) => void; // pct in [0, 1]
+}
+```
+
+- Renders `<input type="range" min="0" max="1" step="0.001" value={currentTime / (duration || 1)}>`.
+  `onChange` → `onSeekPct(parseFloat(e.target.value))`.
+- Renders a readout: `` `${timeFriendly(currentTime)} / ${timeFriendly(duration)}` `` (imported
+  from `classicy`).
+- No audio-element access inside — it is a dumb, independently-testable unit. Keeps the seek
+  side-effects out of the presentational layer and out of `FocusedItemPlayer`'s growing surface.
+
+### Changed: `FocusedItemPlayer.tsx`
+
+- Add `currentTime` / `duration` state.
+- On the `<audio>` element:
+  - `onTimeUpdate` → `setCurrentTime(el.currentTime)`.
+  - Extend existing `onLoadedMetadata` (and add `onDurationChange`) to also
+    `setDuration(el.duration)`.
+  - Add `onEnded` → `setPlaying(false)` so the Play/Pause label is correct at clip end.
+- Add a local `seekToPct(pct)` mirroring classicy's: `el.currentTime = pct * el.duration`, plus an
+  optimistic `setCurrentTime(pct * el.duration)`.
+- Render `<RadioProgressBar currentTime={currentTime} duration={duration} onSeekPct={seekToPct} />`
+  as a new row between the waveform block and `rsFocusedControls`.
+
+## Styling
+
+New `.rsFocusedProgress` (row) plus slider track/thumb classes in `RadioScanner.module.scss`,
+matching the scanner's LCD/panel aesthetic and theming from the same CSS custom properties the
+rest of the focused-player panel uses. Style `::-webkit-slider-thumb` and `::-moz-range-thumb`
+explicitly so the thumb matches in Safari (the app's primary target).
+
+## Testing
+
+- **`RadioProgressBar.test.tsx`** (new): renders the slider `value` derived from
+  `currentTime`/`duration`; an `onChange` on the range input fires `onSeekPct` with the parsed
+  fraction; the readout formats via `timeFriendly`; guards `duration === 0` (no divide-by-zero,
+  value `0`).
+- **`FocusedItemPlayer.test.tsx`** (extend): dispatching `timeupdate` advances the bar value;
+  `loadedmetadata` sets the total-time readout; changing the range input sets
+  `audio.currentTime` (seek); `ended` flips the button back to "Play".
+
+## Out of scope
+
+- Any change to the always-on `StationPlayer` (live, clock-synced) — this is the focused player
+  only.
+- ±10s skip buttons, volume slider, fullscreen (focused player is audio-only).
+- Persisting playback position across focus/dismiss.

--- a/plans/2026-07-22-radioscanner-focused-player-progress.md
+++ b/plans/2026-07-22-radioscanner-focused-player-progress.md
@@ -1,0 +1,390 @@
+# RadioScanner Focused-Player Progress Slider — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a seekable progress/duration slider to the RadioScanner focused player (`rsFocusedPlayer` / `FocusedItemPlayer`), modeled on classicy's QuickTime Movie Player.
+
+**Architecture:** A new pure presentational component `RadioProgressBar` renders a `<input type="range">` bound to `currentTime / duration` plus a `timeFriendly` elapsed/total readout, and reports drags back via an `onSeekPct` callback. `FocusedItemPlayer` owns the audio element, mirrors its native `timeupdate`/`loadedmetadata`/`durationchange`/`ended` events into React state, and turns an `onSeekPct` fraction into `audio.currentTime = pct * duration`. The player is independent of the virtual clock, so no `setDateTimeFromUtc` seam is involved.
+
+**Tech Stack:** Vite + React + TypeScript, Vitest + `@testing-library/react`, SCSS modules, `classicy` (`timeFriendly` helper).
+
+## Global Constraints
+
+- `classicy` is pinned to `"latest"`; never hand-edit its version (`.husky/pre-commit` auto-bumps it). Installed build is `classicy@0.54.0`, which exports `timeFriendly`.
+- Apps never open a WebSocket or write the virtual clock directly — N/A here; the focused player uses a plain `<audio>` element and does not touch the clock.
+- Co-locate tests next to source; there is **no global test setup**, so every test file calls `afterEach(cleanup)` itself.
+- Frontend verification commands (run from repo root): `pnpm --filter @rt911/frontend exec vitest run <path>`, `pnpm build` (tsc -b + vite build), `pnpm lint` (eslint .).
+- Prefer `Number.parseFloat` over the global `parseFloat`.
+
+---
+
+### Task 1: `RadioProgressBar` pure component + styles
+
+**Files:**
+- Create: `packages/frontend/src/Applications/RadioScanner/RadioProgressBar.tsx`
+- Create: `packages/frontend/src/Applications/RadioScanner/RadioProgressBar.test.tsx`
+- Modify: `packages/frontend/src/Applications/RadioScanner/RadioScanner.module.scss` (append new classes after the existing `.rsFocusedControls` block, ~line 357)
+
+**Interfaces:**
+- Consumes: `timeFriendly(seconds: number): string` from `classicy`; SCSS-module class names from `RadioScanner.module.scss`.
+- Produces:
+  ```ts
+  interface RadioProgressBarProps {
+    currentTime: number;            // seconds elapsed
+    duration: number;               // seconds total (0 when unknown)
+    onSeekPct: (pct: number) => void; // pct in [0, 1]
+  }
+  export const RadioProgressBar: React.FC<RadioProgressBarProps>;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/frontend/src/Applications/RadioScanner/RadioProgressBar.test.tsx`:
+
+```tsx
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RadioProgressBar } from "./RadioProgressBar";
+
+afterEach(cleanup);
+
+describe("RadioProgressBar", () => {
+	it("derives the slider value from currentTime / duration", () => {
+		const { container } = render(
+			<RadioProgressBar currentTime={30} duration={120} onSeekPct={() => {}} />,
+		);
+		const input = container.querySelector("input") as HTMLInputElement;
+		expect(input.value).toBe("0.25");
+	});
+
+	it("shows 0 and does not divide by zero when duration is 0", () => {
+		const { container } = render(
+			<RadioProgressBar currentTime={5} duration={0} onSeekPct={() => {}} />,
+		);
+		const input = container.querySelector("input") as HTMLInputElement;
+		expect(input.value).toBe("0");
+	});
+
+	it("formats an elapsed / total readout", () => {
+		const { getByText } = render(
+			<RadioProgressBar currentTime={65} duration={125} onSeekPct={() => {}} />,
+		);
+		expect(getByText("0:01:05 / 0:02:05")).not.toBeNull();
+	});
+
+	it("reports the dragged fraction through onSeekPct", () => {
+		const onSeekPct = vi.fn();
+		const { container } = render(
+			<RadioProgressBar currentTime={0} duration={100} onSeekPct={onSeekPct} />,
+		);
+		const input = container.querySelector("input") as HTMLInputElement;
+		fireEvent.change(input, { target: { value: "0.5" } });
+		expect(onSeekPct).toHaveBeenCalledWith(0.5);
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @rt911/frontend exec vitest run src/Applications/RadioScanner/RadioProgressBar.test.tsx`
+Expected: FAIL — cannot resolve `./RadioProgressBar` (module not found).
+
+- [ ] **Step 3: Write the component**
+
+Create `packages/frontend/src/Applications/RadioScanner/RadioProgressBar.tsx`:
+
+```tsx
+import { timeFriendly } from "classicy";
+import type React from "react";
+import styles from "./RadioScanner.module.scss";
+
+interface RadioProgressBarProps {
+	currentTime: number;
+	duration: number;
+	onSeekPct: (pct: number) => void;
+}
+
+/**
+ * Seekable progress/duration slider for the RadioScanner focused player.
+ * Pure and props-only: the owning FocusedItemPlayer feeds it the audio
+ * element's currentTime/duration and turns onSeekPct back into a seek.
+ */
+export const RadioProgressBar: React.FC<RadioProgressBarProps> = ({
+	currentTime,
+	duration,
+	onSeekPct,
+}) => (
+	<div className={styles.rsFocusedProgress}>
+		<input
+			type="range"
+			className={styles.rsFocusedProgressBar}
+			min={0}
+			max={1}
+			step={0.001}
+			value={duration > 0 ? currentTime / duration : 0}
+			aria-label="Seek"
+			onChange={(e) => onSeekPct(Number.parseFloat(e.target.value))}
+		/>
+		<p className={styles.rsFocusedTime}>
+			{timeFriendly(currentTime)} / {timeFriendly(duration)}
+		</p>
+	</div>
+);
+```
+
+- [ ] **Step 4: Add the styles**
+
+Append to `packages/frontend/src/Applications/RadioScanner/RadioScanner.module.scss` after the `.rsFocusedControls { … }` block (~line 357):
+
+```scss
+.rsFocusedProgress {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--window-padding-size) / 2);
+  z-index: 9;
+}
+
+.rsFocusedProgressBar {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--color-system-05);
+  cursor: pointer;
+
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--color-theme-01);
+    border: 1px solid var(--color-system-05);
+  }
+
+  &::-moz-range-thumb {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--color-theme-01);
+    border: 1px solid var(--color-system-05);
+  }
+}
+
+.rsFocusedTime {
+  font-family: var(--ui-font);
+  font-size: calc(var(--ui-font-size) * 0.75);
+  color: var(--color-theme-02);
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm --filter @rt911/frontend exec vitest run src/Applications/RadioScanner/RadioProgressBar.test.tsx`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/frontend/src/Applications/RadioScanner/RadioProgressBar.tsx \
+        packages/frontend/src/Applications/RadioScanner/RadioProgressBar.test.tsx \
+        packages/frontend/src/Applications/RadioScanner/RadioScanner.module.scss
+git commit -m "feat(radioscanner): RadioProgressBar seekable duration slider"
+```
+
+---
+
+### Task 2: Wire the slider into `FocusedItemPlayer`
+
+**Files:**
+- Modify: `packages/frontend/src/Applications/RadioScanner/FocusedItemPlayer.tsx`
+- Test: `packages/frontend/src/Applications/RadioScanner/FocusedItemPlayer.test.tsx` (extend)
+
+**Interfaces:**
+- Consumes: `RadioProgressBar` from Task 1 (`{ currentTime, duration, onSeekPct }`).
+- Produces: no new exported surface; `FocusedItemPlayer`'s props are unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `packages/frontend/src/Applications/RadioScanner/FocusedItemPlayer.test.tsx`, change the import line
+
+```tsx
+import { cleanup, render } from "@testing-library/react";
+```
+
+to
+
+```tsx
+import { cleanup, fireEvent, render } from "@testing-library/react";
+```
+
+Then add these two tests inside the `describe("FocusedItemPlayer", …)` block:
+
+```tsx
+	it("tracks duration, advances on timeupdate, and seeks via the slider", () => {
+		const { container } = render(
+			<FocusedItemPlayer
+				item={item({})}
+				onDismiss={() => {}}
+				showWaveform={false}
+				vizMode="Wave"
+				onCycleVizMode={() => {}}
+				waveColors={null}
+				maxVolume={1}
+			/>,
+		);
+		const el = container.querySelector("audio") as HTMLAudioElement;
+		Object.defineProperty(el, "duration", { configurable: true, get: () => 200 });
+		const input = () => container.querySelector("input") as HTMLInputElement;
+
+		fireEvent.loadedMetadata(el);
+		expect(input().value).toBe("0");
+
+		el.currentTime = 50;
+		fireEvent.timeUpdate(el);
+		expect(input().value).toBe("0.25");
+
+		fireEvent.change(input(), { target: { value: "0.5" } });
+		expect(el.currentTime).toBe(100);
+	});
+
+	it("returns the button to Play when the clip ends", async () => {
+		const { container, findByText, getByText } = render(
+			<FocusedItemPlayer
+				item={item({})}
+				onDismiss={() => {}}
+				showWaveform={false}
+				vizMode="Wave"
+				onCycleVizMode={() => {}}
+				waveColors={null}
+				maxVolume={1}
+			/>,
+		);
+		// The mount effect calls play() (mocked to resolve) → button shows Pause.
+		await findByText("Pause");
+		const el = container.querySelector("audio") as HTMLAudioElement;
+		fireEvent.ended(el);
+		expect(getByText("Play")).not.toBeNull();
+	});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @rt911/frontend exec vitest run src/Applications/RadioScanner/FocusedItemPlayer.test.tsx`
+Expected: FAIL — no `<input>` in the tree (first test); button stays "Pause"/no seek handling (second test).
+
+- [ ] **Step 3: Add state, event handlers, and seek logic**
+
+In `packages/frontend/src/Applications/RadioScanner/FocusedItemPlayer.tsx`:
+
+3a. Add the import near the other local imports (below the `WaveformVisualizer` import, line 15):
+
+```tsx
+import { RadioProgressBar } from "./RadioProgressBar";
+```
+
+3b. Add state next to the existing `playing`/`readyVersion` state (after line 45):
+
+```tsx
+	const [currentTime, setCurrentTime] = useState(0);
+	const [duration, setDuration] = useState(0);
+```
+
+3c. Add the seek helper next to `togglePlay` (after the `togglePlay` definition, ~line 76):
+
+```tsx
+	const seekToPct = (pct: number) => {
+		const el = audioRef.current;
+		if (!el) return;
+		const seconds = pct * (el.duration || 0);
+		el.currentTime = seconds;
+		setCurrentTime(seconds);
+	};
+```
+
+3d. Replace the existing `<audio …>` element (lines 85–91) with one that mirrors its events into state:
+
+```tsx
+			<audio
+				ref={audioRef}
+				src={item.url}
+				crossOrigin="anonymous"
+				style={{ display: "none" }}
+				onLoadedMetadata={() => {
+					setReadyVersion((v) => v + 1);
+					setDuration(audioRef.current?.duration ?? 0);
+				}}
+				onDurationChange={() => setDuration(audioRef.current?.duration ?? 0)}
+				onTimeUpdate={() => setCurrentTime(audioRef.current?.currentTime ?? 0)}
+				onEnded={() => setPlaying(false)}
+			/>
+```
+
+3e. Render the slider between the waveform block and the `rsFocusedControls` div. Insert this immediately before `<div className={styles.rsFocusedControls}>` (~line 108):
+
+```tsx
+			<RadioProgressBar
+				currentTime={currentTime}
+				duration={duration}
+				onSeekPct={seekToPct}
+			/>
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @rt911/frontend exec vitest run src/Applications/RadioScanner/FocusedItemPlayer.test.tsx`
+Expected: PASS (all existing tests plus the two new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/frontend/src/Applications/RadioScanner/FocusedItemPlayer.tsx \
+        packages/frontend/src/Applications/RadioScanner/FocusedItemPlayer.test.tsx
+git commit -m "feat(radioscanner): show seekable progress in the focused player"
+```
+
+---
+
+### Task 3: Full verification (unit + typecheck + lint + runtime)
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the RadioScanner test suite**
+
+Run: `pnpm --filter @rt911/frontend exec vitest run src/Applications/RadioScanner/`
+Expected: PASS — all RadioScanner specs green.
+
+- [ ] **Step 2: Typecheck + build**
+
+Run: `pnpm build`
+Expected: `tsc -b` and `vite build` complete with no errors.
+
+- [ ] **Step 3: Lint**
+
+Run: `pnpm lint`
+Expected: no errors in the new/modified files.
+
+- [ ] **Step 4: Runtime check (optional but recommended)**
+
+Use the `packages/frontend:verify` skill to drive the dev server: open RadioScanner, click a past item to enter the focused player, and confirm the slider fills as the clip plays, the elapsed/total readout ticks, and dragging the thumb jumps playback. Verify in both light and dark scanner themes.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Seekable slider modeled on QuickTime → Task 1 (`RadioProgressBar`, `onSeekPct`) + Task 2 (`seekToPct`). ✅
+- Bar + elapsed/total time readout, reusing `timeFriendly` → Task 1. ✅
+- Scanner-native styling in `RadioScanner.module.scss`, Safari thumb styling → Task 1 Step 4. ✅
+- `timeupdate`→state mirroring (currentTime not reactive) → Task 2 Step 3d. ✅
+- Duration from `loadedmetadata`/`durationchange`; `onEnded`→Play → Task 2 Step 3d. ✅
+- `RadioProgressBar` pure/independently testable → Task 1 test. ✅
+- Not reusing `QuickTimeSeekBar` (own markup) → Task 1 component uses a bare `<input>`. ✅
+- Out of scope (StationPlayer, ±10s buttons, persistence) → untouched. ✅
+
+**Placeholder scan:** No TBD/TODO; all steps contain concrete code and commands. ✅
+
+**Type consistency:** `RadioProgressBar` props `{ currentTime, duration, onSeekPct }` are identical in the component (Task 1), its test (Task 1), and the call site (Task 2 Step 3e). `seekToPct(pct)` fraction → `pct * duration` seconds is consistent between Task 2 helper and both tests. ✅


### PR DESCRIPTION
Flagged during branch cleanup (no PR found; 5 commits not in main), opened for review — merge or close.

Unique commits vs `main`:
```
792faa817 feat(tv): persist grid selection as source slugs in the reducer
8bfcd8f93 feat(radioscanner): show seekable progress in the focused player
178a7c0ce feat(radioscanner): RadioProgressBar seekable duration slider
f59a776ab docs(radioscanner): implementation plan for focused-player progress slider
5ea2eff77 docs(radioscanner): spec for focused-player progress slider
```