### PR TITLE
ci: auto-label PRs with merge conflicts against their base branch

### DIFF
--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -1,0 +1,26 @@
+name: Label merge conflicts
+
+# Flags any open PR that can't be cleanly merged into its base branch with a
+# "has conflict" label (and removes it again once the conflict is resolved).
+# Runs on every PR event and on every push to main, since a push to main is
+# exactly what can newly conflict an otherwise-clean PR.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: prince-chrismc/label-merge-conflicts-action@21e6705eaa6aab66e4e486279389c8e3e4c465b7 # v3.0.4
+        with:
+          conflict_label_name: "has conflict"
+          github_token: ${{ github.token }}


### PR DESCRIPTION
Adds [prince-chrismc/label-merge-conflicts-action](https://github.com/marketplace/actions/label-merge-conflicts) (pinned to v3.0.4 by commit SHA) to automatically apply a `has conflict` label to any open PR that can no longer merge cleanly with `main`, and remove it once resolved. Runs on every PR event and on push to `main` (a push to main is exactly what can newly conflict an otherwise-clean PR).

Directly useful right now: the batch of stale-branch PRs opened during today's branch cleanup (#497, #498, #499, #501-#515) would all have been auto-flagged instead of needing manual `gh pr view --json mergeable` checks.