### PR TITLE
fix(radio-traffic): drop redundant date in collapsed player's start line

### DIFF
--- a/packages/frontend/src/Applications/RadioTraffic/LaneSmallPlayer.test.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/LaneSmallPlayer.test.tsx
@@ -10,6 +10,10 @@ afterEach(cleanup);
 /** The desktop's display offset on 2001-09-11. */
 const TZ = -4;
 
+// A day after every fixture's start_date below, so the default render exercises
+// the "different day" (date kept) path unless a test overrides currentMs.
+const NEXT_DAY_NOW_MS = Date.UTC(2001, 8, 12, 16, 0, 0);
+
 function renderPlayer(
 	props: Partial<Parameters<typeof LaneSmallPlayer>[0]> = {},
 ): HTMLElement {
@@ -18,6 +22,7 @@ function renderPlayer(
 			item={props.item ?? makeItem()}
 			meta={"meta" in props ? props.meta : makeMeta()}
 			tzOffsetHours={props.tzOffsetHours ?? TZ}
+			currentMs={"currentMs" in props ? (props.currentMs ?? null) : NEXT_DAY_NOW_MS}
 		/>,
 	);
 	return container;
@@ -61,11 +66,21 @@ describe("LaneSmallPlayer content", () => {
 		expect(new Set(colors).size).toBe(3);
 	});
 
-	it("stamps the start with the date, the time and the zone", () => {
+	it("stamps the start with the date, the time and the zone when the clock reads a different day", () => {
 		const container = renderPlayer({
 			item: makeItem({ start_date: "2001-09-11 12:33:00" }),
+			currentMs: NEXT_DAY_NOW_MS,
 		});
 		expect(field(container, "start")?.textContent).toBe("9/11/2001 8:33 AM ET");
+	});
+
+	it("drops the date, keeping the time and zone, when the clock reads the same day (#523)", () => {
+		const container = renderPlayer({
+			item: makeItem({ start_date: "2001-09-11 12:33:00" }),
+			// Later the same display-day: 2001-09-11T16:00Z is noon ET on the 11th.
+			currentMs: Date.UTC(2001, 8, 11, 16, 0, 0),
+		});
+		expect(field(container, "start")?.textContent).toBe("8:33 AM ET");
 	});
 
 	it("spells the duration out in seconds", () => {

--- a/packages/frontend/src/Applications/RadioTraffic/LaneSmallPlayer.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/LaneSmallPlayer.tsx
@@ -34,18 +34,28 @@ export interface LaneSmallPlayerProps {
 	meta?: ItemMeta;
 	/** The desktop's display offset in hours (-4 on 2001-09-11). */
 	tzOffsetHours: number;
+	/**
+	 * The virtual clock's current instant (true UTC, e.g. RadioTraffic's
+	 * `anchorMs`) — read-only, threaded through to `startLabel` so it can drop
+	 * the date when a clip started on the same display-shifted day the clock
+	 * currently reads (issue #523). NOT the ms-precise seek clock: that ticks
+	 * every render frame and would invalidate every folded card's memoisation
+	 * far more often than the day it's read for could actually change.
+	 */
+	currentMs: number | null;
 }
 
 export const LaneSmallPlayer: React.FC<LaneSmallPlayerProps> = ({
 	item,
 	meta,
 	tzOffsetHours,
+	currentMs,
 }) => {
 	const timing = itemTiming(item);
 	// The same fallback the full card uses: an untranscribed clip still has a
 	// title, and a blank quote would read as a rendering fault.
 	const subject = meta?.subject?.trim() || item.full_title;
-	const start = startLabel(timing.startMs, tzOffsetHours);
+	const start = startLabel(timing.startMs, tzOffsetHours, currentMs);
 	const duration = durationSecondsLabel(timing.durationSec);
 	const link = meta?.link?.trim();
 	const tags = meta?.tags ?? [];

--- a/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.test.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.test.tsx
@@ -1189,9 +1189,9 @@ describe("RadioTraffic — a collapsed lane", () => {
 		const small = document.querySelector('[data-small-player="4"]');
 		// The tier tag META gives every item, coloured by its namespace.
 		expect(small?.querySelector("li")?.textContent).toBe("secondary");
-		expect(small?.querySelector('[data-field="start"]')?.textContent).toBe(
-			"9/11/2001 8:55 AM ET",
-		);
+		// NOW_MS is 2001-09-11T12:47Z — the same display-day as this item's start,
+		// so #523 drops the date and keeps the time and zone.
+		expect(small?.querySelector('[data-field="start"]')?.textContent).toBe("8:55 AM ET");
 		expect(small?.querySelector('[data-field="duration"]')?.textContent).toBe("60 seconds");
 	});
 

--- a/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.tsx
@@ -797,11 +797,20 @@ export const RadioTraffic: React.FC = () => {
 	// The folded lanes' players (story 027). One renderer for all three lanes,
 	// because a small player carries no lane-dependent state — no badge, no
 	// transport, no mute — which is exactly what makes it small.
+	// anchorMs, not nowMs: the small player only needs "today" to the nearest
+	// virtual minute, and nowMs is recomputed every render tick for waveform
+	// seeking — keying this callback on it would invalidate every folded card's
+	// memoisation once a second instead of once a minute.
 	const renderCollapsedCard = useCallback(
 		(item: MediaItem) => (
-			<LaneSmallPlayer item={item} meta={mp3Meta[item.id]} tzOffsetHours={tz} />
+			<LaneSmallPlayer
+				item={item}
+				meta={mp3Meta[item.id]}
+				tzOffsetHours={tz}
+				currentMs={anchorMs}
+			/>
 		),
-		[mp3Meta, tz],
+		[mp3Meta, tz, anchorMs],
 	);
 
 	const appMenu = [

--- a/packages/frontend/src/Applications/RadioTraffic/smallPlayerLabels.test.ts
+++ b/packages/frontend/src/Applications/RadioTraffic/smallPlayerLabels.test.ts
@@ -32,25 +32,45 @@ describe("zoneLabel", () => {
 });
 
 describe("startLabel", () => {
-	it("prints the design's date, time and zone", () => {
-		expect(startLabel(AA11_MS, -4)).toBe("9/11/2001 8:33 AM ET");
+	// 2001-09-11T16:00Z — noon in New York, later the same display-day as
+	// AA11_MS (8:33 AM ET). The clock's own current instant (issue #523).
+	const SAME_DAY_NOW_MS = Date.UTC(2001, 8, 11, 16, 0, 0);
+	// 2001-09-12T16:00Z — a different display-day from AA11_MS.
+	const NEXT_DAY_NOW_MS = Date.UTC(2001, 8, 12, 16, 0, 0);
+
+	it("prints the design's date, time and zone when the clock reads a different day", () => {
+		expect(startLabel(AA11_MS, -4, NEXT_DAY_NOW_MS)).toBe("9/11/2001 8:33 AM ET");
+	});
+
+	it("drops the date when the clock reads the same day, keeping the time and zone", () => {
+		expect(startLabel(AA11_MS, -4, SAME_DAY_NOW_MS)).toBe("8:33 AM ET");
 	});
 
 	it("shifts by the DISPLAY offset rather than the browser's own zone", () => {
 		// The same instant, read by a desktop set to UTC. Were this formatted in
 		// the runner's local zone the answer would change with the machine.
-		expect(startLabel(AA11_MS, 0)).toBe("9/11/2001 12:33 PM UTC");
+		expect(startLabel(AA11_MS, 0, NEXT_DAY_NOW_MS)).toBe("9/11/2001 12:33 PM UTC");
 	});
 
 	it("carries the date across a day boundary the offset creates", () => {
 		// 2001-09-11T02:00Z is still the 10th in New York, and a collapsed lane
-		// has no card header to correct a wrong date with.
-		expect(startLabel(Date.UTC(2001, 8, 11, 2, 0, 0), -4)).toBe("9/10/2001 10:00 PM ET");
+		// has no card header to correct a wrong date with — checked against the
+		// clock reading the 10th (same day, date dropped) and the 11th (kept).
+		const startMs = Date.UTC(2001, 8, 11, 2, 0, 0);
+		expect(startLabel(startMs, -4, Date.UTC(2001, 8, 10, 20, 0, 0))).toBe("10:00 PM ET");
+		expect(startLabel(startMs, -4, Date.UTC(2001, 8, 11, 12, 0, 0))).toBe("9/10/2001 10:00 PM ET");
+	});
+
+	it("keeps the date when the clock's current instant is unusable", () => {
+		// A null or non-finite nowMs is not "today is unknowable" grounds to
+		// drop the only thing telling a listener what day this was — fail safe.
+		expect(startLabel(AA11_MS, -4, null)).toBe("9/11/2001 8:33 AM ET");
+		expect(startLabel(AA11_MS, -4, Number.NaN)).toBe("9/11/2001 8:33 AM ET");
 	});
 
 	it("has nothing to say about a row with no usable start", () => {
-		expect(startLabel(null, -4)).toBeNull();
-		expect(startLabel(Number.NaN, -4)).toBeNull();
+		expect(startLabel(null, -4, SAME_DAY_NOW_MS)).toBeNull();
+		expect(startLabel(Number.NaN, -4, SAME_DAY_NOW_MS)).toBeNull();
 	});
 });
 

--- a/packages/frontend/src/Applications/RadioTraffic/smallPlayerLabels.ts
+++ b/packages/frontend/src/Applications/RadioTraffic/smallPlayerLabels.ts
@@ -29,26 +29,49 @@ export function zoneLabel(tzOffsetHours: number): string {
 }
 
 /**
- * `9/11/2001 8:33 AM ET` — the collapsed player's start line.
+ * `9/11/2001 8:33 AM ET` — the collapsed player's start line, or just
+ * `8:33 AM ET` when the clip started on the same (display-shifted) day the
+ * virtual clock currently reads.
  *
  * Shift the true-UTC instant by the display offset and format it AS UTC, which
  * is itemTiming.wallClockLabel's trick and for the same reason: the line has to
  * read identically for a listener in Berlin and one in Boston, which handing
  * the raw instant to the browser's own zone would not. Unlike that helper this
- * one carries the date, because a collapsed lane has no card header to carry it.
+ * one can carry the date, because a collapsed lane has no card header to carry
+ * it — but only when the date is not simply "today" as the Classicy clock
+ * currently sees it (issue #523). `nowMs` is the virtual clock's own current
+ * instant (e.g. RadioTraffic's `anchorMs`), shifted by the same offset before
+ * comparing — this is a "current day" question about the desktop's clock, not
+ * the browser's real-world date.
  */
-export function startLabel(ms: number | null, tzOffsetHours: number): string | null {
+export function startLabel(
+	ms: number | null,
+	tzOffsetHours: number,
+	nowMs: number | null,
+): string | null {
 	if (ms === null || !Number.isFinite(ms)) return null;
-	const stamp = new Date(ms + tzOffsetHours * HOUR_MS).toLocaleString("en-US", {
+	const shifted = new Date(ms + tzOffsetHours * HOUR_MS);
+	const sameDay =
+		nowMs !== null &&
+		Number.isFinite(nowMs) &&
+		isSameUtcDay(shifted, new Date(nowMs + tzOffsetHours * HOUR_MS));
+	const stamp = shifted.toLocaleString("en-US", {
 		timeZone: "UTC",
-		month: "numeric",
-		day: "numeric",
-		year: "numeric",
+		...(sameDay ? {} : { month: "numeric", day: "numeric", year: "numeric" }),
 		hour: "numeric",
 		minute: "2-digit",
 	});
 	// en-US separates the date from the time with a comma; the design does not.
 	return `${stamp.replace(", ", " ")} ${zoneLabel(tzOffsetHours)}`;
+}
+
+/** Same calendar day, comparing the UTC fields of two already-shifted stamps. */
+function isSameUtcDay(a: Date, b: Date): boolean {
+	return (
+		a.getUTCFullYear() === b.getUTCFullYear() &&
+		a.getUTCMonth() === b.getUTCMonth() &&
+		a.getUTCDate() === b.getUTCDate()
+	);
 }
 
 /**


### PR DESCRIPTION
## Summary
- `LaneSmallPlayer`'s collapsed-lane start line (used by the folded UPCOMING lane and any manually-collapsed LIVE/PREVIOUS lane) always printed a full date (`9/11/2001 8:33 AM ET`), which is redundant noise when that date is the same day the Classicy virtual clock currently reads.
- `smallPlayerLabels.ts`'s `startLabel(ms, tzOffsetHours, nowMs)` now takes a third argument — the virtual clock's current instant — shifts both timestamps by the display offset, and compares UTC year/month/day. Same day → time + zone only (`8:33 AM ET`). Different day → unchanged full format. A null/non-finite `nowMs` fails safe and keeps the date.
- `LaneSmallPlayer` takes a new required `currentMs` prop threaded into `startLabel`.
- `RadioTraffic.tsx`'s `renderCollapsedCard` passes its already-computed `anchorMs` (the once-per-virtual-minute clock reading), not the ms-precise `nowMs` used for waveform seeking, to avoid re-rendering every folded card on every tick — added to the `useCallback` deps alongside `mp3Meta`/`tz`.
- The comparison is against the Classicy virtual clock only, never the browser's real-world date, per the approved plan on the issue.

## Test plan
- [x] `pnpm --filter @rt911/frontend exec vitest run src/Applications/RadioTraffic/` — 31 files, 698 tests pass, including new same-day/different-day/unusable-`nowMs` cases in `smallPlayerLabels.test.ts` and `LaneSmallPlayer.test.tsx`, and an updated expectation in `RadioTraffic.test.tsx`'s "keeps the clips' metadata readable while folded".
- [x] `pnpm --filter @rt911/frontend exec vitest run` (full suite) — 295 files, 3205 tests pass.
- [x] `pnpm lint` (oxlint) — no new warnings/errors, only pre-existing warnings in unrelated files.
- [x] `pnpm build` (`tsc -b && vite build`) — succeeds.

Fixes #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)