### PR TITLE
[scratch, do not merge] verify radio-traffic E2E fixes

### DIFF
--- a/packages/frontend/e2e/tests/radio-traffic.spec.ts
+++ b/packages/frontend/e2e/tests/radio-traffic.spec.ts
@@ -105,7 +105,7 @@ test.beforeEach(async ({ page }) => {
 	await expect(page.locator(".classicyDesktop")).toBeVisible({ timeout: 20_000 });
 });
 
-test.skip("opens from the desktop and renders cards into the three lanes without them migrating", async ({
+test("opens from the desktop and renders cards into the three lanes without them migrating", async ({
 	page,
 }) => {
 	const app = await openRadioTraffic(page);
@@ -144,7 +144,7 @@ test.skip("opens from the desktop and renders cards into the three lanes without
 	expect(second).toEqual(first);
 });
 
-test.skip("the tool palette activates exactly one tool at a time", async ({ page }) => {
+test("the tool palette activates exactly one tool at a time", async ({ page }) => {
 	const app = await openRadioTraffic(page);
 	const palette = app.getByRole("radiogroup", { name: "Tools" });
 	const toolNames = ["Solo", "Mute", "Unmute", "Move"];
@@ -162,7 +162,7 @@ test.skip("the tool palette activates exactly one tool at a time", async ({ page
 	}
 });
 
-test.skip("a card's tab bar switches panels", async ({ page }) => {
+test("a card's tab bar switches panels", async ({ page }) => {
 	const app = await openRadioTraffic(page);
 	const card = app.locator("[data-item]").first();
 	await expect(card).toBeVisible({ timeout: 30_000 });
@@ -184,7 +184,7 @@ test.skip("a card's tab bar switches panels", async ({ page }) => {
 	await expect(card.locator('[data-tab="details"]')).toHaveCount(0);
 });
 
-test.skip("checking a small-namespace tag narrows the visible cards", async ({ page }) => {
+test("checking a small-namespace tag narrows the visible cards", async ({ page }) => {
 	const app = await openRadioTraffic(page);
 
 	if (!(await tagsAvailable(app))) {
@@ -217,7 +217,7 @@ test.skip("checking a small-namespace tag narrows the visible cards", async ({ p
 	await expect.poll(totalCards, { timeout: 15_000 }).toBeLessThan(before);
 });
 
-test.skip("opening the aircraft picker, typing and confirming narrows the cards further", async ({
+test("opening the aircraft picker, typing and confirming narrows the cards further", async ({
 	page,
 }) => {
 	const app = await openRadioTraffic(page);

--- a/packages/frontend/src/Applications/RadioTraffic/TrafficCard.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/TrafficCard.tsx
@@ -203,7 +203,14 @@ const TrafficCardImpl: React.FC<TrafficCardProps> = ({
 	);
 
 	const durationMs = (itemTiming(item).durationSec ?? 0) * 1000;
-	const liveMs = calcSeekSeconds(item, nowMs) * 1000;
+	// badgeFor (cardStatus.ts) never reads liveMs for "upcoming" (returns on
+	// `countdown` alone) or "previous" (returns on `userPlaying`/`silent` alone)
+	// — only the LIVE-lane drift calculation uses it. calcSeekSeconds parses
+	// item.start_date through `new Date(...)` on every call, so computing it
+	// unconditionally was real, provably-wasted work on every UPCOMING/PREVIOUS
+	// card, every render — the two lanes with the most cards once a session has
+	// been running a while.
+	const liveMs = lane === "live" ? calcSeekSeconds(item, nowMs) * 1000 : 0;
 
 	// One tick of history, held here rather than in cardStatus so badgeFor stays
 	// a pure function of its arguments — see BadgeArgs.previousKind.


### PR DESCRIPTION
Throwaway PR purely for CI signal — checking whether the perf fixes already on `main` (TrafficCard memoization, PeaksWaveform canvas-draw batching, LaneSection/Newsgroups re-render fixes, pinVirtualClock timeout, liveMs skip) are enough to pass `radio-traffic.spec.ts` reliably on GitHub's runners, now that it's un-skipped here. Will close this PR regardless of outcome — main's own copy stays quarantined either way pending this result.