### PR TITLE
fix(radio-traffic): marquee-scroll overflowing tag chips in folded lanes

### DIFF
--- a/packages/frontend/src/Applications/RadioTraffic/LaneSmallPlayer.test.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/LaneSmallPlayer.test.tsx
@@ -1,5 +1,19 @@
 import { cleanup, render } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// jsdom has no ResizeObserver; the marquee tests below opt LaneSmallPlayer's
+// own useHorizontalOverflow call into actually measuring instead of the
+// hook's no-ResizeObserver "report fits" fallback. Same stub as
+// radio-core/marquee.test.tsx.
+vi.stubGlobal(
+	"ResizeObserver",
+	class {
+		observe() {}
+		unobserve() {}
+		disconnect() {}
+	},
+);
+
 import { LaneSmallPlayer } from "./LaneSmallPlayer";
 import { makeItem, makeMeta } from "./tabs/cardTabFixtures";
 
@@ -22,6 +36,7 @@ function renderPlayer(
 			item={props.item ?? makeItem()}
 			meta={"meta" in props ? props.meta : makeMeta()}
 			tzOffsetHours={props.tzOffsetHours ?? TZ}
+				enableMarquee={props.enableMarquee}
 			currentMs={"currentMs" in props ? (props.currentMs ?? null) : NEXT_DAY_NOW_MS}
 		/>,
 	);
@@ -163,5 +178,49 @@ describe("LaneSmallPlayer chrome", () => {
 		const container = renderPlayer();
 		expect(container.querySelector("button")).toBeNull();
 		expect(container.querySelector("canvas")).toBeNull();
+	});
+});
+
+describe("LaneSmallPlayer marquee (issue #522)", () => {
+	// UPCOMING and PREVIOUS opt into scrolling a chip row too wide to fit,
+	// rather than clipping the rest of a curator's tags away with no way to
+	// ever see them. LIVE never sets `enableMarquee`, so it keeps the plain,
+	// clipped row exercised by the "shows every tag as a chip" test above.
+
+	it("renders the plain chip list, no marquee, when the tags fit", () => {
+		// jsdom reports scrollWidth/clientWidth as 0 by default, so
+		// useHorizontalOverflow's own "fits" arithmetic (0 > 0 + 1) holds even
+		// with a live ResizeObserver — nothing needs to be forced here.
+		const container = renderPlayer({ enableMarquee: true });
+		expect(container.querySelector(".rfm-marquee-container")).toBeNull();
+		const chips = Array.from(container.querySelectorAll("li")).map((li) => li.textContent);
+		expect(chips).toEqual(["Hijacking", "ZBW", "AAL11"]);
+	});
+
+	it("wraps an overflowing chip row in the marquee, keeping every chip present", () => {
+		// Force the row wider than its wrapper: override scrollWidth/clientWidth
+		// on the element prototype so useHorizontalOverflow's synchronous first
+		// measure (on mount, before any real resize) already sees overflow.
+		Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+			configurable: true,
+			get: () => 900,
+		});
+		Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+			configurable: true,
+			get: () => 300,
+		});
+		try {
+			const container = renderPlayer({ enableMarquee: true });
+			expect(container.querySelector(".rfm-marquee-container")).not.toBeNull();
+			// react-fast-marquee duplicates its children for a seamless loop, so
+			// each chip appears more than once — assert presence, not count.
+			const chipTexts = new Set(
+				Array.from(container.querySelectorAll("li")).map((li) => li.textContent),
+			);
+			expect(chipTexts).toEqual(new Set(["Hijacking", "ZBW", "AAL11"]));
+		} finally {
+			Reflect.deleteProperty(HTMLElement.prototype, "scrollWidth");
+			Reflect.deleteProperty(HTMLElement.prototype, "clientWidth");
+		}
 	});
 });

--- a/packages/frontend/src/Applications/RadioTraffic/LaneSmallPlayer.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/LaneSmallPlayer.tsx
@@ -23,6 +23,8 @@
 
 import type React from "react";
 import type { ItemMeta, MediaItem } from "../../Providers/MediaStream/MediaStreamContext";
+import Marquee from "../radio-core/marquee";
+import { useHorizontalOverflow } from "../radio-core/useHorizontalOverflow";
 import styles from "./laneSmallPlayer.module.scss";
 import { durationSecondsLabel, startLabel } from "./smallPlayerLabels";
 import { itemTiming } from "./tabs/itemTiming";
@@ -43,6 +45,16 @@ export interface LaneSmallPlayerProps {
 	 * far more often than the day it's read for could actually change.
 	 */
 	currentMs: number | null;
+	/**
+	 * Whether an overflowing chip row may marquee-scroll (issue #522).
+	 * Defaults to false so a bare `<LaneSmallPlayer>` — every existing test,
+	 * and any future caller that forgets the prop — keeps the old clipped
+	 * single row. RadioTraffic.tsx opts UPCOMING and PREVIOUS in and leaves
+	 * LIVE out: LIVE's collapsed card sits above a mix a listener is actively
+	 * scanning, and a scrolling tag row there would be one more thing moving
+	 * on a card whose whole point is "not the busy view".
+	 */
+	enableMarquee?: boolean;
 }
 
 export const LaneSmallPlayer: React.FC<LaneSmallPlayerProps> = ({
@@ -50,6 +62,7 @@ export const LaneSmallPlayer: React.FC<LaneSmallPlayerProps> = ({
 	meta,
 	tzOffsetHours,
 	currentMs,
+	enableMarquee = false,
 }) => {
 	const timing = itemTiming(item);
 	// The same fallback the full card uses: an untranscribed clip still has a
@@ -59,6 +72,30 @@ export const LaneSmallPlayer: React.FC<LaneSmallPlayerProps> = ({
 	const duration = durationSecondsLabel(timing.durationSec);
 	const link = meta?.link?.trim();
 	const tags = meta?.tags ?? [];
+	const { containerRef, contentRef, overflowing } = useHorizontalOverflow();
+
+	const chipList = (
+		<ul
+			ref={enableMarquee ? contentRef : undefined}
+			className={styles.rtSmallChips}
+			aria-label="Tags"
+		>
+			{tags.map((tag) => (
+				// mp3_tags.color is NULL on every row today, so the namespace
+				// palette is what actually paints these; chipColor honours a
+				// curator's colour first if one is ever set. Same call the
+				// Details panel makes, so the two can never drift.
+				<li
+					key={tag.tag}
+					className={styles.rtSmallChip}
+					data-namespace={tag.namespace}
+					style={{ background: chipColor(tag) }}
+				>
+					{tagLabel(tag)}
+				</li>
+			))}
+		</ul>
+	);
 
 	return (
 		<article className={styles.rtSmallPlayer} data-small-player={item.id}>
@@ -67,24 +104,20 @@ export const LaneSmallPlayer: React.FC<LaneSmallPlayerProps> = ({
 				{`${subject}`}
 			</h3>
 
-			{tags.length > 0 && (
-				<ul className={styles.rtSmallChips} aria-label="Tags">
-					{tags.map((tag) => (
-						// mp3_tags.color is NULL on every row today, so the namespace
-						// palette is what actually paints these; chipColor honours a
-						// curator's colour first if one is ever set. Same call the
-						// Details panel makes, so the two can never drift.
-						<li
-							key={tag.tag}
-							className={styles.rtSmallChip}
-							data-namespace={tag.namespace}
-							style={{ background: chipColor(tag) }}
-						>
-							{tagLabel(tag)}
-						</li>
-					))}
-				</ul>
-			)}
+			{tags.length > 0 &&
+				(enableMarquee ? (
+					<div ref={containerRef} className={styles.rtSmallChipsWrapper}>
+						{overflowing ? (
+							<Marquee direction="left" speed={20} pauseOnHover gradient={false}>
+								{chipList}
+							</Marquee>
+						) : (
+							chipList
+						)}
+					</div>
+				) : (
+					chipList
+				))}
 
 			<div className={styles.rtSmallFooter}>
 				<div className={styles.rtSmallTimings}>

--- a/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.tsx
@@ -796,18 +796,24 @@ export const RadioTraffic: React.FC = () => {
 
 	// The folded lanes' players (story 027). One renderer for all three lanes,
 	// because a small player carries no lane-dependent state — no badge, no
-	// transport, no mute — which is exactly what makes it small.
+	// transport, no mute — which is exactly what makes it small. Curried by
+	// lane, like `renderCard` above, purely to carry `enableMarquee` (issue
+	// #522): LIVE's collapsed card sits above a mix a listener is actively
+	// scanning and keeps the old clipped, non-scrolling chip row; UPCOMING and
+	// PREVIOUS — reference views with nothing else moving on the card — marquee
+	// a chip row too wide to fit instead of silently dropping the rest of it.
 	// anchorMs, not nowMs: the small player only needs "today" to the nearest
 	// virtual minute, and nowMs is recomputed every render tick for waveform
 	// seeking — keying this callback on it would invalidate every folded card's
 	// memoisation once a second instead of once a minute.
 	const renderCollapsedCard = useCallback(
-		(item: MediaItem) => (
+		(lane: Lane) => (item: MediaItem) => (
 			<LaneSmallPlayer
 				item={item}
 				meta={mp3Meta[item.id]}
 				tzOffsetHours={tz}
 				currentMs={anchorMs}
+				enableMarquee={lane !== "live"}
 			/>
 		),
 		[mp3Meta, tz, anchorMs],
@@ -933,7 +939,7 @@ export const RadioTraffic: React.FC = () => {
 								tool={tool}
 								onReorder={(fromId, toIndex) => onReorder(lane, fromId, toIndex)}
 								renderCard={renderCard(lane)}
-								renderCollapsedCard={renderCollapsedCard}
+								renderCollapsedCard={renderCollapsedCard(lane)}
 							/>
 						))}
 					</main>

--- a/packages/frontend/src/Applications/RadioTraffic/laneSmallPlayer.module.scss
+++ b/packages/frontend/src/Applications/RadioTraffic/laneSmallPlayer.module.scss
@@ -27,9 +27,15 @@
   color: var(--color-white, #fff);
   background: #2b2b2b;
   border: var(--window-border-size) solid var(--color-white, #fff);
-  // A long subject or a long chip row is CLIPPED, never scrolled: the collapsed
-  // lane is already the compact view, and a scrollbar inside it would be a
-  // second thing to scroll inside something you folded away to stop scrolling.
+  // A long subject is still CLIPPED, never scrolled — the collapsed lane is
+  // already the compact view, and a scrollbar inside it would be a second
+  // thing to scroll inside something you folded away to stop scrolling. The
+  // chip row is the one exception (issue #522): UPCOMING and PREVIOUS marquee
+  // an overflowing tag row instead of clipping it, because a curator's tags
+  // are the whole reason to keep reading a folded card rather than expanding
+  // it — clipping them silently threw some away with no way to ever see the
+  // rest. See `.rtSmallChipsWrapper` below for the marquee wiring; the
+  // subject line and footer are unaffected and stay clipped/ellipsised.
   overflow: hidden;
 
 }
@@ -50,19 +56,30 @@
 
 // Tags -----------------------------------------------------------------------
 
-// One row, clipped at the card's edge. Wrapping would make the card's height
-// depend on how many tags a curator happened to apply, and with it the height
-// of the whole collapsed lane.
+// Wraps the chip row so `useHorizontalOverflow` has a fixed-width box to
+// measure the row against; the row itself is `width: max-content` (below) so
+// it can be wider than this wrapper without wrapping onto a second line.
+.rtSmallChipsWrapper {
+  min-width: 0;
+}
+
+// One row, never wrapped — wrapping would make the card's height depend on
+// how many tags a curator happened to apply, and with it the height of the
+// whole collapsed lane. `width: max-content` lets the row grow past its
+// wrapper instead of shrinking to fit it, which is what makes `scrollWidth >
+// clientWidth` — and so overflow, and so the marquee — detectable at all
+// (see `useHorizontalOverflow`'s doc comment). Lanes that don't opt into the
+// marquee (LIVE) still clip this via the card's own `overflow: hidden`.
 .rtSmallChips {
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
   gap: var(--window-border-size);
+  width: max-content;
   margin: 0;
   padding: 0;
   min-width: 0;
   list-style: none;
-  overflow: hidden;
 }
 
 .rtSmallChip {


### PR DESCRIPTION
## Summary

- The collapsed/"small" player shown by a folded RadioTraffic lane (`LaneSmallPlayer.tsx`) rendered its tag chips as a single non-wrapping row hard-clipped at the card edge — a card with more chips than fit in the visible width lost the rest with no way to ever see them.
- UPCOMING (always collapsed) and PREVIOUS (when collapsed) now marquee-scroll an overflowing chip row instead, reusing the repo's existing `react-fast-marquee` composition (`radio-core/marquee.ts` + `radio-core/useHorizontalOverflow.ts`) already wired up for MarketWatch's ticker tape, rather than a hand-rolled CSS animation.
- LIVE's collapsed card is deliberately excluded and keeps the old clipped, non-scrolling row — its card sits above a mix a listener is actively scanning, so nothing new should be moving on it.
- When the tags already fit, the plain `<ul>` renders as before — no marquee mounted, no animation cost.
- `laneSmallPlayer.module.scss`'s doc comment (previously stating chip clipping was deliberate) is rewritten to describe the new per-lane marquee behavior; the subject line and footer are unaffected and remain clipped/ellipsised.

Fixes #522

## Test plan

- [x] `pnpm --filter @rt911/frontend exec vitest run` — 295 files / 3207 tests pass, including new `LaneSmallPlayer.test.tsx` coverage: a ResizeObserver stub so the overflow hook actually measures, a forced-overflow case asserting the marquee wrapper mounts with every chip still present, and a fits-in-view case asserting the plain `<ul>` renders with no marquee.
- [x] `pnpm build` (`tsc -b && vite build`) — succeeds.
- [x] `pnpm lint` (oxlint) — no new warnings introduced by this change (pre-existing warnings elsewhere in the codebase are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)