### PR TITLE
feat(backend): support ad-hoc alerts on POST /alert

### DIFF
--- a/packages/backend/SPEC.md
+++ b/packages/backend/SPEC.md
@@ -170,13 +170,25 @@ frames (`clock`, `heartbeat_ack.master_time`).
 Guarded by `X-Alert-Key` (`ALERT_CONTROL_KEY`; unset ⇒ 404, feature off).
 
 - `POST /alert {"id": 42}` — raise `alert_items` row 42 on every connected client now
+- `POST /alert {"title": "…", "content": "…", "severity": "caution"}` — push an
+  ad-hoc alert that has no `alert_items` row at all
 
 Alert *content* already reaches every pod through the `alert_items` NOTIFY
 listener; what that path cannot do is raise an alert off-schedule, because
 delivery is gated on the row's `start_date` against each client's virtual
-clock. This endpoint is that path: the row is read once on the receiving pod,
-fanned out over Redis pub/sub (`alerts:push`), and each pod restamps it with
-each session's own virtual time so it is immediately due for that client.
+clock. This endpoint is that path: the item — loaded by id, or assembled
+ad-hoc — is fanned out over Redis pub/sub (`alerts:push`) exactly once, and
+each pod restamps it with each session's own virtual time so it is immediately
+due for that client.
+
+An ad-hoc alert is **never persisted** — it never enters `alert_items` or the
+Redis media cache, only the fanout bus. It needs `title` (≤500 characters,
+whitespace-only rejected); `content`, `image`, `image_caption` are optional;
+`severity` defaults to `note` and must otherwise be `note`, `caution`, or
+`stop`. It is assigned a negative id — packed from a per-pod random salt and a
+per-pod counter — so it can never collide with a positive Directus id, or with
+an ad-hoc alert issued by a *different* pod, even though the same item (id
+included) is fanned out to every pod in the deployment.
 
 ### `POST /room` — live teacher control
 

--- a/packages/backend/docs/configuration.md
+++ b/packages/backend/docs/configuration.md
@@ -89,8 +89,11 @@ Structured keys you'll see:
 ## Security posture
 
 The streamer is **read-only and unauthenticated** on its data paths (the
-operator endpoints above are the exception, each gated by its own key). It
-assumes:
+operator endpoints above are the exception, each gated by its own key). Treat
+`ALERT_CONTROL_KEY` as an admin credential: an alert's `content` — whether an
+existing `alert_items` row or an ad-hoc payload — is rendered as HTML by every
+connected client's Alerts extension, so the key is the whole access control.
+It assumes:
 
 1. The reverse proxy (or CDN) terminates TLS.
 2. The reverse proxy enforces origin allow-listing if you care — the in-process `CheckOrigin` returns `true` for everything.

--- a/packages/backend/docs/operations.md
+++ b/packages/backend/docs/operations.md
@@ -150,6 +150,26 @@ docker compose exec rt911-cache redis-cli HGET media:items 12345
 
 The Unix timestamp for "2001-09-11T08:46:00Z" is `1000201560`.
 
+### Send an alert to everyone connected right now
+
+Scheduled alerts live in `alert_items` and fire when a client's virtual clock crosses their
+`start_date`. To interrupt everyone *immediately* — a maintenance notice, a classroom
+announcement — POST to `/alert` instead. It needs `ALERT_CONTROL_KEY` set on the streamer, and
+reaches every pod (see [`SPEC.md`](../SPEC.md#post-alert--operator-alert-push)):
+
+```sh
+curl -sS https://stream.911realtime.org/alert \
+  -H "X-Alert-Key: $ALERT_CONTROL_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"title":"Server maintenance in 10 minutes",
+       "content":"<p>The site will be briefly unavailable.</p>",
+       "severity":"caution"}'
+# {"id":-16777216,"title":"Server maintenance in 10 minutes"}
+```
+
+That's an ad-hoc alert — never persisted, gone once delivered. To fire an already-curated
+`alert_items` row early instead, send its id: `-d '{"id":4001}'`.
+
 ### Watch a session in flight
 
 There's no introspection endpoint, but you can correlate by session ID:

--- a/packages/backend/docs/websocket-protocol.md
+++ b/packages/backend/docs/websocket-protocol.md
@@ -417,8 +417,9 @@ backfills anything, only the forward tick delivers alerts. This is deliberate, n
 an alert is meant to fire exactly once, at the instant the virtual clock crosses its `start_date`
 (fire-on-cross); a snapshot would surface alerts whose moment has already passed, which is fine for
 news's headline lookback but wrong for something meant to interrupt. Forward refills use the same
-600 s window as pager/news/usenet. See [`alerts` field reference](#server-initiated-alerts) below
-for the frame shape.
+600 s window as pager/news/usenet. Alerts can additionally be fired **on demand** by an operator
+(`POST /alert`), which reuses the same frame — see [`alerts` field reference](#server-initiated-alerts)
+below for the frame shape and [out-of-band alerts](#out-of-band-alerts) for how those differ.
 
 ### `usenet_filter` and the `usenet` channel
 
@@ -767,8 +768,25 @@ plus one alert-only field:
 | `severity` | string? | `note` \| `caution` \| `stop` — selects the client's alert icon/treatment. Omitted when empty (rows predating the column). |
 
 There is deliberately **no snapshot** frame for this channel (see [the `alerts` channel](#subscribe)
-above) — every `alerts` frame is a forward window, sent once per **window refill** and only when the
-window contains at least one alert; empty windows produce no frame, same as `pager`/`flights`.
+above) — every scheduled `alerts` frame is a forward window, sent once per **window refill** and only
+when the window contains at least one alert; empty windows produce no frame, same as
+`pager`/`flights`.
+
+#### Out-of-band alerts
+
+An operator can also fire an alert *now*, at every connected client, without waiting for the virtual
+clock to cross a scheduled `alert_items` row — see [`POST /alert`](../SPEC.md#post-alert--operator-alert-push).
+There is **no separate frame type** for this: the alert rides the ordinary `alerts` frame above,
+carrying a single item whose `start_date` the server rewrites to just behind *that session's* virtual
+clock, so the client's reveal gate surfaces it on arrival instead of buffering it. Two consequences
+worth knowing on the client side:
+
+- An ad-hoc alert (one not backed by an `alert_items` row) carries a **negative `id`**, packed from a
+  random per-pod salt and a per-pod counter. Directus ids are always positive, so the two can never
+  collide in the client's dedupe map or its dismissed set — and neither can two ad-hoc alerts issued
+  by different pods, even though the fanout bus delivers both to every pod in the deployment.
+- The `start_date` on the wire is the delivery instant, not an authored time, and it differs per
+  session. Don't treat it as stable across clients.
 
 ### Room control (server → client `room_command`)
 

--- a/packages/backend/internal/handler/alert.go
+++ b/packages/backend/internal/handler/alert.go
@@ -1,10 +1,14 @@
 package handler
 
 import (
+	"crypto/rand"
 	"crypto/subtle"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
+	"strings"
+	"sync/atomic"
 
 	"classicy/streamer/internal/db"
 	"classicy/streamer/internal/fanout"
@@ -13,8 +17,28 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+// alertMaxBody bounds the request body. An alert is a headline plus a short
+// HTML paragraph; anything approaching this is a mistake, not a legitimate
+// alert.
+const alertMaxBody = 64 << 10
+
+const alertMaxTitle = 500
+
+// alertSeverities are the only values the client can render (they select the
+// ClassicyAlert icon). Anything else would fall back to "note" silently, so
+// it is rejected instead.
+var alertSeverities = map[string]struct{}{"note": {}, "caution": {}, "stop": {}}
+
 type alertRequest struct {
+	// ID broadcasts an existing alert_items row as-is. When set (>0), every
+	// ad-hoc field below is ignored.
 	ID int `json:"id"`
+
+	Title        string `json:"title,omitempty"`
+	Content      string `json:"content,omitempty"`
+	Severity     string `json:"severity,omitempty"`
+	Image        string `json:"image,omitempty"`
+	ImageCaption string `json:"image_caption,omitempty"`
 }
 
 type alertResponse struct {
@@ -22,9 +46,14 @@ type alertResponse struct {
 	Title string `json:"title"`
 }
 
+var errAlertNoTitle = errors.New("title is required (or pass an existing alert id)")
+var errAlertLongTitle = errors.New("title too long")
+var errAlertSeverity = errors.New("severity must be note, caution or stop")
+
 // NewAlertHandler serves the operator push API for alerts:
 //
-//	POST /alert {"id":42}   → push alert_items row 42 to every connected client
+//	POST /alert {"id":42}                                    → push alert_items row 42 to every connected client
+//	POST /alert {"title":"…","content":"…","severity":"…"}   → push an ad-hoc alert, never persisted
 //
 // Requires the X-Alert-Key header to match key (constant-time). An empty key
 // disables the feature entirely: every request 404s, mirroring /clock.
@@ -33,13 +62,23 @@ type alertResponse struct {
 // every pod's Redis cache through the alert_items NOTIFY listener already; what
 // that path cannot do is raise an alert out of schedule, because delivery is
 // gated on the row's start_date against each client's virtual clock. This
-// endpoint is the "now" path: it reads the row once here, fans the whole item
+// endpoint is the "now" path: it builds (or loads) the item once here, fans it
 // out to every pod (see internal/fanout), and each pod restamps it per session.
 //
 // The row is loaded on this pod and published in full rather than by id alone,
 // so the other pods do not each repeat the same query — and so an id that does
 // not exist fails here, visibly to the operator, instead of silently on N pods.
+//
+// An ad-hoc alert has no database row, so it needs an id the client can key its
+// dedupe and dismissed-set on. adHocSalt is a random value generated once per
+// pod at startup; combined with a per-pod counter it keeps ad-hoc ids unique
+// across every pod in the deployment (not just this one), which matters because
+// the item — id included — is fanned out to all of them. Both halves are kept
+// well clear of Directus' positive alert_items ids by staying strictly negative.
 func NewAlertHandler(pool *pgxpool.Pool, bus *fanout.Bus[model.AlertItem], key string, logger *slog.Logger) http.HandlerFunc {
+	adHocSalt := newAlertPodSalt()
+	var adHocCounter atomic.Uint32
+
 	return func(w http.ResponseWriter, r *http.Request) {
 		if key == "" {
 			http.NotFound(w, r)
@@ -56,37 +95,102 @@ func NewAlertHandler(pool *pgxpool.Pool, bus *fanout.Bus[model.AlertItem], key s
 		}
 
 		var req alertRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, alertMaxBody)).Decode(&req); err != nil {
 			http.Error(w, "bad json: "+err.Error(), http.StatusBadRequest)
 			return
 		}
-		if req.ID <= 0 {
-			http.Error(w, "id required", http.StatusBadRequest)
-			return
-		}
 
-		item, err := db.AlertItemByID(r.Context(), pool, req.ID)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		if item == nil {
-			http.Error(w, "no such alert", http.StatusNotFound)
-			return
+		var item *model.AlertItem
+		if req.ID > 0 {
+			var err error
+			item, err = db.AlertItemByID(r.Context(), pool, req.ID)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			if item == nil {
+				http.Error(w, "no such alert", http.StatusNotFound)
+				return
+			}
+		} else {
+			built, err := buildAdHocAlert(&req, adHocSalt, &adHocCounter)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			item = built
 		}
 
 		// Unlike the clock's publish, a failure here has no backstop: nothing
 		// persists an ephemeral push, so no pod recovers it later. Surface it
 		// to the operator rather than logging and returning success.
 		if err := bus.Publish(r.Context(), *item); err != nil {
-			logger.Error("alert push failed", "id", req.ID, "error", err)
+			logger.Error("alert push failed", "id", item.ID, "error", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		logger.Info("alert pushed", "id", req.ID, "title", item.Title)
+		logger.Info("alert pushed", "id", item.ID, "title", item.Title)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
 		_ = json.NewEncoder(w).Encode(alertResponse{ID: item.ID, Title: item.Title})
 	}
+}
+
+// buildAdHocAlert validates the ad-hoc fields of req and assembles the item to
+// broadcast. It is never persisted and never enters the Redis cache — it goes
+// straight onto the bus.
+func buildAdHocAlert(req *alertRequest, salt uint32, counter *atomic.Uint32) (*model.AlertItem, error) {
+	title := strings.TrimSpace(req.Title)
+	if title == "" {
+		return nil, errAlertNoTitle
+	}
+	if len(title) > alertMaxTitle {
+		return nil, errAlertLongTitle
+	}
+	severity := req.Severity
+	if severity == "" {
+		severity = "note"
+	}
+	if _, ok := alertSeverities[severity]; !ok {
+		return nil, errAlertSeverity
+	}
+
+	return &model.AlertItem{
+		MediaItem: model.MediaItem{
+			ID:        nextAdHocAlertID(salt, counter),
+			Title:     title,
+			FullTitle: title,
+			// Matches what curated alert_items rows carry, so an ad-hoc alert
+			// is indistinguishable on the wire from a scheduled one.
+			Format:       "modal",
+			Content:      req.Content,
+			Image:        req.Image,
+			ImageCaption: req.ImageCaption,
+			Approved:     1,
+		},
+		Severity: &severity,
+	}, nil
+}
+
+// newAlertPodSalt returns a random 24-bit value, generated once per process.
+// Falls back to 0 if the OS RNG is somehow unavailable — the counter alone
+// still guarantees uniqueness within this pod, just not across pods, which is
+// the same single-pod behavior an operator would see from a fresh deploy.
+func newAlertPodSalt() uint32 {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return 0
+	}
+	return (uint32(b[0])<<16 | uint32(b[1])<<8 | uint32(b[2])) & 0xFFFFFF
+}
+
+// nextAdHocAlertID packs the pod salt and a per-pod counter into a single
+// negative id, so ad-hoc alerts issued by different pods — all fanned out to
+// every session in the deployment — can never collide with each other or with
+// a positive Directus alert_items id. Both halves are kept to 24 bits so the
+// packed value stays comfortably within int64, with no sign-bit ambiguity.
+func nextAdHocAlertID(salt uint32, counter *atomic.Uint32) int {
+	n := counter.Add(1) & 0xFFFFFF
+	return -int((int64(salt) << 24) | int64(n))
 }

--- a/packages/backend/internal/handler/alert_test.go
+++ b/packages/backend/internal/handler/alert_test.go
@@ -1,11 +1,13 @@
 package handler
 
 import (
+	"encoding/json"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"classicy/streamer/internal/fanout"
@@ -92,5 +94,108 @@ func TestAlertPushRequiresAPositiveID(t *testing.T) {
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("body %s: status = %d, want 400", body, w.Code)
 		}
+	}
+}
+
+func TestAlertPushAdHocRejectsBlankTitle(t *testing.T) {
+	w := alertPost(t, newAlertTestHandler(t, "right"), "right", `{"title":"   "}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestAlertPushAdHocRejectsLongTitle(t *testing.T) {
+	body := `{"title":"` + strings.Repeat("x", alertMaxTitle+1) + `"}`
+	w := alertPost(t, newAlertTestHandler(t, "right"), "right", body)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestAlertPushAdHocRejectsUnknownSeverity(t *testing.T) {
+	w := alertPost(t, newAlertTestHandler(t, "right"), "right", `{"title":"Evacuate","severity":"urgent"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+// A body over alertMaxBody must be rejected before decode, not just truncated
+// silently — http.MaxBytesReader is what enforces that.
+func TestAlertPushAdHocRejectsOversizedBody(t *testing.T) {
+	body := `{"title":"x","content":"` + strings.Repeat("y", alertMaxBody) + `"}`
+	w := alertPost(t, newAlertTestHandler(t, "right"), "right", body)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestAlertPushAdHocSucceedsAndDefaultsSeverity(t *testing.T) {
+	w := alertPost(t, newAlertTestHandler(t, "right"), "right",
+		`{"title":"Server maintenance","content":"<p>Back in 10 minutes</p>"}`)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202, body: %s", w.Code, w.Body.String())
+	}
+	var resp alertResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Title != "Server maintenance" {
+		t.Fatalf("title = %q, want %q", resp.Title, "Server maintenance")
+	}
+	// Ad-hoc ids must never collide with a positive Directus alert_items id.
+	if resp.ID >= 0 {
+		t.Fatalf("id = %d, want strictly negative", resp.ID)
+	}
+}
+
+func TestAlertPushAdHocAcceptsEachKnownSeverity(t *testing.T) {
+	h := newAlertTestHandler(t, "right")
+	for severity := range alertSeverities {
+		w := alertPost(t, h, "right", `{"title":"Evacuate","severity":"`+severity+`"}`)
+		if w.Code != http.StatusAccepted {
+			t.Fatalf("severity %q: status = %d, want 202", severity, w.Code)
+		}
+	}
+}
+
+func TestAlertPushAdHocIDsIncrementPerRequest(t *testing.T) {
+	h := newAlertTestHandler(t, "right")
+	firstResp := decodeAlertResponse(t, alertPost(t, h, "right", `{"title":"First"}`))
+	secondResp := decodeAlertResponse(t, alertPost(t, h, "right", `{"title":"Second"}`))
+	if firstResp.ID == secondResp.ID {
+		t.Fatalf("expected distinct ids per request, both got %d", firstResp.ID)
+	}
+}
+
+func decodeAlertResponse(t *testing.T, w *httptest.ResponseRecorder) alertResponse {
+	t.Helper()
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202, body: %s", w.Code, w.Body.String())
+	}
+	var resp alertResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return resp
+}
+
+// nextAdHocAlertID is exercised directly (rather than through two full
+// handlers) so the salt can be fixed instead of random — a flaky assertion on
+// two independently-random pod salts happening to differ is not worth writing.
+func TestNextAdHocAlertIDStaysNegativeAndVariesBySaltAndCounter(t *testing.T) {
+	var counterA, counterB atomic.Uint32
+
+	first := nextAdHocAlertID(1, &counterA)
+	second := nextAdHocAlertID(1, &counterA)
+	if first == second {
+		t.Fatalf("expected the counter to advance the id, both got %d", first)
+	}
+	if first >= 0 || second >= 0 {
+		t.Fatalf("expected strictly negative ids, got %d and %d", first, second)
+	}
+
+	fromOtherPod := nextAdHocAlertID(2, &counterB)
+	if fromOtherPod == first {
+		t.Fatalf("expected a different salt to produce a different id, both got %d", first)
 	}
 }


### PR DESCRIPTION
## Summary

- Supersedes #510. That PR proposed a new `POST /alerts` endpoint for on-demand operator alerts, but main independently shipped equivalent by-id push infrastructure first (`/alert`, `Hub.BroadcastAlert`, `fanout.Bus`) with proper cross-pod delivery via Redis pub/sub — #510's version only reached the single pod that served the request.
- This ports the one capability #510 had that main's `/alert` didn't: firing an **ad-hoc alert** (title/content/severity/image) that has no `alert_items` row at all, never persisted.
- Ad-hoc alerts get a negative id packed from a random per-pod salt plus a per-pod counter, rather than #510's bare per-process counter, so ids stay collision-free even though the item is fanned out to every pod in the deployment.
- No changes to `Hub`/`Session` — the existing `PushAlert`/`BroadcastAlert` path (and its test coverage in `alertpush_test.go`/`alertfanout_test.go`) already covers subscription-gating, pause-handling, and cross-pod fanout for both id-based and ad-hoc items.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full backend suite, all packages green)
- [x] New handler tests cover: blank/oversized/too-long title, unknown severity, default severity, per-request id increment, id stays negative and varies by salt/counter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiKAwPVFo6kZq7qy4hHA4v