### PR TITLE
fix(radio-traffic): default the tag filter to clip (and unknown), not tape

### DIFF
--- a/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.test.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.test.tsx
@@ -373,7 +373,12 @@ beforeEach(() => {
 	clock.utcMs = NOW_MS;
 	clock.tzOffset = -4;
 	clock.paused = false;
-	mockAppData.current = {};
+	// checked: [] opts every test that does not care about the tag filter out
+	// of RadioTrafficContext's first-launch default (tier:clip + tier:unknown)
+	// — this suite's fixture tiers are "primary"/"secondary", which that
+	// default would silently hide every card behind. The "tag filtering" and
+	// "persisted state" describes below cover the default itself.
+	mockAppData.current = { checked: [] };
 	mockAppOpen.current = true;
 	mockDispatch.mockClear();
 	audio.elements.clear();
@@ -622,7 +627,7 @@ describe("RadioTraffic — the default mix", () => {
 	});
 
 	it("restores a persisted per-card mute and skips it when choosing the default", async () => {
-		mockAppData.current = { mutedItems: [1] };
+		mockAppData.current = { checked: [], mutedItems: [1] };
 		await renderSettled();
 		expect(audio.elements.get(1)?.muted).toBe(true);
 		// Auto-solo never overrides an explicit mute — it moves to the next card.
@@ -860,7 +865,7 @@ describe("RadioTraffic — the manual hold (story 045)", () => {
 	it("moves an already-muted, untouched LIVE player to PREVIOUS once its window ends", async () => {
 		// Muted from the moment it appeared, never paused, played or scrubbed —
 		// mute alone was never the criterion here, only a touch is.
-		mockAppData.current = { mutedItems: [10] };
+		mockAppData.current = { checked: [], mutedItems: [10] };
 		const { rerender } = await renderHold();
 		expect(laneIds("live")).toEqual([10]);
 		expect(audio.elements.get(10)?.muted).toBe(true);
@@ -997,7 +1002,7 @@ describe("RadioTraffic — persisted state", () => {
 	});
 
 	it("ignores an unreadable laneOrder rather than rendering from it", async () => {
-		mockAppData.current = { laneOrder: { live: [3, "x", 1, 0] } };
+		mockAppData.current = { checked: [], laneOrder: { live: [3, "x", 1, 0] } };
 		await renderSettled();
 		// The bad pin list is dropped whole, so the lane stays chronological.
 		expect(laneIds("live")).toEqual([1, 2, 3]);
@@ -1062,7 +1067,7 @@ describe("RadioTraffic — the LIVE lane mute", () => {
 		// here now" implementation would be indistinguishable on this screen and
 		// wrong on the next one, and the per-card set is where the difference
 		// shows: it stays exactly as the listener left it.
-		mockAppData.current = { mutedItems: [2] };
+		mockAppData.current = { checked: [], mutedItems: [2] };
 		await renderSettled();
 		fireEvent.click(laneMute("live") as Element);
 		await act(async () => {});
@@ -1080,7 +1085,7 @@ describe("RadioTraffic — the LIVE lane mute", () => {
 		// cards already there are individually muted, so with no lane mute the
 		// auto-solo would hand the mix straight to the newcomer. Only the lane
 		// flag keeps it quiet.
-		mockAppData.current = { mutedItems: [1, 2, 3], liveLaneMuted: true };
+		mockAppData.current = { checked: [], mutedItems: [1, 2, 3], liveLaneMuted: true };
 		const arrival = item(8, "2001-09-11T12:46:50.000Z", "2001-09-11T12:52:00.000Z");
 		await renderSettled({ mp3Items: [...LIVE, arrival] });
 
@@ -1149,7 +1154,7 @@ describe("RadioTraffic — the LIVE lane mute", () => {
 		// Unlike solo this names no clip, so a reload cannot make it stale — and
 		// a listener who silenced the app and came back to it talking would
 		// reasonably call that a bug.
-		mockAppData.current = { liveLaneMuted: true };
+		mockAppData.current = { checked: [], liveLaneMuted: true };
 		await renderSettled();
 		expect(audibleLive()).toEqual([]);
 		expect(laneMute("live")?.getAttribute("aria-pressed")).toBe("true");
@@ -1177,14 +1182,14 @@ describe("RadioTraffic — a collapsed lane", () => {
 	it("swaps UPCOMING's full players for small ones", async () => {
 		// UPCOMING is permanently minimized (no stored flag needed to fold it),
 		// but the fixture sets one anyway to show it changes nothing.
-		mockAppData.current = { collapsed: { upcoming: true } };
+		mockAppData.current = { checked: [], collapsed: { upcoming: true } };
 		await renderSettled();
 		expect(smallPlayersIn("upcoming")).toEqual([4, 6]);
 		expect(fullPlayersIn("upcoming")).toEqual([]);
 	});
 
 	it("keeps the clips' metadata readable while folded", async () => {
-		mockAppData.current = { collapsed: { upcoming: true } };
+		mockAppData.current = { checked: [], collapsed: { upcoming: true } };
 		await renderSettled();
 		const small = document.querySelector('[data-small-player="4"]');
 		// The tier tag META gives every item, coloured by its namespace.
@@ -1196,7 +1201,7 @@ describe("RadioTraffic — a collapsed lane", () => {
 	});
 
 	it("leaves the other lanes on their full players", async () => {
-		mockAppData.current = { collapsed: { upcoming: true } };
+		mockAppData.current = { checked: [], collapsed: { upcoming: true } };
 		await renderSettled();
 		expect(laneIds("live")).toEqual([1, 2, 3]);
 		expect(smallPlayersIn("live")).toEqual([]);
@@ -1205,7 +1210,7 @@ describe("RadioTraffic — a collapsed lane", () => {
 	it("keeps LIVE on its full players whatever the stored flag says", async () => {
 		// LIVE has no control to undo a collapse with, so a stale `true` must not
 		// shrink the lane the app exists to show.
-		mockAppData.current = { collapsed: { live: true } };
+		mockAppData.current = { checked: [], collapsed: { live: true } };
 		await renderSettled();
 		expect(laneIds("live")).toEqual([1, 2, 3]);
 		expect(smallPlayersIn("live")).toEqual([]);
@@ -1268,7 +1273,11 @@ describe("RadioTraffic — the waveform color", () => {
 	});
 
 	it("applies a saved color to every card", async () => {
-		mockAppData.current = { useThemeWaveformColor: false, waveformColor: 0x00d25a };
+		mockAppData.current = {
+			checked: [],
+			useThemeWaveformColor: false,
+			waveformColor: 0x00d25a,
+		};
 		await renderSettled();
 		const slots = waveformSlots();
 		expect(slots.length).toBeGreaterThan(1);
@@ -1348,7 +1357,7 @@ describe("RadioTraffic — the original-recording choice", () => {
 	});
 
 	it("plays the source recording when a previous session chose it", async () => {
-		mockAppData.current = { playOriginalAudio: true };
+		mockAppData.current = { checked: [], playOriginalAudio: true };
 		await renderSettled(oneLiveClip);
 		expect(srcOf(1)).toBe(ORIGINAL);
 	});
@@ -1374,7 +1383,7 @@ describe("RadioTraffic — the original-recording choice", () => {
 	});
 
 	it("switches back to the enhanced render just as live", async () => {
-		mockAppData.current = { playOriginalAudio: true };
+		mockAppData.current = { checked: [], playOriginalAudio: true };
 		await renderSettled(oneLiveClip);
 		const element = audio.elements.get(1);
 
@@ -1412,7 +1421,7 @@ describe("RadioTraffic — the original-recording choice", () => {
 	// the safe fallback — the alternative is an undefined src, which fails as a
 	// broken element with nothing on screen to say why.
 	it("falls back to the source recording for a clip with no enhanced copy", async () => {
-		mockAppData.current = { playOriginalAudio: false };
+		mockAppData.current = { checked: [], playOriginalAudio: false };
 		await renderSettled({ ...oneLiveClip, mp3Items: [{ ...both, enhanced_url: null }] });
 		expect(srcOf(1)).toBe(ORIGINAL);
 	});

--- a/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.tsx
@@ -80,7 +80,7 @@ import {
 	sanitizeRadioTrafficState,
 } from "./RadioTrafficContext";
 import { RadioTrafficSettingsWindow } from "./RadioTrafficSettingsWindow";
-import { groupVocabulary, matchesFilter } from "./tagFilter";
+import { groupVocabulary, matchesFilter, withUnknownTier } from "./tagFilter";
 import { TagPickerWindow } from "./TagPickerWindow";
 import { reconcileTagVocabulary, type VocabularyState } from "./tagVocabulary";
 import {
@@ -512,7 +512,12 @@ export const RadioTraffic: React.FC = () => {
 		};
 	}, [mp3MetaGeneration]);
 
-	const groups = useMemo(() => groupVocabulary(vocabulary.vocabulary), [vocabulary]);
+	// withUnknownTier adds a sidebar checkbox for the pseudo-value
+	// matchesFilter treats specially — see tagFilter.ts.
+	const groups = useMemo(
+		() => withUnknownTier(groupVocabulary(vocabulary.vocabulary)),
+		[vocabulary],
+	);
 
 	const visible = useMemo(() => {
 		const keep = (item: MediaItem) => matchesFilter(mp3Meta[item.id]?.tags, checked);

--- a/packages/frontend/src/Applications/RadioTraffic/RadioTrafficContext.test.ts
+++ b/packages/frontend/src/Applications/RadioTraffic/RadioTrafficContext.test.ts
@@ -2,6 +2,7 @@ import type { ActionMessage, ClassicyStore } from "classicy";
 import { describe, expect, it } from "vitest";
 import {
 	classicyRadioTrafficEventHandler,
+	DEFAULT_CHECKED_TAGS,
 	DEFAULT_TOOL,
 	DEFAULT_WAVEFORM_COLOR,
 	radioTrafficSetState,
@@ -26,7 +27,7 @@ const appData = (ds: ClassicyStore) =>
 describe("sanitizeRadioTrafficState", () => {
 	it("returns the documented defaults for absent state", () => {
 		expect(sanitizeRadioTrafficState(undefined)).toEqual({
-			checked: [],
+			checked: [...DEFAULT_CHECKED_TAGS],
 			tool: DEFAULT_TOOL,
 			collapsed: { live: false, upcoming: false, previous: false },
 			laneOrder: { live: [], upcoming: [], previous: [] },
@@ -35,6 +36,39 @@ describe("sanitizeRadioTrafficState", () => {
 			useThemeWaveformColor: true,
 			waveformColor: DEFAULT_WAVEFORM_COLOR,
 			playOriginalAudio: false,
+		});
+	});
+
+	// {} is what a store with a registered but never-persisted-to app entry
+	// looks like, and it must read the same as undefined: `data.checked` is
+	// undefined either way, so a true first launch opens on "clip" whichever
+	// shape an empty app entry happens to take.
+	it("defaults an empty stored object to the same first-launch checked set", () => {
+		expect(sanitizeRadioTrafficState({}).checked).toEqual([...DEFAULT_CHECKED_TAGS]);
+	});
+
+	describe("the checked tag filters", () => {
+		// The true first-launch case: `checked` was never persisted at all.
+		// tier:unknown rides along with tier:clip — see DEFAULT_CHECKED_TAGS.
+		it("defaults to tier:clip and tier:unknown when checked was never stored", () => {
+			expect(sanitizeRadioTrafficState(undefined).checked).toEqual([
+				"tier:clip",
+				"tier:unknown",
+			]);
+			expect(sanitizeRadioTrafficState({}).checked).toEqual(["tier:clip", "tier:unknown"]);
+		});
+
+		// A listener who unticked every box gets that choice back, not the
+		// first-launch default re-applied on top of it.
+		it("respects an explicit empty selection instead of re-defaulting it", () => {
+			expect(sanitizeRadioTrafficState({ checked: [] }).checked).toEqual([]);
+		});
+
+		// A previously-persisted, non-default selection survives untouched.
+		it("respects a persisted non-default selection", () => {
+			expect(sanitizeRadioTrafficState({ checked: ["tier:tape"] }).checked).toEqual([
+				"tier:tape",
+			]);
 		});
 	});
 

--- a/packages/frontend/src/Applications/RadioTraffic/RadioTrafficContext.ts
+++ b/packages/frontend/src/Applications/RadioTraffic/RadioTrafficContext.ts
@@ -22,6 +22,7 @@ import { z } from "zod";
 import { sanitizeItemIds } from "../radio-core/radioPlayback";
 import type { Lane } from "./cardStatus";
 import { LANES, type LaneOrder } from "./laneOrder";
+import { UNKNOWN_TIER_TAG } from "./tagFilter";
 import { type Tool, TOOLS } from "./toolMode";
 
 const appId = "RadioTraffic.app";
@@ -113,6 +114,40 @@ function sanitizeTags(value: unknown): string[] {
 	return Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
 }
 
+/**
+ * The tags checked on a first-ever launch, before anything has been persisted.
+ *
+ * `tier:clip` — short recordings, the vast majority of the corpus — is what a
+ * new listener should see; `tier:tape`'s long continuous position tapes stay
+ * hidden until asked for. {@link UNKNOWN_TIER_TAG} rides along with it: party
+ * identification (the offline pass that writes a `tier:*` tag at all) is
+ * manual, does not cover every recording RadioTraffic can show, and skips some
+ * of what it does reach — so a card with no tier tag of its own is not the
+ * same thing as a tape, and defaulting to `tier:clip` alone would silently
+ * bury it with no box in the sidebar able to bring it back. This is a boot
+ * default, not a fallback for bad data: see {@link sanitizeChecked} for why it
+ * applies only when `checked` was never stored at all.
+ */
+export const DEFAULT_CHECKED_TAGS: readonly string[] = ["tier:clip", UNKNOWN_TIER_TAG];
+
+/**
+ * `checked`'s own sanitizer, distinct from {@link sanitizeTags} because it is
+ * the one field where "absent" and "present but empty" must be told apart.
+ *
+ * Every other field in this module treats an unreadable or missing value the
+ * same way: fall back to a fixed default. `checked` cannot, because `[]` is
+ * also its most common *legitimate* value — a listener who unchecked every tag
+ * on purpose. Defaulting `undefined` to {@link DEFAULT_CHECKED_TAGS} but
+ * passing an explicit `[]` straight through `sanitizeTags` is what lets a true
+ * first launch open on "clip" while a listener's deliberate clear survives a
+ * reload. (The persistence effect in RadioTraffic.tsx writes this
+ * already-defaulted state straight back out on mount, so the first save is
+ * `["tier:clip"]`, never `[]` — see the effect's comment.)
+ */
+function sanitizeChecked(value: unknown): string[] {
+	return value === undefined ? [...DEFAULT_CHECKED_TAGS] : sanitizeTags(value);
+}
+
 /** Anything outside the four modal tools falls back — see the header. */
 function sanitizeTool(value: unknown): Tool {
 	return TOOLS.includes(value as Tool) ? (value as Tool) : DEFAULT_TOOL;
@@ -192,7 +227,7 @@ function sanitizeLaneOrder(value: unknown): LaneOrder {
 export function sanitizeRadioTrafficState(stored: unknown): RadioTrafficState {
 	const data = (stored ?? {}) as Record<string, unknown>;
 	return {
-		checked: sanitizeTags(data.checked),
+		checked: sanitizeChecked(data.checked),
 		tool: sanitizeTool(data.tool),
 		collapsed: sanitizeCollapsed(data.collapsed),
 		laneOrder: sanitizeLaneOrder(data.laneOrder),

--- a/packages/frontend/src/Applications/RadioTraffic/tagFilter.test.ts
+++ b/packages/frontend/src/Applications/RadioTraffic/tagFilter.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { TagDef } from "../../Providers/MediaStream/MediaStreamContext";
-import { groupVocabulary, LARGE_NAMESPACES, matchesFilter } from "./tagFilter";
+import {
+	groupVocabulary,
+	LARGE_NAMESPACES,
+	matchesFilter,
+	UNKNOWN_TIER_TAG,
+	withUnknownTier,
+} from "./tagFilter";
 
 /** A vocabulary row as the wire delivers it: `namespace:value` split out. */
 function def(tag: string): TagDef {
@@ -193,5 +199,63 @@ describe("matchesFilter", () => {
 		const checked = new Set(["facility:zbw", "orphan"]);
 		expect(matchesFilter([zbw], checked)).toBe(false);
 		expect(matchesFilter([zbw, { tag: "orphan" }], checked)).toBe(true);
+	});
+
+	describe("tier:unknown", () => {
+		const clip = def("tier:clip");
+		const tape = def("tier:tape");
+
+		it("matches an item with no tags at all", () => {
+			const checked = new Set([UNKNOWN_TIER_TAG]);
+			expect(matchesFilter([], checked)).toBe(true);
+			expect(matchesFilter(undefined, checked)).toBe(true);
+		});
+
+		it("matches an item whose tags carry no tier namespace", () => {
+			const checked = new Set([UNKNOWN_TIER_TAG]);
+			expect(matchesFilter([zbw, aal11], checked)).toBe(true);
+		});
+
+		it("does not match an item that already carries a real tier tag", () => {
+			const checked = new Set([UNKNOWN_TIER_TAG]);
+			expect(matchesFilter([tape], checked)).toBe(false);
+			expect(matchesFilter([clip], checked)).toBe(false);
+		});
+
+		it("ORs with tier:clip, the pair RadioTrafficContext defaults to", () => {
+			const checked = new Set(["tier:clip", UNKNOWN_TIER_TAG]);
+			expect(matchesFilter([clip], checked)).toBe(true);
+			expect(matchesFilter([], checked)).toBe(true);
+			expect(matchesFilter([tape], checked)).toBe(false);
+		});
+
+		it("still ANDs against an unrelated namespace also checked", () => {
+			const checked = new Set([UNKNOWN_TIER_TAG, "facility:zbw"]);
+			// No tier tag (satisfies tier:unknown) but the wrong facility.
+			expect(matchesFilter([zny], checked)).toBe(false);
+			expect(matchesFilter([zbw], checked)).toBe(true);
+		});
+	});
+});
+
+describe("withUnknownTier", () => {
+	it("appends an Unknown value to the tier group only", () => {
+		const groups = withUnknownTier(
+			groupVocabulary([def("tier:clip"), def("tier:tape"), def("topic:hijack")]),
+		);
+		const tier = groups.find((g) => g.namespace === "tier");
+		const topic = groups.find((g) => g.namespace === "topic");
+		expect(tier?.values.map((v) => v.tag)).toEqual(["tier:clip", "tier:tape", UNKNOWN_TIER_TAG]);
+		expect(topic?.values.map((v) => v.tag)).toEqual(["topic:hijack"]);
+	});
+
+	it("leaves every other group's values untouched", () => {
+		expect(withUnknownTier(groupVocabulary([def("topic:hijack")]))).toEqual(
+			groupVocabulary([def("topic:hijack")]),
+		);
+	});
+
+	it("does nothing to an empty vocabulary", () => {
+		expect(withUnknownTier(groupVocabulary([]))).toEqual([]);
 	});
 });

--- a/packages/frontend/src/Applications/RadioTraffic/tagFilter.ts
+++ b/packages/frontend/src/Applications/RadioTraffic/tagFilter.ts
@@ -76,6 +76,27 @@ function namespaceOf(tag: string): string {
 }
 
 /**
+ * The one namespace `tier_for` (video-grabber's `parties/identify.py`) ever
+ * writes into, and the one this module special-cases below.
+ */
+export const TIER_NAMESPACE = "tier";
+
+/**
+ * A pseudo-value standing for "party identification has not tagged this
+ * recording's tier at all" — never a value the server's vocabulary ships,
+ * because it names an *absence* rather than a row in `mp3_tags`.
+ *
+ * Identification is a manual, offline pass over conversation-kind recordings
+ * (see `docs/party-identification.md`); it does not run over every recording
+ * RadioTraffic can show, and some it does reach it skips outright when there
+ * is nothing to identify from. Both leave an item with no `tier:*` tag at all.
+ * Without this pseudo-value, checking `tier:clip` by default (see
+ * `RadioTrafficContext.ts`'s `DEFAULT_CHECKED_TAGS`) would silently hide those
+ * items forever, with no box in the sidebar that could ever bring them back.
+ */
+export const UNKNOWN_TIER_TAG = `${TIER_NAMESPACE}:unknown`;
+
+/**
  * Does `tags` survive `checked`? OR within a namespace, AND across namespaces.
  *
  * Checking a second facility widens the result; adding an aircraft narrows it.
@@ -84,26 +105,60 @@ function namespaceOf(tag: string): string {
  * inside one are alternative answers to it.
  *
  * An empty checked set matches everything, so the unfiltered app costs one Set
- * size check per item. Once any box is ticked an item with no tags is excluded:
- * it cannot answer the question that was asked.
+ * size check per item. Once any box is ticked an item with no tags is excluded
+ * — UNLESS the only thing that would have excluded it is {@link UNKNOWN_TIER_TAG},
+ * which asks for exactly that: an item carrying no `tier:*` tag of its own.
  */
 export function matchesFilter(
 	tags: TagDef[] | undefined,
 	checked: ReadonlySet<string>,
 ): boolean {
 	if (checked.size === 0) return true;
-	if (!tags || tags.length === 0) return false;
 
-	const own = new Set(tags.map((t) => t.tag));
+	// One pass over the item's own tags builds both the exact-tag set (for a
+	// normal hit) and the set of namespaces it carries at all (for the
+	// tier:unknown special case) — never two scans of the same array.
+	const own = new Set<string>();
+	const ownNamespaces = new Set<string>();
+	for (const t of tags ?? []) {
+		own.add(t.tag);
+		if (t.namespace) ownNamespaces.add(t.namespace);
+	}
+
 	// One hit anywhere in a namespace satisfies it (OR); every checked namespace
 	// must be satisfied (AND).
 	const satisfied = new Map<string, boolean>();
 	for (const tag of checked) {
 		const namespace = namespaceOf(tag);
-		satisfied.set(namespace, (satisfied.get(namespace) ?? false) || own.has(tag));
+		const hit =
+			tag === UNKNOWN_TIER_TAG ? !ownNamespaces.has(TIER_NAMESPACE) : own.has(tag);
+		satisfied.set(namespace, (satisfied.get(namespace) ?? false) || hit);
 	}
 	for (const hit of satisfied.values()) {
 		if (!hit) return false;
 	}
 	return true;
+}
+
+/**
+ * Adds the {@link UNKNOWN_TIER_TAG} checkbox to the tier group, for the
+ * sidebar to render alongside the server's real `clip`/`tape` values.
+ *
+ * Deliberately not folded into {@link groupVocabulary}: that function is a
+ * faithful mirror of the vocabulary `GET /mp3/tags` served, and this value
+ * never comes from the server — mixing the two would make groupVocabulary's
+ * output lie about what the API returned.
+ */
+export function withUnknownTier(groups: TagGroup[]): TagGroup[] {
+	return groups.map((group) =>
+		group.namespace === TIER_NAMESPACE
+			? {
+					...group,
+					values: [
+						...group.values,
+						{ tag: UNKNOWN_TIER_TAG, namespace: TIER_NAMESPACE, value: "Unknown" },
+					],
+				}
+			: group,
+	);
 }


### PR DESCRIPTION
## Summary
- RadioTraffic's left-hand filter panel booted with nothing checked, which `matchesFilter` treats as "show everything" — clip and tape traffic mixed together on a fresh session.
- `sanitizeRadioTrafficState` now defaults `checked` to `["tier:clip", "tier:unknown"]` only when the key was never persisted at all; an explicit empty selection or a previously-saved choice (including `tier:tape`) still passes through untouched.
- Adds a `tier:unknown` synthetic filter value: party identification (the offline pass that writes a recording's `tier:clip`/`tier:tape` tag) is manual-only and doesn't reach every recording RadioTraffic can show, so defaulting to `tier:clip` alone would have silently buried untagged items with no way to bring them back.

Fixes #517

## Test plan
- [x] `pnpm --filter @rt911/frontend exec vitest run src/Applications/RadioTraffic` — 712/712 passed
- [x] `pnpm build` (tsc -b && vite build) — clean
- [x] `pnpm lint` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)