### PR TITLE
fix(frontend): move large-namespace filter buttons above FilterTree

### DIFF
--- a/packages/frontend/src/Applications/RadioTraffic/FilterTree.test.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/FilterTree.test.tsx
@@ -4,6 +4,11 @@ import type { TagDef } from "../../Providers/MediaStream/MediaStreamContext";
 import { FilterTree, OPEN_BY_DEFAULT } from "./FilterTree";
 import { groupVocabulary, LARGE_NAMESPACES, type TagGroup } from "./tagFilter";
 
+// FilterTree renders only the five small, disclosure-based namespaces — the
+// three large ones (Aircraft/Facility/Person) are LargeNamespaceButtons'
+// concern now, sitting above the tree rather than inside it. See
+// LargeNamespaceButtons.test.tsx for their coverage.
+
 // rt911 has no global test setup, so testing-library does not auto-clean the
 // DOM between tests; do it explicitly to keep document-level queries isolated.
 afterEach(cleanup);
@@ -14,49 +19,34 @@ function def(tag: string): TagDef {
 	return { tag, namespace: tag.slice(0, i), value: tag.slice(i + 1) };
 }
 
-// All 8 namespaces the corpus actually has, in the order the server sends them.
-// Trimmed to a handful of values each — the counts (377/372/339 vs 25/6/5/5/2)
-// are what decide large-vs-small, and that decision lives in tagFilter.
+// The five small namespaces the corpus has, in the order the server sends
+// them. Trimmed to a handful of values each.
 const VOCAB = [
 	def("topic:hijack"),
 	def("topic:scramble"),
-	def("facility:zbw"),
-	def("facility:zny"),
 	def("link:primary"),
 	def("link:landline"),
 	def("tier:1"),
 	def("tier:2"),
-	def("aircraft:aal11"),
-	def("aircraft:ual175"),
 	def("agency:faa"),
 	def("agency:neads"),
 	def("role:pilot"),
 	def("role:controller"),
-	def("person:ong"),
 ];
 
 const GROUPS = groupVocabulary(VOCAB);
-const SMALL = GROUPS.filter((g) => !g.large);
-const LARGE = GROUPS.filter((g) => g.large);
 
 const onToggle = vi.fn();
-const onOpenPicker = vi.fn();
 afterEach(() => {
 	onToggle.mockReset();
-	onOpenPicker.mockReset();
 });
 
-function renderTree(
-	checked: string[] = [],
-	groups: TagGroup[] = GROUPS,
-	stale = false,
-) {
+function renderTree(checked: string[] = [], groups: TagGroup[] = GROUPS, stale = false) {
 	render(
 		<FilterTree
 			groups={groups}
 			checked={new Set(checked)}
 			onToggle={onToggle}
-			onOpenPicker={onOpenPicker}
 			stale={stale}
 		/>,
 	);
@@ -80,22 +70,21 @@ const row = (label: string) => {
 	expect(found).toHaveLength(1);
 	return found[0];
 };
-/** The whole disclosure a small namespace's row heads, children included. */
+/** The whole disclosure a namespace's row heads, children included. */
 const section = (label: string) => row(label).closest(".classicyDisclosure");
 const box = (value: string) => screen.getByLabelText(value) as HTMLInputElement;
 
 describe("FilterTree", () => {
 	it("renders exactly one row per namespace", () => {
 		renderTree();
-		expect(GROUPS).toHaveLength(8);
-		// `row` fails if a namespace renders none or more than one — a large
-		// namespace that also expanded inline would show up here.
+		expect(GROUPS).toHaveLength(5);
+		// `row` fails if a namespace renders none or more than one.
 		for (const group of GROUPS) expect(row(group.label)).not.toBeNull();
 	});
 
-	it("expands the five small namespaces inline, a checkbox per value", () => {
+	it("expands every namespace inline, a checkbox per value", () => {
 		renderTree();
-		expect(SMALL.map((g) => g.namespace)).toEqual([
+		expect(GROUPS.map((g) => g.namespace)).toEqual([
 			"topic",
 			"link",
 			"tier",
@@ -103,7 +92,7 @@ describe("FilterTree", () => {
 			"role",
 		]);
 
-		for (const group of SMALL) {
+		for (const group of GROUPS) {
 			const inline = section(group.label);
 			expect(inline).not.toBeNull();
 			for (const tag of group.values) {
@@ -113,7 +102,7 @@ describe("FilterTree", () => {
 		}
 	});
 
-	it("collapses and re-expands a small namespace when its row is clicked", () => {
+	it("collapses and re-expands a namespace when its row is clicked", () => {
 		renderTree();
 		const header = row("Topic");
 		const before = header.getAttribute("aria-expanded");
@@ -122,41 +111,6 @@ describe("FilterTree", () => {
 		expect(header.getAttribute("aria-expanded")).not.toBe(before);
 		fireEvent.click(header);
 		expect(header.getAttribute("aria-expanded")).toBe(before);
-	});
-
-	it("opens the picker for a large namespace instead of expanding it", () => {
-		renderTree();
-		expect(LARGE.map((g) => g.namespace).sort()).toEqual([
-			...LARGE_NAMESPACES,
-		].sort());
-
-		for (const group of LARGE) {
-			// 377 checkboxes do not belong in a 141px sidebar — the row is a door.
-			expect(section(group.label)).toBeNull();
-			for (const tag of group.values) {
-				expect(screen.queryByLabelText(tag.value as string)).toBeNull();
-			}
-
-			fireEvent.click(row(group.label));
-			expect(onOpenPicker).toHaveBeenLastCalledWith(group.namespace);
-		}
-		expect(onOpenPicker).toHaveBeenCalledTimes(LARGE.length);
-	});
-
-	it("shows a large namespace's checked count, which is all the row can show", () => {
-		renderTree(["aircraft:aal11", "aircraft:ual175", "facility:zbw"]);
-
-		expect(row("Aircraft").textContent).toContain("2");
-		expect(row("Facility").textContent).toContain("1");
-		// A row with nothing checked stays quiet rather than reading "(0)".
-		expect(row("Person").textContent).not.toMatch(/\d/);
-	});
-
-	it("counts only tags the namespace actually has", () => {
-		// A checked tag the vocabulary no longer carries has no box in the picker
-		// either, so counting it would advertise a filter the user cannot clear.
-		renderTree(["aircraft:aal11", "aircraft:retired"]);
-		expect(row("Aircraft").textContent).toContain("1");
 	});
 
 	it("reports the tag string, not the display value, when a value is checked", () => {
@@ -181,34 +135,31 @@ describe("FilterTree", () => {
 	});
 
 	it("omits a namespace with no values", () => {
-		// Nothing to tick and nothing for a picker to list — the row would be a
-		// dead end either way.
+		// Nothing to tick — the row would be a dead end.
 		const empty: TagGroup[] = [
 			{ namespace: "topic", label: "Topic", values: [def("topic:hijack")], large: false },
 			{ namespace: "role", label: "Role", values: [], large: false },
-			{ namespace: "person", label: "Person", values: [], large: true },
 		];
 		renderTree([], empty);
 
 		expect(row("Topic")).not.toBeNull();
 		expect(rowsFor("Role")).toEqual([]);
-		expect(rowsFor("Person")).toEqual([]);
 	});
 
 	it("boots the namespaces that fit already open, which ClassicyDisclosure cannot", () => {
 		// The whole reason for the repo-local Disclosure: `defaultOpen`. classicy's
 		// own disclosure always boots closed, so every row below would read
-		// aria-expanded="false" and the sidebar would open as eight dead headers.
+		// aria-expanded="false" and the tree would open as five dead headers.
 		renderTree();
 		expect(OPEN_BY_DEFAULT.size).toBeGreaterThan(0);
 
-		for (const group of SMALL) {
+		for (const group of GROUPS) {
 			expect(row(group.label).getAttribute("aria-expanded")).toBe(
 				String(OPEN_BY_DEFAULT.has(group.namespace)),
 			);
 		}
-		// A large namespace has no disclosure to open, so listing one would be a
-		// default that never applies.
+		// A large namespace never reaches FilterTree, so listing one in
+		// OPEN_BY_DEFAULT would be a default that never applies.
 		for (const namespace of OPEN_BY_DEFAULT) {
 			expect(LARGE_NAMESPACES.has(namespace)).toBe(false);
 		}

--- a/packages/frontend/src/Applications/RadioTraffic/FilterTree.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/FilterTree.tsx
@@ -1,6 +1,7 @@
 /**
- * The filter sidebar: one row per tag namespace, and the only navigation Radio
- * Traffic has.
+ * The filter sidebar: one disclosure per small tag namespace, part of Radio
+ * Traffic's only navigation alongside the large-namespace buttons rendered
+ * above it (`LargeNamespaceButtons`).
  *
  * Fully controlled. The tree owns no checked state — it renders the set it is
  * handed and reports the tag a click landed on, so the app shell (Step 19) is
@@ -8,24 +9,23 @@
  * have to be reconciled with the picker's, which is handed the same whole set
  * for exactly this reason.
  */
-import { ClassicyBevelButton, ClassicyCheckbox } from "classicy";
+import { ClassicyCheckbox } from "classicy";
 import type React from "react";
 import { Disclosure } from "../../Components/Disclosure/Disclosure";
 import styles from "./filterTree.module.scss";
 import type { TagGroup } from "./tagFilter";
 
 /**
- * The namespaces the sidebar boots expanded.
+ * The namespaces the tree boots expanded.
  *
- * The tree has ~555px below the toolbar in a 601px window. Eight headers plus
- * these four namespaces' 18 values (tier 2, link 5, agency 5, role 6) fit
- * without scrolling; `topic`'s 25 values on their own would more than double
- * that, so it opens on request. The three large namespaces are absent because
- * they have no disclosure to open.
+ * The tree has ~555px below the toolbar and the large-namespace buttons in a
+ * 601px window. Five headers plus these four namespaces' 18 values (tier 2,
+ * link 5, agency 5, role 6) fit without scrolling; `topic`'s 25 values on
+ * their own would more than double that, so it opens on request.
  *
  * `defaultOpen` is why this uses the repo-local Disclosure rather than
- * `ClassicyDisclosure`, which always boots closed — with it the sidebar would
- * open as eight dead headers hiding every checkbox.
+ * `ClassicyDisclosure`, which always boots closed — with it the tree would
+ * open as five dead headers hiding every checkbox.
  */
 export const OPEN_BY_DEFAULT: ReadonlySet<string> = new Set([
 	"tier",
@@ -35,14 +35,12 @@ export const OPEN_BY_DEFAULT: ReadonlySet<string> = new Set([
 ]);
 
 export interface FilterTreeProps {
-	/** Every namespace, in the order the vocabulary arrived in. */
+	/** The five small, disclosure-based namespaces, in the order they arrived. */
 	groups: TagGroup[];
 	/** The whole sidebar's checked tag strings, large namespaces included. */
 	checked: ReadonlySet<string>;
 	/** A value's box was clicked; the owner adds or removes the tag. */
 	onToggle: (tag: string) => void;
-	/** A large namespace's row was clicked; the owner opens that picker. */
-	onOpenPicker: (namespace: string) => void;
 	/**
 	 * The vocabulary is the last-known-good copy because `GET /mp3/tags` failed.
 	 * The tree still renders it — see the notice below.
@@ -50,46 +48,13 @@ export interface FilterTreeProps {
 	stale?: boolean;
 }
 
-/**
- * How many of a namespace's values are checked.
- *
- * Counted against the namespace's own values rather than by prefix-matching the
- * checked set: a checked tag the vocabulary no longer carries has no box in the
- * picker either, so counting it would advertise a filter the user cannot reach
- * to clear.
- */
-function checkedIn(group: TagGroup, checked: ReadonlySet<string>): number {
-	let n = 0;
-	for (const tag of group.values) if (checked.has(tag.tag)) n += 1;
-	return n;
-}
-
-/**
- * A large namespace's row. 377 aircraft cannot expand into a 141px column, so
- * the row is a door to the picker and the checked count is the only state it
- * can show. Zero reads as no count at all rather than "(0)" — an unfiltered
- * namespace is the resting state, not a fact worth printing eight times.
- */
-const LargeNamespaceRow: React.FC<{
-	group: TagGroup;
-	count: number;
-	onOpen: (namespace: string) => void;
-}> = ({ group, count, onOpen }) => (
-	<ClassicyBevelButton data-filter-large-row onClickFunc={() => onOpen(group.namespace)}>
-		<span>{group.label}…</span>
-		{count > 0 && <span className={styles.rtFilterCount}>({count})</span>}
-	</ClassicyBevelButton>
-);
-
 export const FilterTree: React.FC<FilterTreeProps> = ({
 	groups,
 	checked,
 	onToggle,
-	onOpenPicker,
 	stale = false,
 }) => {
-	// A namespace with no values is a dead end in both shapes: nothing to tick
-	// inline, and a picker that would open on an empty list.
+	// A namespace with no values is a dead end: nothing to tick inline.
 	const shown = groups.filter((group) => group.values.length > 0);
 
 	// Decision 5: tag filtering IS the navigation here, so a failed vocabulary
@@ -110,34 +75,25 @@ export const FilterTree: React.FC<FilterTreeProps> = ({
 					{notice}
 				</p>
 			)}
-			{shown.map((group) =>
-				group.large ? (
-					<LargeNamespaceRow
-						key={group.namespace}
-						group={group}
-						count={checkedIn(group, checked)}
-						onOpen={onOpenPicker}
-					/>
-				) : (
-					<Disclosure
-						key={group.namespace}
-						label={group.label}
-						defaultOpen={OPEN_BY_DEFAULT.has(group.namespace)}
-					>
-						{group.values.map((tag) => (
-							<ClassicyCheckbox
-								key={tag.tag}
-								// Prefixed like the picker's ids: a bare `topic:hijack` as a
-								// DOM id would let a label in one address a box in the other.
-								id={`rt_filter_${tag.tag}`}
-								label={tag.value ?? tag.tag}
-								checked={checked.has(tag.tag)}
-								onClickFunc={() => onToggle(tag.tag)}
-							/>
-						))}
-					</Disclosure>
-				),
-			)}
+			{shown.map((group) => (
+				<Disclosure
+					key={group.namespace}
+					label={group.label}
+					defaultOpen={OPEN_BY_DEFAULT.has(group.namespace)}
+				>
+					{group.values.map((tag) => (
+						<ClassicyCheckbox
+							key={tag.tag}
+							// Prefixed like the picker's ids: a bare `topic:hijack` as a
+							// DOM id would let a label in one address a box in the other.
+							id={`rt_filter_${tag.tag}`}
+							label={tag.value ?? tag.tag}
+							checked={checked.has(tag.tag)}
+							onClickFunc={() => onToggle(tag.tag)}
+						/>
+					))}
+				</Disclosure>
+			))}
 		</div>
 	);
 };

--- a/packages/frontend/src/Applications/RadioTraffic/LargeNamespaceButtons.test.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/LargeNamespaceButtons.test.tsx
@@ -1,0 +1,112 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TagDef } from "../../Providers/MediaStream/MediaStreamContext";
+import { LargeNamespaceButtons } from "./LargeNamespaceButtons";
+import { groupVocabulary, LARGE_NAMESPACES, type TagGroup } from "./tagFilter";
+
+// rt911 has no global test setup, so testing-library does not auto-clean the
+// DOM between tests; do it explicitly to keep document-level queries isolated.
+afterEach(cleanup);
+
+/** A vocabulary row as the wire delivers it: `namespace:value` split out. */
+function def(tag: string): TagDef {
+	const i = tag.indexOf(":");
+	return { tag, namespace: tag.slice(0, i), value: tag.slice(i + 1) };
+}
+
+// The three large namespaces the corpus has, trimmed to a handful of values
+// each — the counts (377/372/339) are what decide large-vs-small, and that
+// decision lives in tagFilter.
+const VOCAB = [
+	def("aircraft:aal11"),
+	def("aircraft:ual175"),
+	def("facility:zbw"),
+	def("facility:zny"),
+	def("person:ong"),
+];
+
+const GROUPS = groupVocabulary(VOCAB);
+
+const onOpenPicker = vi.fn();
+afterEach(() => {
+	onOpenPicker.mockReset();
+});
+
+function renderButtons(checked: string[] = [], groups: TagGroup[] = GROUPS) {
+	render(
+		<LargeNamespaceButtons
+			groups={groups}
+			checked={new Set(checked)}
+			onOpenPicker={onOpenPicker}
+		/>,
+	);
+}
+
+/**
+ * Every control named after a namespace — its row, and nothing else. Matched
+ * loosely and case-sensitively for the same reason FilterTree.test.tsx's
+ * `rowsFor` is: namespace labels are capitalised where tag values are not.
+ */
+const rowsFor = (label: string) =>
+	screen.queryAllByRole("button", { name: new RegExp(label) });
+
+/** A namespace's one row, asserting on the way through that it has exactly one. */
+const row = (label: string) => {
+	const found = rowsFor(label);
+	expect(found).toHaveLength(1);
+	return found[0];
+};
+
+describe("LargeNamespaceButtons", () => {
+	it("renders exactly one row per large namespace", () => {
+		renderButtons();
+		expect(GROUPS.map((g) => g.namespace).sort()).toEqual([...LARGE_NAMESPACES].sort());
+
+		for (const group of GROUPS) expect(row(group.label)).not.toBeNull();
+	});
+
+	it("opens the picker for a namespace when its row is clicked", () => {
+		renderButtons();
+
+		for (const group of GROUPS) {
+			fireEvent.click(row(group.label));
+			expect(onOpenPicker).toHaveBeenLastCalledWith(group.namespace);
+		}
+		expect(onOpenPicker).toHaveBeenCalledTimes(GROUPS.length);
+	});
+
+	it("shows a namespace's checked count, which is all the row can show", () => {
+		renderButtons(["aircraft:aal11", "aircraft:ual175", "facility:zbw"]);
+
+		expect(row("Aircraft").textContent).toContain("2");
+		expect(row("Facility").textContent).toContain("1");
+		// A row with nothing checked stays quiet rather than reading "(0)".
+		expect(row("Person").textContent).not.toMatch(/\d/);
+	});
+
+	it("counts only tags the namespace actually has", () => {
+		// A checked tag the vocabulary no longer carries has no box in the picker
+		// either, so counting it would advertise a filter the user cannot clear.
+		renderButtons(["aircraft:aal11", "aircraft:retired"]);
+		expect(row("Aircraft").textContent).toContain("1");
+	});
+
+	it("omits a namespace with no values", () => {
+		// Nothing for a picker to list — the row would be a dead end.
+		const withEmpty: TagGroup[] = [
+			{ namespace: "aircraft", label: "Aircraft", values: [def("aircraft:aal11")], large: true },
+			{ namespace: "person", label: "Person", values: [], large: true },
+		];
+		renderButtons([], withEmpty);
+
+		expect(row("Aircraft")).not.toBeNull();
+		expect(rowsFor("Person")).toEqual([]);
+	});
+
+	it("renders nothing when there are no large namespaces to show", () => {
+		const { container } = render(
+			<LargeNamespaceButtons groups={[]} checked={new Set()} onOpenPicker={onOpenPicker} />,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+});

--- a/packages/frontend/src/Applications/RadioTraffic/LargeNamespaceButtons.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/LargeNamespaceButtons.tsx
@@ -1,0 +1,79 @@
+/**
+ * The three large-namespace "doors" (Aircraft, Facility, Person) — a small,
+ * non-scrolling stack that sits above `FilterTree`, not inside it.
+ *
+ * Fully controlled, same as `FilterTree`: it owns no checked state, just
+ * renders the set it is handed and reports which picker a click asked for.
+ */
+import { ClassicyBevelButton } from "classicy";
+import type React from "react";
+import styles from "./largeNamespaceButtons.module.scss";
+import type { TagGroup } from "./tagFilter";
+
+export interface LargeNamespaceButtonsProps {
+	/** The large namespaces only — the caller filters `groups` by `.large`. */
+	groups: TagGroup[];
+	/** The whole sidebar's checked tag strings, small namespaces included. */
+	checked: ReadonlySet<string>;
+	/** A row was clicked; the owner opens that namespace's picker. */
+	onOpenPicker: (namespace: string) => void;
+}
+
+/**
+ * How many of a namespace's values are checked.
+ *
+ * Counted against the namespace's own values rather than by prefix-matching the
+ * checked set: a checked tag the vocabulary no longer carries has no box in the
+ * picker either, so counting it would advertise a filter the user cannot reach
+ * to clear.
+ */
+function checkedIn(group: TagGroup, checked: ReadonlySet<string>): number {
+	let n = 0;
+	for (const tag of group.values) if (checked.has(tag.tag)) n += 1;
+	return n;
+}
+
+/**
+ * A large namespace's row. 377 aircraft cannot expand into a 141px column, so
+ * the row is a door to the picker and the checked count is the only state it
+ * can show. Zero reads as no count at all rather than "(0)" — an unfiltered
+ * namespace is the resting state, not a fact worth printing three times.
+ */
+const LargeNamespaceRow: React.FC<{
+	group: TagGroup;
+	count: number;
+	onOpen: (namespace: string) => void;
+}> = ({ group, count, onOpen }) => (
+	<ClassicyBevelButton data-filter-large-row onClickFunc={() => onOpen(group.namespace)}>
+		<span>{group.label}…</span>
+		{count > 0 && <span className={styles.rtFilterCount}>({count})</span>}
+	</ClassicyBevelButton>
+);
+
+export const LargeNamespaceButtons: React.FC<LargeNamespaceButtonsProps> = ({
+	groups,
+	checked,
+	onOpenPicker,
+}) => {
+	// A namespace with no values is a dead end: a picker that would open on an
+	// empty list, same reasoning `FilterTree` applies to the small namespaces.
+	const shown = groups.filter((group) => group.values.length > 0);
+
+	// Nothing to show and nothing to say about it — the "Tags unavailable"
+	// notice belongs to `FilterTree` alone, so an empty large-namespace set
+	// renders as a plain absence rather than a second notice.
+	if (shown.length === 0) return null;
+
+	return (
+		<div className={styles.rtLargeNamespaceButtons} role="group" aria-label="Tag pickers">
+			{shown.map((group) => (
+				<LargeNamespaceRow
+					key={group.namespace}
+					group={group}
+					count={checkedIn(group, checked)}
+					onOpen={onOpenPicker}
+				/>
+			))}
+		</div>
+	);
+};

--- a/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.tsx
@@ -66,6 +66,7 @@ import { FilterTree } from "./FilterTree";
 import { LANES, type LaneOrder, reconcileLaneOrder, reorderLane } from "./laneOrder";
 import { LaneSection } from "./LaneSection";
 import { LaneSmallPlayer } from "./LaneSmallPlayer";
+import { LargeNamespaceButtons } from "./LargeNamespaceButtons";
 import {
 	IDLE_RELEASE_MS,
 	nextHeldLiveIds,
@@ -899,11 +900,15 @@ export const RadioTraffic: React.FC = () => {
 					)}
 					<aside className={styles.rtSidebar}>
 						<ToolPalette tool={tool} onSelect={setTool} />
+						<LargeNamespaceButtons
+							groups={groups.filter((group) => group.large)}
+							checked={checked}
+							onOpenPicker={setPickerNamespace}
+						/>
 						<FilterTree
-							groups={groups}
+							groups={groups.filter((group) => !group.large)}
 							checked={checked}
 							onToggle={toggleTag}
-							onOpenPicker={setPickerNamespace}
 							stale={vocabulary.stale}
 						/>
 					</aside>

--- a/packages/frontend/src/Applications/RadioTraffic/filterTree.module.scss
+++ b/packages/frontend/src/Applications/RadioTraffic/filterTree.module.scss
@@ -19,30 +19,6 @@
   }
 }
 
-// A large namespace's row sits at the same indent as a disclosure header so the
-// eight namespaces read as one list, despite behaving differently.
-//
-// Story 030: ClassicyBevelButton builds its own className and drops the one it
-// is handed, so the row hangs its look off `[data-filter-large-row]` instead —
-// the same pattern laneSection.module.scss uses for `[data-lane-mute]`.
-.rtFilterTree [data-filter-large-row] {
-  display: flex;
-  flex-grow: 1;
-  flex-direction: row;
-  align-items: center;
-  gap: calc(var(--window-border-size) * 4);
-  font-family: inherit;
-  font-size: inherit;
-  color: var(--color-system-06);
-  text-align: left;
-  cursor: pointer;
-  flex-grow: 1;
-}
-
-.rtFilterCount {
-  color: var(--color-system-05);
-}
-
 .rtFilterNotice {
   margin: 0 0 calc(var(--window-border-size) * 4);
   color: var(--color-system-05);

--- a/packages/frontend/src/Applications/RadioTraffic/largeNamespaceButtons.module.scss
+++ b/packages/frontend/src/Applications/RadioTraffic/largeNamespaceButtons.module.scss
@@ -1,0 +1,36 @@
+// The three large-namespace "doors" — a small, non-scrolling stack sitting
+// above FilterTree rather than inside its scrolling list. Full width to match
+// the sidebar's 141px lane, same as a FilterTree row.
+
+.rtLargeNamespaceButtons {
+  display: flex;
+  flex-direction: column;
+  width: calc(100% - var(--window-control-size));
+  flex: 0 0 auto;
+  gap: calc(var(--window-border-size) * 2);
+  padding: calc(var(--window-border-size) * 4);
+  padding-bottom: 0;
+  font-family: var(--ui-font);
+  font-size: var(--ui-font-size);
+}
+
+// Story 030: ClassicyBevelButton builds its own className and drops the one
+// it is handed, so the row hangs its look off `[data-filter-large-row]`
+// instead — the same pattern laneSection.module.scss uses for
+// `[data-lane-mute]`.
+.rtLargeNamespaceButtons [data-filter-large-row] {
+  display: flex;
+  flex-grow: 1;
+  flex-direction: row;
+  align-items: center;
+  gap: calc(var(--window-border-size) * 4);
+  font-family: inherit;
+  font-size: inherit;
+  color: var(--color-system-06);
+  text-align: left;
+  cursor: pointer;
+}
+
+.rtFilterCount {
+  color: var(--color-system-05);
+}


### PR DESCRIPTION
## Summary
- Aircraft/Facility/Person filter rows previously rendered as `ClassicyBevelButton` "door to a picker" rows interleaved inside `FilterTree`'s scrolling disclosure list. This PR splits that presentation into a new sibling component, `LargeNamespaceButtons`, rendered above `FilterTree` in the sidebar — mirroring how `ToolPalette` already sits above it.
- `FilterTree` now only renders the five small, disclosure-based namespaces (topic/link/tier/agency/role) and no longer knows about `large` namespaces or `onOpenPicker` at all.
- `LargeNamespaceButtons` is a small, non-scrolling vertical stack; it renders nothing (`null`) when its filtered `groups` array is empty, per the issue author's clarification.
- The `[data-filter-large-row]`/`.rtFilterCount` scss rules moved from `filterTree.module.scss` to a new `largeNamespaceButtons.module.scss`.

Fixes #518

## Test plan
- [x] `pnpm --filter @rt911/frontend exec vitest run src/Applications/RadioTraffic/FilterTree.test.tsx src/Applications/RadioTraffic/LargeNamespaceButtons.test.tsx` — 17 passed
- [x] `pnpm --filter @rt911/frontend exec vitest run src/Applications/RadioTraffic/RadioTraffic.test.tsx` — 62 passed, unmocked
- [x] `pnpm --filter @rt911/frontend exec vitest run src/Applications/RadioTraffic` (full app directory) — 703 passed across 32 files
- [x] `pnpm lint` — clean (only pre-existing warnings unrelated to these files)
- [x] `pnpm build` (`tsc -b && vite build`) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)