### PR TITLE
Radio Traffic: move Tags box from Details tab to Mentions tab

### DIFF
--- a/packages/frontend/src/Applications/RadioTraffic/tabs/DetailsTab.test.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/tabs/DetailsTab.test.tsx
@@ -17,77 +17,41 @@ const column = (root: HTMLElement, name: string) =>
 	root.querySelector(`[data-column="${name}"]`);
 
 describe("DetailsTab layout", () => {
-	it("renders two columns, Details and Tags, and no Summary", () => {
-		// Summary is a tab of its own (story 035). It is the panel's longest
-		// content and the reason every tab can now share one fixed height, so a
-		// Details panel that still drew it would put the height back.
+	it("renders a single Details column, and no Tags or Summary", () => {
+		// Summary is a tab of its own (story 035); Tags moved to the Mentions
+		// tab (issue #521), so Details is down to the one column it has left.
 		const { container, getByText, queryByText } = render(
 			<DetailsTab item={makeItem()} meta={makeMeta()} tzOffsetHours={TZ} />,
 		);
 		expect(column(container, "call-details")).not.toBeNull();
-		expect(column(container, "tags")).not.toBeNull();
+		expect(column(container, "tags")).toBeNull();
 		expect(column(container, "summary")).toBeNull();
-		for (const heading of ["Details", "Tags"]) {
-			expect(getByText(heading)).toBeTruthy();
-		}
+		expect(getByText("Details")).toBeTruthy();
+		expect(queryByText("Tags")).toBeNull();
 		expect(queryByText("Summary")).toBeNull();
 	});
 
 	it("keeps the timings in Details and never prints the subject", () => {
-		// Which column a fact lands in is the whole point of the redesign — a
-		// panel that renders both headings but files the subject under Tags would
-		// pass a heading-only check.
 		const { container, queryByText } = render(
 			<DetailsTab item={makeItem()} meta={makeMeta()} tzOffsetHours={TZ} />,
 		);
 		expect(column(container, "call-details")?.querySelector('[data-field="start"]')).not.toBeNull();
 		expect(container.querySelector('[data-field="subject"]')).toBeNull();
 		expect(queryByText(makeMeta().subject as string)).toBeNull();
-		expect(column(container, "tags")?.querySelectorAll("li").length).toBe(3);
 	});
 
-	it("groups chips into a labelled row per namespace, in vocabulary order", () => {
-		const { container } = render(
-			<DetailsTab item={makeItem()} meta={makeMeta()} tzOffsetHours={TZ} />,
-		);
-		const groups = [...container.querySelectorAll("[data-tag-group]")];
-		expect(groups.map((g) => g.getAttribute("data-tag-group"))).toEqual([
-			"topic",
-			"facility",
-			"aircraft",
-		]);
-		expect(groups.map((g) => g.querySelector("dt")?.textContent)).toEqual([
-			"Topics",
-			"Facilities",
-			"Aircraft",
-		]);
-	});
-
-	it("files a tag from an unknown namespace under Other rather than dropping it", () => {
-		// mp3_tags.namespace is NOT NULL, so a ninth namespace means a curator
-		// added one. Hiding their tag would look exactly like the tag not existing.
+	it("keeps the Details column, saying so, when nothing is timeable", () => {
+		// A collapsed column would leave cards in a lane misaligned with each
+		// other, and an empty box reads as a broken tab rather than an untimed
+		// clip.
 		const { container, getByText } = render(
 			<DetailsTab
-				item={makeItem()}
-				meta={makeMeta({
-					tags: [{ tag: "weather:vfr", namespace: "weather", value: "VFR" }],
-				})}
+				item={makeItem({ start_date: "not-a-date", end_date: undefined, calc_duration: undefined })}
 				tzOffsetHours={TZ}
 			/>,
 		);
-		expect(container.querySelector('[data-tag-group="other"]')).not.toBeNull();
-		expect(getByText("VFR")).toBeTruthy();
-	});
-
-	it("keeps both columns, each saying so, for an item with no metadata", () => {
-		// Columns that collapsed would leave cards in a lane misaligned with each
-		// other, and an empty box reads as a broken tab rather than an untagged clip.
-		const { container, getByText } = render(
-			<DetailsTab item={makeItem()} tzOffsetHours={TZ} />,
-		);
 		expect(column(container, "call-details")).not.toBeNull();
-		expect(column(container, "tags")).not.toBeNull();
-		expect(getByText("No tags.")).toBeTruthy();
+		expect(getByText("No timings.")).toBeTruthy();
 	});
 });
 
@@ -100,41 +64,6 @@ describe("DetailsTab", () => {
 		expect(field(container, "end")).toMatch(/^8:49:44\sAM$/);
 		expect(field(container, "duration")).toBe("03:13");
 		expect(field(container, "link")).toBe("ZBW ↔ AAL11");
-	});
-
-	it("renders one chip per tag, labelled by its vocabulary value", () => {
-		const { getAllByRole } = render(
-			<DetailsTab item={makeItem()} meta={makeMeta()} tzOffsetHours={TZ} />,
-		);
-		expect(getAllByRole("listitem").map((li) => li.textContent)).toEqual([
-			"Hijacking",
-			"ZBW",
-			"AAL11",
-		]);
-	});
-
-	it("colours chips by namespace, because mp3_tags.color is null on every row", () => {
-		const { getAllByRole } = render(
-			<DetailsTab item={makeItem()} meta={makeMeta()} tzOffsetHours={TZ} />,
-		);
-		const backgrounds = getAllByRole("listitem").map((li) => li.style.background);
-		expect(backgrounds.every((b) => b.length > 0)).toBe(true);
-		expect(new Set(backgrounds).size).toBe(3);
-	});
-
-	it("lets a curator's colour win when one is ever set", () => {
-		const { getAllByRole } = render(
-			<DetailsTab
-				item={makeItem()}
-				meta={makeMeta({
-					tags: [
-						{ tag: "facility:zbw", namespace: "facility", value: "ZBW", color: "rgb(1, 2, 3)" },
-					],
-				})}
-				tzOffsetHours={TZ}
-			/>,
-		);
-		expect(getAllByRole("listitem")[0].style.background).toBe("rgb(1, 2, 3)");
 	});
 
 	it("shifts the clock with the display offset rather than the browser's zone", () => {
@@ -160,12 +89,9 @@ describe("DetailsTab", () => {
 		expect(container.querySelector('[data-field="duration"]')).toBeNull();
 	});
 
-	it("omits the link and chips for an item with no metadata", () => {
-		const { container, queryAllByRole } = render(
-			<DetailsTab item={makeItem()} tzOffsetHours={TZ} />,
-		);
+	it("omits the link for an item with no metadata", () => {
+		const { container } = render(<DetailsTab item={makeItem()} tzOffsetHours={TZ} />);
 		expect(container.querySelector('[data-field="link"]')).toBeNull();
-		expect(queryAllByRole("listitem")).toHaveLength(0);
 		// The times come off the item itself, so they survive the metadata gap.
 		expect(field(container, "start")).toMatch(/^8:46:31\sAM$/);
 	});

--- a/packages/frontend/src/Applications/RadioTraffic/tabs/DetailsTab.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/tabs/DetailsTab.tsx
@@ -1,56 +1,25 @@
 import type React from "react";
-import type { TagDef } from "../../../Providers/MediaStream/MediaStreamContext";
 import type { CardTabProps } from "./cardTabProps";
 import styles from "./cardTabs.module.scss";
 import { durationLabel, itemTiming, wallClockLabel } from "./itemTiming";
-import { chipColor, namespaceLabel, tagLabel, TAG_NAMESPACES } from "./tagPalette";
 
 /**
- * When the clip ran and how it is tagged — two of the three columns Figma drew
- * on the Details tab. The third, Summary, is a tab of its own (SummaryTab.tsx):
- * `subject` is prose of no fixed length and it was what made this panel's height
- * unpredictable, which a shared fixed panel height cannot afford.
+ * When the clip ran — the one column Figma drew on the Details tab that
+ * survives here. The other two moved out: Summary is a tab of its own
+ * (SummaryTab.tsx, story 035), and Tags moved to the Mentions tab (issue
+ * #521) — the Tags column had no vertical scroll, so a clip with many tags
+ * got clipped, and Mentions already scrolls the way Transcript does.
  *
- * The timings come off the MediaItem and the tags off ItemMeta, which is why
- * this panel still says something useful for the 59 items that have no
- * metadata: a clip always has a start, whether or not anything transcribed it.
- * Each column keeps its heading and prints its own "nothing here" line rather
- * than collapsing, so the columns stay aligned across cards and a reader can
- * tell an untagged clip from a misrendered one.
+ * The timings come off the MediaItem, which is why this panel still says
+ * something useful for the 59 items that have no metadata: a clip always has
+ * a start, whether or not anything transcribed it. The column keeps its
+ * heading and prints its own "nothing here" line rather than collapsing, so
+ * cards stay aligned across a lane and a reader can tell an untimed clip from
+ * a misrendered one.
  *
- * Rows whose value is unknown are still dropped inside a column — an absent End
- * is not a fact about the recording, it is a fact about the row.
+ * Rows whose value is unknown are still dropped inside the column — an absent
+ * End is not a fact about the recording, it is a fact about the row.
  */
-
-/** One labelled row of chips: a namespace and the tags that belong to it. */
-interface TagGroup {
-	key: string;
-	label: string;
-	tags: TagDef[];
-}
-
-/**
- * The tags grouped into the rows the design shows, in vocabulary order.
- *
- * A tag whose namespace is outside the eight tags.py emits is collected into a
- * trailing "Other" row rather than dropped: mp3_tags.namespace is NOT NULL, so
- * a ninth value means a curator added a namespace, and silently hiding their
- * tag would look identical to the tag not existing.
- */
-function tagGroups(tags: readonly TagDef[] | undefined): TagGroup[] {
-	const all = tags ?? [];
-	const known = new Set<string>(TAG_NAMESPACES);
-	const groups: TagGroup[] = TAG_NAMESPACES.map((namespace) => ({
-		key: namespace,
-		label: namespaceLabel(namespace),
-		tags: all.filter((tag) => tag.namespace === namespace),
-	})).filter((group) => group.tags.length > 0);
-
-	const other = all.filter((tag) => !tag.namespace || !known.has(tag.namespace));
-	if (other.length > 0) groups.push({ key: "other", label: "Other", tags: other });
-	return groups;
-}
-
 export const DetailsTab: React.FC<CardTabProps> = ({ item, meta, tzOffsetHours }) => {
 	const timing = itemTiming(item);
 	const rows = [
@@ -59,8 +28,6 @@ export const DetailsTab: React.FC<CardTabProps> = ({ item, meta, tzOffsetHours }
 		{ field: "duration", label: "Duration", value: durationLabel(timing.durationSec) },
 		{ field: "link", label: "Link", value: meta?.link?.trim() || null },
 	].filter((row) => row.value !== null);
-
-	const groups = tagGroups(meta?.tags);
 
 	return (
 		<div className={styles.rtTabPanel} data-tab="details">
@@ -79,43 +46,6 @@ export const DetailsTab: React.FC<CardTabProps> = ({ item, meta, tzOffsetHours }
 								>
 									<dt className={styles.rtDetailLabel}>{row.label}</dt>
 									<dd className={styles.rtDetailValue}>{row.value}</dd>
-								</div>
-							))}
-						</dl>
-					)}
-				</section>
-
-				<section className={styles.rtPanelColumn} data-column="tags">
-					<h4 className={styles.rtPanelColumnHead}>Tags</h4>
-					{groups.length === 0 ? (
-						<p className={styles.rtEmpty}>No tags.</p>
-					) : (
-						<dl className={styles.rtDetailRows}>
-							{groups.map((group) => (
-								<div
-									key={group.key}
-									className={styles.rtDetailRow}
-									data-tag-group={group.key}
-								>
-									<dt className={styles.rtDetailLabel}>{group.label}</dt>
-									{/* Chips wrap and must not be ellipsised, so this cell is
-									    not the single-line .rtDetailValue the text rows use. */}
-									<dd className={styles.rtChipCell}>
-										<ul className={styles.rtChips} aria-label={group.label}>
-											{group.tags.map((tag) => (
-												// mp3_tags.color is NULL on every row today, so
-												// the namespace palette is the source of truth;
-												// color is honoured only if a curator sets one.
-												<li
-													key={tag.tag}
-													className={styles.rtChip}
-													style={{ background: chipColor(tag) }}
-												>
-													{tagLabel(tag)}
-												</li>
-											))}
-										</ul>
-									</dd>
 								</div>
 							))}
 						</dl>

--- a/packages/frontend/src/Applications/RadioTraffic/tabs/MentionsTab.test.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/tabs/MentionsTab.test.tsx
@@ -7,8 +7,11 @@ afterEach(cleanup);
 
 const TZ = -4;
 
+// Excludes the tags section's own `data-column="tags"` — a fifth,
+// differently-shaped section (issue #521), not one of the four mentions
+// columns this helper is naming.
 const columnNames = (root: HTMLElement) =>
-	Array.from(root.querySelectorAll("[data-column]")).map((c) =>
+	Array.from(root.querySelectorAll('[data-column]:not([data-column="tags"])')).map((c) =>
 		c.getAttribute("data-column"),
 	);
 
@@ -16,6 +19,10 @@ const columnValues = (root: HTMLElement, name: string) =>
 	Array.from(root.querySelectorAll(`[data-column="${name}"] li`)).map(
 		(li) => li.textContent,
 	);
+
+const tagsSection = (root: HTMLElement) => root.querySelector('[data-column="tags"]');
+
+const tagGroupEls = (root: HTMLElement) => [...root.querySelectorAll("[data-tag-group]")];
 
 describe("MentionsTab", () => {
 	it("renders four columns: facilities, aircraft, people and topics", () => {
@@ -113,5 +120,112 @@ describe("MentionsTab", () => {
 			/>,
 		);
 		expect(columnNames(container)).toEqual(["facilities"]);
+	});
+});
+
+// The tags section — moved here from the Details tab's Tags column (issue
+// #521), which had no vertical scroll and clipped a clip with many tags.
+// Mentions already scrolls the way Transcript does, so the chips read in
+// full here instead.
+describe("MentionsTab tags section", () => {
+	it("renders a fifth section, appended after the four mentions columns", () => {
+		const { container } = render(
+			<MentionsTab item={makeItem()} meta={makeMeta()} tzOffsetHours={TZ} />,
+		);
+		expect(columnNames(container)).toEqual(["facilities", "aircraft", "people", "topics"]);
+		expect(tagsSection(container)).not.toBeNull();
+	});
+
+	it("groups chips into a labelled row per namespace, in vocabulary order", () => {
+		const { container } = render(
+			<MentionsTab item={makeItem()} meta={makeMeta()} tzOffsetHours={TZ} />,
+		);
+		const groups = tagGroupEls(container);
+		expect(groups.map((g) => g.getAttribute("data-tag-group"))).toEqual([
+			"topic",
+			"facility",
+			"aircraft",
+		]);
+		expect(groups.map((g) => g.querySelector("dt")?.textContent)).toEqual([
+			"Topics",
+			"Facilities",
+			"Aircraft",
+		]);
+	});
+
+	it("renders one chip per tag, labelled by its vocabulary value", () => {
+		const { container } = render(
+			<MentionsTab item={makeItem()} meta={makeMeta()} tzOffsetHours={TZ} />,
+		);
+		const chips = [...(tagsSection(container)?.querySelectorAll("li") ?? [])];
+		expect(chips.map((li) => li.textContent)).toEqual(["Hijacking", "ZBW", "AAL11"]);
+	});
+
+	it("colours chips by namespace, because mp3_tags.color is null on every row", () => {
+		const { container } = render(
+			<MentionsTab item={makeItem()} meta={makeMeta()} tzOffsetHours={TZ} />,
+		);
+		const chips = [
+			...(tagsSection(container)?.querySelectorAll<HTMLLIElement>("li") ?? []),
+		];
+		const backgrounds = chips.map((li) => li.style.background);
+		expect(backgrounds.every((b) => b.length > 0)).toBe(true);
+		expect(new Set(backgrounds).size).toBe(3);
+	});
+
+	it("lets a curator's colour win when one is ever set", () => {
+		const { container } = render(
+			<MentionsTab
+				item={makeItem()}
+				meta={makeMeta({
+					tags: [
+						{ tag: "facility:zbw", namespace: "facility", value: "ZBW", color: "rgb(1, 2, 3)" },
+					],
+				})}
+				tzOffsetHours={TZ}
+			/>,
+		);
+		const chip = tagsSection(container)?.querySelector<HTMLLIElement>("li");
+		expect(chip?.style.background).toBe("rgb(1, 2, 3)");
+	});
+
+	it("files a tag from an unknown namespace under Other rather than dropping it", () => {
+		// mp3_tags.namespace is NOT NULL, so a ninth namespace means a curator
+		// added one. Hiding their tag would look exactly like the tag not
+		// existing.
+		const { container, getByText } = render(
+			<MentionsTab
+				item={makeItem()}
+				meta={makeMeta({
+					tags: [{ tag: "weather:vfr", namespace: "weather", value: "VFR" }],
+				})}
+				tzOffsetHours={TZ}
+			/>,
+		);
+		expect(container.querySelector('[data-tag-group="other"]')).not.toBeNull();
+		expect(getByText("VFR")).toBeTruthy();
+	});
+
+	it("omits the tags section — not a \"No tags.\" line — for an item with no tags", () => {
+		// Consistent with the four mentions columns' own empty behaviour: an
+		// absent value drops its section rather than printing that it is absent.
+		const { container, queryByText } = render(
+			<MentionsTab
+				item={makeItem()}
+				meta={makeMeta({
+					mentions: { facilities: ["ZNY"], aircraft: [], people: [] },
+					tags: [],
+				})}
+				tzOffsetHours={TZ}
+			/>,
+		);
+		expect(tagsSection(container)).toBeNull();
+		expect(queryByText("No tags.")).toBeNull();
+		expect(queryByText("Tags")).toBeNull();
+	});
+
+	it("omits the tags section for an item with no metadata at all", () => {
+		const { container } = render(<MentionsTab item={makeItem()} tzOffsetHours={TZ} />);
+		expect(tagsSection(container)).toBeNull();
 	});
 });

--- a/packages/frontend/src/Applications/RadioTraffic/tabs/MentionsTab.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/tabs/MentionsTab.tsx
@@ -1,10 +1,11 @@
 import type React from "react";
 import type { CardTabProps } from "./cardTabProps";
 import styles from "./cardTabs.module.scss";
-import { tagLabel, tagsIn } from "./tagPalette";
+import { chipColor, tagGroups, tagLabel, tagsIn } from "./tagPalette";
 
 /**
- * Who and what the recording named without being party to, in four columns.
+ * Who and what the recording named without being party to, in four columns,
+ * plus every tag it carries.
  *
  * The first three read the structured `mentions` lists, not tags, and that is
  * the whole reason those fields exist: tags.py emits `facility:` for both a
@@ -20,6 +21,15 @@ import { tagLabel, tagsIn } from "./tagPalette";
  *
  * Empty columns are dropped: at 206x39 a heading with nothing under it spends a
  * quarter of the panel saying nothing.
+ *
+ * The tags section below the four columns is what used to be the Details tab's
+ * Tags column (issue #521): that column had no vertical scroll of its own, so
+ * a clip with many tags got clipped. This panel already scrolls the way
+ * Transcript does (see cardTabs.module.scss's `[data-tab="mentions"]`
+ * override), so the same namespace-grouped chips read in full here instead.
+ * Same rule as the four columns above — an item with no tags omits the
+ * section rather than printing "No tags.", so an untagged clip's Mentions tab
+ * never renders a heading with nothing under it.
  */
 export const MentionsTab: React.FC<CardTabProps> = ({ meta }) => {
 	const mentions = meta?.mentions;
@@ -30,29 +40,70 @@ export const MentionsTab: React.FC<CardTabProps> = ({ meta }) => {
 		{ key: "topics", label: "Topics", values: tagsIn(meta?.tags, "topic").map(tagLabel) },
 	].filter((column) => (column.values?.length ?? 0) > 0);
 
+	const groups = tagGroups(meta?.tags);
+
 	return (
 		<div className={styles.rtTabPanel} data-tab="mentions">
-			{columns.length === 0 ? (
+			{columns.length === 0 && groups.length === 0 ? (
 				<p className={styles.rtEmpty}>Nothing else named.</p>
 			) : (
-				<div className={styles.rtColumns}>
-					{columns.map((column) => (
-						<div
-							key={column.key}
-							className={styles.rtColumn}
-							data-column={column.key}
-						>
-							<h4 className={styles.rtColumnLabel}>{column.label}</h4>
-							<ul className={styles.rtColumnList}>
-								{column.values?.map((value) => (
-									<li key={value} className={styles.rtColumnValue}>
-										{value}
-									</li>
-								))}
-							</ul>
+				<>
+					{columns.length > 0 && (
+						<div className={styles.rtColumns}>
+							{columns.map((column) => (
+								<div
+									key={column.key}
+									className={styles.rtColumn}
+									data-column={column.key}
+								>
+									<h4 className={styles.rtColumnLabel}>{column.label}</h4>
+									<ul className={styles.rtColumnList}>
+										{column.values?.map((value) => (
+											<li key={value} className={styles.rtColumnValue}>
+												{value}
+											</li>
+										))}
+									</ul>
+								</div>
+							))}
 						</div>
-					))}
-				</div>
+					)}
+
+					{groups.length > 0 && (
+						<section className={styles.rtPanelColumn} data-column="tags">
+							<h4 className={styles.rtPanelColumnHead}>Tags</h4>
+							<dl className={styles.rtDetailRows}>
+								{groups.map((group) => (
+									<div
+										key={group.key}
+										className={styles.rtDetailRow}
+										data-tag-group={group.key}
+									>
+										<dt className={styles.rtDetailLabel}>{group.label}</dt>
+										{/* Chips wrap and must not be ellipsised, so this cell is
+										    not the single-line .rtDetailValue the text rows use. */}
+										<dd className={styles.rtChipCell}>
+											<ul className={styles.rtChips} aria-label={group.label}>
+												{group.tags.map((tag) => (
+													// mp3_tags.color is NULL on every row today, so
+													// the namespace palette is the source of truth;
+													// color is honoured only if a curator sets one.
+													<li
+														key={tag.tag}
+														className={styles.rtChip}
+														style={{ background: chipColor(tag) }}
+													>
+														{tagLabel(tag)}
+													</li>
+												))}
+											</ul>
+										</dd>
+									</div>
+								))}
+							</dl>
+						</section>
+					)}
+				</>
 			)}
 		</div>
 	);

--- a/packages/frontend/src/Applications/RadioTraffic/tabs/cardTabs.module.scss
+++ b/packages/frontend/src/Applications/RadioTraffic/tabs/cardTabs.module.scss
@@ -301,6 +301,19 @@
   overflow-x: hidden;
 }
 
+// Mentions ------------------------------------------------------------------
+//
+// The second scrolling panel (issue #521). Mentions gained a tags section
+// with the same unbounded-namespace-groups shape Transcript's cue list has —
+// a clip can carry many tags, and the fixed panel height would otherwise clip
+// them the way the old Details "Tags" column did. Same rule as Transcript's
+// override: `auto`, so a short mentions panel that fits shows no scrollbar,
+// and vertical only, since the content here wraps rather than running wide.
+.rtTabPanel[data-tab="mentions"] {
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
 .rtCueList {
   margin: 0;
   padding: 0;

--- a/packages/frontend/src/Applications/RadioTraffic/tabs/tagPalette.test.ts
+++ b/packages/frontend/src/Applications/RadioTraffic/tabs/tagPalette.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { chipColor, tagLabel, tagsIn, TAG_NAMESPACES } from "./tagPalette";
+import { chipColor, tagGroups, tagLabel, tagsIn, TAG_NAMESPACES } from "./tagPalette";
 
 describe("chipColor", () => {
 	it("keys off the namespace, because mp3_tags.color is null on every row", () => {
@@ -69,5 +69,39 @@ describe("tagsIn", () => {
 
 	it("is empty for an item with no tags at all", () => {
 		expect(tagsIn(undefined, "topic")).toEqual([]);
+	});
+});
+
+describe("tagGroups", () => {
+	const tags = [
+		{ tag: "topic:hijacking", namespace: "topic", value: "Hijacking" },
+		{ tag: "facility:zbw", namespace: "facility", value: "ZBW" },
+		{ tag: "aircraft:aal11", namespace: "aircraft", value: "AAL11" },
+	];
+
+	it("groups tags into a labelled row per namespace, in vocabulary order", () => {
+		expect(tagGroups(tags).map((g) => g.key)).toEqual(["topic", "facility", "aircraft"]);
+		expect(tagGroups(tags).map((g) => g.label)).toEqual(["Topics", "Facilities", "Aircraft"]);
+	});
+
+	it("drops a namespace with no tags rather than printing an empty row", () => {
+		expect(tagGroups(tags).map((g) => g.key)).not.toContain("person");
+	});
+
+	it("files a tag from an unknown namespace under a trailing Other row", () => {
+		// mp3_tags.namespace is NOT NULL, so a ninth namespace means a curator
+		// added one, not that a tag lost its namespace.
+		const groups = tagGroups([{ tag: "weather:vfr", namespace: "weather", value: "VFR" }]);
+		expect(groups).toEqual([
+			{
+				key: "other",
+				label: "Other",
+				tags: [{ tag: "weather:vfr", namespace: "weather", value: "VFR" }],
+			},
+		]);
+	});
+
+	it("is empty for an item with no tags at all", () => {
+		expect(tagGroups(undefined)).toEqual([]);
 	});
 });

--- a/packages/frontend/src/Applications/RadioTraffic/tabs/tagPalette.ts
+++ b/packages/frontend/src/Applications/RadioTraffic/tabs/tagPalette.ts
@@ -87,3 +87,36 @@ export function tagsIn(
 ): TagDef[] {
 	return (tags ?? []).filter((tag) => tag.namespace === namespace);
 }
+
+/** One labelled row of chips: a namespace and the tags that belong to it. */
+export interface TagGroup {
+	key: string;
+	label: string;
+	tags: TagDef[];
+}
+
+/**
+ * The tags grouped into the rows the design shows, in vocabulary order.
+ *
+ * A tag whose namespace is outside the eight tags.py emits is collected into a
+ * trailing "Other" row rather than dropped: mp3_tags.namespace is NOT NULL, so
+ * a ninth value means a curator added a namespace, and silently hiding their
+ * tag would look identical to the tag not existing.
+ *
+ * Shared by the Mentions tab's tags section and (formerly) the Details tab's
+ * Tags column — lifted here so the namespace-grouping/"Other"-bucket logic
+ * has exactly one implementation (issue #521).
+ */
+export function tagGroups(tags: readonly TagDef[] | undefined): TagGroup[] {
+	const all = tags ?? [];
+	const known = new Set<string>(TAG_NAMESPACES);
+	const groups: TagGroup[] = TAG_NAMESPACES.map((namespace) => ({
+		key: namespace,
+		label: namespaceLabel(namespace),
+		tags: all.filter((tag) => tag.namespace === namespace),
+	})).filter((group) => group.tags.length > 0);
+
+	const other = all.filter((tag) => !tag.namespace || !known.has(tag.namespace));
+	if (other.length > 0) groups.push({ key: "other", label: "Other", tags: other });
+	return groups;
+}


### PR DESCRIPTION
## Summary
- Removes the "Tags" column from the RadioTraffic Player Card's Details tab — it had no vertical scroll, so a clip with many tags got clipped.
- Adds a fifth section to the Mentions tab with the same namespace-grouped tag chips, appended after the existing Facilities/Aircraft/People/Topics columns (kept as-is, per clarification during plan review — this is additive, not a replacement of those columns).
- Gives the Mentions tab panel `overflow-y: auto` (mirroring the existing Transcript tab override), so all tags are reachable by scrolling.
- Lifts `tagGroups()` (namespace grouping + "Other" bucket for unknown namespaces) out of `DetailsTab.tsx` into the shared `tagPalette.ts`, so both the Mentions tab and any future caller share one implementation instead of duplicating it.
- An item with no tags omits the new section entirely rather than rendering a "No tags." line, consistent with how the Mentions tab already drops empty columns. Verified the marquee-scroll behavior added for issue #522 lives entirely in `LaneSmallPlayer.tsx`/`laneSmallPlayer.module.scss` (the collapsed small-player card) — it shares no CSS classes or code path with the Details/Mentions tab panels, so the empty tags state here cannot trigger it.

Fixes #521

## Test plan
- [x] `pnpm --filter @rt911/frontend exec vitest run` scoped to `DetailsTab.test.tsx`, `MentionsTab.test.tsx`, `tagPalette.test.ts` — 36 passed
- [x] `pnpm --filter @rt911/frontend exec vitest run src/Applications/RadioTraffic` — 707 passed (31 files)
- [x] `pnpm lint` — no new warnings/errors (pre-existing warnings elsewhere untouched)
- [x] `pnpm build` (`tsc -b && vite build`) — succeeds, no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)