### PR TITLE
Radio Traffic: wrap left filter panel in a ClassicyControlGroup

### DIFF
--- a/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.test.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.test.tsx
@@ -140,7 +140,18 @@ vi.mock("classicy", () => ({
 		<input id={id} aria-label={labelTitle} />
 	),
 	ClassicyBalloonHelp: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
-	ClassicyControlGroup: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+	ClassicyControlGroup: ({
+		children,
+		label,
+	}: {
+		children?: React.ReactNode;
+		label?: string;
+	}) => (
+		<fieldset>
+			<legend>{label}</legend>
+			{children}
+		</fieldset>
+	),
 	ClassicyColorPicker: ({
 		labelTitle,
 		value,
@@ -548,6 +559,23 @@ describe("RadioTraffic — lanes", () => {
 		clock.tzOffset = -4;
 		await renderSettled();
 		expect(laneIds("live")).toEqual([1, 2, 3]);
+	});
+});
+
+// Issue 519: the filter panel is a labeled Mac HIG group box, not a bare div.
+describe("RadioTraffic — the sidebar group box", () => {
+	it("wraps the filter panel in a 'Filter By...' group", async () => {
+		await renderSettled();
+		expect(screen.getByRole("group", { name: "Filter By..." })).not.toBeNull();
+	});
+
+	// The tool palette and the filter tree still have to work — the group box is
+	// chrome around them, not a replacement for their own rendering.
+	it("still renders the tool palette and the filter tree inside the group", async () => {
+		await renderSettled();
+		const group = screen.getByRole("group", { name: "Filter By..." });
+		expect(group.querySelector('[role="radio"]')).not.toBeNull();
+		expect(screen.getByLabelText("Primary")).not.toBeNull();
 	});
 });
 

--- a/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.tsx
@@ -21,6 +21,7 @@
 
 import {
 	ClassicyApp,
+	ClassicyControlGroup,
 	ClassicyIcons,
 	ClassicyWindow,
 	intToHex,
@@ -904,18 +905,20 @@ export const RadioTraffic: React.FC = () => {
 						</div>
 					)}
 					<aside className={styles.rtSidebar}>
-						<ToolPalette tool={tool} onSelect={setTool} />
-						<LargeNamespaceButtons
-							groups={groups.filter((group) => group.large)}
-							checked={checked}
-							onOpenPicker={setPickerNamespace}
-						/>
-						<FilterTree
-							groups={groups.filter((group) => !group.large)}
-							checked={checked}
-							onToggle={toggleTag}
-							stale={vocabulary.stale}
-						/>
+						<ClassicyControlGroup label="Filter By..." variant="secondary">
+							<ToolPalette tool={tool} onSelect={setTool} />
+							<LargeNamespaceButtons
+								groups={groups.filter((group) => group.large)}
+								checked={checked}
+								onOpenPicker={setPickerNamespace}
+							/>
+							<FilterTree
+								groups={groups.filter((group) => !group.large)}
+								checked={checked}
+								onToggle={toggleTag}
+								stale={vocabulary.stale}
+							/>
+						</ClassicyControlGroup>
 					</aside>
 					<main className={styles.rtLanes}>
 						{LANES.map((lane) => (

--- a/packages/frontend/src/Applications/RadioTraffic/radioTraffic.module.scss
+++ b/packages/frontend/src/Applications/RadioTraffic/radioTraffic.module.scss
@@ -47,7 +47,22 @@
   flex: 0 0 auto;
   padding: calc(var(--window-border-size) * 4) 0 calc(var(--window-border-size) * 4) calc(var(--window-border-size) * 4);
   border-right: var(--window-border-size) solid var(--color-system-04);
+  background-color: var(--color-system-03);
   overflow: hidden;
+
+  // ClassicyControlGroup's fieldset defaults to flex-grow: 0 (sized to
+  // content), but FilterTree needs a bounded-height ancestor for its own
+  // overflow-y: scroll to kick in instead of pushing the sidebar (and the
+  // window) taller. Once the group box wraps everything the fieldset is
+  // .rtSidebar's only child, so it takes over the flex column job this
+  // element's direct children used to do — the min-height: 0 is what lets it
+  // shrink below its content size so FilterTree's own scroll actually fires.
+  fieldset {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    min-height: 0;
+  }
 }
 
 // The lanes stack and NOTHING here scrolls. The column hands each lane a fixed


### PR DESCRIPTION
## Summary
- Wraps RadioTraffic's left sidebar (ToolPalette, LargeNamespaceButtons, FilterTree) in `ClassicyControlGroup label="Filter By..." variant="secondary"`, the Mac HIG "group box" component (confirmed as the correct component in issue review — `ClassicyFieldGroup` doesn't exist in the pinned classicy 0.77.2).
- Adds a small override on the group's rendered `<fieldset>` (`flex: 1; display: flex; flex-direction: column; min-height: 0;`) so FilterTree's own `overflow-y: scroll` still bounds it, instead of the fieldset's default `flex-grow: 0` letting the panel grow taller than the window.
- Adds `background-color: var(--color-system-03);` to `.rtSidebar`, per the issue.

## Test plan
- [x] `pnpm --filter @rt911/frontend exec vitest run src/Applications/RadioTraffic/` — 32 files / 724 tests pass, including two new tests asserting the sidebar renders a `role="group"` named "Filter By..." and that the tool palette + filter tree still render inside it.
- [x] `pnpm --filter @rt911/frontend exec vitest run` (full suite) — 296 files / 3231 tests pass.
- [x] `pnpm --filter @rt911/frontend exec tsc -b` — clean.
- [x] `pnpm --filter @rt911/frontend exec oxlint .` — no new warnings (same pre-existing set as main).
- [ ] Live dev-server / screenshot check of the layout fix — not completed in this environment (see PR description note below); reviewer should give it a quick visual pass before merging given `fieldset` flex layout is inherently a bit fiddly across browsers.

Fixes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)