### PR TITLE
Playlist Editor: fill timeline thumbnail dead space, stop scroll re-fetch

### DIFF
--- a/packages/frontend/src/Applications/PlaylistEditor/LanePreview.test.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/LanePreview.test.tsx
@@ -58,6 +58,62 @@ describe("LanePreview", () => {
 		expect(imgs[0].src).toContain("files.911realtime.org/thumbnails/cnn/");
 	});
 
+	it("sizes each TV tile to fill the viewport width with no dead space", () => {
+		const viewportPx = 400;
+		render(<LanePreview group="tv" channel="cnn" {...props} viewportPx={viewportPx} />);
+		const imgs = [
+			...document.querySelectorAll<HTMLImageElement>(".playlistTimelinePreviewThumb"),
+		];
+		expect(imgs.length).toBeGreaterThan(1);
+
+		// Matches .playlistTimelinePreview's `gap: 2px` in PlaylistEditor.scss.
+		const GAP_PX = 2;
+		const totalWidth =
+			imgs.reduce((sum, img) => sum + parseFloat(img.style.width), 0) +
+			(imgs.length - 1) * GAP_PX;
+		// count * tileWidth + gaps === viewportPx exactly — no dead space at the
+		// right edge, regardless of the tiles' real (intrinsic) aspect ratio.
+		expect(totalWidth).toBeCloseTo(viewportPx, 6);
+	});
+
+	it("keeps TV <img> DOM nodes across a small visible-span pan", () => {
+		// Two hours of span at this viewport/tile size gives stride = 900s (see
+		// the equivalent thumbnailBuckets.test.ts case) — a 30s pan is far
+		// smaller than that, so this is a few pixels of scroll, not a zoom
+		// change.
+		const spanProps = {
+			...props,
+			visibleStartMs: Date.UTC(2001, 8, 11, 12, 0),
+			visibleEndMs: Date.UTC(2001, 8, 11, 14, 0),
+			viewportPx: 800,
+		};
+		const { container, rerender } = render(<LanePreview group="tv" channel="cnn" {...spanProps} />);
+		const before = [
+			...container.querySelectorAll<HTMLImageElement>(".playlistTimelinePreviewThumb"),
+		];
+		expect(before.length).toBeGreaterThan(1);
+
+		rerender(
+			<LanePreview
+				group="tv"
+				channel="cnn"
+				{...spanProps}
+				visibleStartMs={spanProps.visibleStartMs + 30_000}
+				visibleEndMs={spanProps.visibleEndMs + 30_000}
+			/>,
+		);
+		const after = [
+			...container.querySelectorAll<HTMLImageElement>(".playlistTimelinePreviewThumb"),
+		];
+
+		// All but (at most) the edge tile that scrolled out of range survive as
+		// the SAME DOM node — proving React reused them via a stable key instead
+		// of unmounting/remounting the whole strip, which would flash to blank
+		// and re-issue every <img src> request on each scroll tick.
+		const survivors = after.filter((img) => before.includes(img));
+		expect(survivors.length).toBeGreaterThanOrEqual(before.length - 1);
+	});
+
 	it("renders nothing for a group with no preview", () => {
 		const { container } = render(<LanePreview group="flights" channel="AA11" {...props} />);
 		expect(container.firstChild).toBeNull();

--- a/packages/frontend/src/Applications/PlaylistEditor/LanePreview.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/LanePreview.tsx
@@ -6,6 +6,9 @@ import { usePeaksForSpan } from "./usePeaksForSpan";
 const THUMB_BASE = "https://files.911realtime.org/thumbnails";
 const OFFLINE = `${THUMB_BASE}/offline.jpg`;
 
+/** Matches `.playlistTimelinePreview`'s `gap: 2px` in PlaylistEditor.scss. */
+const TILE_GAP_PX = 2;
+
 /** Matches `.playlistTimelinePreviewRadio`'s height in PlaylistEditor.scss. */
 const WAVEFORM_HEIGHT = 40;
 
@@ -76,6 +79,15 @@ export function LanePreview({
 	});
 	if (buckets.length === 0) return null;
 
+	// Explicit per-tile width rather than the thumbnail's intrinsic aspect
+	// ratio (`width: auto` in PlaylistEditor.scss): `count * tileWidth +
+	// (count - 1) * TILE_GAP_PX` works out to exactly `viewportPx` this way,
+	// independent of `Math.floor` in thumbnailBuckets or the real image
+	// dimensions, so the strip fills the bar with no dead space at the right
+	// edge. `object-fit: cover` (PlaylistEditor.scss) crops each tile to this
+	// width instead of stretching/squishing it.
+	const tileWidth = (viewportPx - (buckets.length - 1) * TILE_GAP_PX) / buckets.length;
+
 	const slug = channel.toLowerCase();
 	return (
 		// Sticky for the same reason the label is: the lane is far wider than
@@ -86,6 +98,7 @@ export function LanePreview({
 				<img
 					key={ts}
 					className="playlistTimelinePreviewThumb"
+					style={{ width: tileWidth }}
 					src={`${THUMB_BASE}/${slug}/${ts}.jpg`}
 					onError={(e) => {
 						e.currentTarget.src = OFFLINE;

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistDocumentWindow.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistDocumentWindow.tsx
@@ -92,7 +92,7 @@ export function PlaylistDocumentWindow({
 	// close box just closed would leave it off screen.
 	const revealSelf = useCallback(() => {
 		dispatch({ type: "ClassicyWindowOpen", app: { id: appId }, window: { id: windowId } });
-		dispatch({ type: "ClassicyWindowFocus", app: { id: appId }, window: { id: g } });
+		dispatch({ type: "ClassicyWindowFocus", app: { id: appId }, window: { id: windowId } });
 	}, [dispatch, appId, windowId]);
 
 	// Raise this window whenever the provider is asked to open this playlist —

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.scss
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.scss
@@ -221,7 +221,15 @@ $lane-bar-height: 20px;
 
 .playlistTimelinePreviewThumb {
 	height: 54px;
-	width: auto;
+	// Width comes from an inline style (LanePreview.tsx) sized to exactly fill
+	// the strip's viewport width — `width: auto` here left dead space at the
+	// right edge whenever a tile's intrinsic aspect ratio didn't happen to sum
+	// to the full width. `object-fit: cover` crops instead of stretching a
+	// tile to that explicit width, and the black background shows through
+	// instead of whatever sits behind the strip for any sliver `cover` doesn't
+	// paint over (a crop-edge rounding gap, or an image that hasn't loaded yet).
+	object-fit: cover;
+	background-color: #000;
 }
 
 /* The radio preview is a time-positioned overlay, not a summary strip: each

--- a/packages/frontend/src/Applications/PlaylistEditor/thumbnailBuckets.test.ts
+++ b/packages/frontend/src/Applications/PlaylistEditor/thumbnailBuckets.test.ts
@@ -40,4 +40,41 @@ describe("thumbnailBuckets", () => {
 			startMs: at(12, 0), endMs: at(13, 0), viewportPx: 0, tilePx: 100,
 		})).toEqual([]);
 	});
+
+	it("keeps the sampled set stable when the window pans by less than one stride", () => {
+		// Two hours of span, 8 tiles => stride = 240 buckets / 8 = 30 buckets =
+		// 900s. A pan of one bucket (30s) is far smaller than that stride, so
+		// this should only ever drop/add an edge, not re-sample the whole strip
+		// (the bug: re-basing buckets on `startBucket` shifted every sampled
+		// index on every call, so React remounted and re-fetched every `<img>`
+		// on the tiniest scroll).
+		const base = { viewportPx: 800, tilePx: 100 };
+		const before = thumbnailBuckets({ startMs: at(12, 0), endMs: at(14, 0), ...base });
+		const after = thumbnailBuckets({
+			startMs: at(12, 0, 30), endMs: at(14, 0, 30), ...base,
+		});
+
+		expect(before).toHaveLength(8);
+		expect(after).toHaveLength(8);
+
+		const shared = after.filter((ts) => before.includes(ts));
+		// All but (at most) the edge that scrolled out should survive.
+		expect(shared.length).toBeGreaterThanOrEqual(before.length - 1);
+		// The window DID move — this isn't just two calls landing on an
+		// identical grid by coincidence.
+		expect(after).not.toEqual(before);
+	});
+
+	it("still fills the width after a large pan (control for the stability test)", () => {
+		// Same shape as above but panned by far more than one stride — every
+		// bucket is free to change, proving the stability assertion above is
+		// actually exercising something rather than always passing.
+		const base = { viewportPx: 800, tilePx: 100 };
+		const before = thumbnailBuckets({ startMs: at(12, 0), endMs: at(14, 0), ...base });
+		const after = thumbnailBuckets({ startMs: at(20, 0), endMs: at(22, 0), ...base });
+
+		expect(before).toHaveLength(8);
+		expect(after).toHaveLength(8);
+		expect(after.some((ts) => before.includes(ts))).toBe(false);
+	});
 });

--- a/packages/frontend/src/Applications/PlaylistEditor/thumbnailBuckets.ts
+++ b/packages/frontend/src/Applications/PlaylistEditor/thumbnailBuckets.ts
@@ -40,9 +40,23 @@ export function thumbnailBuckets({
 	const count = Math.min(fit, available);
 	const stride = available / count;
 
+	// Sample from a stride-aligned grid anchored at bucket 0 (i.e. multiples of
+	// `stride`), not offsets counted from `startBucket`. A pan at a fixed zoom
+	// keeps `stride` unchanged (same span length, same tile budget), so the
+	// grid itself doesn't move — only the window sliding across it does, which
+	// drops the points that scrolled out and adds the ones newly in range
+	// without renumbering everything in between. Re-basing on `startBucket`
+	// (the previous behaviour) shifted every sampled index by the same
+	// sub-bucket amount on every call, so scrolling by even a few pixels
+	// selected an entirely different set of timestamps — the caller keys
+	// `<img>` nodes by timestamp (`LanePreview.tsx`), so that churn unmounted
+	// and re-fetched the whole strip on every scroll tick instead of just its
+	// edges.
+	const firstGridIndex = Math.ceil(startBucket / stride);
+
 	const out: number[] = [];
 	for (let i = 0; i < count; i++) {
-		const bucket = startBucket + Math.floor(i * stride);
+		const bucket = Math.floor((firstGridIndex + i) * stride);
 		out.push(bucket * BUCKET_SECONDS);
 	}
 	return out;


### PR DESCRIPTION
## Summary

- Fixes #533: the expanded TV timeline thumbnail strip left dead space at the right edge, and scrolling made thumbnails vanish and re-download instead of staying mounted.
- `LanePreview.tsx` (TV branch): each `<img>` now gets an explicit inline `width` computed from `viewportPx`, so `count * tileWidth + gaps === viewportPx` exactly, independent of `Math.floor` in `thumbnailBuckets` or the thumbnails' real aspect ratio.
- `thumbnailBuckets.ts`: bucket sampling is now grid-anchored (multiples of `stride`, anchored at bucket 0) instead of re-based on each call's `startBucket`. A pan at fixed zoom now keeps most sampled timestamps unchanged, so React reuses the existing `<img>` DOM nodes (keyed by timestamp) instead of unmounting/remounting the whole strip and re-issuing every request. `fit`'s `Math.floor` rounding is unchanged, per the approved plan.
- `PlaylistEditor.scss`: `.playlistTimelinePreviewThumb` drops `width: auto`, adds `object-fit: cover` and a black background, so a crop (or a not-yet-loaded image) shows black instead of stretching or leaving whatever's behind it visible — per the plan's answered open question ("Have them cover over a black background, please").

### Unrelated fix included

`PlaylistDocumentWindow.tsx` had a `ReferenceError: g is not defined` (`window: { id: g } }`, a typo introduced by the immediately-preceding "Collapse playlist windows" commit) that crashed 4 whole test files and blocked a clean `pnpm test` run. Fixed to `window: { id: windowId } }`, matching the line right above it. This is outside the scope of #533 but was blocking the required green test suite, so I fixed it rather than opening a PR with red/crashing tests.

## Test plan

- [x] `pnpm --filter @rt911/frontend exec vitest run src/Applications/PlaylistEditor/thumbnailBuckets.test.ts src/Applications/PlaylistEditor/LanePreview.test.tsx` — 16/16 pass (includes 3 new tests: grid-stability + large-pan control in `thumbnailBuckets.test.ts`, tile-width-fills-viewport + DOM-node-identity-across-pan in `LanePreview.test.tsx`)
- [x] `pnpm test` (full suite) — 3235/3235 pass
- [x] `pnpm lint` — clean (pre-existing warnings only, no errors, none in touched files)
- [x] `pnpm build` (`tsc -b && vite build`) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)