### PR TITLE
fix(playlist): timeline bar collapses on click, Media row click expands it

### DIFF
--- a/packages/frontend/src/Applications/PlaylistEditor/MediaCardRow.test.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/MediaCardRow.test.tsx
@@ -1,0 +1,72 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MediaCardRow, type MediaCardEntry } from "./MediaCardRow";
+
+afterEach(cleanup);
+
+const entry = (uid: string, itemId: string): MediaCardEntry => ({
+	uid,
+	entry: { kind: "media", app: "tv", itemId },
+});
+
+const cardRow = (entries: MediaCardEntry[], props: Partial<{
+	selectedUid: string | null;
+	onSelect: (uid: string) => void;
+	onEdit: (uid: string) => void;
+	onRemove: (uid: string) => void;
+}> = {}) =>
+	render(
+		<MediaCardRow
+			entries={entries}
+			selectedUid={props.selectedUid ?? null}
+			onSelect={props.onSelect ?? vi.fn()}
+			onEdit={props.onEdit ?? vi.fn()}
+			onRemove={props.onRemove ?? vi.fn()}
+			logoFor={() => undefined}
+			listLabel="Test cards"
+		/>,
+	);
+
+describe("MediaCardRow", () => {
+	it("clicking a card calls onSelect with its uid", () => {
+		const onSelect = vi.fn();
+		cardRow([entry("e1", "cnn")], { onSelect });
+		screen.getByRole("listitem").click();
+		expect(onSelect).toHaveBeenCalledWith("e1");
+	});
+
+	it("clicking Edit or Remove does not also call onSelect", () => {
+		const onSelect = vi.fn();
+		const onEdit = vi.fn();
+		const onRemove = vi.fn();
+		cardRow([entry("e1", "cnn")], { onSelect, onEdit, onRemove });
+
+		screen.getByRole("button", { name: "Edit CNN" }).click();
+		expect(onEdit).toHaveBeenCalledWith("e1");
+		expect(onSelect).not.toHaveBeenCalled();
+
+		screen.getByRole("button", { name: "Remove CNN" }).click();
+		expect(onRemove).toHaveBeenCalledWith("e1");
+		expect(onSelect).not.toHaveBeenCalled();
+	});
+
+	it("Enter or Space on a focused card calls onSelect", () => {
+		const onSelect = vi.fn();
+		cardRow([entry("e1", "cnn")], { onSelect });
+		const card = screen.getByRole("listitem");
+
+		fireEvent.keyDown(card, { key: "Enter" });
+		expect(onSelect).toHaveBeenCalledWith("e1");
+
+		onSelect.mockClear();
+		fireEvent.keyDown(card, { key: " " });
+		expect(onSelect).toHaveBeenCalledWith("e1");
+	});
+
+	it("ignores other keys on a focused card", () => {
+		const onSelect = vi.fn();
+		cardRow([entry("e1", "cnn")], { onSelect });
+		fireEvent.keyDown(screen.getByRole("listitem"), { key: "Tab" });
+		expect(onSelect).not.toHaveBeenCalled();
+	});
+});

--- a/packages/frontend/src/Applications/PlaylistEditor/MediaCardRow.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/MediaCardRow.tsx
@@ -1,4 +1,5 @@
 import { ClassicyButton, ClassicyControlLabel } from "classicy";
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 import type { MediaEntry } from "../../Providers/Playlist/playlistTypes";
 import type { EditorEntry } from "./editorState";
 import { playlistEditorIcons } from "./playlistIcons";
@@ -10,7 +11,10 @@ export type MediaCardEntry = EditorEntry & { entry: MediaEntry };
  * A side-scrolling row of station cards — logo, call sign, pencil/trash — for
  * the Media tab's sections whose entries address a whole station rather than a
  * single clip (TV Channels, Radio Stations). Pencil mirrors the tree rows' Edit
- * (select + reveal the Settings window); trash removes.
+ * (select + reveal the Settings window); trash removes. Clicking the card
+ * itself (or Enter/Space while it's focused) expands the entry's timeline bar
+ * via `onSelect` — a lighter-weight action than Edit, which also opens the
+ * Settings window.
  *
  * Where the artwork comes from is the caller's business: TV reads the bundled
  * EPG icons synchronously, radio reads a Directus-backed map that only arrives
@@ -20,6 +24,7 @@ export type MediaCardEntry = EditorEntry & { entry: MediaEntry };
 export function MediaCardRow({
 	entries,
 	selectedUid,
+	onSelect,
 	onEdit,
 	onRemove,
 	logoFor,
@@ -28,6 +33,9 @@ export function MediaCardRow({
 }: {
 	entries: MediaCardEntry[];
 	selectedUid: string | null;
+	/** Expands this entry's timeline bar (and, via the reducer's single
+	 * selectedUid, collapses whatever bar was previously expanded). */
+	onSelect: (uid: string) => void;
 	onEdit: (uid: string) => void;
 	onRemove: (uid: string) => void;
 	logoFor: (itemId: string) => string | undefined;
@@ -44,11 +52,19 @@ export function MediaCardRow({
 				const label = e.entry.itemId.toUpperCase();
 				const logo = logoFor(e.entry.itemId);
 				const logoClass = `playlistMediaCardLogo ${logoClassName}`.trim();
+				const handleKeyDown = (ev: ReactKeyboardEvent<HTMLDivElement>) => {
+					if (ev.key !== "Enter" && ev.key !== " ") return;
+					ev.preventDefault();
+					onSelect(e.uid);
+				};
 				return (
 					<div
 						key={e.uid}
 						role="listitem"
+						tabIndex={0}
 						className={`playlistMediaCard${e.uid === selectedUid ? " playlistMediaCardSelected" : ""}`}
+						onClick={() => onSelect(e.uid)}
+						onKeyDown={handleKeyDown}
 					>
 						{logo ? (
 							<img className={logoClass} src={logo} alt="" />
@@ -56,7 +72,17 @@ export function MediaCardRow({
 							<div className="playlistMediaCardLogo" />
 						)}
 						<ClassicyControlLabel label={label} labelSize="small" />
-						<div className="playlistMediaCardButtons">
+						{/* stopPropagation here, not inside each onClickFunc: ClassicyButton's
+						  * callback shape isn't guaranteed to forward the native event (it
+						  * doesn't everywhere else in this codebase), but the click DOM event
+						  * itself always bubbles through this wrapper on its way to the card's
+						  * onClick above, so stopping it here reliably keeps Edit/Remove from
+						  * also firing a card-level select. */}
+						<div
+							className="playlistMediaCardButtons"
+							onClick={(ev) => ev.stopPropagation()}
+							onKeyDown={(ev) => ev.stopPropagation()}
+						>
 							<ClassicyButton
 								buttonShape="square"
 								buttonSize="small"

--- a/packages/frontend/src/Applications/PlaylistEditor/MediaRadioRow.test.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/MediaRadioRow.test.tsx
@@ -25,6 +25,7 @@ const radioEntry = (uid: string, itemId: string): RadioEditorEntry => ({
 
 const row = (entries: RadioEditorEntry[], props: Partial<{
 	selectedUid: string | null;
+	onSelect: (uid: string) => void;
 	onEdit: (uid: string) => void;
 	onRemove: (uid: string) => void;
 }> = {}) =>
@@ -32,6 +33,7 @@ const row = (entries: RadioEditorEntry[], props: Partial<{
 		<MediaRadioRow
 			entries={entries}
 			selectedUid={props.selectedUid ?? null}
+			onSelect={props.onSelect ?? vi.fn()}
 			onEdit={props.onEdit ?? vi.fn()}
 			onRemove={props.onRemove ?? vi.fn()}
 		/>,
@@ -91,6 +93,13 @@ describe("MediaRadioRow", () => {
 		row([radioEntry("e1", "WINS")], { onRemove });
 		screen.getByRole("button", { name: "Remove WINS" }).click();
 		expect(onRemove).toHaveBeenCalledWith("e1");
+	});
+
+	it("clicking the card reports the entry's uid via onSelect", () => {
+		const onSelect = vi.fn();
+		row([radioEntry("e1", "WINS")], { onSelect });
+		screen.getByRole("listitem").click();
+		expect(onSelect).toHaveBeenCalledWith("e1");
 	});
 
 	it("highlights only the selected entry's card", () => {

--- a/packages/frontend/src/Applications/PlaylistEditor/MediaRadioRow.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/MediaRadioRow.tsx
@@ -20,11 +20,13 @@ export type RadioEditorEntry = MediaCardEntry;
 export function MediaRadioRow({
 	entries,
 	selectedUid,
+	onSelect,
 	onEdit,
 	onRemove,
 }: {
 	entries: RadioEditorEntry[];
 	selectedUid: string | null;
+	onSelect: (uid: string) => void;
 	onEdit: (uid: string) => void;
 	onRemove: (uid: string) => void;
 }) {
@@ -46,6 +48,7 @@ export function MediaRadioRow({
 		<MediaCardRow
 			entries={entries}
 			selectedUid={selectedUid}
+			onSelect={onSelect}
 			onEdit={onEdit}
 			onRemove={onRemove}
 			// Read lazily: the generic radio glyph is classicy's, and reading it

--- a/packages/frontend/src/Applications/PlaylistEditor/MediaTvRow.test.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/MediaTvRow.test.tsx
@@ -45,6 +45,7 @@ describe("MediaTvRow", () => {
 			<MediaTvRow
 				entries={[tvEntry("e1", "cnn"), tvEntry("e2", "bbc")]}
 				selectedUid={null}
+				onSelect={vi.fn()}
 				onEdit={vi.fn()}
 				onRemove={vi.fn()}
 			/>,
@@ -63,6 +64,7 @@ describe("MediaTvRow", () => {
 			<MediaTvRow
 				entries={[tvEntry("e1", "cnn")]}
 				selectedUid={null}
+				onSelect={vi.fn()}
 				onEdit={onEdit}
 				onRemove={vi.fn()}
 			/>,
@@ -77,6 +79,7 @@ describe("MediaTvRow", () => {
 			<MediaTvRow
 				entries={[tvEntry("e1", "cnn")]}
 				selectedUid={null}
+				onSelect={vi.fn()}
 				onEdit={vi.fn()}
 				onRemove={onRemove}
 			/>,
@@ -85,11 +88,27 @@ describe("MediaTvRow", () => {
 		expect(onRemove).toHaveBeenCalledWith("e1");
 	});
 
+	it("clicking the card reports the entry's uid via onSelect", () => {
+		const onSelect = vi.fn();
+		render(
+			<MediaTvRow
+				entries={[tvEntry("e1", "cnn")]}
+				selectedUid={null}
+				onSelect={onSelect}
+				onEdit={vi.fn()}
+				onRemove={vi.fn()}
+			/>,
+		);
+		screen.getByRole("listitem").click();
+		expect(onSelect).toHaveBeenCalledWith("e1");
+	});
+
 	it("highlights only the selected entry's card", () => {
 		render(
 			<MediaTvRow
 				entries={[tvEntry("e1", "cnn"), tvEntry("e2", "bbc")]}
 				selectedUid="e2"
+				onSelect={vi.fn()}
 				onEdit={vi.fn()}
 				onRemove={vi.fn()}
 			/>,

--- a/packages/frontend/src/Applications/PlaylistEditor/MediaTvRow.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/MediaTvRow.tsx
@@ -29,11 +29,13 @@ export function stationLogo(itemId: string): string {
 export function MediaTvRow({
 	entries,
 	selectedUid,
+	onSelect,
 	onEdit,
 	onRemove,
 }: {
 	entries: TvEditorEntry[];
 	selectedUid: string | null;
+	onSelect: (uid: string) => void;
 	onEdit: (uid: string) => void;
 	onRemove: (uid: string) => void;
 }) {
@@ -41,6 +43,7 @@ export function MediaTvRow({
 		<MediaCardRow
 			entries={entries}
 			selectedUid={selectedUid}
+			onSelect={onSelect}
 			onEdit={onEdit}
 			onRemove={onRemove}
 			logoFor={stationLogo}

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.scss
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditor.scss
@@ -335,6 +335,7 @@ $lane-bar-height: 20px;
 	padding: 4px;
 	border: 1px solid var(--color-system-05);
 	background-color: var(--color-system-01);
+	cursor: pointer;
 }
 
 .playlistMediaCardSelected {

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditorMain.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistEditorMain.tsx
@@ -100,8 +100,16 @@ export function PlaylistEditorMain({
 }) {
 	const dispatch = (action: EditorAction) => edit(state.playlistId, action);
 
-	const editEntry = (uid: string) => {
+	// Row-click always JUST expands the entry's timeline bar — unlike editEntry
+	// below, it never opens the Settings window. Both share this dispatch: the
+	// reducer's selectedUid is a single scalar, so selecting a new uid already
+	// collapses whatever bar was previously expanded.
+	const selectEntry = (uid: string) => {
 		dispatch({ type: "select", uid });
+	};
+
+	const editEntry = (uid: string) => {
+		selectEntry(uid);
 		openSettings();
 	};
 
@@ -139,6 +147,7 @@ export function PlaylistEditorMain({
 						<MediaTvRow
 							entries={entries as TvEditorEntry[]}
 							selectedUid={state.selectedUid}
+							onSelect={selectEntry}
 							onEdit={editEntry}
 							onRemove={(uid) => dispatch({ type: "removeEntry", uid })}
 						/>
@@ -148,6 +157,7 @@ export function PlaylistEditorMain({
 						<MediaRadioRow
 							entries={entries}
 							selectedUid={state.selectedUid}
+							onSelect={selectEntry}
 							onEdit={editEntry}
 							onRemove={(uid) => dispatch({ type: "removeEntry", uid })}
 						/>

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistTimeline.test.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistTimeline.test.tsx
@@ -18,7 +18,7 @@ import { resolveTimelineMeta } from "./resolveTimelineMeta";
  */
 function Controlled({ entries, onSelect = vi.fn() }: {
 	entries: EditorEntry[];
-	onSelect?: (uid: string) => void;
+	onSelect?: (uid: string | null) => void;
 }) {
 	const [zoom, setZoom] = useState(1);
 	return (
@@ -71,6 +71,26 @@ describe("PlaylistTimeline", () => {
 
 		fireEvent.click(flags[0]);
 		expect(onSelect).toHaveBeenCalledWith("e2");
+	});
+
+	it("toggles: clicking the already-selected bar collapses it, clicking an unselected bar still selects it", () => {
+		const onSelect = vi.fn();
+		const { rerender } = render(
+			<PlaylistTimeline entries={entries} selectedUid={null} onSelect={onSelect} {...atRest} />,
+		);
+		const bar = document.querySelector(".playlistTimelineBar") as HTMLElement;
+
+		// Not yet selected: clicking it selects it.
+		fireEvent.click(bar);
+		expect(onSelect).toHaveBeenCalledWith("e1");
+
+		// Now selected (selectedUid is controlled by the caller — simulate the
+		// caller having applied that dispatch): clicking the same bar again
+		// collapses it.
+		onSelect.mockClear();
+		rerender(<PlaylistTimeline entries={entries} selectedUid="e1" onSelect={onSelect} {...atRest} />);
+		fireEvent.click(bar);
+		expect(onSelect).toHaveBeenCalledWith(null);
 	});
 
 	it("combines both fade edges into one maskImage on a bar with no start/end", () => {

--- a/packages/frontend/src/Applications/PlaylistEditor/PlaylistTimeline.tsx
+++ b/packages/frontend/src/Applications/PlaylistEditor/PlaylistTimeline.tsx
@@ -85,7 +85,10 @@ export function PlaylistTimeline({
 }: {
 	entries: EditorEntry[];
 	selectedUid: string | null;
-	onSelect: (uid: string) => void;
+	/** Selects a bar/flag's uid, or — passed null — collapses whatever bar is
+	 * currently expanded. The bar itself toggles (see its onClick below); flags
+	 * always select, never toggle. */
+	onSelect: (uid: string | null) => void;
 	/** Commit an edge drag: set one bound of a media entry's window. Handles
 	 * only render when this is wired, so a read-only host shows plain bars. */
 	onSetEntryBound?: (uid: string, edge: "start" | "end", iso: string) => void;
@@ -440,7 +443,7 @@ export function PlaylistTimeline({
 												maskImage: barMaskImage(fadeStart, fadeEnd),
 											}}
 											title={b.label}
-											onClick={() => onSelect(b.uid)}
+											onClick={() => onSelect(b.uid === selectedUid ? null : b.uid)}
 										>
 											{b.focus === "once" && <span aria-hidden>▸</span>}
 											{b.focus === "locked" && <span aria-hidden>🔒</span>}


### PR DESCRIPTION
## Summary
- Clicking an already-expanded `playlistTimelineBar` now collapses it (`onSelect(null)`) instead of re-selecting the same uid with no visible effect. `onSelect`'s type widens to `(uid: string | null) => void` to allow this — a no-op for the existing caller wiring, since `select`'s `uid` field was already nullable.
- Clicking a `playlistMediaCardRow` card (TV Channels / Radio Stations sections of the Media tab) now expands that entry's timeline bar via a new `onSelect` prop on `MediaCardRow`, threaded through `MediaTvRow`/`MediaRadioRow` to a `selectEntry` helper extracted in `PlaylistEditorMain` (shared with the existing `editEntry`, which also opens the Settings window). Row-click always expands and never toggles/collapses — a deliberate asymmetry vs. the bar's toggle behavior.
- Because `selectedUid` is a single reducer scalar, dispatching `select` for a new uid automatically collapses whatever bar was previously expanded — no explicit "collapse the others" logic needed.
- Card is now keyboard-operable (`tabIndex={0}`, Enter/Space triggers select) and Edit/Remove clicks `stopPropagation()` so they don't also fire the new card-level select.
- `.playlistMediaCard` gets `cursor: pointer` now that it's clickable.

## Test plan
- [x] `pnpm --filter @rt911/frontend exec vitest run src/Applications/PlaylistEditor/PlaylistTimeline.test.tsx src/Applications/PlaylistEditor/MediaCardRow.test.tsx src/Applications/PlaylistEditor/MediaTvRow.test.tsx src/Applications/PlaylistEditor/MediaRadioRow.test.tsx src/Applications/PlaylistEditor/PlaylistEditorMain.test.tsx` — 42 passed
- [x] `pnpm test` (full suite) — 3238 passed
- [x] `pnpm lint` — clean (only pre-existing warning categories, two new a11y warnings on the now-clickable card div are the same "non-interactive element with a role" tradeoff the plan called out)
- [x] `tsc -b` — clean

Fixes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)