### PR TITLE
fix(radio-traffic): count tab switches as a Live-card touch for the idle-release hold

### DIFF
--- a/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.test.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.test.tsx
@@ -868,6 +868,23 @@ describe("RadioTraffic — the manual hold (story 045)", () => {
 		restoreBox.mockRestore();
 	});
 
+	it("holds a card the listener switched tabs on, past its clock window (issue #538)", async () => {
+		const { rerender } = await renderHold();
+		expect(laneIds("live")).toEqual([10]);
+
+		const tab = cardOf(10)?.querySelector('[data-tab-id="summary"]');
+		expect(tab).not.toBeNull();
+		fireEvent.click(tab as Element);
+		await act(async () => {});
+
+		await rerenderAt(rerender, PAST_END);
+
+		// Switching tabs was the only touch — still held, past the window, the
+		// same way a pause or a scrub holds it.
+		expect(laneIds("live")).toEqual([10]);
+		expect(laneIds("previous")).toEqual([]);
+	});
+
 	it("does not release a touched card's hold by muting it afterward", async () => {
 		// Touched by scrub rather than by pause: pausing releases the element
 		// (the shell only registers audio for LIVE ids not in `stopped`), and a

--- a/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.tsx
@@ -207,8 +207,8 @@ function toggleId(set: ReadonlySet<number>, id: number): ReadonlySet<number> {
  * `set` with `id` added, or `set` itself when it was already there.
  *
  * Unlike toggleId, this never removes — a touch is a one-way latch (see
- * touchedLiveIds below), so a second play/pause or a second scrub on the same
- * card must not undo the first one's hold.
+ * touchedLiveIds below), so a second play/pause, a second scrub, or a second
+ * tab switch on the same card must not undo the first one's hold.
  */
 function addId(set: ReadonlySet<number>, id: number): ReadonlySet<number> {
 	if (set.has(id)) return set;
@@ -305,11 +305,12 @@ export const RadioTraffic: React.FC = () => {
 	/** PREVIOUS clips the listener started by hand — these do NOT follow the clock. */
 	const [userStarted, setUserStarted] = useState<ReadonlySet<number>>(() => new Set());
 	/**
-	 * LIVE cards the listener has manually touched — paused/played, or scrubbed
-	 * the waveform. This is the whole criterion for Story 045's hold below: an
-	 * untouched card simply disappears once its clock window ends, and a touched
-	 * one stays no matter what they do to it afterward (mute it, pause it again),
-	 * which is why this is add-only (addId) rather than a toggle like `stopped`.
+	 * LIVE cards the listener has manually touched — paused/played, scrubbed
+	 * the waveform, or switched a tab. This is the whole criterion for Story
+	 * 045's hold below: an untouched card simply disappears once its clock
+	 * window ends, and a touched one stays no matter what they do to it
+	 * afterward (mute it, pause it again), which is why this is add-only
+	 * (addId) rather than a toggle like `stopped`.
 	 *
 	 * The hold itself is not permanent: `pruneIdleTouches` below drops an id
 	 * once IDLE_RELEASE_MS passes with nothing happening on it — see
@@ -737,6 +738,18 @@ export const RadioTraffic: React.FC = () => {
 		setTouchedLiveIds((ids) => addId(ids, itemId));
 	}, []);
 
+	/**
+	 * A LIVE card's tab was switched — a third touch, alongside pause and scrub
+	 * (issue #538). A listener reading through a card's tabs is actively engaged
+	 * with it exactly as much as one pausing or scrubbing it, so it both
+	 * establishes the hold on an untouched card and re-stamps it on one already
+	 * held.
+	 */
+	const onTabSelect = useCallback((itemId: number) => {
+		lastLiveActivityRef.current.set(itemId, Date.now());
+		setTouchedLiveIds((ids) => addId(ids, itemId));
+	}, []);
+
 	const onReorder = useCallback(
 		(lane: Lane, fromId: number, toIndex: number) =>
 			setLaneOrder((order) =>
@@ -781,6 +794,9 @@ export const RadioTraffic: React.FC = () => {
 					// from wherever the listener starts it, following no clock a scrub
 					// would need to override.
 					onManualSeek={lane === "live" ? () => onManualSeek(item.id) : undefined}
+					// Same live-lane-only gating as onManualSeek above: UPCOMING and
+					// PREVIOUS have no clock-window hold to establish.
+					onTabSelect={lane === "live" ? () => onTabSelect(item.id) : undefined}
 					waveformColor={waveformColor}
 				/>
 			</div>
@@ -797,6 +813,7 @@ export const RadioTraffic: React.FC = () => {
 			onCardClick,
 			onTogglePause,
 			onManualSeek,
+			onTabSelect,
 			waveformColor,
 		],
 	);

--- a/packages/frontend/src/Applications/RadioTraffic/TrafficCard.test.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/TrafficCard.test.tsx
@@ -72,6 +72,7 @@ function renderCard(
 		onTogglePause?: () => void;
 		onManualSeek?: () => void;
 		onToggleMute?: () => void;
+		onTabSelect?: () => void;
 	} = {},
 ) {
 	return render(
@@ -88,6 +89,7 @@ function renderCard(
 			onTogglePause={props.onTogglePause ?? (() => {})}
 			onManualSeek={props.onManualSeek}
 			onToggleMute={props.onToggleMute}
+			onTabSelect={props.onTabSelect}
 		/>,
 	);
 }
@@ -612,6 +614,20 @@ describe("TrafficCard tabs", () => {
 		fireEvent.click(getByRole("tab", { name: "Transcript" }));
 		expect(container.querySelector('[data-tab="transcript"]')).not.toBeNull();
 		expect(container.querySelector('[data-tab="details"]')).toBeNull();
+	});
+
+	it("reports a tab switch to the shell, in addition to swapping the panel (issue #538)", () => {
+		const onTabSelect = vi.fn();
+		const { getByRole, container } = renderCard({ meta: makeMeta(), onTabSelect });
+		fireEvent.click(getByRole("tab", { name: "Transcript" }));
+		expect(container.querySelector('[data-tab="transcript"]')).not.toBeNull();
+		expect(onTabSelect).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not fail when onTabSelect is omitted, as UPCOMING/PREVIOUS cards do today", () => {
+		const { getByRole, container } = renderCard({ meta: makeMeta(), lane: "upcoming" });
+		fireEvent.click(getByRole("tab", { name: "Transcript" }));
+		expect(container.querySelector('[data-tab="transcript"]')).not.toBeNull();
 	});
 
 	it("hands the transcript panel the element's own position", async () => {

--- a/packages/frontend/src/Applications/RadioTraffic/TrafficCard.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/TrafficCard.tsx
@@ -77,6 +77,14 @@ export interface TrafficCardProps {
 	 */
 	onManualSeek?: () => void;
 	/**
+	 * The listener switched this card's tab — LIVE only (see RadioTraffic.tsx's
+	 * renderCard), the same signal `onManualSeek` sends for a scrub. A listener
+	 * reading through a card's tabs is exactly the "actively touching it" Story
+	 * 045's hold exists to detect, so this fires alongside the panel switch
+	 * rather than instead of it.
+	 */
+	onTabSelect?: () => void;
+	/**
 	 * The waveform's ink as a CSS color, or undefined to follow the theme.
 	 *
 	 * A `color` on the waveform slot rather than a prop passed into
@@ -177,6 +185,7 @@ const TrafficCardImpl: React.FC<TrafficCardProps> = ({
 	onManualSeek,
 	waveformColor,
 	onToggleMute,
+	onTabSelect,
 }) => {
 	const [active, setActive] = useState(CARD_TABS[0].id);
 
@@ -337,6 +346,16 @@ const TrafficCardImpl: React.FC<TrafficCardProps> = ({
 	const tabs = useMemo(() => visibleCardTabs(meta), [meta]);
 	const panel = tabs.find((tab) => tab.id === active) ?? tabs[0];
 
+	// The existing panel switch, plus Story 045's touch signal alongside it —
+	// see onTabSelect above.
+	const handleTabSelect = useCallback(
+		(id: string) => {
+			setActive(id);
+			onTabSelect?.();
+		},
+		[onTabSelect],
+	);
+
 	// The one thing the design signals with brightness: not "is this card
 	// running" but "is this one of the clips you are hearing". Both halves are
 	// needed — a muted clip still advances (audioCoordinator silences rather than
@@ -455,7 +474,7 @@ const TrafficCardImpl: React.FC<TrafficCardProps> = ({
 			</div>
 
 			<div className={styles.rtCardTabs}>
-				<CardTabBar tabs={tabs} active={panel.id} onSelect={setActive} />
+				<CardTabBar tabs={tabs} active={panel.id} onSelect={handleTabSelect} />
 				<div className={styles.rtCardPanel}>
 					<panel.Panel
 						item={item}
@@ -472,15 +491,15 @@ const TrafficCardImpl: React.FC<TrafficCardProps> = ({
 };
 
 /**
- * `onTogglePause`/`onManualSeek`/`onToggleMute` are fresh closures on every
- * RadioTraffic render — `renderCard` (RadioTraffic.tsx) is invoked anew per
- * render, not cached per item — but each one only ever does something with
- * THIS card's own `item.id`/`lane`, which are already compared below. Ignoring
- * them here, rather than requiring the shell to stabilize three per-item
- * callbacks, is what lets `memo` actually skip the other ~30+ cards' full
- * render (waveform draw, tab-bar overflow measurement, …) when a change
- * affects only one card, or nothing about any card at all — e.g. selecting a
- * different tool in the palette, which no prop here depends on.
+ * `onTogglePause`/`onManualSeek`/`onToggleMute`/`onTabSelect` are fresh
+ * closures on every RadioTraffic render — `renderCard` (RadioTraffic.tsx) is
+ * invoked anew per render, not cached per item — but each one only ever does
+ * something with THIS card's own `item.id`/`lane`, which are already compared
+ * below. Ignoring them here, rather than requiring the shell to stabilize
+ * four per-item callbacks, is what lets `memo` actually skip the other ~30+
+ * cards' full render (waveform draw, tab-bar overflow measurement, …) when a
+ * change affects only one card, or nothing about any card at all — e.g.
+ * selecting a different tool in the palette, which no prop here depends on.
  */
 function propsAreEqual(prev: TrafficCardProps, next: TrafficCardProps): boolean {
 	return (


### PR DESCRIPTION
## Summary
- Story 045's manual-hold mechanism keeps a LIVE player card in the Live lane past its clock window once the listener has touched it (played/paused it, or scrubbed its waveform), until `IDLE_RELEASE_MS` passes with no further activity. Interacting with a card's tabs (`CardTabBar`) did not count as a touch, so a card the listener was actively reading could silently drop out of the Live lane mid-read.
- Added a third touch point, `onTabSelect`, following the exact shape of the existing `onManualSeek`: `TrafficCard.tsx` now calls it (live lane only) whenever a tab is picked, in addition to switching the visible panel; `RadioTraffic.tsx` stamps `lastLiveActivityRef` and adds the id to `touchedLiveIds` the same way `onTogglePause`/`onManualSeek` already do.
- UPCOMING/PREVIOUS cards get `onTabSelect={undefined}`, same gating as `onManualSeek`, since there is no live-lane hold to establish for either.

## Test plan
- [x] `pnpm --filter @rt911/frontend exec tsc -b` — clean
- [x] `pnpm lint` — clean (only pre-existing warnings in unrelated files)
- [x] `pnpm --filter @rt911/frontend exec vitest run src/Applications/RadioTraffic/TrafficCard.test.tsx src/Applications/RadioTraffic/RadioTraffic.test.tsx` — 122/122 passed
- [x] `pnpm --filter @rt911/frontend exec vitest run` (full suite) — 3245/3245 passed
- New tests: `TrafficCard.test.tsx` covers `onTabSelect` firing alongside the panel switch and being safely omitted on non-live cards; `RadioTraffic.test.tsx` adds `"holds a card the listener switched tabs on, past its clock window"` to the story 045 hold suite.

Fixes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)