### PR TITLE
RadioTraffic cards: header-only focus, live-resync button, start countdown, lane-mute icon states

### DIFF
--- a/packages/frontend/src/Applications/RadioTraffic/LaneSection.test.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/LaneSection.test.tsx
@@ -28,6 +28,7 @@ function renderLane(
 		collapsed?: boolean;
 		onToggleCollapse?: (collapsed: boolean) => void;
 		muted?: boolean;
+		partiallyMuted?: boolean;
 		onToggleMute?: (muted: boolean) => void;
 		tool?: Tool;
 		onReorder?: (fromId: number, toIndex: number) => void;
@@ -41,6 +42,7 @@ function renderLane(
 			collapsed={props.collapsed}
 			onToggleCollapse={props.onToggleCollapse}
 			muted={props.muted}
+			partiallyMuted={props.partiallyMuted}
 			onToggleMute={props.onToggleMute}
 			tool={props.tool ?? "hand"}
 			onReorder={props.onReorder}
@@ -272,6 +274,79 @@ describe("LaneSection lane mute", () => {
 		expect(container.querySelector("[data-lane-mute]")?.getAttribute("aria-pressed")).toBe(
 			"false",
 		);
+	});
+});
+
+describe("LaneSection lane mute, third icon state (issue #537 item 5)", () => {
+	// Three looks: nothing muted (cone + arc), at least one station muted by
+	// hand short of mute-all (cone alone, neither arc nor cross), and mute-all
+	// (cone + cross) — but only ever TWO pressed states, since `partiallyMuted`
+	// is cosmetic and never itself presses the button.
+	const paths = (container: HTMLElement) =>
+		container.querySelectorAll("[data-lane-mute] svg path").length;
+
+	it("draws the cone-plus-arc look when nothing is muted at all", () => {
+		const { container } = renderLane({
+			lane: "live",
+			muted: false,
+			partiallyMuted: false,
+			onToggleMute: vi.fn(),
+		});
+		expect(paths(container)).toBe(2);
+	});
+
+	it("draws neither the arc nor the cross when some stations are muted individually", () => {
+		const { container } = renderLane({
+			lane: "live",
+			muted: false,
+			partiallyMuted: true,
+			onToggleMute: vi.fn(),
+		});
+		expect(paths(container)).toBe(1);
+	});
+
+	it("draws the crossed-cone mute-all look regardless of partiallyMuted", () => {
+		const { container } = renderLane({
+			lane: "live",
+			muted: true,
+			partiallyMuted: true,
+			onToggleMute: vi.fn(),
+		});
+		expect(paths(container)).toBe(2);
+	});
+
+	it("never presses the button for partiallyMuted alone — only mute-all presses it", () => {
+		const { container } = renderLane({
+			lane: "live",
+			muted: false,
+			partiallyMuted: true,
+			onToggleMute: vi.fn(),
+		});
+		expect(container.querySelector("[data-lane-mute]")?.getAttribute("aria-pressed")).toBe(
+			"false",
+		);
+	});
+
+	it("tells assistive tech some stations are muted, on top of the Mute/Unmute name", () => {
+		const { getByRole } = renderLane({
+			lane: "live",
+			muted: false,
+			partiallyMuted: true,
+			onToggleMute: vi.fn(),
+		});
+		expect(
+			getByRole("button", { name: `Mute ${LANE_LABELS.live} (some stations muted)` }),
+		).not.toBeNull();
+	});
+
+	it("says nothing extra when nothing is muted at all", () => {
+		const { getByRole } = renderLane({
+			lane: "live",
+			muted: false,
+			partiallyMuted: false,
+			onToggleMute: vi.fn(),
+		});
+		expect(getByRole("button", { name: `Mute ${LANE_LABELS.live}` })).not.toBeNull();
 	});
 });
 

--- a/packages/frontend/src/Applications/RadioTraffic/LaneSection.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/LaneSection.tsx
@@ -78,7 +78,7 @@ interface DragState {
 }
 
 /**
- * The lane mute control's artwork, in its two states.
+ * The lane mute control's artwork, in its three states (issue #537 item 5).
  *
  * The same speaker TrafficCard draws on its own mute button, REDRAWN for the
  * size this one is: the lane strip is one --window-control-size wide, and a
@@ -88,15 +88,28 @@ interface DragState {
  * survives being drawn six pixels wide. Same idea, legibly, rather than the
  * same path data illegibly.
  *
+ * `partial` is the new middle state: at least one station is muted by hand,
+ * short of the mute-ALL press this button itself makes. It draws the same
+ * cone with no sound wave at all — neither the crossed-out "everything is
+ * silent" mark nor the arc that means "everything is getting through" — so a
+ * listener can tell "some of the mix is silenced" apart from both ends
+ * without the button itself reporting the pressed, mute-everything state
+ * `muted` means. `muted` (mute-all) still wins when both are true: pressing
+ * mute-all while some cards are already muted by hand is still the button
+ * saying "everything", not "some things".
+ *
  * Inline rather than an <img> so it takes the strip's ink through
  * `currentColor`.
  */
-const SpeakerIcon: React.FC<{ muted: boolean }> = ({ muted }) => (
+const SpeakerIcon: React.FC<{ muted: boolean; partial?: boolean }> = ({
+	muted,
+	partial = false,
+}) => (
 	<svg viewBox="0 0 16 16" aria-hidden="true" focusable="false" role="presentation">
 		<path d="M1 6h4l5-4.5v13L5 10H1z" fill="currentColor" />
 		{muted ? (
 			<path d="M2 14L14 2" stroke="currentColor" strokeWidth="2.5" fill="none" />
-		) : (
+		) : partial ? null : (
 			<path
 				d="M12 4.5a5 5 0 0 1 0 7"
 				stroke="currentColor"
@@ -155,6 +168,14 @@ export interface LaneSectionProps {
 	 */
 	muted?: boolean;
 	/**
+	 * Issue #537 item 5: at least one player in this lane is muted individually
+	 * — the middle of the mute button's three icon states — WITHOUT the whole
+	 * lane being silenced by `muted`. Purely cosmetic: it changes the glyph
+	 * `SpeakerIcon` draws and nothing about `on`/aria-pressed, which stay
+	 * `muted`'s alone — the button is only ever actually PRESSED for mute-all.
+	 */
+	partiallyMuted?: boolean;
+	/**
 	 * Flip the lane mute. Its presence is also what puts the control on the
 	 * strip — the shell hands it to LIVE and to no one else, because LIVE is the
 	 * only lane with a mix to silence (UPCOMING has no audio yet, and PREVIOUS
@@ -182,6 +203,7 @@ export const LaneSection: React.FC<LaneSectionProps> = ({
 	collapsed = false,
 	onToggleCollapse,
 	muted = false,
+	partiallyMuted = false,
 	onToggleMute,
 	tool,
 	onReorder,
@@ -363,12 +385,21 @@ export const LaneSection: React.FC<LaneSectionProps> = ({
 						bevelWidth="small"
 						on={muted}
 						data-lane-mute
+						// Cosmetic only, never read for the pressed state itself — see
+						// SpeakerIcon's doc comment. A screen reader is told the same
+						// "some stations are muted" fact the icon draws, on top of
+						// whichever of Mute/Unmute the press itself still does.
+						data-partially-muted={!muted && partiallyMuted}
 						className={styles.rtLaneMute}
-						aria-label={`${muted ? "Unmute" : "Mute"} ${label}`}
-						title={`${muted ? "Unmute" : "Mute"} ${label}`}
+						aria-label={`${muted ? "Unmute" : "Mute"} ${label}${
+							!muted && partiallyMuted ? " (some stations muted)" : ""
+						}`}
+						title={`${muted ? "Unmute" : "Mute"} ${label}${
+							!muted && partiallyMuted ? " (some stations muted)" : ""
+						}`}
 						onChangeFunc={onToggleMute}
 					>
-						<SpeakerIcon muted={muted} />
+						<SpeakerIcon muted={muted} partial={!muted && partiallyMuted} />
 					</ClassicyBevelButton>
 				)}
 				{collapsible && (

--- a/packages/frontend/src/Applications/RadioTraffic/LaneSmallPlayer.test.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/LaneSmallPlayer.test.tsx
@@ -184,6 +184,33 @@ describe("LaneSmallPlayer chrome", () => {
 	});
 });
 
+describe("LaneSmallPlayer start countdown (issue #537)", () => {
+	// The fixture item's start_date, matching cardTabFixtures' default.
+	const START_MS = Date.parse("2001-09-11T12:46:31Z");
+
+	it("counts down above the link line when the clock is before the clip's start", () => {
+		const container = renderPlayer({ currentMs: START_MS - 4_000 });
+		expect(field(container, "countdown")?.textContent).toBe("4s");
+		// The link line is unaffected — both can show at once.
+		expect(field(container, "link")?.textContent).toBe("ZBW ↔ AAL11");
+	});
+
+	it("uses the same MM:SS/HH:MM:SS rendering as the full card's UPCOMING badge", () => {
+		const container = renderPlayer({ currentMs: START_MS - 200_000 });
+		expect(field(container, "countdown")?.textContent).toBe("03:20");
+	});
+
+	it("drops the countdown once the start has passed, rather than pinning it at 0s", () => {
+		const container = renderPlayer({ currentMs: START_MS + 1_000 });
+		expect(field(container, "countdown")).toBeNull();
+	});
+
+	it("drops the countdown when currentMs is not known", () => {
+		const container = renderPlayer({ currentMs: null });
+		expect(field(container, "countdown")).toBeNull();
+	});
+});
+
 describe("LaneSmallPlayer marquee (issue #522)", () => {
 	// UPCOMING and PREVIOUS opt into scrolling a chip row too wide to fit,
 	// rather than clipping the rest of a curator's tags away with no way to

--- a/packages/frontend/src/Applications/RadioTraffic/LaneSmallPlayer.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/LaneSmallPlayer.tsx
@@ -25,6 +25,7 @@ import type React from "react";
 import type { ItemMeta, MediaItem } from "../../Providers/MediaStream/MediaStreamContext";
 import Marquee from "../radio-core/marquee";
 import { useHorizontalOverflow } from "../radio-core/useHorizontalOverflow";
+import { countdownFor } from "./cardStatus";
 import styles from "./laneSmallPlayer.module.scss";
 import { durationSecondsLabel, startLabel } from "./smallPlayerLabels";
 import { itemTiming } from "./tabs/itemTiming";
@@ -73,6 +74,20 @@ export const LaneSmallPlayer: React.FC<LaneSmallPlayerProps> = ({
 	const link = meta?.link?.trim();
 	const tags = meta?.tags ?? [];
 	const { containerRef, contentRef, overflowing } = useHorizontalOverflow();
+
+	/**
+	 * Time remaining until this clip's `start_date` — "59s" under a minute,
+	 * "MM:SS" beyond it, "HH:MM:SS" from an hour out (cardStatus.countdownFor,
+	 * the same rendering the UPCOMING lane's full-card badge already uses).
+	 * Dropped once the start has passed rather than pinned at "0s": a LIVE or
+	 * PREVIOUS clip's collapsed player has nothing left to count down to, same
+	 * as the `start`/`duration`/`link` lines above are each dropped when the
+	 * fact they carry is absent rather than printed empty.
+	 */
+	const startCountdown =
+		currentMs !== null && timing.startMs !== null && timing.startMs > currentMs
+			? countdownFor(item, currentMs)
+			: null;
 
 	const chipList = (
 		<ul
@@ -134,10 +149,19 @@ export const LaneSmallPlayer: React.FC<LaneSmallPlayerProps> = ({
 						</span>
 					)}
 				</div>
-				{link && (
-					<span className={styles.rtSmallLink} data-field="link" title={link}>
-						{link}
-					</span>
+				{(startCountdown || link) && (
+					<div className={styles.rtSmallLinkGroup}>
+						{startCountdown && (
+							<span className={styles.rtSmallCountdown} data-field="countdown">
+								{startCountdown}
+							</span>
+						)}
+						{link && (
+							<span className={styles.rtSmallLink} data-field="link" title={link}>
+								{link}
+							</span>
+						)}
+					</div>
 				)}
 			</div>
 		</article>

--- a/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.test.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import type React from "react";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -897,7 +897,9 @@ describe("RadioTraffic — the manual hold (story 045)", () => {
 		await act(async () => {});
 
 		fireEvent.click(screen.getByRole("radio", { name: "Mute" }));
-		fireEvent.pointerUp(document.querySelector("[data-card-slot='10']") as Element);
+		fireEvent.pointerUp(
+			document.querySelector("[data-card-slot='10'] [data-card-header]") as Element,
+		);
 		await act(async () => {});
 		expect(audio.elements.get(10)?.muted).toBe(true);
 
@@ -1004,7 +1006,9 @@ describe("RadioTraffic — persisted state", () => {
 	it("persists a per-card mute made with the mute tool", async () => {
 		await renderSettled();
 		fireEvent.click(screen.getByRole("radio", { name: "Mute" }));
-		fireEvent.pointerUp(document.querySelector("[data-card-slot='2']") as Element);
+		fireEvent.pointerUp(
+			document.querySelector("[data-card-slot='2'] [data-card-header]") as Element,
+		);
 
 		expect(lastPersisted()?.mutedItems).toEqual([2]);
 		await act(async () => {});
@@ -1059,7 +1063,9 @@ describe("RadioTraffic — persisted state", () => {
 describe("RadioTraffic — the tools", () => {
 	it("solos the clicked card under the arrow tool", async () => {
 		await renderSettled();
-		fireEvent.pointerUp(document.querySelector("[data-card-slot='3']") as Element);
+		fireEvent.pointerUp(
+			document.querySelector("[data-card-slot='3'] [data-card-header]") as Element,
+		);
 		await act(async () => {});
 
 		expect(audio.elements.get(3)?.muted).toBe(false);
@@ -1070,9 +1076,29 @@ describe("RadioTraffic — the tools", () => {
 	it("does not change the mix under the hand tool", async () => {
 		await renderSettled();
 		fireEvent.click(screen.getByRole("radio", { name: "Move" }));
-		fireEvent.pointerUp(document.querySelector("[data-card-slot='3']") as Element);
+		fireEvent.pointerUp(
+			document.querySelector("[data-card-slot='3'] [data-card-header]") as Element,
+		);
 		await act(async () => {});
 
+		expect(audio.elements.get(1)?.muted).toBe(false);
+		expect(audio.elements.get(3)?.muted).toBe(true);
+	});
+
+	// Issue #537 item 1: a click anywhere in the card used to fire the same
+	// solo/focus toggle as a click on the header, including a click on the
+	// CardTabBar tabs — so switching a tab in one Live player could steal focus
+	// from another. The wrapper (RadioTraffic.tsx's `rtCardSlot`) now scopes its
+	// pointerup to a click that landed inside `[data-card-header]` specifically.
+	it("does not solo a card when only its tab bar is clicked", async () => {
+		await renderSettled();
+		const card = cardOf(3) as HTMLElement;
+
+		fireEvent.click(within(card).getByRole("tab", { name: "Summary" }));
+		await act(async () => {});
+
+		// The default mix (card 1 soloed) is untouched — a tab switch on card 3
+		// did not also solo card 3.
 		expect(audio.elements.get(1)?.muted).toBe(false);
 		expect(audio.elements.get(3)?.muted).toBe(true);
 	});
@@ -1145,7 +1171,9 @@ describe("RadioTraffic — the LIVE lane mute", () => {
 		fireEvent.click(laneMute("live") as Element);
 		await act(async () => {});
 
-		fireEvent.pointerUp(document.querySelector("[data-card-slot='3']") as Element);
+		fireEvent.pointerUp(
+			document.querySelector("[data-card-slot='3'] [data-card-header]") as Element,
+		);
 		await act(async () => {});
 
 		expect(audibleLive()).toEqual([3]);
@@ -1205,6 +1233,21 @@ describe("RadioTraffic — the LIVE lane mute", () => {
 		await renderSettled();
 		expect(audibleLive()).toEqual([]);
 		expect(laneMute("live")?.getAttribute("aria-pressed")).toBe("true");
+	});
+
+	// Issue #537 item 5: the lane mute button's third, cosmetic icon state —
+	// wiring-level check that anyLiveMuted reaches LaneSection as partiallyMuted.
+	it("marks the lane mute as partially muted once one station is muted by hand, without pressing it", async () => {
+		mockAppData.current = { checked: [], mutedItems: [2] };
+		await renderSettled();
+
+		expect(laneMute("live")?.getAttribute("data-partially-muted")).toBe("true");
+		expect(laneMute("live")?.getAttribute("aria-pressed")).toBe("false");
+	});
+
+	it("carries no partially-muted flag when nothing is individually muted", async () => {
+		await renderSettled();
+		expect(laneMute("live")?.getAttribute("data-partially-muted")).toBe("false");
 	});
 });
 

--- a/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.tsx
@@ -531,6 +531,20 @@ export const RadioTraffic: React.FC = () => {
 		};
 	}, [lanes, mp3Meta, checked]);
 
+	/**
+	 * Issue #537 item 5: at least one Live card carries its own explicit mute,
+	 * short of the whole lane being silenced by `liveLaneMuted`. This is what
+	 * lets the lane-mute button draw a third icon state — "some stations are
+	 * muted" — without itself reporting the pressed, mute-everything state that
+	 * `liveLaneMuted` alone means. A solo's IMPLICIT silence on every other card
+	 * does not count here: this names cards the listener silenced by hand, via
+	 * `audio.muted`, not ones merely excepted from a solo.
+	 */
+	const anyLiveMuted = useMemo(
+		() => visible.live.some((item) => audio.muted.has(item.id)),
+		[visible.live, audio.muted],
+	);
+
 	// ── Audio ────────────────────────────────────────────────────────────────
 	// The mix is the FILTER-VISIBLE live cards, so hiding the solo target hands
 	// the solo on rather than silencing the grid. Called on every visible-mix
@@ -708,7 +722,7 @@ export const RadioTraffic: React.FC = () => {
 				setAudio((state) => releaseLaneMute(state, lanes.live, itemId));
 				return;
 			}
-			setAudio((state) => applyToolClick(state, tool, itemId));
+			setAudio((state) => applyToolClick(state, tool, itemId, lanes.live));
 		},
 		[liveLaneMuted, lanes.live, tool],
 	);
@@ -760,15 +774,26 @@ export const RadioTraffic: React.FC = () => {
 
 	const renderCard = useCallback(
 		(lane: Lane) => (item: MediaItem) => (
-			// A plain div with a pointer handler, exactly like the lane slot it
-			// sits in: making it focusable would put a tab stop in front of every
-			// card's own tab bar and transport button. Under the `hand` tool the
-			// slot's drag handlers run too, and applyToolClick("hand") is a no-op,
-			// so a drag cannot also mute something.
+			// A plain div, exactly like the lane slot it sits in: making it
+			// focusable would put a tab stop in front of every card's own tab bar
+			// and transport button. Issue #537: a click anywhere in the card used
+			// to fire the same solo/mute toggle as a click on the header, including
+			// the CardTabBar tabs, so switching a tab in one Live player could steal
+			// focus from another. Scoping the toggle to a click that landed inside
+			// `[data-card-header]` — rather than moving the handler onto
+			// TrafficCard itself — keeps this closure (and the `tool` it reads
+			// through `onCardClick`) OUTSIDE TrafficCard's memo boundary: that memo
+			// deliberately skips a re-render on a tool change alone (see
+			// TrafficCard's propsAreEqual), so a handler passed in as a prop would
+			// go stale the moment the tool changed underneath it.
 			<div
 				className={styles.rtCardSlot}
 				data-card-slot={item.id}
-				onPointerUp={() => onCardClick(item.id, lane)}
+				onPointerUp={(e) => {
+					if ((e.target as HTMLElement).closest("[data-card-header]")) {
+						onCardClick(item.id, lane);
+					}
+				}}
 			>
 				<TrafficCard
 					item={item}
@@ -968,6 +993,10 @@ export const RadioTraffic: React.FC = () => {
 								// part of the solo/mute model at all.
 								muted={lane === "live" && liveLaneMuted}
 								onToggleMute={lane === "live" ? setLiveLaneMuted : undefined}
+								// Story #537 item 5: LIVE alone has individual per-card mutes to
+								// report — UPCOMING has no mix yet and PREVIOUS's clips are not
+								// part of the solo/mute model at all.
+								partiallyMuted={lane === "live" && anyLiveMuted}
 								tool={tool}
 								onReorder={(fromId, toIndex) => onReorder(lane, fromId, toIndex)}
 								renderCard={renderCard(lane)}

--- a/packages/frontend/src/Applications/RadioTraffic/TrafficCard.test.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/TrafficCard.test.tsx
@@ -397,6 +397,119 @@ describe("TrafficCard rewind", () => {
 	});
 });
 
+// Issue #537 item 1. The header row is marked with `data-card-header` so the
+// shell (RadioTraffic.tsx's `rtCardSlot` wrapper) can scope its active-tool
+// click to it specifically — see that file's own tests for the click-routing
+// behavior itself. TrafficCard's own part of the contract is just carrying
+// the attribute.
+describe("TrafficCard header", () => {
+	it("marks the header row so the shell can scope its click to it", () => {
+		const { container } = renderCard();
+		expect(container.querySelector("header")?.hasAttribute("data-card-header")).toBe(true);
+	});
+});
+
+// Issue #537 item 2. A button next to rewind that seeks the card back to
+// wherever the virtual clock says it should be, resuming playback if stopped.
+describe("TrafficCard sync-to-live button", () => {
+	it("renders unconditionally, same as the rewind button, on every lane", () => {
+		for (const lane of ["live", "upcoming", "previous"] as const) {
+			const { getByRole } = renderCard({ lane, nowMs: START_MS });
+			expect(getByRole("button", { name: "Sync back live" })).not.toBeNull();
+			cleanup();
+		}
+	});
+
+	it("is disabled off the live lane", () => {
+		const { getByRole } = renderCard({ lane: "upcoming", nowMs: START_MS - 30_000 });
+		expect(getByRole("button", { name: "Sync back live" })).toHaveProperty("disabled", true);
+	});
+
+	it("is disabled once the clock has run past the clip's end", () => {
+		// liveMs (nowMs - start) exceeds durationMs once the clock is past the end
+		// of the recording — there is nowhere sensible left to sync TO.
+		const { getByRole } = renderCard({
+			lane: "live",
+			nowMs: START_MS + DURATION_MS + 5_000,
+		});
+		expect(getByRole("button", { name: "Sync back live" })).toHaveProperty("disabled", true);
+	});
+
+	it("is disabled for a clip of unknown length", () => {
+		const endless = { ...makeItem(), end_date: undefined, calc_duration: undefined };
+		const { getByRole } = renderCard({ item: endless, lane: "live" });
+		expect(getByRole("button", { name: "Sync back live" })).toHaveProperty("disabled", true);
+	});
+
+	it("seeks to the clock's live position through the coordinator", () => {
+		const { getByRole } = renderCard({ lane: "live", nowMs: START_MS + 60_000 });
+
+		fireEvent.click(getByRole("button", { name: "Sync back live" }));
+
+		expect(audio.seekTo).toHaveBeenCalledWith(makeItem().id, 60_000);
+	});
+
+	it("reports the sync to the shell, same signal a rewind or scrub reports", () => {
+		const onManualSeek = vi.fn();
+		const { getByRole } = renderCard({
+			lane: "live",
+			nowMs: START_MS + 60_000,
+			onManualSeek,
+		});
+
+		fireEvent.click(getByRole("button", { name: "Sync back live" }));
+
+		expect(onManualSeek).toHaveBeenCalledTimes(1);
+	});
+
+	it("resumes playback when the card was stopped", () => {
+		const onTogglePause = vi.fn();
+		const { getByRole } = renderCard({
+			lane: "live",
+			nowMs: START_MS + 60_000,
+			paused: true,
+			onTogglePause,
+		});
+
+		fireEvent.click(getByRole("button", { name: "Sync back live" }));
+
+		expect(onTogglePause).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not touch playback when the card is already playing", () => {
+		const onTogglePause = vi.fn();
+		const { getByRole } = renderCard({
+			lane: "live",
+			nowMs: START_MS + 60_000,
+			paused: false,
+			onTogglePause,
+		});
+
+		fireEvent.click(getByRole("button", { name: "Sync back live" }));
+
+		expect(onTogglePause).not.toHaveBeenCalled();
+	});
+
+	it("keeps its click to itself, so the active tool does not also fire", () => {
+		const onSlotPointerUp = vi.fn();
+		const { getByRole } = render(
+			<div onPointerUp={onSlotPointerUp}>
+				<TrafficCard
+					item={makeItem()}
+					lane="live"
+					tzOffsetHours={-4}
+					nowMs={START_MS + 60_000}
+					onTogglePause={() => {}}
+				/>
+			</div>,
+		);
+
+		fireEvent.pointerUp(getByRole("button", { name: "Sync back live" }));
+
+		expect(onSlotPointerUp).not.toHaveBeenCalled();
+	});
+});
+
 // Story 028. A card follows the virtual clock until the listener says
 // otherwise; the transport button is one of the two ways they say it.
 describe("TrafficCard clock-follow", () => {

--- a/packages/frontend/src/Applications/RadioTraffic/TrafficCard.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/TrafficCard.tsx
@@ -152,6 +152,31 @@ const RewindIcon: React.FC = () => (
 	</svg>
 );
 
+/**
+ * A broadcast glyph — a filled dot inside a signal arc — for the sync-to-live
+ * button. `currentColor`, same treatment as RewindIcon: one asset has to read
+ * on both a bright LIVE card and a dimmed, disabled one.
+ */
+const LiveSyncIcon: React.FC = () => (
+	<svg viewBox="0 0 16 16" aria-hidden="true" focusable="false" role="presentation">
+		<circle cx="8" cy="8" r="1.8" fill="currentColor" />
+		<path
+			d="M5.6 5.6a3.3 3.3 0 0 0 0 4.8M10.4 5.6a3.3 3.3 0 0 1 0 4.8"
+			stroke="currentColor"
+			strokeWidth="1.4"
+			fill="none"
+			strokeLinecap="round"
+		/>
+		<path
+			d="M3.3 3.3a6.6 6.6 0 0 0 0 9.4M12.7 3.3a6.6 6.6 0 0 1 0 9.4"
+			stroke="currentColor"
+			strokeWidth="1.4"
+			fill="none"
+			strokeLinecap="round"
+		/>
+	</svg>
+);
+
 /** The badge, in the few characters the 196px header can spare beside a subject. */
 function badgeLabel(badge: Badge): string {
 	switch (badge.kind) {
@@ -287,6 +312,26 @@ const TrafficCardImpl: React.FC<TrafficCardProps> = ({
 		onManualSeek?.();
 	}, [item.id, onManualSeek]);
 
+	/**
+	 * Sync back live (issue #537 item 2): seek the element to where the virtual
+	 * clock says the audio should be right now — `liveMs`, the same number the
+	 * drift badge above is computed from — and, if the listener had stopped this
+	 * card, resume it. Reported through onManualSeek exactly like the rewind
+	 * button: a deliberate resync is exactly the kind of press that should count
+	 * as a touch under Story 045's hold.
+	 *
+	 * Disabled (see the button below) whenever there is nowhere sensible to sync
+	 * TO — off the LIVE lane, a clip with no known duration, or a LIVE clip the
+	 * clock has already run past the end of — so the press is never offered a
+	 * position that does not exist.
+	 */
+	const onSyncLive = useCallback(() => {
+		seekTo(item.id, liveMs);
+		onManualSeek?.();
+		if (paused) onTogglePause();
+	}, [item.id, liveMs, onManualSeek, paused, onTogglePause]);
+	const syncLiveDisabled = lane !== "live" || durationMs <= 0 || liveMs > durationMs;
+
 	// Stopping means opposite things in the two lanes that can be playing.
 	//
 	// A LIVE card is running on the virtual clock, so the listener stopping it is
@@ -378,6 +423,18 @@ const TrafficCardImpl: React.FC<TrafficCardProps> = ({
 			{/* The lane is repeated here so the header's colour has a selector of its
 			    own to hang off. It is the same prop the card frame carries, not a
 			    second derivation, so the two cannot come to disagree. */}
+			{/* Issue #537: the ONLY interaction that solos/mutes-toggles this card
+			    via the active tool, or steals focus from another Live card, is a
+			    click here — the shell's `rtCardSlot` wrapper (RadioTraffic.tsx)
+			    scopes its pointerup to this element specifically, so a click
+			    anywhere else in the card, including the CardTabBar tabs below
+			    (which used to bubble a pointerup all the way up to the same
+			    handler), does not fire the same toggle. That scoping lives on the
+			    wrapper, outside this memo'd component, rather than as a prop here:
+			    the toggle's behavior depends on the active tool, which this card
+			    deliberately does not re-render for (see propsAreEqual below), so a
+			    closure passed in as a prop would go stale the moment the tool
+			    changed without also changing one of the props actually compared. */}
 			<header className={styles.rtCardHeader} data-card-header data-lane={lane}>
 				{/* `title` gives the full subject on hover — the header ellipsises. */}
 				<h3 className={styles.rtCardTitle} data-card-title title={title}>
@@ -446,6 +503,21 @@ const TrafficCardImpl: React.FC<TrafficCardProps> = ({
 					<RewindIcon />
 				</ClassicyBevelButton>
 				<ClassicyBevelButton
+					square
+					bevelWidth="small"
+					data-card-sync-live
+					disabled={syncLiveDisabled}
+					aria-label="Sync back live"
+					title="Sync back live"
+					onClickFunc={onSyncLive}
+					// Same collision every other control in this row already guards
+					// against — left to bubble, letting go of a resync press would
+					// also fire whatever the active tool does to the card underneath.
+					onPointerUp={(e) => e.stopPropagation()}
+				>
+					<LiveSyncIcon />
+				</ClassicyBevelButton>
+				<ClassicyBevelButton
 					mode="toggle"
 					square
 					bevelWidth="small"
@@ -500,6 +572,9 @@ const TrafficCardImpl: React.FC<TrafficCardProps> = ({
  * cards' full render (waveform draw, tab-bar overflow measurement, …) when a
  * change affects only one card, or nothing about any card at all — e.g.
  * selecting a different tool in the palette, which no prop here depends on.
+ * (The active-tool click itself is scoped to the header row by the shell's
+ * wrapper, outside this memo, for exactly this reason — see the header's own
+ * comment above.)
  */
 function propsAreEqual(prev: TrafficCardProps, next: TrafficCardProps): boolean {
 	return (

--- a/packages/frontend/src/Applications/RadioTraffic/laneSmallPlayer.module.scss
+++ b/packages/frontend/src/Applications/RadioTraffic/laneSmallPlayer.module.scss
@@ -124,6 +124,17 @@
   text-overflow: ellipsis;
 }
 
+// Stacks the start countdown above the link type, mirroring .rtSmallTimings
+// on the opposite side of the footer — the pair the design's "bottom left /
+// bottom right" arrangement was already built around, just with a second row
+// on the right now that the countdown needs one.
+.rtSmallLinkGroup {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  min-width: 0;
+}
+
 // The one thing on the card the design emphasises besides the subject.
 .rtSmallLink {
   flex: 0 1 auto;
@@ -134,4 +145,13 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+// Issue #537 item 3: time remaining until the clip starts. Same size as the
+// timings on the opposite side of the footer — it is the same KIND of fact —
+// and dropped entirely once the start has passed rather than pinned at "0s"
+// (see LaneSmallPlayer.tsx's startCountdown).
+.rtSmallCountdown {
+  font-size: calc(var(--ui-font-size) * 0.75);
+  white-space: nowrap;
 }

--- a/packages/frontend/src/Applications/RadioTraffic/toolMode.test.ts
+++ b/packages/frontend/src/Applications/RadioTraffic/toolMode.test.ts
@@ -170,14 +170,30 @@ describe("applyToolClick", () => {
 			expect(isAudible(next, 11, "live")).toBe(true);
 		});
 
-		it("releases the solo when the muted card IS the solo target", () => {
+		it("releases the solo when the muted card IS the solo target, materialising every other mix member's implicit silence", () => {
 			// Otherwise the click is a silent no-op: effectiveMutedIds keeps the solo
 			// target audible in spite of its manual mute, so the one card the
 			// listener is actually hearing would be the one card they cannot mute.
-			const next = applyToolClick(state(11, []), "mute", 11);
+			// And every OTHER live card was only silent because the solo excepted
+			// 11 from an implicit mute — dropping the solo without folding that
+			// implicit silence into `muted` would reopen the whole board the moment
+			// the listener silenced the one thing they were listening to.
+			const next = applyToolClick(state(11, []), "mute", 11, ALL);
 			expect(next.soloId).toBeNull();
 			expect(isAudible(next, 11, "live")).toBe(false);
-			expect([...next.muted]).toEqual([11]);
+			expect([...next.muted].sort()).toEqual([10, 11, 12]);
+		});
+
+		it("repro: soloing a card then muting it silences the board, not reopens it", () => {
+			// Solo 11 among [10, 11, 12] — everyone else is only implicitly quiet —
+			// then mute 11 with the mute tool. Not the right design for it to hand
+			// 10 and 12 back audible with no click of their own; muting the one card
+			// you are listening to should silence the board.
+			const soloed = applyToolClick(state(null), "arrow", 11);
+			const next = applyToolClick(soloed, "mute", 11, ALL);
+			expect(next.soloId).toBeNull();
+			expect([...next.muted].sort()).toEqual([10, 11, 12]);
+			for (const id of [10, 11, 12]) expect(isAudible(next, id, "live")).toBe(false);
 		});
 
 		it("returns the same object when the card is already muted", () => {

--- a/packages/frontend/src/Applications/RadioTraffic/toolMode.ts
+++ b/packages/frontend/src/Applications/RadioTraffic/toolMode.ts
@@ -105,8 +105,20 @@ export function isAudible(state: AudioState, itemId: number, lane: Lane): boolea
  * The click, interpreted by the active tool. Returns the state object unchanged
  * when nothing moved — the shell feeds this straight back into React state, and
  * a fresh object per click would re-render the grid for no reason.
+ *
+ * `mix` is the LIVE, filter-visible mix — the same list `reconcileSolo` and
+ * `releaseLaneMute` already take, and for the same reason: it is only read by
+ * the `mute` case, and only when the card being muted IS the current solo
+ * target (see that case below). Every other tool ignores it, so callers that
+ * cannot hit that branch (tests exercising `arrow`/`unmute`/`hand` alone) may
+ * omit it — the default empty mix is only wrong for the one case that reads it.
  */
-export function applyToolClick(state: AudioState, tool: Tool, itemId: number): AudioState {
+export function applyToolClick(
+	state: AudioState,
+	tool: Tool,
+	itemId: number,
+	mix: readonly MediaItem[] = [],
+): AudioState {
 	switch (tool) {
 		case "arrow": {
 			if (state.soloId === itemId) return state;
@@ -127,13 +139,23 @@ export function applyToolClick(state: AudioState, tool: Tool, itemId: number): A
 			// focus — under a solo it was already inaudible, and with no solo it is
 			// an ordinary per-card mute.
 			if (state.soloId !== itemId) return { ...state, muted };
-			// Muting the solo target releases the solo. Without this the click is a
-			// silent no-op — effectiveMutedIds keeps the solo target audible in spite
-			// of its manual mute, so the one card the listener is actually hearing
-			// would be the one card they could not silence. And the release is
-			// RECORDED, because it is the listener quietening the lane rather than a
-			// clip running out: reconcileSolo must not answer it by promoting the
-			// next card, which is what made the Live lane impossible to silence.
+			// Muting the solo target releases the solo — but every OTHER live card
+			// was only audible because the solo excepted it from an implicit mute,
+			// not because of any mute of its own. Dropping the solo without
+			// materialising that implicit silence into explicit per-card mutes is
+			// what let muting the one card a listener was actually listening to
+			// reopen the whole board: with the solo gone and nothing else in
+			// `muted`, effectiveMutedIds has nothing left to silence. So every other
+			// mix member is folded into `muted` here, the same move releaseLaneMute
+			// makes in the opposite direction (naming one card to hear materialises
+			// everyone else's implicit audibility into an explicit mute).
+			for (const item of mix) {
+				if (item.id !== itemId) muted.add(item.id);
+			}
+			// The release is RECORDED, because it is the listener quietening the
+			// lane rather than a clip running out: reconcileSolo must not answer it
+			// by promoting the next card, which is what made the Live lane
+			// impossible to silence.
 			return { soloId: null, muted, soloReleasedByMute: true };
 		}
 		case "unmute": {

--- a/packages/frontend/src/Applications/RadioTraffic/trafficCard.module.scss
+++ b/packages/frontend/src/Applications/RadioTraffic/trafficCard.module.scss
@@ -293,10 +293,11 @@
 
 // ClassicyBevelButton builds its own className and drops the one it is
 // handed, so — same as the lane strip's mute/toggle controls — the sizing
-// hangs off the `data-card-transport`/`data-card-rewind`/`data-card-mute`
-// attributes the component library forwards untouched.
+// hangs off the `data-card-transport`/`data-card-rewind`/`data-card-mute`/
+// `data-card-sync-live` attributes the component library forwards untouched.
 .rtCardControls [data-card-transport],
 .rtCardControls [data-card-rewind],
+.rtCardControls [data-card-sync-live],
 .rtCardControls [data-card-mute] {
   flex: 0 0 auto;
   box-sizing: border-box;
@@ -317,12 +318,13 @@
   cursor: pointer;
 }
 
-// The speaker and the rewind arrow both take the button's ink, so one asset
-// each serves a bright LIVE card and a dimmed UPCOMING one. They fill the
-// button rather than carrying a size of their own, which is what keeps them
-// on the card's scale for free.
+// The speaker, the rewind arrow and the sync-live glyph all take the button's
+// ink, so one asset each serves a bright LIVE card and a dimmed UPCOMING one.
+// They fill the button rather than carrying a size of their own, which is
+// what keeps them on the card's scale for free.
 .rtCardControls [data-card-mute] svg,
-.rtCardControls [data-card-rewind] svg {
+.rtCardControls [data-card-rewind] svg,
+.rtCardControls [data-card-sync-live] svg {
   width: 100%;
   height: 100%;
 }
@@ -331,6 +333,16 @@
 // that departs from the button's default ink.
 .rtCardControls [data-card-mute][data-muted="true"] {
   color: var(--color-system-04);
+}
+
+// A greyed-out sync-live button — off the LIVE lane, an unknown-duration
+// clip, or a LIVE clip the clock has already run past the end of — has
+// nowhere sensible to seek to. Dimmed rather than hidden, same as the rest of
+// the app's disabled chrome, so the control stays in the same place on every
+// card and a listener never has to relocate it.
+.rtCardControls [data-card-sync-live]:disabled {
+  color: var(--color-system-05);
+  cursor: default;
 }
 
 // Tabs ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Scopes the active-tool card click to the `rtCardHeader` row alone, so switching a `CardTabBar` tab in one Live player can no longer steal focus/solo from another.
- Adds a disabled-aware "sync back live" button next to rewind on every card, greyed out off the live lane, on an unknown-duration clip, or once the clock has run past the clip's end.
- Shows a countdown to start (`4s` / `MM:SS` / `HH:MM:SS`) above the collapsed lane player's link line, dropped once the start has passed.
- Fixes a real bug found during planning: muting the current solo target used to unmute every other live card, because dropping the solo left nothing else in the per-card mute set. `applyToolClick`'s `mute` case now materializes every other mix member's implicit silence into an explicit mute before releasing the solo.
- Gives the Live lane's mute button a third, purely cosmetic icon state (cone with neither arc nor cross) for "some stations muted individually," without ever pressing the button itself — only mute-all does that.

The header-click scoping deliberately does **not** route through a new `TrafficCard` prop, unlike an earlier interrupted implementation attempt. That approach collided with `TrafficCard`'s existing memo (`propsAreEqual`), which intentionally skips re-rendering ~30+ cards on a tool change alone — so a click handler closing over the active tool would go stale the instant the tool changed without any *compared* prop changing. The shell's `rtCardSlot` wrapper (`RadioTraffic.tsx`) now scopes its own pointerup handler to a click that landed inside `[data-card-header]`, keeping the tool-aware logic outside the memo boundary entirely, matching the pre-existing architecture.

## Test plan
- [x] `pnpm --filter @rt911/frontend exec vitest run src/Applications/RadioTraffic` — 755 tests pass
- [x] `pnpm --filter @rt911/frontend exec vitest run` — full frontend suite, 3271 tests pass
- [x] `pnpm lint` — clean (only pre-existing, unrelated warnings)
- [x] `pnpm --filter @rt911/frontend exec tsc -b` — clean

Fixes #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)