### PR TITLE
RadioTraffic: show a dashed drag outline when reordering Player Cards, like TV Channels

### DIFF
--- a/packages/frontend/src/Applications/RadioTraffic/LaneSection.test.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/LaneSection.test.tsx
@@ -622,6 +622,110 @@ describe("LaneSection drag, with the hand tool", () => {
 	});
 });
 
+describe("LaneSection drag outline (issue #540)", () => {
+	// The dashed cursor-following outline that mirrors TV's tvDragOutline —
+	// see useThumbnailReorder.test.ts for the TV-side equivalents of these.
+	// jsdom gives every unstubbed getBoundingClientRect an all-zero box, so
+	// the `.rtLaneCards` strip itself (stripRect) needs no extra stub: its
+	// left/top are already 0, and a fresh element's scrollLeft is 0 too —
+	// only the dragged card's own box (stubSlotBoxes) is load-bearing here.
+
+	it("shows no outline before the pointer crosses the drag threshold", () => {
+		const { container } = renderLane({ tool: "hand", onReorder: vi.fn() });
+		stubSlotBoxes(container);
+		const source = slot(container, 3);
+		const press = centreOf(source);
+		fireEvent.pointerDown(source, { ...press, pointerId: 1 });
+		expect(container.querySelector("[data-drag-outline]")).toBeNull();
+		const nudged = { clientX: press.clientX + 2, clientY: press.clientY + 1 };
+		fireEvent.pointerMove(source, { ...nudged, pointerId: 1 });
+		expect(container.querySelector("[data-drag-outline]")).toBeNull();
+	});
+
+	it("renders an outline sized to the dragged card, centred on the pointer, once dragging starts", () => {
+		const { container } = renderLane({ tool: "hand", onReorder: vi.fn() });
+		stubSlotBoxes(container);
+		// Card 3 sits in the third slot (index 2): stubSlotBoxes gives every slot
+		// the same 210×124 box, so the outline's size is that regardless of which
+		// card is dragged.
+		const source = slot(container, 3);
+		fireEvent.pointerDown(source, { ...centreOf(source), pointerId: 1 });
+		fireEvent.pointerMove(source, { clientX: 300, clientY: 400, pointerId: 1 });
+		const outline = container.querySelector("[data-drag-outline]") as HTMLElement;
+		expect(outline).not.toBeNull();
+		// x = clientX - stripLeft(0) + scrollLeft(0) - width/2(105) = 300 - 105
+		expect(outline.style.left).toBe("195px");
+		// y = clientY - stripTop(0) - height/2(62) = 400 - 62
+		expect(outline.style.top).toBe("338px");
+		expect(outline.style.width).toBe("210px");
+		expect(outline.style.height).toBe("124px");
+	});
+
+	it("tracks a later pointermove to a new position", () => {
+		const { container } = renderLane({ tool: "hand", onReorder: vi.fn() });
+		stubSlotBoxes(container);
+		const source = slot(container, 3);
+		fireEvent.pointerDown(source, { ...centreOf(source), pointerId: 1 });
+		fireEvent.pointerMove(source, { clientX: 300, clientY: 400, pointerId: 1 });
+		fireEvent.pointerMove(source, { clientX: 350, clientY: 450, pointerId: 1 });
+		const outline = container.querySelector("[data-drag-outline]") as HTMLElement;
+		expect(outline.style.left).toBe("245px");
+		expect(outline.style.top).toBe("388px");
+	});
+
+	it("dims the dragged card's own slot at the same time the outline tracks the pointer", () => {
+		// The split issue #540 asks for: the outline moves, the original slot
+		// dims via the existing [data-dragging] rule — not one or the other.
+		const { container } = renderLane({ tool: "hand", onReorder: vi.fn() });
+		stubSlotBoxes(container);
+		const source = slot(container, 3);
+		fireEvent.pointerDown(source, { ...centreOf(source), pointerId: 1 });
+		fireEvent.pointerMove(source, { clientX: 300, clientY: 400, pointerId: 1 });
+		expect(container.querySelector("[data-drag-outline]")).not.toBeNull();
+		expect(container.querySelector("[data-dragging]")?.getAttribute("data-lane-item")).toBe("3");
+	});
+
+	it("clears the outline on pointerup", () => {
+		const { container } = renderLane({ tool: "hand", onReorder: vi.fn() });
+		stubSlotBoxes(container);
+		const source = slot(container, 3);
+		fireEvent.pointerDown(source, { ...centreOf(source), pointerId: 1 });
+		fireEvent.pointerMove(source, { clientX: 300, clientY: 400, pointerId: 1 });
+		expect(container.querySelector("[data-drag-outline]")).not.toBeNull();
+		fireEvent.pointerUp(source, { clientX: 300, clientY: 400, pointerId: 1 });
+		expect(container.querySelector("[data-drag-outline]")).toBeNull();
+	});
+
+	it("clears the outline on pointercancel", () => {
+		const { container } = renderLane({ tool: "hand", onReorder: vi.fn() });
+		stubSlotBoxes(container);
+		const source = slot(container, 3);
+		fireEvent.pointerDown(source, { ...centreOf(source), pointerId: 1 });
+		fireEvent.pointerMove(source, { clientX: 300, clientY: 400, pointerId: 1 });
+		expect(container.querySelector("[data-drag-outline]")).not.toBeNull();
+		fireEvent.pointerCancel(source, { pointerId: 1 });
+		expect(container.querySelector("[data-drag-outline]")).toBeNull();
+	});
+
+	it("clears the outline on Escape", () => {
+		const { container } = renderLane({ tool: "hand", onReorder: vi.fn() });
+		stubSlotBoxes(container);
+		const source = slot(container, 3);
+		fireEvent.pointerDown(source, { ...centreOf(source), pointerId: 1 });
+		fireEvent.pointerMove(source, { clientX: 300, clientY: 400, pointerId: 1 });
+		expect(container.querySelector("[data-drag-outline]")).not.toBeNull();
+		fireEvent.keyDown(source, { key: "Escape" });
+		expect(container.querySelector("[data-drag-outline]")).toBeNull();
+	});
+
+	it("never shows an outline under a non-hand tool", () => {
+		const { container } = renderLane({ tool: "arrow", onReorder: vi.fn() });
+		stubSlotBoxes(container);
+		drag(slot(container, 3), slotCentre(0));
+		expect(container.querySelector("[data-drag-outline]")).toBeNull();
+	});
+});
+
 describe("LaneSection drag across lanes", () => {
 	/** LIVE at the top of the page, UPCOMING in a band 1000px below it. */
 	const UPCOMING_TOP = 1_000;

--- a/packages/frontend/src/Applications/RadioTraffic/LaneSection.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/LaneSection.tsx
@@ -78,6 +78,25 @@ interface DragState {
 }
 
 /**
+ * The cursor-following drag visual: a box the size of the dragged card,
+ * centered on the pointer, in the lane's `.rtLaneCards` strip's content
+ * coordinates (relative to the strip's border box with its horizontal scroll
+ * added back, so it can be absolutely positioned inside the scrolling strip).
+ *
+ * Same shape, and the same TV thumbnail-strip technique it is named after —
+ * see `TV/useThumbnailReorder.ts`'s `DragOutline` — but computed inline here
+ * rather than shared: this lane's strip can be a flex row OR (LIVE) a 2-row
+ * CSS grid, and this is plain rect math against the container either way, not
+ * flex/grid-aware, so nothing about that difference actually needs sharing.
+ */
+interface DragOutline {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+/**
  * The lane mute control's artwork, in its three states (issue #537 item 5).
  *
  * The same speaker TrafficCard draws on its own mute button, REDRAWN for the
@@ -215,6 +234,10 @@ export const LaneSection: React.FC<LaneSectionProps> = ({
 	// Only the id being dragged is state; the rest of the gesture lives in a ref
 	// because nothing renders from it and a pointermove per frame should not.
 	const [draggingId, setDraggingId] = useState<number | null>(null);
+	// The cursor-following outline's box, live for the duration of a drag —
+	// unlike draggingId this DOES change every pointermove, because it is what
+	// the outline element's inline style reads.
+	const [dragOutline, setDragOutline] = useState<DragOutline | null>(null);
 	// The ids this lane rendered last tick — stabilizeLaneOrder's "before".
 	// Undefined until the first commit: there is nothing to compare the very
 	// first render against.
@@ -320,6 +343,7 @@ export const LaneSection: React.FC<LaneSectionProps> = ({
 	const endDrag = (target: HTMLElement, pointerId: number) => {
 		dragRef.current = null;
 		setDraggingId(null);
+		setDragOutline(null);
 		target.releasePointerCapture?.(pointerId);
 	};
 
@@ -333,12 +357,29 @@ export const LaneSection: React.FC<LaneSectionProps> = ({
 		},
 		onPointerMove: (e: React.PointerEvent<HTMLDivElement>) => {
 			const drag = dragRef.current;
-			if (!drag || drag.dragging) return;
-			if (Math.hypot(e.clientX - drag.startX, e.clientY - drag.startY) <= DRAG_THRESHOLD_PX) {
-				return;
+			if (!drag) return;
+			if (!drag.dragging) {
+				if (Math.hypot(e.clientX - drag.startX, e.clientY - drag.startY) <= DRAG_THRESHOLD_PX) {
+					return;
+				}
+				drag.dragging = true;
+				setDraggingId(drag.fromId);
 			}
-			drag.dragging = true;
-			setDraggingId(drag.fromId);
+			// Pointer capture keeps events on the pressed card, so currentTarget is
+			// always the dragged card's own slot — same as TV's useThumbnailReorder.
+			const cards = cardsRef.current;
+			if (cards) {
+				const stripRect = cards.getBoundingClientRect();
+				const cardRect = e.currentTarget.getBoundingClientRect();
+				const width = cardRect.right - cardRect.left;
+				const height = cardRect.bottom - cardRect.top;
+				setDragOutline({
+					x: e.clientX - stripRect.left + cards.scrollLeft - width / 2,
+					y: e.clientY - stripRect.top - height / 2,
+					width,
+					height,
+				});
+			}
 		},
 		onPointerUp: (e: React.PointerEvent<HTMLDivElement>) => {
 			const drag = dragRef.current;
@@ -357,6 +398,7 @@ export const LaneSection: React.FC<LaneSectionProps> = ({
 			if (e.key === "Escape" && dragRef.current) {
 				dragRef.current = null;
 				setDraggingId(null);
+				setDragOutline(null);
 			}
 		},
 	});
@@ -441,6 +483,23 @@ export const LaneSection: React.FC<LaneSectionProps> = ({
 						{isCollapsed ? renderCollapsedCard(item) : renderCard(item)}
 					</div>
 				))}
+				{dragOutline && (
+					// The cursor-following "marching ants" box — TV's tvDragOutline
+					// technique, RadioTraffic-prefixed. Rendered last so it paints above
+					// every card slot; the dragged card's own slot keeps the dim
+					// (data-dragging → opacity 0.5) rather than hiding it, exactly the
+					// tvPlayerDragging/tvDragOutline split TV.tsx uses.
+					<div
+						className={styles.rtDragOutline}
+						data-drag-outline
+						style={{
+							left: dragOutline.x,
+							top: dragOutline.y,
+							width: dragOutline.width,
+							height: dragOutline.height,
+						}}
+					/>
+				)}
 			</div>
 		</section>
 	);

--- a/packages/frontend/src/Applications/RadioTraffic/laneSection.module.scss
+++ b/packages/frontend/src/Applications/RadioTraffic/laneSection.module.scss
@@ -411,3 +411,31 @@
   cursor: grabbing;
   opacity: 0.5;
 }
+
+// Classic Mac OS 8 "marching ants": a dashed rectangle the size of the
+// dragged card follows the cursor while the original slot stays put (dimmed
+// via the [data-dragging] rule above) — same technique and same class shape
+// as TV.module.scss's .tvDragOutline / @keyframes tvMarchingAnts, RadioTraffic-
+// prefixed per this module's convention. The four repeating gradients draw
+// one dashed edge each; animating their positions marches the ants clockwise.
+.rtDragOutline {
+  position: absolute;
+  z-index: 2;
+  pointer-events: none;
+  --ant-color: var(--color-black, #000);
+  background-image:
+    repeating-linear-gradient(90deg, var(--ant-color) 0 4px, transparent 4px 8px),
+    repeating-linear-gradient(90deg, var(--ant-color) 0 4px, transparent 4px 8px),
+    repeating-linear-gradient(0deg, var(--ant-color) 0 4px, transparent 4px 8px),
+    repeating-linear-gradient(0deg, var(--ant-color) 0 4px, transparent 4px 8px);
+  background-size: 100% 2px, 100% 2px, 2px 100%, 2px 100%;
+  background-position: 0 0, 0 100%, 0 0, 100% 0;
+  background-repeat: no-repeat;
+  animation: rtMarchingAnts 0.5s linear infinite;
+}
+
+@keyframes rtMarchingAnts {
+  to {
+    background-position: 8px 0, -8px 100%, 0 -8px, 100% 8px;
+  }
+}


### PR DESCRIPTION
## Summary
- Dragging a Player Card in any Radio Traffic lane now shows a dashed "marching ants" outline, sized to the card, that follows the cursor — matching the TV Channels app's reorder outline style and animation.
- The dragged card's own slot keeps its existing dim (`[data-dragging] { opacity: 0.5 }`) while the new outline is what actually tracks the pointer, mirroring TV's `tvPlayerDragging`/`tvDragOutline` split.
- Implemented inline in `LaneSection.tsx` (not extracted into a shared hook with TV's `useThumbnailReorder.ts`), per the approved plan: RadioTraffic's drag model (per-lane slots that can be a flex row or, for LIVE, a 2-row CSS grid; drop resolution via `dropIndexAt`'s hit-testing) differs enough from TV's flat thumbnail-sibling model that sharing a hook would mean parameterizing around the differences rather than removing duplication — following the codebase's own established precedent of `LaneSection.tsx` independently re-implementing TV's `DRAG_THRESHOLD_PX` idea.

## Test plan
- [x] `pnpm --filter @rt911/frontend exec vitest run src/Applications/RadioTraffic/LaneSection.test.tsx` — 60 passed (8 new drag-outline tests: threshold gating, outline sizing/position off the dragged card's rect, live pointer tracking, dim+outline coexisting, clearing on pointerup/pointercancel/Escape, inert under non-hand tools)
- [x] `pnpm test` — 3279 passed (296 files)
- [x] `pnpm lint` — no new warnings (pre-existing warnings only, none in the changed lines)
- [x] `pnpm build` (`tsc -b && vite build`) — succeeds with no type errors

Fixes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)