### PR TITLE
perf(mobile): split desktop out of the phone's boot path, calm the iPod shell

### DIFF
--- a/packages/frontend/src/DesktopRoot.tsx
+++ b/packages/frontend/src/DesktopRoot.tsx
@@ -1,0 +1,24 @@
+// The desktop boot branch: provider tree + ClassicyDesktop in one chunk.
+//
+// Desktop is imported EAGERLY within this module on purpose: mounting
+// ClassicyDesktop lazily (a tick after ClassicyAppManagerProvider) corrupts
+// classicy's manager state — early dispatches hit a reducer that iterates
+// state the desktop hasn't seeded yet, and every dispatch after that throws
+// (windows can no longer open). Verified empirically 2026-07-14: `lazy(() =>
+// import("./Desktop"))` under an already-mounted provider reproduces it.
+// This module sidesteps the bug instead of depending on a classicy fix: the
+// provider and the desktop live in the SAME lazy chunk and mount in the same
+// commit, so there is never a provider-without-desktop tick. That is what
+// lets app.tsx lazy-load the whole branch and keep desktop-only code
+// (Applications, html2canvas, …) out of the phone's boot path.
+import "classicy/dist/fonts.css";
+import { AppProviders } from "./boot/AppProviders";
+import Desktop from "./Desktop";
+
+export default function DesktopRoot() {
+	return (
+		<AppProviders>
+			<Desktop />
+		</AppProviders>
+	);
+}

--- a/packages/frontend/src/Mobile/IpodChrome.tsx
+++ b/packages/frontend/src/Mobile/IpodChrome.tsx
@@ -2,6 +2,7 @@
 // The iPod device: vendored static artwork + interactive wheel/buttons.
 // Layout geometry (the inline percentage styles) comes from the DoodleDev
 // export and must not be "cleaned up" — it is the device's proportions.
+import { memo } from "react";
 import type { ClickWheel } from "./useClickWheel";
 import {
 	BASE_HTML,
@@ -28,7 +29,18 @@ const vendored = (html: string) => (
 	<div style={{ display: "contents" }} dangerouslySetInnerHTML={{ __html: html }} />
 );
 
-export function IpodChrome({ wheel, children }: IpodChromeProps) {
+// Module-level constant elements: the shell re-renders every clock tick and
+// stream frame, and an identical element reference lets React skip these
+// subtrees entirely instead of re-diffing the (large) vendored markup.
+const SHELL_DEFS = vendored(SHELL_DEFS_SVG);
+const BASE = vendored(BASE_HTML);
+const SCREEN_BEZEL = vendored(SCREEN_BEZEL_SVG);
+const WHEEL_RING = vendored(WHEEL_RING_HTML);
+
+// The wheel + buttons only depend on the ClickWheel object, whose identity
+// changes only when a button's pressed state does (useClickWheel memoizes
+// it) — so ambient shell re-renders skip this whole section.
+const ControlWheel = memo(function ControlWheel({ wheel }: { wheel: ClickWheel }) {
 	const { wheelRef, wheelHandlers, buttonDown, pressed } = wheel;
 	const rockClass = {
 		menu: " rock-menu",
@@ -39,9 +51,63 @@ export function IpodChrome({ wheel, children }: IpodChromeProps) {
 	}[pressed ?? "select"] ?? "";
 
 	return (
+		<section
+			className={`item${rockClass}`}
+			id="control-wheel"
+			style={{ height: "37.721%", isolation: "isolate", left: "18.3288%", top: "52.1669%", width: "63.3423%", zIndex: 3 }}
+			ref={wheelRef as React.RefObject<HTMLElement>}
+			{...wheelHandlers}
+		>
+			{WHEEL_RING}
+			<div
+				className={`item interactive${pressed === "select" ? " pressed" : ""}`}
+				id="mid-button"
+				style={{ height: "35%", left: "32.5%", top: "32.5%", width: "35%", zIndex: 3 }}
+				onPointerDown={buttonDown("select")}
+				// Static vendored artwork, not user input — see VENDORED.md.
+				dangerouslySetInnerHTML={{ __html: MID_BUTTON_SVG }}
+			/>
+			<div
+				className={`item interactive${pressed === "menu" ? " pressed" : ""}`}
+				id="menu-btn"
+				style={{ height: "6.86%", left: "41.61%", opacity: 0.28, top: "5.47%", width: "16.78%", zIndex: 4 }}
+				onPointerDown={buttonDown("menu")}
+			>
+				<img className="shape" src={menuIcon} alt="Menu" draggable={false} />
+			</div>
+			<div
+				className={`item interactive${pressed === "next" ? " pressed" : ""}`}
+				id="next-btn"
+				style={{ height: "4.63%", left: "84.56%", opacity: 0.28, top: "47.685%", width: "12.16%", zIndex: 5 }}
+				onPointerDown={buttonDown("next")}
+			>
+				<img className="shape" src={nextIcon} alt="Next" draggable={false} />
+			</div>
+			<div
+				className={`item interactive${pressed === "prev" ? " pressed" : ""}`}
+				id="prev-btn"
+				style={{ height: "4.63%", left: "3%", opacity: 0.28, top: "47.685%", width: "12.16%", zIndex: 6 }}
+				onPointerDown={buttonDown("prev")}
+			>
+				<img className="shape" src={prevIcon} alt="Previous" draggable={false} />
+			</div>
+			<div
+				className={`item interactive${pressed === "playPause" ? " pressed" : ""}`}
+				id="play-pause-btn"
+				style={{ height: "6.77%", left: "45.53%", opacity: 0.28, top: "89.62%", width: "8.94%", zIndex: 7 }}
+				onPointerDown={buttonDown("playPause")}
+			>
+				<img className="shape" src={playPauseIcon} alt="Play/Pause" draggable={false} />
+			</div>
+		</section>
+	);
+});
+
+export function IpodChrome({ wheel, children }: IpodChromeProps) {
+	return (
 		<div className="ipodDevice">
-			{vendored(SHELL_DEFS_SVG)}
-			{vendored(BASE_HTML)}
+			{SHELL_DEFS}
+			{BASE}
 			<section
 				className="item"
 				id="viewport"
@@ -52,59 +118,11 @@ export function IpodChrome({ wheel, children }: IpodChromeProps) {
 					id="screen"
 					style={{ height: "88.6364%", left: "0%", opacity: 1, top: "11.3636%", width: "91.7404%", zIndex: 2 }}
 				>
-					{vendored(SCREEN_BEZEL_SVG)}
+					{SCREEN_BEZEL}
 					<div id="ipod-screen-content">{children}</div>
 				</div>
 			</section>
-			<section
-				className={`item${rockClass}`}
-				id="control-wheel"
-				style={{ height: "37.721%", isolation: "isolate", left: "18.3288%", top: "52.1669%", width: "63.3423%", zIndex: 3 }}
-				ref={wheelRef as React.RefObject<HTMLElement>}
-				{...wheelHandlers}
-			>
-				{vendored(WHEEL_RING_HTML)}
-				<div
-					className={`item interactive${pressed === "select" ? " pressed" : ""}`}
-					id="mid-button"
-					style={{ height: "35%", left: "32.5%", top: "32.5%", width: "35%", zIndex: 3 }}
-					onPointerDown={buttonDown("select")}
-					// Static vendored artwork, not user input — see VENDORED.md.
-					dangerouslySetInnerHTML={{ __html: MID_BUTTON_SVG }}
-				/>
-				<div
-					className={`item interactive${pressed === "menu" ? " pressed" : ""}`}
-					id="menu-btn"
-					style={{ height: "6.86%", left: "41.61%", opacity: 0.28, top: "5.47%", width: "16.78%", zIndex: 4 }}
-					onPointerDown={buttonDown("menu")}
-				>
-					<img className="shape" src={menuIcon} alt="Menu" draggable={false} />
-				</div>
-				<div
-					className={`item interactive${pressed === "next" ? " pressed" : ""}`}
-					id="next-btn"
-					style={{ height: "4.63%", left: "84.56%", opacity: 0.28, top: "47.685%", width: "12.16%", zIndex: 5 }}
-					onPointerDown={buttonDown("next")}
-				>
-					<img className="shape" src={nextIcon} alt="Next" draggable={false} />
-				</div>
-				<div
-					className={`item interactive${pressed === "prev" ? " pressed" : ""}`}
-					id="prev-btn"
-					style={{ height: "4.63%", left: "3%", opacity: 0.28, top: "47.685%", width: "12.16%", zIndex: 6 }}
-					onPointerDown={buttonDown("prev")}
-				>
-					<img className="shape" src={prevIcon} alt="Previous" draggable={false} />
-				</div>
-				<div
-					className={`item interactive${pressed === "playPause" ? " pressed" : ""}`}
-					id="play-pause-btn"
-					style={{ height: "6.77%", left: "45.53%", opacity: 0.28, top: "89.62%", width: "8.94%", zIndex: 7 }}
-					onPointerDown={buttonDown("playPause")}
-				>
-					<img className="shape" src={playPauseIcon} alt="Play/Pause" draggable={false} />
-				</div>
-			</section>
+			<ControlWheel wheel={wheel} />
 		</div>
 	);
 }

--- a/packages/frontend/src/Mobile/IpodShell.tsx
+++ b/packages/frontend/src/Mobile/IpodShell.tsx
@@ -6,6 +6,7 @@
 // state and register scroll/select meaning via useScreenWheel.
 import { useAppManager, useClassicyDateTime } from "classicy";
 import {
+	memo,
 	useCallback,
 	useEffect,
 	useMemo,
@@ -59,6 +60,22 @@ export type NowPlayingSource =
 // The mobile shell never shows the waveform (showWaveform is always false),
 // so StationPlayer's viz props are inert here — defaults and a stable no-op.
 const noopCycleVizMode = () => {};
+
+// The shell re-renders on every clock tick (1 Hz) and on every
+// MediaStreamContext change (heartbeats, reveal-buffer promotions, …), since
+// useMediaStream subscribes it to the whole context. Memoizing the screens
+// means those ambient renders reconcile only the header/status text — a
+// screen re-renders when its own props change (or its own state/hooks do),
+// not because the shell ticked. All props passed below are identity-stable
+// except the ones that legitimately drive UI (nowMs, stations, channels).
+const MemoMainMenu = memo(MainMenu);
+const MemoAboutScreen = memo(AboutScreen);
+const MemoRadioScreen = memo(RadioScreen);
+const MemoTVScreen = memo(TVScreen);
+const MemoNowPlayingScreen = memo(NowPlayingScreen);
+const MemoTimeTravelScreen = memo(TimeTravelScreen);
+const MemoBookmarksScreen = memo(BookmarksScreen);
+const MemoScrubScreen = memo(ScrubScreen);
 
 export default function IpodShell() {
 	const [stackState, dispatchStack] = useReducer(screenStackReducer, initialScreenStack);
@@ -186,11 +203,11 @@ export default function IpodShell() {
 						)}
 						<div className="ipodScreenBody" key={screen}>
 							{screen === "menu" && (
-								<MainMenu hasNowPlaying={nowPlaying !== null} />
+								<MemoMainMenu hasNowPlaying={nowPlaying !== null} />
 							)}
-							{screen === "about" && <AboutScreen />}
+							{screen === "about" && <MemoAboutScreen />}
 							{screen === "radio" && (
-								<RadioScreen
+								<MemoRadioScreen
 									stations={stations}
 									nowMs={nowMs}
 									activeStationKey={
@@ -201,7 +218,7 @@ export default function IpodShell() {
 								/>
 							)}
 							{screen === "tv" && (
-								<TVScreen
+								<MemoTVScreen
 									channels={tvChannels}
 									activeTvId={nowPlaying?.kind === "tv" ? nowPlaying.id : null}
 									onTune={tuneTvChannel}
@@ -209,7 +226,7 @@ export default function IpodShell() {
 								/>
 							)}
 							{screen === "nowPlaying" && (
-								<NowPlayingScreen
+								<MemoNowPlayingScreen
 									station={activeStation}
 									tvChannel={activeTvItem}
 									nowMs={nowMs}
@@ -217,10 +234,12 @@ export default function IpodShell() {
 									clockPaused={clockPaused}
 								/>
 							)}
-							{screen === "timeTravel" && <TimeTravelScreen />}
-							{screen === "bookmarks" && <BookmarksScreen tzOffset={tzOffset} />}
+							{screen === "timeTravel" && <MemoTimeTravelScreen />}
+							{screen === "bookmarks" && (
+								<MemoBookmarksScreen tzOffset={tzOffset} />
+							)}
 							{screen === "scrub" && (
-								<ScrubScreen getNowMs={getNowMs} tzOffset={tzOffset} />
+								<MemoScrubScreen getNowMs={getNowMs} tzOffset={tzOffset} />
 							)}
 						</div>
 					</IpodChrome>

--- a/packages/frontend/src/Mobile/shell.css
+++ b/packages/frontend/src/Mobile/shell.css
@@ -139,6 +139,10 @@
 	gap: calc(var(--u) * 8);
 	font-weight: 600;
 	border-bottom: calc(var(--u) * 1) solid #eee;
+	/* iOS Safari treats elements without a pointer cursor (or a direct click
+	   handler) as non-clickable in some delegation paths; be explicit so row
+	   taps always dispatch a click promptly. */
+	cursor: pointer;
 }
 .ipodRoot .ipodMenuItem .label {
 	white-space: nowrap;

--- a/packages/frontend/src/Mobile/useClickWheel.ts
+++ b/packages/frontend/src/Mobile/useClickWheel.ts
@@ -98,5 +98,11 @@ export function useClickWheel(handlers: ClickWheelHandlers): ClickWheel {
 		[],
 	);
 
-	return { wheelRef, wheelHandlers, buttonDown, pressed };
+	// Stable object identity (only `pressed` varies): IpodChrome's artwork is
+	// memoized on it, so the shell's per-second re-renders (clock tick, stream
+	// frames) don't reconcile the wheel/button subtree at all.
+	return useMemo(
+		() => ({ wheelRef, wheelHandlers, buttonDown, pressed }),
+		[wheelHandlers, buttonDown, pressed],
+	);
 }

--- a/packages/frontend/src/MobileRoot.tsx
+++ b/packages/frontend/src/MobileRoot.tsx
@@ -1,0 +1,24 @@
+// The mobile boot branch: provider tree + the iPod shell, with none of the
+// desktop's application code in the chunk graph. IpodShell is imported
+// eagerly here — the whole branch is the lazy unit (see app.tsx), so the
+// shell no longer needs its own lazy() indirection.
+//
+// classicy's Platinum fonts (~900 kB of base64 @font-face) are NOT imported
+// here: the iPod shell renders in its own typeface (see shell.css), so the
+// phone shouldn't pay the decode cost during boot. The one classicy-styled
+// component on mobile (TvPlayer's QuickTimeVideoEmbed chrome) falls back to
+// system fonts until the deferred import below lands, then picks up the real
+// faces — fetched idle-priority, well after first interaction.
+import { AppProviders } from "./boot/AppProviders";
+import IpodShell from "./Mobile/IpodShell";
+import { runWhenIdle } from "./lib/runWhenIdle";
+
+runWhenIdle(() => void import("classicy/dist/fonts.css"));
+
+export default function MobileRoot() {
+	return (
+		<AppProviders>
+			<IpodShell />
+		</AppProviders>
+	);
+}

--- a/packages/frontend/src/Pages/PagesSite.tsx
+++ b/packages/frontend/src/Pages/PagesSite.tsx
@@ -1,4 +1,10 @@
 import { ClassicyButton, ClassicyIcons } from "classicy";
+// Classicy styles + Platinum fonts moved out of the entry chunk (the fonts
+// alone are ~900 kB of base64 the mobile shell shouldn't parse at boot); this
+// surface uses the Classicy look, so it imports both itself — classicy.css
+// otherwise arrives via boot/AppProviders.tsx, which pages never mount.
+import "classicy/dist/classicy.css";
+import "classicy/dist/fonts.css";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { initGoogleAnalytics, trackPageView } from "../lib/analytics";
 import { DIRECTUS_URL } from "../lib/endpoints";

--- a/packages/frontend/src/app.tsx
+++ b/packages/frontend/src/app.tsx
@@ -1,49 +1,51 @@
 import { Component, lazy, StrictMode, Suspense, type ReactNode } from "react";
 import { createRoot } from "react-dom/client";
 import "./app.css";
-import "classicy/dist/classicy.css";
-// Opt-in since classicy 0.70.0, which split every base64 @font-face rule out
-// of classicy.css into this sibling stylesheet so consumers aren't forced to
-// download ~900 kB of fonts they may not use. We DO use them — Chicago,
-// Geneva, Monaco and Charcoal are the whole Platinum look — so we opt in.
-// Dropping this import doesn't error, it just silently falls back to system
-// fonts everywhere.
-import "classicy/dist/fonts.css";
-import { ClassicyAppManagerProvider, registerClassicyFileSystemAdapter } from "classicy";
-import { directusFilesystemAdapter } from "./Providers/FilesystemSync/directusFilesystemAdapter";
-import { FilesystemSyncProvider } from "./Providers/FilesystemSync/FilesystemSyncProvider";
-import { DefaultFileSystem } from "./data/DefaultFileSystem";
-// Desktop is imported EAGERLY on purpose: mounting ClassicyDesktop lazily
-// (a tick after ClassicyAppManagerProvider) corrupts classicy's manager
-// state — early dispatches hit a reducer that iterates state the desktop
-// hasn't seeded yet, and every dispatch after that throws (windows can no
-// longer open). Verified empirically 2026-07-14: `lazy(() =>
-// import("./Desktop"))` alone reproduces it; a static import is clean.
-// Re-splitting the desktop chunk for mobile is blocked on a classicy fix.
-import Desktop from "./Desktop";
 import { isMobileDevice } from "./Mobile/detectMobile";
-import { GA_MEASUREMENT_ID, isProductionHost } from "./lib/analytics";
+import { runWhenIdle } from "./lib/runWhenIdle";
 import { pagesRouteSlug } from "./Pages/route";
-import { AuthProvider } from "./Providers/Auth/AuthProvider";
-import { MediaStreamProvider } from "./Providers/MediaStream/MediaStreamProvider";
-import { PlaylistProvider } from "./Providers/Playlist/PlaylistProvider";
-import { initTracker } from "./openreplay";
 
-initTracker();
+// The entry stays tiny and branch-blind: each boot surface is its own lazy
+// chunk, so a phone parses the iPod shell's graph without the desktop's
+// application code, and the desktop never waits on mobile code. The provider
+// tree lives INSIDE DesktopRoot/MobileRoot (see boot/AppProviders.tsx) so
+// ClassicyAppManagerProvider always mounts in the same commit as its shell —
+// the lazy-ClassicyDesktop corruption documented in DesktopRoot.tsx cannot
+// occur, because there is no provider-mounted-without-desktop tick.
+const DesktopRoot = lazy(() => import("./DesktopRoot"));
+const MobileRoot = lazy(() => import("./MobileRoot"));
 
-// Sync the signed-in user's filesystem to Directus/Wasabi. Snapshot mode with a
-// 3s debounce so rapid edits coalesce into one upload; anonymous users are a no-op.
-registerClassicyFileSystemAdapter(directusFilesystemAdapter, { snapshotDebounceMs: 3000 });
-
-const IpodShell = lazy(() => import("./Mobile/IpodShell"));
-
-// The CMS pages surface. Safe to lazy-load, unlike Desktop: it is static chrome
-// styled to resemble Classicy and mounts no ClassicyDesktop, so the app-manager
-// corruption described above does not apply.
+// The CMS pages surface. Static chrome styled to resemble Classicy; mounts no
+// ClassicyDesktop and no app manager, so it is safe as its own lazy chunk.
 const PagesSite = lazy(() => import("./Pages/PagesSite"));
 
-// If the mobile chunk fails to load (bad network, stale deploy), fall back to
-// the desktop branch — never a blank page.
+const mobile = isMobileDevice();
+
+// A CMS page is present-day static content: it reads Directus directly and has
+// nothing to do with the virtual clock, the streamer, playlists, auth, or the
+// user filesystem. Branching here rather than inside the tree means visiting
+// /about does not spin up a WebSocket to the streamer or boot the app manager.
+const pageSlug = pagesRouteSlug(window.location.pathname);
+
+// OpenReplay session replay. On phones it is deferred past boot: the tracker
+// observes every DOM mutation from the moment it starts, and the iPod shell
+// re-renders on each clock tick and stream frame — starting it during boot
+// makes the first taps compete with recording overhead on top of script
+// parse. Desktop and pages start immediately, as they always have. The
+// dynamic import also keeps the tracker out of the entry chunk; openreplay.ts
+// is a module singleton, so identifyUser()/track*() callers in the app see
+// the same instance once this init runs.
+const startTracker = () =>
+	void import("./openreplay").then((m) => m.initTracker());
+if (mobile && pageSlug === null) {
+	runWhenIdle(startTracker);
+} else {
+	startTracker();
+}
+
+// If the mobile chunk fails to load (bad network, stale deploy) or the shell
+// throws, fall back to the desktop branch — never a blank page. DesktopRoot
+// mounts a fresh provider + desktop together, so the fallback is a clean boot.
 class MobileFallbackBoundary extends Component<
 	{ children: ReactNode },
 	{ failed: boolean }
@@ -63,97 +65,25 @@ class MobileFallbackBoundary extends Component<
 		}
 	}
 	render() {
-		return this.state.failed ? <Desktop /> : this.props.children;
+		return this.state.failed ? <DesktopRoot /> : this.props.children;
 	}
 }
-
-const mobile = isMobileDevice();
 
 const rootElement = document.getElementById("root");
 if (!rootElement) throw new Error("Root element not found");
 
-// A CMS page is present-day static content: it reads Directus directly and has
-// nothing to do with the virtual clock, the streamer, playlists, auth, or the
-// user filesystem. Branching here rather than inside the tree means visiting
-// /about does not spin up a WebSocket to the streamer or boot the app manager.
-const pageSlug = pagesRouteSlug(window.location.pathname);
-
 createRoot(rootElement).render(
-	pageSlug !== null ? (
-		<StrictMode>
-			<Suspense fallback={null}>
-				<PagesSite />
-			</Suspense>
-		</StrictMode>
-	) : (
 	<StrictMode>
-		<ClassicyAppManagerProvider
-			// Desktop-branch analytics. The pages branch above mounts outside this
-			// provider and loads the same property itself — see lib/analytics.ts.
-			// Empty outside production hostnames: classicy wires gaMeasurementIds
-			// straight into its own GA plugin with no gating of its own, so dev/CI/
-			// PR-preview hosts would otherwise report real hits into production GA.
-			gaMeasurementIds={isProductionHost() ? [GA_MEASUREMENT_ID] : []}
-			defaultFileSystem={DefaultFileSystem}
-			defaultFileSystemMode="exclusive"
-			defaultState={{
-				System: {
-					Manager: {
-						DateAndTime: {
-							// Boot the desktop clock at 8:40 AM US Eastern on
-							// 2001-09-11 (EDT, UTC-4 → 12:40 UTC). Seed-only: applies
-							// on a fresh visit; persisted state wins on reload.
-							dateTime: "2001-09-11T12:40:00.000Z",
-							timeZoneOffset: "-4",
-							// Date & Time's Sync takes only the real-world time of
-							// day and leaves the calendar date alone — this desktop
-							// is pinned to 2001-09-11, so a plain Sync would drag it
-							// to today and strand every app with no media to play.
-							syncTimeOnly: true,
-						},
-						Applications: {
-							apps: {
-								"TV.app": {
-									data: {
-										// Hide lower-priority / non-US channels by default.
-										// Users can re-enable any of these via TV Settings.
-										disabledChannels: [
-											"ANT1",
-											"AZT",
-											"BET",
-											"CCTV4",
-											"IRAQ",
-											"MCM",
-											"MSNBC",
-											"PSC",
-											"WETA",
-										],
-									},
-								},
-							},
-						},
-					},
-				},
-			}}
-		>
-			<PlaylistProvider>
-				<AuthProvider>
-					<FilesystemSyncProvider>
-						<MediaStreamProvider>
-							<Suspense fallback={null}>
-								{mobile ? (
-									<MobileFallbackBoundary>
-										<IpodShell />
-									</MobileFallbackBoundary>
-								) : (
-									<Desktop />
-								)}
-							</Suspense>
-						</MediaStreamProvider>
-					</FilesystemSyncProvider>
-				</AuthProvider>
-			</PlaylistProvider>
-		</ClassicyAppManagerProvider>
-	</StrictMode>
-	),
+		<Suspense fallback={null}>
+			{pageSlug !== null ? (
+				<PagesSite />
+			) : mobile ? (
+				<MobileFallbackBoundary>
+					<MobileRoot />
+				</MobileFallbackBoundary>
+			) : (
+				<DesktopRoot />
+			)}
+		</Suspense>
+	</StrictMode>,
 );

--- a/packages/frontend/src/boot/AppProviders.tsx
+++ b/packages/frontend/src/boot/AppProviders.tsx
@@ -1,0 +1,83 @@
+// The provider tree shared by both boot branches (DesktopRoot / MobileRoot).
+// Extracted from app.tsx so the entry chunk can lazy-load one branch or the
+// other: phones stop parsing the desktop's application code just to render
+// the iPod shell. Everything here mounts in the SAME commit as the branch's
+// shell component (Desktop or IpodShell), which preserves the invariant
+// documented in DesktopRoot.tsx — ClassicyDesktop must never mount a tick
+// after ClassicyAppManagerProvider.
+import "classicy/dist/classicy.css";
+import type { ReactNode } from "react";
+import { ClassicyAppManagerProvider, registerClassicyFileSystemAdapter } from "classicy";
+import { DefaultFileSystem } from "../data/DefaultFileSystem";
+import { GA_MEASUREMENT_ID, isProductionHost } from "../lib/analytics";
+import { AuthProvider } from "../Providers/Auth/AuthProvider";
+import { directusFilesystemAdapter } from "../Providers/FilesystemSync/directusFilesystemAdapter";
+import { FilesystemSyncProvider } from "../Providers/FilesystemSync/FilesystemSyncProvider";
+import { MediaStreamProvider } from "../Providers/MediaStream/MediaStreamProvider";
+import { PlaylistProvider } from "../Providers/Playlist/PlaylistProvider";
+
+// Sync the signed-in user's filesystem to Directus/Wasabi. Snapshot mode with a
+// 3s debounce so rapid edits coalesce into one upload; anonymous users are a no-op.
+registerClassicyFileSystemAdapter(directusFilesystemAdapter, { snapshotDebounceMs: 3000 });
+
+export function AppProviders({ children }: { children: ReactNode }) {
+	return (
+		<ClassicyAppManagerProvider
+			// Desktop/mobile-branch analytics. The pages branch mounts outside this
+			// provider and loads the same property itself — see lib/analytics.ts.
+			// Empty outside production hostnames: classicy wires gaMeasurementIds
+			// straight into its own GA plugin with no gating of its own, so dev/CI/
+			// PR-preview hosts would otherwise report real hits into production GA.
+			gaMeasurementIds={isProductionHost() ? [GA_MEASUREMENT_ID] : []}
+			defaultFileSystem={DefaultFileSystem}
+			defaultFileSystemMode="exclusive"
+			defaultState={{
+				System: {
+					Manager: {
+						DateAndTime: {
+							// Boot the desktop clock at 8:40 AM US Eastern on
+							// 2001-09-11 (EDT, UTC-4 → 12:40 UTC). Seed-only: applies
+							// on a fresh visit; persisted state wins on reload.
+							dateTime: "2001-09-11T12:40:00.000Z",
+							timeZoneOffset: "-4",
+							// Date & Time's Sync takes only the real-world time of
+							// day and leaves the calendar date alone — this desktop
+							// is pinned to 2001-09-11, so a plain Sync would drag it
+							// to today and strand every app with no media to play.
+							syncTimeOnly: true,
+						},
+						Applications: {
+							apps: {
+								"TV.app": {
+									data: {
+										// Hide lower-priority / non-US channels by default.
+										// Users can re-enable any of these via TV Settings.
+										disabledChannels: [
+											"ANT1",
+											"AZT",
+											"BET",
+											"CCTV4",
+											"IRAQ",
+											"MCM",
+											"MSNBC",
+											"PSC",
+											"WETA",
+										],
+									},
+								},
+							},
+						},
+					},
+				},
+			}}
+		>
+			<PlaylistProvider>
+				<AuthProvider>
+					<FilesystemSyncProvider>
+						<MediaStreamProvider>{children}</MediaStreamProvider>
+					</FilesystemSyncProvider>
+				</AuthProvider>
+			</PlaylistProvider>
+		</ClassicyAppManagerProvider>
+	);
+}

--- a/packages/frontend/src/lib/runWhenIdle.ts
+++ b/packages/frontend/src/lib/runWhenIdle.ts
@@ -1,0 +1,14 @@
+/**
+ * Run non-urgent boot work after the main thread has gone idle, so it never
+ * competes with first paint or the user's first taps. iOS Safari gained
+ * requestIdleCallback only recently, so older WebKit falls back to a fixed
+ * post-boot delay. The `timeout` bounds how long "idle" can be deferred on a
+ * busy page before the work runs anyway.
+ */
+export function runWhenIdle(work: () => void, timeoutMs = 10000): void {
+	if (typeof window.requestIdleCallback === "function") {
+		window.requestIdleCallback(() => work(), { timeout: timeoutMs });
+	} else {
+		window.setTimeout(work, Math.min(timeoutMs, 5000));
+	}
+}

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -154,7 +154,22 @@ const localProxy: Record<string, ProxyOptions> = {
 // https://vite.dev/config/
 export default defineConfig({
 	plugins: [react(), crossOriginIsolationExceptPages()],
-	server: { proxy: localProxy },
+	server: {
+		proxy: localProxy,
+		// The boot branches are lazy chunks (app.tsx → DesktopRoot/MobileRoot),
+		// so on a COLD dev server their module graphs aren't discovered until
+		// the entry has executed and the dynamic import lands — a second,
+		// serialized transform phase that landed AFTER page load. That pushed
+		// first-boot-to-desktop past the 5s expect budget of the quickest e2e
+		// specs in CI (measured: goto→desktop 5.9s cold vs 0.9s on the old
+		// eager entry; specs later in the run pass because the server is warm
+		// by then). Pre-transform both branch graphs at server startup so the
+		// first navigation finds them hot. Dev-only; the production bundle is
+		// prebuilt and unaffected.
+		warmup: {
+			clientFiles: ["./src/DesktopRoot.tsx", "./src/MobileRoot.tsx"],
+		},
+	},
 	// `vite preview` serves the built bundle, and a production-mode build bakes
 	// the ABSOLUTE Directus URL — which localhost can't call. Pair this with
 	// `vite build --mode preview` (see the preview:auth script) so the bundle


### PR DESCRIPTION
## Problem

The mobile (iPod) shell is sluggish on iPhone Safari — tapping a menu item takes visibly long to respond. Profiling the built bundle found two compounding causes:

1. **The phone booted the entire desktop.** `app.tsx` imported `Desktop` eagerly (the documented workaround for classicy's lazy-`ClassicyDesktop` corruption), so a phone parsed the desktop's whole application graph — ~0.8 MB of desktop-only JS, ~0.9 MB of base64 Platinum fonts (`classicy/dist/fonts.css`), and the OpenReplay tracker — before a 5-row menu could respond. The iPod shell's own chunk is 27 kB.
2. **Steady-state churn.** The shell subscribes to the whole `MediaStreamContext`, so it re-renders on every stream frame plus the 1 Hz clock tick, re-reconciling the vendored SVG chrome and active screen each time — with OpenReplay recording every one of those DOM mutations from boot.

(Safari's classic 350 ms tap delay was ruled out: `touch-action: manipulation` and a `width=device-width` viewport are already in place.)

## Changes

**Boot split** — the entry is now branch-blind and lazy-loads one of two roots:
- `DesktopRoot.tsx` — providers + `Desktop` + fonts, all eager *within* the chunk.
- `MobileRoot.tsx` — providers + `IpodShell`; no desktop code in the graph. Fonts and OpenReplay start via `runWhenIdle()` (`requestIdleCallback` with a `setTimeout` fallback for older WebKit) so they never compete with first paint or first taps.
- `boot/AppProviders.tsx` — the provider tree, moved out of `app.tsx`. Because the provider now lives **inside** each lazy root, `ClassicyAppManagerProvider` always mounts in the same commit as its shell — the lazy-`ClassicyDesktop` corruption documented in the old `app.tsx` comment cannot occur (there is never a provider-without-desktop tick), which is what unblocks the split without an upstream classicy fix.
- `PagesSite` imports `classicy.css`/`fonts.css` itself now that the entry no longer provides them globally.
- `vite.config.ts` gains `server.warmup` for both roots: on a cold dev server the lazy split deferred desktop-graph discovery until after page load, pushing first-boot past the quickest e2e specs' 5 s assert in CI (measured cold goto→desktop: 0.9 s eager → 5.9 s split → 2.5 s with warmup). Dev-only; the production bundle is prebuilt.

**Steady-state calm** —
- `useClickWheel` returns a stable object (identity changes only with `pressed`).
- `IpodChrome`: vendored artwork hoisted to module-constant elements; the wheel/buttons section is `memo`ized on the `ClickWheel` object.
- Every screen is `memo`ized at the shell, so ambient re-renders reconcile only the header text.
- `cursor: pointer` on menu rows for prompt iOS click dispatch.

## Measurements (built bundle)

| | before | after |
|---|---|---|
| Mobile critical-path fetches | one 10.9 MB `index.js` + 0.9 MB fonts CSS | entry 189 kB + `MobileRoot` 27 kB + shared chunks; **no `DesktopRoot`, fonts/openreplay idle-deferred** |
| Desktop-only JS parsed on phones | ~0.8 MB (+181 kB tracker at boot) | 0 (tracker at idle) |
| Tap→navigate, 6× CPU throttle | 54–145 ms | 47–98 ms (~30% better), idle long tasks 1 → 0 |

**Known limit:** the dominant remaining boot cost is classicy itself — a single ~9.3 MB chunk both surfaces need (the shell uses its app-manager/clock hooks). A real fix needs an upstream `classicy/core` subpath export (state manager + hooks without the bundled desktop OS); worth filing against classicy.

## Verification

- `tsc -b`, `oxlint` clean; `vitest run` passing locally (the 2 `alertsSettings` failures pre-date this change — fail identically on a clean tree, A/B'd via stash).
- Playwright e2e green in CI on the merged head after the warmup fix; the desktop window-opening flows (`about-app`, `account`) pass, confirming the lazy-root pattern doesn't corrupt the classicy manager.
- Built-bundle network audit per branch confirms the chunk graph above.

*(Note: the reload-resume / audio-resync work briefly described here post-merge landed separately in #548 — it was pushed minutes after this PR merged.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbHaqWdA8iVcRLoPtpFJHU