### PR TITLE
feat(mobile): resume the tuned source after a reload, in sync with the clock

### DIFF
--- a/packages/frontend/src/Applications/radio-core/StationPlayer.test.tsx
+++ b/packages/frontend/src/Applications/radio-core/StationPlayer.test.tsx
@@ -180,6 +180,31 @@ describe("StationPlayer", () => {
 			expect(playSpy).toHaveBeenCalled();
 		});
 
+		it("re-anchors a blocked element to the clock when the gesture finally starts it", () => {
+			// The virtual clock keeps running while an element sits autoplay-
+			// blocked (on mobile every fresh page load is blocked until the first
+			// tap). Resuming from the offset computed at load time started audio
+			// behind the clock — and drift under the health check's 30s window
+			// stuck until the next scrub. tryPlay must re-seek before starting.
+			let now = t("2001-09-11T12:47:00Z");
+			const { container } = render(
+				<StationPlayer {...base} getNowMs={() => now} />,
+			);
+			const audio = container.querySelector('audio[src="a.mp3"]') as HTMLAudioElement;
+			audio.currentTime = 420; // synced when metadata loaded at 12:47 (item started 12:40)
+			now += 20_000; // 20s pass while playback stays blocked
+			document.dispatchEvent(new Event("click"));
+			expect(audio.currentTime).toBe(440); // resumed AT the clock, not 20s behind
+		});
+
+		it("leaves currentTime alone on a healthy start (drift inside tolerance)", () => {
+			const { container } = render(<StationPlayer {...base} />);
+			const audio = container.querySelector('audio[src="a.mp3"]') as HTMLAudioElement;
+			audio.currentTime = 419.5; // half a second off expected 420: not worth a stutter
+			document.dispatchEvent(new Event("click"));
+			expect(audio.currentTime).toBe(419.5);
+		});
+
 		it("does not retry while the clock is paused", () => {
 			render(<StationPlayer {...base} clockPaused={true} />);
 			playSpy.mockClear();

--- a/packages/frontend/src/Applications/radio-core/StationPlayer.tsx
+++ b/packages/frontend/src/Applications/radio-core/StationPlayer.tsx
@@ -74,6 +74,8 @@ export const StationPlayer: React.FC<StationPlayerProps> = ({
 	clockPausedRef.current = clockPaused;
 	const getNowMsRef = useRef(getNowMs);
 	getNowMsRef.current = getNowMs;
+	const stationRef = useRef(station);
+	stationRef.current = station;
 
 	// Elements whose play() has resolved at least once. Until then an element
 	// must stay el.muted = true (that's what lets the browser permit autoplay),
@@ -104,6 +106,21 @@ export const StationPlayer: React.FC<StationPlayerProps> = ({
 	// any success clears the element's token.
 	const tryPlay = useCallback(
 		(id: number, el: HTMLAudioElement) => {
+			// Re-anchor to the virtual clock before starting. A blocked element
+			// resumes from the currentTime it had when its metadata loaded, but the
+			// clock kept running while it sat paused — and Safari refuses every
+			// gesture-less play() after a page load, so on mobile a fresh page
+			// always sits blocked until the first tap. That gap used to persist as
+			// audible desync: the health check only corrects drift beyond 30s, so
+			// anything smaller stuck until the next clock scrub re-seeked it
+			// ("starts at the wrong point until you change the time"). The 2s
+			// tolerance leaves healthy starts (canplay right after loadedmetadata,
+			// clock-pause resumes, where the clock was frozen too) alone.
+			const item = stationRef.current.items.find((i) => i.id === id);
+			if (item) {
+				const expected = calcSeekSeconds(item, getNowMsRef.current());
+				if (Math.abs(el.currentTime - expected) > 2) el.currentTime = expected;
+			}
 			el.play()
 				.then(() => {
 					clearAudioBlocked(`play-${id}`);

--- a/packages/frontend/src/Mobile/IpodShell.test.tsx
+++ b/packages/frontend/src/Mobile/IpodShell.test.tsx
@@ -43,6 +43,9 @@ afterEach(() => {
 	mockDateTimeLocked = false;
 	mockPause.mockClear();
 	mockResume.mockClear();
+	// Tuning persists the now-playing source (nowPlayingStore.ts); clear it so
+	// one test's tuned station never boots the next test's shell pre-tuned.
+	window.localStorage.clear();
 });
 window.HTMLElement.prototype.scrollIntoView = vi.fn();
 
@@ -229,5 +232,53 @@ describe("IpodShell forced clock", () => {
 		pressPlayPause(container);
 		expect(mockPause).toHaveBeenCalledTimes(1); // mocked paused: false → pause()
 		expect(mockResume).not.toHaveBeenCalled();
+	});
+});
+
+// A refreshed/reopened phone resumes the tuned source: the shell seeds
+// nowPlaying from nowPlayingStore (localStorage) and writes every change
+// back. The virtual clock itself survives reloads via classicy's persisted
+// store, so restoring the source is what makes "close and reopen" come back
+// playing the same station at the same moment.
+describe("IpodShell now-playing persistence", () => {
+	it("restores a persisted radio station on boot", () => {
+		window.localStorage.setItem(
+			"rt911IpodNowPlaying",
+			JSON.stringify({ kind: "radio", key: "WINS" }),
+		);
+		renderShell(STREAM_UP);
+		expect(screen.getByTestId("station-player")).toBeTruthy();
+		expect(screen.queryByTestId("qt-embed")).toBeNull();
+	});
+
+	it("restores a persisted TV channel on boot (hidden on the menu, audio alive)", () => {
+		window.localStorage.setItem(
+			"rt911IpodNowPlaying",
+			JSON.stringify({ kind: "tv", id: 42 }),
+		);
+		renderShell(STREAM_UP);
+		expect(screen.getByTestId("qt-embed")).toBeTruthy();
+		// Boot lands on the menu; the player is mounted but hidden, same as
+		// backing out of Now Playing with MENU.
+		expect(document.querySelector(".ipodTvPlayerHidden")).toBeTruthy();
+	});
+
+	it("boots untuned when the persisted source references nothing in the stream", () => {
+		window.localStorage.setItem(
+			"rt911IpodNowPlaying",
+			JSON.stringify({ kind: "tv", id: 999 }),
+		);
+		renderShell(STREAM_UP);
+		expect(screen.queryByTestId("qt-embed")).toBeNull();
+		expect(screen.queryByTestId("station-player")).toBeNull();
+	});
+
+	it("persists tuning so the next boot can restore it", () => {
+		renderShell(STREAM_UP);
+		fireEvent.click(screen.getByText("TV"));
+		fireEvent.click(screen.getByText("WABC"));
+		expect(
+			JSON.parse(window.localStorage.getItem("rt911IpodNowPlaying") ?? "null"),
+		).toEqual({ kind: "tv", id: 42 });
 	});
 });

--- a/packages/frontend/src/Mobile/IpodShell.tsx
+++ b/packages/frontend/src/Mobile/IpodShell.tsx
@@ -28,6 +28,11 @@ import {
 	screenStackReducer,
 	type ScreenId,
 } from "./screenStack";
+import {
+	loadNowPlaying,
+	type NowPlayingSource,
+	saveNowPlaying,
+} from "./nowPlayingStore";
 import { TvPlayer } from "./TvPlayer";
 import { useClickWheel } from "./useClickWheel";
 import { useFineClock } from "./useFineClock";
@@ -51,11 +56,7 @@ const APP_ID = "IpodShell.mobile";
 // its reference is stable — useMediaStream memoizes the filtered list on it.
 const TV_CHANNELS_FILTER: MediaStreamFilter = { format: ["m3u8"], approved: true };
 
-/** The single "now playing" source — tuning either kind evicts the other,
- *  which is the whole one-at-a-time rule (design decision 2026-07-15). */
-export type NowPlayingSource =
-	| { kind: "radio"; key: string }
-	| { kind: "tv"; id: number };
+export type { NowPlayingSource } from "./nowPlayingStore";
 
 // The mobile shell never shows the waveform (showWaveform is always false),
 // so StationPlayer's viz props are inert here — defaults and a stable no-op.
@@ -102,7 +103,18 @@ export default function IpodShell() {
 		return () => unsubscribeMp3(APP_ID);
 	}, [subscribeMp3, unsubscribeMp3]);
 
-	const [nowPlaying, setNowPlaying] = useState<NowPlayingSource | null>(null);
+	// Seeded from localStorage so a refreshed/reopened phone resumes the same
+	// tuned station or channel (the virtual clock already survives reloads via
+	// classicy's persisted store); saved back on every change below. The
+	// persisted key/id may reference a station or channel that no longer
+	// exists — the activeStation/activeTvItem lookups already resolve that to
+	// null, so nothing mounts until the stream delivers a match.
+	const [nowPlaying, setNowPlaying] = useState<NowPlayingSource | null>(
+		loadNowPlaying,
+	);
+	useEffect(() => {
+		saveNowPlaying(nowPlaying);
+	}, [nowPlaying]);
 	const stations = useMemo(
 		() => mergeWithSources(sources.audio, mp3Items),
 		[sources.audio, mp3Items],

--- a/packages/frontend/src/Mobile/nowPlayingStore.test.ts
+++ b/packages/frontend/src/Mobile/nowPlayingStore.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadNowPlaying, saveNowPlaying } from "./nowPlayingStore";
+
+const KEY = "rt911IpodNowPlaying";
+
+afterEach(() => {
+	window.localStorage.clear();
+	vi.restoreAllMocks();
+});
+
+describe("nowPlayingStore", () => {
+	it("round-trips a radio source", () => {
+		saveNowPlaying({ kind: "radio", key: "WINS" });
+		expect(loadNowPlaying()).toEqual({ kind: "radio", key: "WINS" });
+	});
+
+	it("round-trips a TV source", () => {
+		saveNowPlaying({ kind: "tv", id: 42 });
+		expect(loadNowPlaying()).toEqual({ kind: "tv", id: 42 });
+	});
+
+	it("clears the stored source on null", () => {
+		saveNowPlaying({ kind: "radio", key: "WINS" });
+		saveNowPlaying(null);
+		expect(window.localStorage.getItem(KEY)).toBeNull();
+		expect(loadNowPlaying()).toBeNull();
+	});
+
+	it("loads null when nothing was stored", () => {
+		expect(loadNowPlaying()).toBeNull();
+	});
+
+	// localStorage survives deploys, so a stored value is untrusted input: any
+	// shape mismatch must fall back to "nothing tuned", never crash boot.
+	it("rejects corrupt JSON and malformed shapes", () => {
+		window.localStorage.setItem(KEY, "{not json");
+		expect(loadNowPlaying()).toBeNull();
+		window.localStorage.setItem(KEY, JSON.stringify({ kind: "radio" }));
+		expect(loadNowPlaying()).toBeNull();
+		window.localStorage.setItem(KEY, JSON.stringify({ kind: "tv", id: "42" }));
+		expect(loadNowPlaying()).toBeNull();
+		window.localStorage.setItem(KEY, JSON.stringify({ kind: "cassette", id: 1 }));
+		expect(loadNowPlaying()).toBeNull();
+		window.localStorage.setItem(KEY, JSON.stringify("radio"));
+		expect(loadNowPlaying()).toBeNull();
+	});
+
+	it("degrades to session-only when storage throws (private-mode Safari)", () => {
+		vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+			throw new Error("denied");
+		});
+		vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+			throw new Error("denied");
+		});
+		expect(loadNowPlaying()).toBeNull();
+		expect(() => saveNowPlaying({ kind: "radio", key: "WINS" })).not.toThrow();
+	});
+});

--- a/packages/frontend/src/Mobile/nowPlayingStore.ts
+++ b/packages/frontend/src/Mobile/nowPlayingStore.ts
@@ -1,0 +1,48 @@
+// Persistence for the iPod shell's tuned "now playing" source, so a phone
+// that is refreshed or closed and reopened comes back with the same radio
+// station or TV channel playing (the virtual clock already survives reloads
+// via classicy's persisted store, so the media resumes at the moment the
+// page went away). Same localStorage-mirror pattern as
+// Applications/Alerts/alertsSettings.ts: throw-safe accessors so private-mode
+// Safari (where storage access throws) degrades to session-only behavior.
+//
+// The stored value is re-validated on load — localStorage survives deploys,
+// so treat it as untrusted input and fall back to "nothing tuned" on any
+// shape mismatch rather than letting a stale write crash boot.
+
+/** The single "now playing" source — tuning either kind evicts the other,
+ *  which is the whole one-at-a-time rule (design decision 2026-07-15). */
+export type NowPlayingSource =
+	| { kind: "radio"; key: string }
+	| { kind: "tv"; id: number };
+
+const STORAGE_KEY = "rt911IpodNowPlaying";
+
+function isNowPlayingSource(v: unknown): v is NowPlayingSource {
+	if (typeof v !== "object" || v === null) return false;
+	const s = v as Record<string, unknown>;
+	if (s.kind === "radio") return typeof s.key === "string" && s.key.length > 0;
+	if (s.kind === "tv") return typeof s.id === "number" && Number.isFinite(s.id);
+	return false;
+}
+
+export function loadNowPlaying(): NowPlayingSource | null {
+	try {
+		const raw = window.localStorage.getItem(STORAGE_KEY);
+		if (!raw) return null;
+		const parsed: unknown = JSON.parse(raw);
+		return isNowPlayingSource(parsed) ? parsed : null;
+	} catch {
+		// Storage unavailable (private-mode Safari) or corrupt JSON: boot untuned.
+		return null;
+	}
+}
+
+export function saveNowPlaying(source: NowPlayingSource | null): void {
+	try {
+		if (source === null) window.localStorage.removeItem(STORAGE_KEY);
+		else window.localStorage.setItem(STORAGE_KEY, JSON.stringify(source));
+	} catch {
+		// Storage unavailable: the tuned source is session-only.
+	}
+}


### PR DESCRIPTION
Continuation of #547 — that PR merged a few minutes before this commit was pushed to its branch, so the resume work needed a fresh PR (the branch was restarted from `main`; this is the one stranded commit rebased onto the merge).

## What

Two halves of "close/refresh the phone and come back where you were":

**1. Restore what was playing.** The virtual clock already survives reloads via classicy's persisted store, but the iPod shell's tuned source (radio station / TV channel) lived in plain `useState` and died with the page. New `Mobile/nowPlayingStore.ts` persists it in localStorage — the same throw-safe mirror pattern as `Alerts/alertsSettings.ts` (private-mode Safari degrades to session-only), with the stored value re-validated on load since localStorage outlives deploys. The shell seeds `nowPlaying` from it and writes every change back, so a reopened phone remounts the same station or channel at the persisted moment. A stale key that no longer matches the stream resolves to null exactly as before. iOS still requires a first tap before restored audio is audible — the existing gesture-retry path starts it.

**2. Start it at the right point** (the reported "audio starts at the wrong point after a refresh until you change the time"). `StationPlayer` set each clip's `currentTime` once, at `loadedmetadata` — but Safari refuses every gesture-less `play()` after a page load, so on mobile the element sat blocked while the virtual clock ran on, then resumed from the stale offset on the user's first tap. Drift under the health check's 30 s window persisted indefinitely; only a clock scrub (>5 s jump) re-seeked it. `tryPlay` now re-anchors the element to the clock (2 s tolerance) before starting, so late-unlocked audio comes in synced. Desktop rarely hit this because the POWER ON click grants user activation before any media mounts; the mobile shell has no such gate.

## Verification

- `tsc -b`, `oxlint` clean; `vitest run` 3299 passed (the 2 `alertsSettings` failures pre-date this change and fail identically on a clean tree).
- New unit tests: now-playing store (round-trip, corrupt/malformed values, throwing storage), shell restore/persist on boot (radio, TV, stale key), and the blocked-playback re-anchor (clock advances 20 s while blocked → resumes at the clock; sub-tolerance drift left alone).
- Browser smoke of the `?ipod` boot with a persisted source seeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbHaqWdA8iVcRLoPtpFJHU

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbHaqWdA8iVcRLoPtpFJHU)_