### PR TITLE
fix(mobile): clock-synced audio on iOS; wheel time skips, About scrolling, station logos

### DIFF
--- a/packages/frontend/src/Applications/radio-core/StationPlayer.test.tsx
+++ b/packages/frontend/src/Applications/radio-core/StationPlayer.test.tsx
@@ -64,7 +64,11 @@ describe("StationPlayer", () => {
 	it("renders one <audio> per in-window segment with its url (overlap → both)", () => {
 		const { container } = render(<StationPlayer {...base} />);
 		const audios = Array.from(container.querySelectorAll("audio"));
-		expect(audios.map((a) => a.getAttribute("src")).sort()).toEqual(["a.mp3", "b.mp3"]);
+		// Each src carries a #t= start-position fragment at its clock offset.
+		expect(audios.map((a) => a.getAttribute("src")).sort()).toEqual([
+			"a.mp3#t=420",
+			"b.mp3#t=120",
+		]);
 	});
 
 	it("renders no <audio> in a gap between segments", () => {
@@ -100,7 +104,9 @@ describe("StationPlayer", () => {
 	it("sets volume 0 for files in mutedItems and 1 for others", () => {
 		const { container } = render(<StationPlayer {...base} mutedItems={[1]} />);
 		const audios = Array.from(container.querySelectorAll("audio")) as HTMLAudioElement[];
-		const bySrc = new Map(audios.map((a) => [a.getAttribute("src"), a.volume]));
+		const bySrc = new Map(
+			audios.map((a) => [(a.getAttribute("src") ?? "").split("#")[0], a.volume]),
+		);
 		expect(bySrc.get("a.mp3")).toBe(0); // id 1 muted
 		expect(bySrc.get("b.mp3")).toBe(1); // id 2 not muted
 	});
@@ -124,7 +130,7 @@ describe("StationPlayer", () => {
 
 	it("mutes a playing element via el.muted, not just volume", async () => {
 		const { container, rerender } = render(<StationPlayer {...base} />);
-		const audio = container.querySelector('audio[src="a.mp3"]') as HTMLAudioElement;
+		const audio = container.querySelector('audio[src^="a.mp3"]') as HTMLAudioElement;
 		await unlock(audio);
 		expect(audio.muted).toBe(false);
 		rerender(<StationPlayer {...base} mutedItems={[1]} />);
@@ -134,7 +140,7 @@ describe("StationPlayer", () => {
 
 	it("unmuting a playing element restores el.muted = false", async () => {
 		const { container, rerender } = render(<StationPlayer {...base} mutedItems={[1]} />);
-		const audio = container.querySelector('audio[src="a.mp3"]') as HTMLAudioElement;
+		const audio = container.querySelector('audio[src^="a.mp3"]') as HTMLAudioElement;
 		await unlock(audio);
 		expect(audio.muted).toBe(true); // canplay while muted keeps it silent
 		rerender(<StationPlayer {...base} mutedItems={[]} />);
@@ -144,7 +150,7 @@ describe("StationPlayer", () => {
 
 	it("never unmutes an element still waiting for its autoplay unlock", () => {
 		const { rerender, container } = render(<StationPlayer {...base} mutedItems={[2]} />);
-		const audio = container.querySelector('audio[src="a.mp3"]') as HTMLAudioElement;
+		const audio = container.querySelector('audio[src^="a.mp3"]') as HTMLAudioElement;
 		expect(audio.muted).toBe(true); // pre-play autoplay mute
 		rerender(<StationPlayer {...base} mutedItems={[]} />);
 		expect(audio.muted).toBe(true); // mute-state change must not unlock it
@@ -152,7 +158,7 @@ describe("StationPlayer", () => {
 
 	it("onCanPlay honors the current mute list instead of unconditionally unmuting", async () => {
 		const { container } = render(<StationPlayer {...base} mutedItems={[1]} />);
-		const audio = container.querySelector('audio[src="a.mp3"]') as HTMLAudioElement;
+		const audio = container.querySelector('audio[src^="a.mp3"]') as HTMLAudioElement;
 		await unlock(audio);
 		expect(audio.muted).toBe(true);
 		expect(audio.volume).toBe(0);
@@ -160,7 +166,7 @@ describe("StationPlayer", () => {
 
 	it("mutes and unmutes through the in-graph gain as well (Safari)", () => {
 		const { container, rerender } = render(<StationPlayer {...base} />);
-		const audio = container.querySelector('audio[src="a.mp3"]') as HTMLAudioElement;
+		const audio = container.querySelector('audio[src^="a.mp3"]') as HTMLAudioElement;
 		vi.mocked(setAudioLevel).mockClear();
 		rerender(<StationPlayer {...base} mutedItems={[1]} />);
 		expect(vi.mocked(setAudioLevel)).toHaveBeenCalledWith(audio, 0);
@@ -190,7 +196,7 @@ describe("StationPlayer", () => {
 			const { container } = render(
 				<StationPlayer {...base} getNowMs={() => now} />,
 			);
-			const audio = container.querySelector('audio[src="a.mp3"]') as HTMLAudioElement;
+			const audio = container.querySelector('audio[src^="a.mp3"]') as HTMLAudioElement;
 			audio.currentTime = 420; // synced when metadata loaded at 12:47 (item started 12:40)
 			now += 20_000; // 20s pass while playback stays blocked
 			document.dispatchEvent(new Event("click"));
@@ -199,7 +205,7 @@ describe("StationPlayer", () => {
 
 		it("leaves currentTime alone on a healthy start (drift inside tolerance)", () => {
 			const { container } = render(<StationPlayer {...base} />);
-			const audio = container.querySelector('audio[src="a.mp3"]') as HTMLAudioElement;
+			const audio = container.querySelector('audio[src^="a.mp3"]') as HTMLAudioElement;
 			audio.currentTime = 419.5; // half a second off expected 420: not worth a stutter
 			document.dispatchEvent(new Event("click"));
 			expect(audio.currentTime).toBe(419.5);
@@ -257,7 +263,7 @@ describe("StationPlayer", () => {
 
 		it("marks blocked on a pause it did not initiate (Safari unmute-pause)", () => {
 			const { container, unmount } = render(<StationPlayer {...base} />);
-			const audio = container.querySelector('audio[src="a.mp3"]') as HTMLAudioElement;
+			const audio = container.querySelector('audio[src^="a.mp3"]') as HTMLAudioElement;
 			expect(isAudioBlocked()).toBe(false);
 			fireEvent(audio, new Event("pause"));
 			expect(isAudioBlocked()).toBe(true);
@@ -267,7 +273,7 @@ describe("StationPlayer", () => {
 
 		it("ignores the pause caused by the clock pausing", () => {
 			const { container, rerender } = render(<StationPlayer {...base} />);
-			const audio = container.querySelector('audio[src="a.mp3"]') as HTMLAudioElement;
+			const audio = container.querySelector('audio[src^="a.mp3"]') as HTMLAudioElement;
 			rerender(<StationPlayer {...base} clockPaused={true} />);
 			fireEvent(audio, new Event("pause"));
 			expect(isAudioBlocked()).toBe(false);
@@ -278,7 +284,7 @@ describe("StationPlayer", () => {
 				.spyOn(window.HTMLMediaElement.prototype, "ended", "get")
 				.mockReturnValue(true);
 			const { container } = render(<StationPlayer {...base} />);
-			const audio = container.querySelector('audio[src="a.mp3"]') as HTMLAudioElement;
+			const audio = container.querySelector('audio[src^="a.mp3"]') as HTMLAudioElement;
 			fireEvent(audio, new Event("pause"));
 			expect(isAudioBlocked()).toBe(false);
 			endedSpy.mockRestore();
@@ -310,5 +316,58 @@ describe("StationPlayer", () => {
 			rerender(<StationPlayer {...base} maxVolume={0.2} />);
 			expect(el.volume).toBe(0.2);
 		});
+	});
+});
+
+// iOS Safari clamps currentTime writes whose target isn't buffered yet on
+// long progressive files (desktop browsers queue them), which left mobile
+// audio ignoring clock jumps entirely. StationPlayer counters with a #t=
+// media-fragment start position and a seeked-event verification that falls
+// back to a fragment reload — see segmentSeek.ts.
+describe("clock-synced seeking (iOS clamp resistance)", () => {
+	let loadSpy: ReturnType<typeof vi.spyOn>;
+	beforeAll(() => {
+		loadSpy = vi.spyOn(window.HTMLMediaElement.prototype, "load").mockImplementation(() => {});
+	});
+	afterAll(() => loadSpy.mockRestore());
+
+	it("mounts each element with a #t= start-position fragment at its clock offset", () => {
+		const { container } = render(<StationPlayer {...base} />);
+		// item 1 started at 12:40, clock is 12:47 → 420s in; item 2 at 12:45 → 120s.
+		expect(container.querySelector('audio[src="a.mp3#t=420"]')).toBeTruthy();
+		expect(container.querySelector('audio[src="b.mp3#t=120"]')).toBeTruthy();
+	});
+
+	it("accepts a seek that landed and does not reload", () => {
+		const { container } = render(<StationPlayer {...base} />);
+		const audio = container.querySelector('audio[src^="a.mp3"]') as HTMLAudioElement;
+		loadSpy.mockClear();
+		fireEvent(audio, new Event("loadedmetadata")); // issues the nudge seek → 420
+		expect(audio.currentTime).toBe(420);
+		fireEvent(audio, new Event("seeked")); // landed exactly where intended
+		expect(loadSpy).not.toHaveBeenCalled();
+	});
+
+	it("reloads at a fresh fragment when the browser clamped the seek, once per intent", () => {
+		const { container } = render(<StationPlayer {...base} />);
+		const audio = container.querySelector('audio[src^="a.mp3"]') as HTMLAudioElement;
+		loadSpy.mockClear();
+		fireEvent(audio, new Event("loadedmetadata")); // intent: 420
+		audio.currentTime = 3; // iOS-style clamp toward the start
+		fireEvent(audio, new Event("seeked"));
+		expect(loadSpy).toHaveBeenCalledTimes(1);
+		expect(audio.getAttribute("src")).toBe("a.mp3#t=420");
+		// The fallback also failing must not loop — one retry per intent.
+		audio.currentTime = 3;
+		fireEvent(audio, new Event("seeked"));
+		expect(loadSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("a clock scrub re-seeks mounted elements to the new position", () => {
+		const { container, rerender } = render(<StationPlayer {...base} />);
+		const audio = container.querySelector('audio[src^="a.mp3"]') as HTMLAudioElement;
+		const later = t("2001-09-11T12:49:00Z"); // +2min: a scrub, not a tick
+		rerender(<StationPlayer {...base} nowMs={later} getNowMs={() => later} />);
+		expect(audio.currentTime).toBe(540);
 	});
 });

--- a/packages/frontend/src/Applications/radio-core/StationPlayer.tsx
+++ b/packages/frontend/src/Applications/radio-core/StationPlayer.tsx
@@ -1,6 +1,9 @@
 import type React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { vttUrl } from "../../Providers/MediaStream/MediaStreamContext";
+import {
+	type MediaItem,
+	vttUrl,
+} from "../../Providers/MediaStream/MediaStreamContext";
 import { clearAudioBlocked, markAudioBlocked } from "./audioBlocked";
 import { setAudioLevel } from "./audioCapture";
 import { CaptionOverlay } from "./CaptionOverlay";
@@ -10,6 +13,11 @@ import {
 	type VizMode,
 } from "./radioScannerSettings";
 import { resolveAudioUrl } from "./audioSource";
+import {
+	type PendingSeek,
+	seekLanded,
+	withStartFragment,
+} from "./segmentSeek";
 import {
 	activeSegments,
 	calcSeekSeconds,
@@ -76,6 +84,81 @@ export const StationPlayer: React.FC<StationPlayerProps> = ({
 	getNowMsRef.current = getNowMs;
 	const stationRef = useRef(station);
 	stationRef.current = station;
+	const playOriginalAudioRef = useRef(playOriginalAudio);
+	playOriginalAudioRef.current = playOriginalAudio;
+
+	// Per-segment src, frozen at mount WITH a #t= start-position fragment:
+	// Safari resolves media fragments natively with a ranged fetch, so an
+	// element begins at its clock position without needing a post-load seek —
+	// the operation iOS clamps on long progressive files (see segmentSeek.ts).
+	// Recomputed from scratch when the original/enhanced toggle changes.
+	const initialSrcRef = useRef<Map<number, string>>(new Map());
+	const srcModeRef = useRef(playOriginalAudio);
+	if (srcModeRef.current !== playOriginalAudio) {
+		srcModeRef.current = playOriginalAudio;
+		initialSrcRef.current.clear();
+	}
+	const srcFor = (item: MediaItem): string => {
+		let src = initialSrcRef.current.get(item.id);
+		if (src === undefined) {
+			src = withStartFragment(
+				resolveAudioUrl(item, playOriginalAudio),
+				calcSeekSeconds(item, getNowMsRef.current()),
+			);
+			initialSrcRef.current.set(item.id, src);
+		}
+		return src;
+	};
+
+	// Every programmatic seek goes through here so it can be VERIFIED: iOS
+	// Safari clamps currentTime writes whose target isn't buffered yet (desktop
+	// browsers queue them), which left mobile audio ignoring clock jumps
+	// entirely. The element's `seeked` event checks where the seek landed; a
+	// clamp triggers one fragment-reload fallback per intent (see verifySeek).
+	const pendingSeekRef = useRef<Map<number, PendingSeek>>(new Map());
+	const seekSegmentTo = useCallback(
+		(item: MediaItem, el: HTMLAudioElement, want: number) => {
+			pendingSeekRef.current.set(item.id, {
+				want,
+				atMs: Date.now(),
+				retried: false,
+			});
+			el.currentTime = want;
+		},
+		[],
+	);
+
+	const verifySeek = useCallback((item: MediaItem, el: HTMLAudioElement) => {
+		const pending = pendingSeekRef.current.get(item.id);
+		if (!pending) return;
+		if (seekLanded(el.currentTime, pending, Date.now(), clockPausedRef.current)) {
+			pendingSeekRef.current.delete(item.id);
+			return;
+		}
+		if (pending.retried) {
+			// The fallback also missed — stop here; the health check re-issues a
+			// fresh intent within 15s while the drift persists.
+			pendingSeekRef.current.delete(item.id);
+			return;
+		}
+		// Clamped: reposition by reloading at a fresh #t= fragment, which Safari
+		// honors with a ranged fetch at the target. Keep React's rendered src in
+		// agreement so the next render doesn't undo it. onCanPlay restarts
+		// playback through the usual autoplay dance.
+		const target = calcSeekSeconds(item, getNowMsRef.current());
+		const src = withStartFragment(
+			resolveAudioUrl(item, playOriginalAudioRef.current),
+			target,
+		);
+		pendingSeekRef.current.set(item.id, {
+			want: target,
+			atMs: Date.now(),
+			retried: true,
+		});
+		initialSrcRef.current.set(item.id, src);
+		el.src = src;
+		el.load();
+	}, []);
 
 	// Elements whose play() has resolved at least once. Until then an element
 	// must stay el.muted = true (that's what lets the browser permit autoplay),
@@ -119,7 +202,9 @@ export const StationPlayer: React.FC<StationPlayerProps> = ({
 			const item = stationRef.current.items.find((i) => i.id === id);
 			if (item) {
 				const expected = calcSeekSeconds(item, getNowMsRef.current());
-				if (Math.abs(el.currentTime - expected) > 2) el.currentTime = expected;
+				if (Math.abs(el.currentTime - expected) > 2) {
+					seekSegmentTo(item, el, expected);
+				}
 			}
 			el.play()
 				.then(() => {
@@ -132,7 +217,7 @@ export const StationPlayer: React.FC<StationPlayerProps> = ({
 					}
 				});
 		},
-		[unlockAndApplyMuteState],
+		[unlockAndApplyMuteState, seekSegmentTo],
 	);
 
 	// Health check: keep each mounted element playing and within 30s of expected.
@@ -150,11 +235,13 @@ export const StationPlayer: React.FC<StationPlayerProps> = ({
 					tryPlay(segId, el);
 				}
 				const expected = calcSeekSeconds(item, now);
-				if (Math.abs(el.currentTime - expected) > 30) el.currentTime = expected;
+				if (Math.abs(el.currentTime - expected) > 30) {
+					seekSegmentTo(item, el, expected);
+				}
 			}
 		}, 15_000);
 		return () => clearInterval(id);
-	}, [station, tryPlay]);
+	}, [station, tryPlay, seekSegmentTo]);
 
 	// A user gesture is the first moment blocked playback can start: Safari
 	// refuses gesture-less play() on page load, so a restored session autoplays
@@ -213,10 +300,10 @@ export const StationPlayer: React.FC<StationPlayerProps> = ({
 		if (Math.abs(delta) > 5_000) {
 			for (const [segId, el] of audioRefs.current) {
 				const item = station.items.find((i) => i.id === segId);
-				if (item) el.currentTime = calcSeekSeconds(item, nowMs);
+				if (item) seekSegmentTo(item, el, calcSeekSeconds(item, nowMs));
 			}
 		}
-	}, [nowMs, station]);
+	}, [nowMs, station, seekSegmentTo]);
 
 	// Stable per-segment ref callbacks: a fixed identity means React invokes the
 	// callback only on real mount/unmount, so a playing element is never re-muted
@@ -241,6 +328,8 @@ export const StationPlayer: React.FC<StationPlayerProps> = ({
 					unlockedRef.current.delete(id);
 					// A gone element no longer needs a gesture.
 					clearAudioBlocked(`play-${id}`);
+					initialSrcRef.current.delete(id);
+					pendingSeekRef.current.delete(id);
 				}
 			};
 			refCallbacks.current.set(id, cb);
@@ -257,11 +346,13 @@ export const StationPlayer: React.FC<StationPlayerProps> = ({
 				<audio
 					key={item.id}
 					ref={audioRef(item.id)}
-					src={resolveAudioUrl(item, playOriginalAudio)}
+					src={srcFor(item)}
 					crossOrigin="anonymous"
 					style={{ display: "none" }}
 					onLoadedMetadata={(e) => {
-						e.currentTarget.currentTime = calcSeekSeconds(item, getNowMsRef.current());
+						// The #t= fragment already positioned the element near its clock
+						// spot; this nudge covers the load time and non-fragment browsers.
+						seekSegmentTo(item, e.currentTarget, calcSeekSeconds(item, getNowMsRef.current()));
 						setReadyVersions((prev) => {
 							const next = new Map(prev);
 							next.set(item.id, (prev.get(item.id) ?? 0) + 1);
@@ -273,6 +364,7 @@ export const StationPlayer: React.FC<StationPlayerProps> = ({
 						if (clockPausedRef.current) return;
 						tryPlay(item.id, el);
 					}}
+					onSeeked={(e) => verifySeek(item, e.currentTarget)}
 					onPause={(e) => {
 						const el = e.currentTarget;
 						// A pause we didn't initiate is the autoplay policy speaking —

--- a/packages/frontend/src/Applications/radio-core/segmentSeek.test.ts
+++ b/packages/frontend/src/Applications/radio-core/segmentSeek.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { seekLanded, withStartFragment } from "./segmentSeek";
+
+describe("withStartFragment", () => {
+	it("appends a floored #t= fragment", () => {
+		expect(withStartFragment("a.mp3", 420.9)).toBe("a.mp3#t=420");
+	});
+	it("replaces an existing fragment instead of stacking", () => {
+		expect(withStartFragment("a.mp3#t=99", 10)).toBe("a.mp3#t=10");
+	});
+	it("omits the fragment at (or clamped to) zero", () => {
+		expect(withStartFragment("a.mp3", 0)).toBe("a.mp3");
+		expect(withStartFragment("a.mp3", -5)).toBe("a.mp3");
+	});
+});
+
+describe("seekLanded", () => {
+	const pending = { want: 420, atMs: 1_000, retried: false };
+	it("accepts a landing within tolerance of the clock-adjusted target", () => {
+		// 3s elapsed in flight → expected 423; landed at 424.
+		expect(seekLanded(424, pending, 4_000, false)).toBe(true);
+	});
+	it("rejects an iOS-style clamp toward the file start", () => {
+		expect(seekLanded(3, pending, 4_000, false)).toBe(false);
+	});
+	it("does not credit elapsed wall time while the clock is paused", () => {
+		// Paused: expected stays 420 even after 100s in flight.
+		expect(seekLanded(420, { ...pending, atMs: 0 }, 100_000, true)).toBe(true);
+		expect(seekLanded(520, { ...pending, atMs: 0 }, 100_000, true)).toBe(false);
+	});
+});

--- a/packages/frontend/src/Applications/radio-core/segmentSeek.ts
+++ b/packages/frontend/src/Applications/radio-core/segmentSeek.ts
@@ -1,0 +1,51 @@
+// Clock-synced seeking that survives iOS Safari.
+//
+// Desktop browsers queue a `currentTime` write that points outside the
+// currently buffered/seekable region of a long progressive file and perform
+// it once the data exists. iOS Safari does not: the write is clamped to the
+// nearest seekable position (often ~0 on a freshly loaded multi-hour mp3) or
+// dropped outright — which left mobile station audio playing "at the same
+// location" no matter where the virtual clock jumped. Two counter-measures,
+// used by StationPlayer:
+//
+// 1. Position elements at LOAD time with a `#t=` media fragment on the src.
+//    Safari resolves media fragments natively with a ranged fetch at the
+//    target, so the element never needs a post-load seek to reach its start.
+// 2. VERIFY every programmatic seek once the element reports `seeked`: if it
+//    landed outside tolerance (a clamp), reload the element with a fresh
+//    fragment instead of fighting `currentTime`.
+
+/** How far a completed seek may land from its target before it counts as a
+ *  clamp. Also absorbs the clock advancing while the seek was in flight. */
+export const SEEK_LANDED_TOLERANCE_S = 5;
+
+/** Replace any fragment on `url` with a `#t=` start-position media fragment. */
+export function withStartFragment(url: string, seconds: number): string {
+	const base = url.split("#")[0];
+	const t = Math.max(0, Math.floor(seconds));
+	return t > 0 ? `${base}#t=${t}` : base;
+}
+
+/** A seek awaiting its `seeked` verification. */
+export interface PendingSeek {
+	/** Target position, in media seconds, at the moment the seek was issued. */
+	want: number;
+	/** Wall-clock ms when the seek was issued (the clock keeps moving). */
+	atMs: number;
+	/** A fragment-reload fallback already ran for this intent — don't loop. */
+	retried: boolean;
+}
+
+/**
+ * Did the seek land? `want` is compared against where the clock will have
+ * moved to while the seek was in flight (frozen clocks don't advance).
+ */
+export function seekLanded(
+	currentTime: number,
+	pending: PendingSeek,
+	nowWallMs: number,
+	clockPaused: boolean,
+): boolean {
+	const drift = clockPaused ? 0 : (nowWallMs - pending.atMs) / 1000;
+	return Math.abs(currentTime - (pending.want + drift)) <= SEEK_LANDED_TOLERANCE_S;
+}

--- a/packages/frontend/src/Mobile/IpodShell.test.tsx
+++ b/packages/frontend/src/Mobile/IpodShell.test.tsx
@@ -1,16 +1,21 @@
 // packages/frontend/src/Mobile/IpodShell.test.tsx
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { useContext } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { MediaStreamContextValue } from "../Providers/MediaStream/MediaStreamContext";
 import { MediaStreamContext } from "../Providers/MediaStream/MediaStreamContext";
 import IpodShell from "./IpodShell";
+import {
+	clearAudioBlocked,
+	markAudioBlocked,
+} from "../Applications/radio-core/audioBlocked";
 
 // Mutated per-test to drive forced-clock enforcement (see PlaylistProvider.test.tsx
 // for the same mutable-mock convention).
 let mockDateTimeLocked = false;
 const mockPause = vi.fn();
 const mockResume = vi.fn();
+const mockSetDateTime = vi.fn();
 
 vi.mock("classicy", async (importOriginal) => ({
 	...(await importOriginal<object>()),
@@ -22,7 +27,7 @@ vi.mock("classicy", async (importOriginal) => ({
 		localDate: new Date("2001-09-11T08:40:00.000Z"),
 		paused: false,
 		tzOffset: -4,
-		setDateTime: vi.fn(),
+		setDateTime: mockSetDateTime,
 		pause: mockPause,
 		resume: mockResume,
 	}),
@@ -38,11 +43,19 @@ vi.mock("../Applications/radio-core/StationPlayer", () => ({
 	StationPlayer: () => <div data-testid="station-player" />,
 }));
 
+// Now Playing fetches station artwork from Directus via this hook; tests
+// must not hit the network.
+vi.mock("../Applications/radio-core/stationLogos", () => ({
+	useStationLogos: () => ({}),
+}));
+
 afterEach(() => {
 	cleanup();
 	mockDateTimeLocked = false;
 	mockPause.mockClear();
 	mockResume.mockClear();
+	mockSetDateTime.mockClear();
+	clearAudioBlocked("test-banner");
 	// Tuning persists the now-playing source (nowPlayingStore.ts); clear it so
 	// one test's tuned station never boots the next test's shell pre-tuned.
 	window.localStorage.clear();
@@ -96,6 +109,13 @@ function pressMenu(container: HTMLElement) {
 	const wheelEl = container.querySelector("#control-wheel") as HTMLElement;
 	const menuBtn = container.querySelector("#menu-btn") as HTMLElement;
 	fireEvent.pointerDown(menuBtn, { pointerId: 1, clientX: 0, clientY: 0 });
+	fireEvent.pointerUp(wheelEl, { pointerId: 1, clientX: 0, clientY: 0 });
+}
+
+function pressWheelButton(container: HTMLElement, btnId: string) {
+	const wheelEl = container.querySelector("#control-wheel") as HTMLElement;
+	const btn = container.querySelector(btnId) as HTMLElement;
+	fireEvent.pointerDown(btn, { pointerId: 1, clientX: 0, clientY: 0 });
 	fireEvent.pointerUp(wheelEl, { pointerId: 1, clientX: 0, clientY: 0 });
 }
 
@@ -280,5 +300,66 @@ describe("IpodShell now-playing persistence", () => {
 		expect(
 			JSON.parse(window.localStorage.getItem("rt911IpodNowPlaying") ?? "null"),
 		).toEqual({ kind: "tv", id: 42 });
+	});
+});
+
+// ⏮/⏭ drive the virtual clock: a tap skips 30 seconds, each hold-repeat tick
+// skips a minute, and everything goes through the setDateTimeFromUtc seam
+// (asserted here via the classicy setDateTime callback it wraps). The mocked
+// clock is pinned at 12:40:00 UTC, so expected targets are absolute.
+describe("IpodShell wheel time skips", () => {
+	const NOW = Date.parse("2001-09-11T12:40:00.000Z");
+
+	it("tapping ⏭ skips the clock forward 30 seconds", () => {
+		const { container } = renderShell({ connected: true });
+		pressWheelButton(container, "#next-btn");
+		expect(mockSetDateTime).toHaveBeenCalledTimes(1);
+		expect(+mockSetDateTime.mock.calls[0][0]).toBe(NOW + 30_000);
+	});
+
+	it("tapping ⏮ skips the clock back 30 seconds", () => {
+		const { container } = renderShell({ connected: true });
+		pressWheelButton(container, "#prev-btn");
+		expect(mockSetDateTime).toHaveBeenCalledTimes(1);
+		expect(+mockSetDateTime.mock.calls[0][0]).toBe(NOW - 30_000);
+	});
+
+	it("holding ⏭ repeats one-minute skips and suppresses the 30s tap", () => {
+		vi.useFakeTimers();
+		const { container } = renderShell({ connected: true });
+		const wheelEl = container.querySelector("#control-wheel") as HTMLElement;
+		const btn = container.querySelector("#next-btn") as HTMLElement;
+		fireEvent.pointerDown(btn, { pointerId: 1, clientX: 0, clientY: 0 });
+		vi.advanceTimersByTime(550 + 500); // HOLD_DELAY_MS + one HOLD_REPEAT_MS
+		fireEvent.pointerUp(wheelEl, { pointerId: 1, clientX: 0, clientY: 0 });
+		vi.useRealTimers();
+		expect(mockSetDateTime).toHaveBeenCalledTimes(2); // two hold ticks, no tap
+		// The mocked clock is pinned, so every tick seeks from 12:40 → 12:41.
+		for (const call of mockSetDateTime.mock.calls) {
+			expect(+call[0]).toBe(NOW + 60_000);
+		}
+	});
+
+	it("is inert while the streamer's forced clock is active", () => {
+		mockDateTimeLocked = true;
+		const { container } = renderShell({ connected: true });
+		pressWheelButton(container, "#next-btn");
+		pressWheelButton(container, "#prev-btn");
+		expect(mockSetDateTime).not.toHaveBeenCalled();
+	});
+});
+
+// iOS refuses gesture-less audio after a reload — a policy that cannot be
+// bypassed — so the shell must at least SAY so. StationPlayer marks the
+// shared audioBlocked signal while the gate holds playback; the shell shows
+// a banner that doubles as the instruction (any tap retries playback).
+describe("IpodShell tap-to-start banner", () => {
+	it("appears while audio is autoplay-blocked and leaves when it clears", () => {
+		renderShell(STREAM_UP);
+		expect(screen.queryByText(/Tap anywhere to start audio/)).toBeNull();
+		act(() => markAudioBlocked("test-banner"));
+		expect(screen.getByText(/Tap anywhere to start audio/)).toBeTruthy();
+		act(() => clearAudioBlocked("test-banner"));
+		expect(screen.queryByText(/Tap anywhere to start audio/)).toBeNull();
 	});
 });

--- a/packages/frontend/src/Mobile/IpodShell.tsx
+++ b/packages/frontend/src/Mobile/IpodShell.tsx
@@ -13,11 +13,22 @@ import {
 	useReducer,
 	useRef,
 	useState,
+	useSyncExternalStore,
 } from "react";
+import {
+	isAudioBlocked,
+	subscribeAudioBlocked,
+} from "../Applications/radio-core/audioBlocked";
 import { DEFAULT_RADIO_SCANNER_SETTINGS } from "../Applications/radio-core/radioScannerSettings";
 import { StationPlayer } from "../Applications/radio-core/StationPlayer";
-import { mergeWithSources } from "../Applications/radio-core/stationGrouping";
-import { formatUtcAsLocalTime } from "../Applications/TimeMachine/setVirtualClock";
+import {
+	BROADCAST_STATIONS,
+	mergeWithSources,
+} from "../Applications/radio-core/stationGrouping";
+import {
+	formatUtcAsLocalTime,
+	setDateTimeFromUtc,
+} from "../Applications/TimeMachine/setVirtualClock";
 import type { MediaStreamFilter } from "../Providers/MediaStream/MediaStreamContext";
 import { useMediaStream } from "../Providers/MediaStream/useMediaStream";
 import { IpodChrome } from "./IpodChrome";
@@ -52,6 +63,10 @@ import { TVScreen } from "./screens/TVScreen";
 
 const APP_ID = "IpodShell.mobile";
 
+// ⏮/⏭ clock skips: a tap moves 30s; each hold-repeat tick moves a minute.
+const TAP_SEEK_MS = 30_000;
+const HOLD_SEEK_MS = 60_000;
+
 // Same filter as the desktop TV app: every approved HLS channel. Hoisted so
 // its reference is stable — useMediaStream memoizes the filtered list on it.
 const TV_CHANNELS_FILTER: MediaStreamFilter = { format: ["m3u8"], approved: true };
@@ -82,7 +97,14 @@ export default function IpodShell() {
 	const [stackState, dispatchStack] = useReducer(screenStackReducer, initialScreenStack);
 	const screen = currentScreen(stackState);
 	const { nowMs, getNowMs, clockPaused, tzOffset } = useFineClock();
-	const { paused, pause, resume } = useClassicyDateTime();
+	// iOS refuses gesture-less audio after a page load, so a restored session
+	// sits silent until the first tap — a policy no web page can bypass. What
+	// we CAN do is say so: StationPlayer marks this signal while the autoplay
+	// gate holds it back, and any tap anywhere retries (its document-level
+	// pointerdown listener), so the banner is both the explanation and the
+	// instruction. It disappears on its own the moment playback starts.
+	const audioBlocked = useSyncExternalStore(subscribeAudioBlocked, isAudioBlocked);
+	const { paused, pause, resume, setDateTime } = useClassicyDateTime();
 	// While the server forces the clock, nothing on this shell may move it:
 	// Time Travel/Bookmarks/Scrub get evicted and the wheel's play/pause is inert.
 	const dateTimeLocked = useAppManager(
@@ -115,8 +137,14 @@ export default function IpodShell() {
 	useEffect(() => {
 		saveNowPlaying(nowPlaying);
 	}, [nowPlaying]);
+	// Broadcast stations only — the same filter as the desktop RadioTuner.
+	// The comm-traffic clips and tapes belong to Radio Traffic; on the phone
+	// the Radio list is just the stations you could have had on in a kitchen.
 	const stations = useMemo(
-		() => mergeWithSources(sources.audio, mp3Items),
+		() =>
+			mergeWithSources(sources.audio, mp3Items).filter((s) =>
+				BROADCAST_STATIONS.has(s.key),
+			),
 		[sources.audio, mp3Items],
 	);
 	const activeStation =
@@ -168,11 +196,41 @@ export default function IpodShell() {
 		}
 	}, [dateTimeLocked, screen]);
 
+	// ⏮/⏭ as a time remote: a tap skips the virtual clock 30 seconds, holding
+	// the button keeps skipping in one-minute steps (useClickWheel's
+	// hold-repeat). Writes go through the sanctioned setDateTimeFromUtc seam,
+	// and — like the wheel's play/pause — are inert while the streamer's
+	// forced clock is active. Both steps stay under MediaStreamProvider's 90s
+	// SEEK_THRESHOLD_MS, so skipping nudges the buffers instead of forcing a
+	// full server-side seek on every press.
+	const seekBy = useCallback(
+		(deltaMs: number) => {
+			if (dateTimeLocked) return;
+			setDateTimeFromUtc(setDateTime, new Date(getNowMs() + deltaMs).toISOString());
+		},
+		[dateTimeLocked, setDateTime, getNowMs],
+	);
+
 	const wheel = useClickWheel({
 		onScroll: (steps) => screenHandlersRef.current.onScroll?.(steps),
 		onSelect: () => screenHandlersRef.current.onSelect?.(),
-		onPrev: () => screenHandlersRef.current.onPrev?.(),
-		onNext: () => screenHandlersRef.current.onNext?.(),
+		// A screen that registers its own ⏮/⏭ meaning wins (none do today);
+		// otherwise the buttons drive the clock. Hold-repeat only applies to
+		// the clock meaning — a screen-owned button behaves as a plain tap.
+		onPrev: () => {
+			if (screenHandlersRef.current.onPrev) screenHandlersRef.current.onPrev();
+			else seekBy(-TAP_SEEK_MS);
+		},
+		onNext: () => {
+			if (screenHandlersRef.current.onNext) screenHandlersRef.current.onNext();
+			else seekBy(TAP_SEEK_MS);
+		},
+		onPrevHold: () => {
+			if (!screenHandlersRef.current.onPrev) seekBy(-HOLD_SEEK_MS);
+		},
+		onNextHold: () => {
+			if (!screenHandlersRef.current.onNext) seekBy(HOLD_SEEK_MS);
+		},
 		onMenu: () => dispatchStack({ type: "pop" }),
 		onPlayPause: () => {
 			if (dateTimeLocked) return;
@@ -200,6 +258,9 @@ export default function IpodShell() {
 								{clockLabel}
 							</span>
 						</div>
+						{audioBlocked && (
+							<div className="ipodTapBanner">Tap anywhere to start audio</div>
+						)}
 						{/* The menu, About, and Time Travel all work without the stream —
 						    only data screens gate on the connection (RadioScreen shows
 						    its own Connecting… state). */}

--- a/packages/frontend/src/Mobile/WheelContext.tsx
+++ b/packages/frontend/src/Mobile/WheelContext.tsx
@@ -23,16 +23,21 @@ export function useScreenWheel(handlers: ScreenWheelHandlers): void {
 	const { register } = useContext(WheelContext);
 	const ref = useRef(handlers);
 	ref.current = handlers;
-	useEffect(
-		() =>
-			register({
-				onScroll: (s) => ref.current.onScroll?.(s),
-				onSelect: () => ref.current.onSelect?.(),
-				onPrev: () => ref.current.onPrev?.(),
-				onNext: () => ref.current.onNext?.(),
-			}),
-		[register],
-	);
+	useEffect(() => {
+		// Register ONLY the meanings this screen actually has. The shell gives
+		// unclaimed buttons a default meaning (⏮/⏭ skip the clock), and it
+		// detects a claim by the key being present — registering an
+		// always-defined wrapper for a handler the screen never passed would
+		// silently swallow the default. A screen's handler SET is static for
+		// its lifetime (the values stay fresh through the ref).
+		const h = ref.current;
+		return register({
+			onScroll: h.onScroll ? (s) => ref.current.onScroll?.(s) : undefined,
+			onSelect: h.onSelect ? () => ref.current.onSelect?.() : undefined,
+			onPrev: h.onPrev ? () => ref.current.onPrev?.() : undefined,
+			onNext: h.onNext ? () => ref.current.onNext?.() : undefined,
+		});
+	}, [register]);
 }
 
 export interface ScreenNav {

--- a/packages/frontend/src/Mobile/screens/AboutScreen.tsx
+++ b/packages/frontend/src/Mobile/screens/AboutScreen.tsx
@@ -1,7 +1,23 @@
 // packages/frontend/src/Mobile/screens/AboutScreen.tsx
+import { useRef } from "react";
+import { useScreenWheel } from "../WheelContext";
+
+// One wheel detent scrolls about a line of the About text.
+const SCROLL_STEP_PX = 44;
+
 export function AboutScreen() {
+	const bodyRef = useRef<HTMLDivElement>(null);
+	// The wheel scrolls the text: .ipodTextScreen is the overflow container,
+	// so a step just moves its scrollTop (scrollBy isn't implemented in jsdom,
+	// and a direct scrollTop write behaves identically in real browsers).
+	useScreenWheel({
+		onScroll: (steps) => {
+			const el = bodyRef.current;
+			if (el) el.scrollTop += steps * SCROLL_STEP_PX;
+		},
+	});
 	return (
-		<div className="ipodTextScreen">
+		<div className="ipodTextScreen" ref={bodyRef}>
 			<div className="ipodMarquee ipodCenter">911realtime</div>
 			<p>
 				A living archive of September 11, 2001. Radio, television, and news

--- a/packages/frontend/src/Mobile/screens/NowPlayingScreen.test.tsx
+++ b/packages/frontend/src/Mobile/screens/NowPlayingScreen.test.tsx
@@ -1,8 +1,14 @@
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Station } from "../../Applications/radio-core/stationGrouping";
 import type { MediaItem } from "../../Providers/MediaStream/MediaStreamContext";
 import { NowPlayingScreen } from "./NowPlayingScreen";
+
+// The screen resolves station artwork through this Directus-backed hook;
+// tests supply the map directly instead of hitting the network.
+vi.mock("../../Applications/radio-core/stationLogos", () => ({
+	useStationLogos: () => ({ WCBS: "https://example.test/wcbs-logo.png" }),
+}));
 
 afterEach(cleanup);
 
@@ -99,5 +105,59 @@ describe("NowPlayingScreen", () => {
 			/>,
 		);
 		expect(screen.getByText("paused")).toBeTruthy();
+	});
+});
+
+// The station's artwork shows above the title, resolved exactly as on the
+// desktop RadioTuner: a streaming item's image first, else the station's own
+// logo from the Directus map (mocked above).
+describe("NowPlayingScreen station logo", () => {
+	it("shows the streaming item's image when the station carries one", () => {
+		const withImage: Station = {
+			...station,
+			items: [{ ...station.items[0], image: "https://example.test/wins-art.png" }],
+		};
+		const { container } = render(
+			<NowPlayingScreen
+				station={withImage}
+				tvChannel={null}
+				nowMs={NOW}
+				tzOffset={-4}
+				clockPaused={false}
+			/>,
+		);
+		const img = container.querySelector("img.ipodStationLogo") as HTMLImageElement;
+		expect(img).toBeTruthy();
+		expect(img.getAttribute("src")).toBe("https://example.test/wins-art.png");
+	});
+
+	it("falls back to the station's Directus logo when nothing is streaming", () => {
+		const dark: Station = { key: "WCBS", label: "WCBS", items: [] };
+		const { container } = render(
+			<NowPlayingScreen
+				station={dark}
+				tvChannel={null}
+				nowMs={NOW}
+				tzOffset={-4}
+				clockPaused={false}
+			/>,
+		);
+		const img = container.querySelector("img.ipodStationLogo") as HTMLImageElement;
+		expect(img).toBeTruthy();
+		expect(img.getAttribute("src")).toBe("https://example.test/wcbs-logo.png");
+	});
+
+	it("renders no logo element when the station has no artwork at all", () => {
+		const dark: Station = { key: "KNOWN-NOWHERE", label: "X", items: [] };
+		const { container } = render(
+			<NowPlayingScreen
+				station={dark}
+				tvChannel={null}
+				nowMs={NOW}
+				tzOffset={-4}
+				clockPaused={false}
+			/>,
+		);
+		expect(container.querySelector("img.ipodStationLogo")).toBeNull();
 	});
 });

--- a/packages/frontend/src/Mobile/screens/NowPlayingScreen.tsx
+++ b/packages/frontend/src/Mobile/screens/NowPlayingScreen.tsx
@@ -7,8 +7,10 @@ import {
 	activeSegments,
 	primarySegment,
 	startTimeLabel,
+	stationLogo,
 	type Station,
 } from "../../Applications/radio-core/stationGrouping";
+import { useStationLogos } from "../../Applications/radio-core/stationLogos";
 import { formatUtcAsLocalTime } from "../../Applications/TimeMachine/setVirtualClock";
 import type { MediaItem } from "../../Providers/MediaStream/MediaStreamContext";
 
@@ -29,6 +31,11 @@ export function NowPlayingScreen({
 	clockPaused,
 }: NowPlayingScreenProps) {
 	const clock = formatUtcAsLocalTime(new Date(nowMs).toISOString(), tzOffset);
+	// Same artwork the desktop RadioTuner shows: the streaming item's image
+	// when one is on the air, else the station's own logo from Directus (a
+	// fetch failure just leaves the logo off — the hook degrades to {}).
+	const logos = useStationLogos();
+	const logo = station ? stationLogo(station, [], logos) : undefined;
 
 	if (tvChannel) {
 		return (
@@ -54,6 +61,7 @@ export function NowPlayingScreen({
 
 	return (
 		<div className="ipodTextScreen">
+			{logo && <img className="ipodStationLogo" src={logo} alt="" />}
 			<div className="ipodMarquee ipodCenter">{station.label}</div>
 			{primary ? (
 				<>

--- a/packages/frontend/src/Mobile/screens/RadioScreen.test.tsx
+++ b/packages/frontend/src/Mobile/screens/RadioScreen.test.tsx
@@ -58,6 +58,25 @@ describe("RadioScreen", () => {
 		expect(push).toHaveBeenCalledWith("nowPlaying");
 	});
 
+	it("tunes an off-air station (desktop RadioTuner parity: dark ≠ unavailable)", () => {
+		const onTune = vi.fn();
+		const push = vi.fn();
+		render(
+			<ScreenNavContext.Provider value={{ push, pop: vi.fn() }}>
+				<RadioScreen
+					stations={[onAir("WINS"), offAir("WCBS")]}
+					nowMs={NOW}
+					activeStationKey=""
+					onTune={onTune}
+					connected={true}
+				/>
+			</ScreenNavContext.Provider>,
+		);
+		fireEvent.click(screen.getByText("WCBS"));
+		expect(onTune).toHaveBeenCalledWith("WCBS");
+		expect(push).toHaveBeenCalledWith("nowPlaying");
+	});
+
 	it("keeps the highlight on the same station when the sort order reshuffles", () => {
 		// Non-pinned stations (WINS/WCBS are pinned): both start on-air, so the
 		// incoming order [KYW, WBZ] is the display order. Selecting WBZ (index 1)

--- a/packages/frontend/src/Mobile/screens/RadioScreen.tsx
+++ b/packages/frontend/src/Mobile/screens/RadioScreen.tsx
@@ -47,13 +47,17 @@ export function RadioScreen({
 		sorted.findIndex((s) => s.key === selectedKey),
 	);
 
+	// Off-air stations stay TUNABLE, matching the desktop RadioTuner: most
+	// broadcast stations hold one recording and are dark for most of the
+	// virtual day, but tuning one is meaningful — the shell mounts its player
+	// and the audio comes alive the moment its tape starts. Only the label
+	// says "offline"; nothing is disabled.
 	const items = sorted.map((s) => {
 		const onAir = activeSegments(s, nowMs).length > 0;
 		return {
 			key: s.key,
 			label: s.label,
 			value: s.key === activeStationKey ? "▶" : onAir ? undefined : "offline",
-			disabled: !onAir,
 		};
 	});
 
@@ -63,7 +67,7 @@ export function RadioScreen({
 	};
 
 	const activate = (i: number) => {
-		if (!items[i] || items[i].disabled) return;
+		if (!sorted[i]) return;
 		onTune(sorted[i].key);
 		push("nowPlaying");
 	};

--- a/packages/frontend/src/Mobile/shell.css
+++ b/packages/frontend/src/Mobile/shell.css
@@ -245,3 +245,24 @@
 	position: absolute;
 	inset: -30px;
 }
+
+/* ── Now Playing station logo ── */
+.ipodRoot .ipodStationLogo {
+	display: block;
+	margin: 0 auto;
+	max-width: 60%;
+	max-height: calc(var(--u) * 56);
+	object-fit: contain;
+}
+
+/* ── Tap-to-start banner (iOS autoplay gate) ── */
+.ipodRoot .ipodTapBanner {
+	flex-shrink: 0;
+	background: linear-gradient(to bottom, #fffbe6, #f5ecc0);
+	border-bottom: calc(var(--u) * 1) solid #c9bd85;
+	color: #6b5f1e;
+	text-align: center;
+	font-size: calc(var(--u) * 12);
+	font-weight: 600;
+	padding: calc(var(--u) * 3) calc(var(--u) * 6);
+}

--- a/packages/frontend/src/Mobile/useClickWheel.test.tsx
+++ b/packages/frontend/src/Mobile/useClickWheel.test.tsx
@@ -1,6 +1,11 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useClickWheel, type ClickWheelHandlers } from "./useClickWheel";
+import {
+	HOLD_DELAY_MS,
+	HOLD_REPEAT_MS,
+	useClickWheel,
+	type ClickWheelHandlers,
+} from "./useClickWheel";
 
 afterEach(cleanup);
 
@@ -15,6 +20,8 @@ function Harness({ handlers }: { handlers: ClickWheelHandlers }) {
 		>
 			<button type="button" data-testid="menu-btn" onPointerDown={buttonDown("menu")} />
 			<button type="button" data-testid="mid-btn" onPointerDown={buttonDown("select")} />
+			<button type="button" data-testid="prev-btn" onPointerDown={buttonDown("prev")} />
+			<button type="button" data-testid="next-btn" onPointerDown={buttonDown("next")} />
 		</div>
 	);
 }
@@ -83,5 +90,73 @@ describe("useClickWheel", () => {
 		fireEvent.pointerUp(wheel, { pointerId: 1, ...at(0) });
 		expect(wheel.dataset.pressed).toBe("");
 		expect(handlers.onSelect).toHaveBeenCalledTimes(1);
+	});
+});
+
+// Holding ⏮/⏭ past HOLD_DELAY_MS repeats the hold handler instead of firing
+// the tap on release — the shell maps tap to a 30s clock skip and each hold
+// tick to a one-minute skip.
+describe("useClickWheel hold-repeat", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	const holdHandlers = () => ({
+		...makeHandlers(),
+		onPrevHold: vi.fn(),
+		onNextHold: vi.fn(),
+	});
+
+	it("fires the hold handler after the delay, repeats, and suppresses the tap", () => {
+		vi.useFakeTimers();
+		const handlers = holdHandlers();
+		render(<Harness handlers={handlers} />);
+		const wheel = screen.getByTestId("wheel");
+		fireEvent.pointerDown(screen.getByTestId("prev-btn"), { pointerId: 1, ...at(180) });
+		vi.advanceTimersByTime(HOLD_DELAY_MS);
+		expect(handlers.onPrevHold).toHaveBeenCalledTimes(1);
+		vi.advanceTimersByTime(HOLD_REPEAT_MS * 2);
+		expect(handlers.onPrevHold).toHaveBeenCalledTimes(3);
+		fireEvent.pointerUp(wheel, { pointerId: 1, ...at(180) });
+		expect(handlers.onPrev).not.toHaveBeenCalled(); // the hold consumed the gesture
+		vi.advanceTimersByTime(HOLD_REPEAT_MS * 3);
+		expect(handlers.onPrevHold).toHaveBeenCalledTimes(3); // stopped on release
+	});
+
+	it("a quick tap still fires the tap handler and never the hold", () => {
+		vi.useFakeTimers();
+		const handlers = holdHandlers();
+		render(<Harness handlers={handlers} />);
+		const wheel = screen.getByTestId("wheel");
+		fireEvent.pointerDown(screen.getByTestId("next-btn"), { pointerId: 1, ...at(0) });
+		vi.advanceTimersByTime(100);
+		fireEvent.pointerUp(wheel, { pointerId: 1, ...at(0) });
+		expect(handlers.onNext).toHaveBeenCalledTimes(1);
+		vi.advanceTimersByTime(HOLD_DELAY_MS + HOLD_REPEAT_MS * 3);
+		expect(handlers.onNextHold).not.toHaveBeenCalled();
+	});
+
+	it("a drag that becomes a scroll cancels the pending hold", () => {
+		vi.useFakeTimers();
+		const handlers = holdHandlers();
+		render(<Harness handlers={handlers} />);
+		const wheel = screen.getByTestId("wheel");
+		fireEvent.pointerDown(screen.getByTestId("prev-btn"), { pointerId: 1, ...at(90) });
+		fireEvent.pointerMove(wheel, { pointerId: 1, ...at(120) }); // crosses the dead zone
+		vi.advanceTimersByTime(HOLD_DELAY_MS + HOLD_REPEAT_MS * 2);
+		expect(handlers.onPrevHold).not.toHaveBeenCalled();
+		fireEvent.pointerUp(wheel, { pointerId: 1, ...at(120) });
+		expect(handlers.onPrev).not.toHaveBeenCalled(); // scrolls never tap either
+	});
+
+	it("without a hold handler, a long press stays an ordinary tap", () => {
+		vi.useFakeTimers();
+		const handlers = makeHandlers(); // no onPrevHold/onNextHold registered
+		render(<Harness handlers={handlers} />);
+		const wheel = screen.getByTestId("wheel");
+		fireEvent.pointerDown(screen.getByTestId("prev-btn"), { pointerId: 1, ...at(180) });
+		vi.advanceTimersByTime(HOLD_DELAY_MS + HOLD_REPEAT_MS * 4);
+		fireEvent.pointerUp(wheel, { pointerId: 1, ...at(180) });
+		expect(handlers.onPrev).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/frontend/src/Mobile/useClickWheel.ts
+++ b/packages/frontend/src/Mobile/useClickWheel.ts
@@ -2,13 +2,20 @@
 // elements of the wheel: their pointerdown marks which button is pressed
 // (and bubbles up so the wheel starts angle tracking); the wheel's pointerup
 // fires the button action only when the gesture stayed a tap (never crossed
-// the scroll dead zone). preventDefault() on pointerdown suppresses the
+// the scroll dead zone). The ⏮/⏭ buttons additionally support hold-repeat:
+// held past HOLD_DELAY_MS they fire onPrevHold/onNextHold on an interval
+// instead of the tap action. preventDefault() on pointerdown suppresses the
 // browser's synthetic click — which is why audioCapture.ts and
 // StationPlayer.tsx also listen for pointerdown to unlock audio (Task 10).
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { angleDeg, WheelTracker } from "./wheelMath";
 
 export type WheelButton = "select" | "menu" | "prev" | "next" | "playPause";
+
+/** Holding ⏮/⏭ this long arms hold-repeat (a normal tap stays well under it). */
+export const HOLD_DELAY_MS = 550;
+/** While held, the hold handler repeats at this interval. */
+export const HOLD_REPEAT_MS = 500;
 
 export interface ClickWheelHandlers {
 	onScroll: (steps: number) => void;
@@ -17,6 +24,15 @@ export interface ClickWheelHandlers {
 	onPrev: () => void;
 	onNext: () => void;
 	onPlayPause: () => void;
+	/**
+	 * Optional hold-repeat for the ⏮/⏭ buttons: fired once when the press has
+	 * been held for {@link HOLD_DELAY_MS}, then every {@link HOLD_REPEAT_MS}
+	 * until release. Once a hold has fired, the release does NOT also fire the
+	 * tap handler (onPrev/onNext) — a hold is a different gesture, not a long
+	 * tap. Scrolling cancels a pending or active hold, same as it cancels taps.
+	 */
+	onPrevHold?: () => void;
+	onNextHold?: () => void;
 }
 
 export interface ClickWheel {
@@ -41,6 +57,54 @@ export function useClickWheel(handlers: ClickWheelHandlers): ClickWheel {
 	const handlersRef = useRef(handlers);
 	handlersRef.current = handlers;
 
+	// Hold-repeat state for the ⏮/⏭ buttons: a delay timer arms the repeat,
+	// an interval drives it, and holdFiredRef suppresses the tap on release.
+	const holdTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const holdIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+	const holdFiredRef = useRef(false);
+
+	const stopHold = useCallback(() => {
+		if (holdTimerRef.current !== null) {
+			clearTimeout(holdTimerRef.current);
+			holdTimerRef.current = null;
+		}
+		if (holdIntervalRef.current !== null) {
+			clearInterval(holdIntervalRef.current);
+			holdIntervalRef.current = null;
+		}
+	}, []);
+
+	const startHold = useCallback(
+		(b: WheelButton) => {
+			stopHold();
+			holdFiredRef.current = false;
+			const holdHandler = () =>
+				b === "prev"
+					? handlersRef.current.onPrevHold
+					: handlersRef.current.onNextHold;
+			if (!holdHandler()) return; // no hold behavior registered
+			const tick = () => {
+				// A drag that crossed the scroll dead zone turns the gesture into a
+				// scroll — stop repeating, exactly as taps are cancelled by scrolls.
+				if (trackerRef.current.hasScrolled) {
+					stopHold();
+					return;
+				}
+				holdFiredRef.current = true;
+				holdHandler()?.();
+			};
+			holdTimerRef.current = setTimeout(() => {
+				holdTimerRef.current = null;
+				tick();
+				holdIntervalRef.current = setInterval(tick, HOLD_REPEAT_MS);
+			}, HOLD_DELAY_MS);
+		},
+		[stopHold],
+	);
+
+	// Never leave a repeat running past unmount.
+	useEffect(() => stopHold, [stopHold]);
+
 	const angleOf = useCallback((e: React.PointerEvent): number => {
 		const rect = (wheelRef.current as HTMLElement).getBoundingClientRect();
 		return angleDeg(
@@ -53,8 +117,10 @@ export function useClickWheel(handlers: ClickWheelHandlers): ClickWheel {
 
 	const wheelHandlers = useMemo(() => {
 		const end = () => {
+			stopHold();
 			const button = pressedRef.current;
-			if (button && !trackerRef.current.hasScrolled) {
+			// A hold that fired consumed the gesture — release is not also a tap.
+			if (button && !trackerRef.current.hasScrolled && !holdFiredRef.current) {
 				const h = handlersRef.current;
 				(
 					{
@@ -81,21 +147,26 @@ export function useClickWheel(handlers: ClickWheelHandlers): ClickWheel {
 			onPointerMove: (e: React.PointerEvent) => {
 				if (!draggingRef.current) return;
 				const steps = trackerRef.current.move(angleOf(e), Date.now());
+				// Crossing the scroll dead zone re-types the gesture as a scroll:
+				// cancel any pending or running hold-repeat along with the tap.
+				if (trackerRef.current.hasScrolled) stopHold();
 				if (steps !== 0) handlersRef.current.onScroll(steps);
 			},
 			onPointerUp: () => end(),
 			onPointerCancel: () => end(),
 		};
-	}, [angleOf]);
+	}, [angleOf, stopHold]);
 
 	const buttonDown = useCallback(
 		(b: WheelButton) => () => {
 			pressedRef.current = b;
 			setPressed(b);
+			// ⏮/⏭ support hold-repeat (see ClickWheelHandlers.onPrevHold).
+			if (b === "prev" || b === "next") startHold(b);
 			// No stopPropagation: the event bubbles to the wheel, which starts
 			// angle tracking so a drag that began on a button still scrolls.
 		},
-		[],
+		[startHold],
 	);
 
 	// Stable object identity (only `pressed` varies): IpodChrome's artwork is


### PR DESCRIPTION
## Summary

Two commits: a root-cause fix for the persistent mobile audio desync, and a batch of iPod-shell features.

### iOS clock-synced audio fix (`ee3e6df`)

The bug ("WINS plays at the same location no matter which bookmark you jump to", "tapping to play always starts a file at the beginning") is iOS Safari clamping `currentTime` writes. Desktop browsers queue a seek that targets an unbuffered region of a long progressive mp3 and perform it once data arrives; iOS Safari clamps the write to the nearest seekable position (~0 on a freshly loaded multi-hour file) or drops it. Every sync path in `StationPlayer` relied on such writes, so on iOS they all silently no-opped.

New `radio-core/segmentSeek.ts` provides two counter-measures, wired into `StationPlayer`:

- **Position at load time with `#t=` media fragments.** Each segment's `src` is frozen per segment with a `#t=<clock-derived seconds>` fragment. Safari resolves media fragments natively with a ranged fetch at the target, so the element never needs a post-load seek to reach its start.
- **Verify every programmatic seek.** All four seek paths (metadata nudge, play re-anchor, 15s health check, scrub) record a `PendingSeek`; on `seeked`, if the element landed outside a 5s tolerance (clock drift credited while in flight), the element is reloaded with a fresh fragment instead of fighting `currentTime` — capped at one retry per intent, with the health check as the backstop.

Desktop is unaffected: its seeks land on the first try, so verification is a no-op and behavior is unchanged.

### Mobile features (`7ad444c`)

- **⏮/⏭ time skips**: a tap skips the virtual clock ±30 seconds; holding past a single click (550ms) repeats ±1 minute every 500ms. Routed through the sanctioned `setDateTimeFromUtc` seam, inert while the streamer's forced clock (`dateTimeLocked`) is active, and screens that own the buttons (e.g. Now Playing) still win. This surfaced a real bug in `WheelContext`: `useScreenWheel` registered wrapper handlers for keys the screen never provided, so shell-level fallbacks could never run — it now registers only the handlers a screen actually passes.
- **About screen scrolling**: the click wheel scrolls the About text.
- **Now Playing logos**: radio stations show their station logo (same `stationLogo`/`useStationLogos` pipeline the desktop tuner uses).
- **Broadcast-only station list**: the mobile Radio menu now lists only continuous broadcast stations (`BROADCAST_STATIONS`), not shorter clips/tapes, and off-air stations are tunable — matching desktop RadioTuner behavior.
- **Tap-to-start banner**: the iOS autoplay gate itself can't be removed (Apple policy — a user gesture is required before audio can start), but it's now discoverable: a "Tap anywhere to start audio" banner appears whenever playback is blocked and clears once audio starts.

## Testing

- `tsc -b` and `oxlint` clean; vitest suite passes (3,344 tests) including new coverage for `segmentSeek`, the StationPlayer fragment/verify/reload paths, hold-repeat wheel behavior, shell time skips, the banner, off-air tuning, and Now Playing logos.
- Playwright e2e (mobile iPod, About, account) green.
- **The iOS `currentTime` clamp cannot be reproduced in this environment** (no WebKit available) — please verify on an actual iPhone via the PR preview: play WINS, then jump to any bookmark; audio should land at the clock position instead of replaying the same spot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbHaqWdA8iVcRLoPtpFJHU

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbHaqWdA8iVcRLoPtpFJHU)_