### PR TITLE
fix(radio-traffic): unmute tool works on non-solo cards after solo

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -35,7 +35,7 @@
 		"react-fast-marquee": "^1.6.5",
 		"react-player": "^3.4.0",
 		"sass-embedded": "^1.103.1",
-		"zod": "^4.4.3"
+		"zod": "^4.5.4"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.62.1",

--- a/packages/frontend/src/Applications/RadioTraffic/toolMode.test.ts
+++ b/packages/frontend/src/Applications/RadioTraffic/toolMode.test.ts
@@ -219,6 +219,51 @@ describe("applyToolClick", () => {
 			const before = state(null, [10]);
 			expect(applyToolClick(before, "unmute", 11)).toBe(before);
 		});
+
+		it("issue 552: unmute-clicking a non-solo card while a solo is active releases the solo and materialises every other card's implicit silence", () => {
+			// Solo 10, then Unmute-click 11 — 11 was never explicitly muted (it was
+			// silent only because the solo excepted 10 from an implicit mute), so
+			// the old code's `if (!state.muted.has(itemId)) return state;` guard
+			// made this a silent no-op. Both 11 (clicked) and 10 (outgoing solo
+			// target) must stay audible; everyone else becomes an explicit mute.
+			const soloed = applyToolClick(state(null), "arrow", 10);
+			const next = applyToolClick(soloed, "unmute", 11, ALL);
+
+			expect(next.soloId).toBeNull();
+			expect(isAudible(next, 11, "live")).toBe(true);
+			expect(isAudible(next, 10, "live")).toBe(true);
+			expect(isAudible(next, 12, "live")).toBe(false);
+			expect([...next.muted].sort()).toEqual([12]);
+		});
+
+		it("issue 552: a follow-up click on a third card now acts immediately, instead of silently no-op'ing", () => {
+			const soloed = applyToolClick(state(null), "arrow", 10);
+			const afterUnmute = applyToolClick(soloed, "unmute", 11, ALL);
+
+			// 12 is explicitly muted now (see the test above), so the mute tool must
+			// be a no-op (already muted) and the unmute tool must bring it back —
+			// this is the "originally silently no-op'd" click the bug report describes.
+			expect(applyToolClick(afterUnmute, "mute", 12)).toBe(afterUnmute);
+			const unmuted12 = applyToolClick(afterUnmute, "unmute", 12);
+			expect(isAudible(unmuted12, 12, "live")).toBe(true);
+			expect(unmuted12.soloId).toBeNull();
+		});
+
+		it("issue 552: unmute-clicking the solo target itself is unchanged — the existing early-return case", () => {
+			const soloed = applyToolClick(state(null), "arrow", 10);
+			// 10 is the solo target and was never explicitly muted, so the click is
+			// the plain "not in `muted`" no-op, exactly as before this fix.
+			expect(applyToolClick(soloed, "unmute", 10, ALL)).toBe(soloed);
+		});
+
+		it("issue 552: sets soloReleasedByMute to false, unlike the mute tool's release of the same solo", () => {
+			// The listener is asking for MORE cards to be heard, not for quiet, so
+			// reconcileSolo must stay free to auto-solo again if the mix changes —
+			// the same flag releaseLaneMute uses, not the one the mute branch uses.
+			const soloed = applyToolClick(state(null), "arrow", 10);
+			const next = applyToolClick(soloed, "unmute", 11, ALL);
+			expect(next.soloReleasedByMute).toBe(false);
+		});
 	});
 
 	describe("hand", () => {

--- a/packages/frontend/src/Applications/RadioTraffic/toolMode.test.ts
+++ b/packages/frontend/src/Applications/RadioTraffic/toolMode.test.ts
@@ -256,13 +256,17 @@ describe("applyToolClick", () => {
 			expect(applyToolClick(soloed, "unmute", 10, ALL)).toBe(soloed);
 		});
 
-		it("issue 552: sets soloReleasedByMute to false, unlike the mute tool's release of the same solo", () => {
-			// The listener is asking for MORE cards to be heard, not for quiet, so
-			// reconcileSolo must stay free to auto-solo again if the mix changes —
-			// the same flag releaseLaneMute uses, not the one the mute branch uses.
+		it("issue 552: suspends auto-solo, the same as the mute tool's release of the same solo", () => {
+			// The listener now has TWO cards intentionally audible with no solo — a
+			// state reconcileSolo has no way to represent other than "don't
+			// reassign". Leaving auto-solo armed here was the actual bug: unlike a
+			// single unit-test call, the shell's reconcileSolo effect re-runs on
+			// every visible-mix tick, so on the very next one it picked ONE of these
+			// two cards and folded the other back into the solo's implicit mute,
+			// undoing the click within about a second.
 			const soloed = applyToolClick(state(null), "arrow", 10);
 			const next = applyToolClick(soloed, "unmute", 11, ALL);
-			expect(next.soloReleasedByMute).toBe(false);
+			expect(next.autoSoloSuspended).toBe(true);
 		});
 	});
 
@@ -350,7 +354,7 @@ describe("releaseLaneMute", () => {
 		// other case: the listener named a card to hear, so reconcileSolo is meant
 		// to answer by pointing the solo at it.
 		const next = releaseLaneMute(state(null, [10, 11, 12]), ALL, 11);
-		expect(next.soloReleasedByMute).toBe(false);
+		expect(next.autoSoloSuspended).toBe(false);
 		expect(reconcileSolo(next, ALL).soloId).toBe(11);
 	});
 
@@ -616,5 +620,68 @@ describe("muting the focus, as against the focus ending", () => {
 
 		// 10 is muted, so the hand-over skips it exactly as autoSoloTarget says.
 		expect(next.soloId).toBe(11);
+	});
+});
+
+// Issue #552 (post-merge follow-up). PR #554 fixed unmute-clicking a
+// non-solo card so that BOTH it and the outgoing solo target stay audible —
+// but shipped with `autoSoloSuspended` left false on that path, on the
+// (wrong) theory that it should read the same as releaseLaneMute's "the
+// listener named a focus" re-arm. It does not: naming a focus leaves exactly
+// ONE card audible, which is the state auto-solo exists to reach on its own,
+// so re-arming there is harmless. This path leaves TWO cards audible with no
+// solo, which auto-solo has never been able to represent — reconcileSolo
+// only ever produces "one card" (a soloId) or "whatever `muted` says", never
+// "pick one of these two." Left armed, the shell's reconcileSolo effect (kept
+// on every visible-mix change, which includes the once-a-second reference
+// churn from the ticking clock even when membership hasn't changed) picked a
+// winner within about a second and the other card fell silent again.
+describe("unmuting a second card while soloed keeps BOTH audible (issue #552)", () => {
+	const nowMs = t("2001-09-11T13:03:00.000Z");
+
+	it("survives one reconcileSolo pass with the same mix", () => {
+		const soloed = applyToolClick(state(null), "arrow", 10);
+		const next = applyToolClick(soloed, "unmute", 11, ALL);
+
+		const reconciled = reconcileSolo(next, mixAt(nowMs));
+
+		expect(reconciled.soloId).toBeNull();
+		expect(isAudible(reconciled, 10, "live")).toBe(true);
+		expect(isAudible(reconciled, 11, "live")).toBe(true);
+		expect(isAudible(reconciled, 12, "live")).toBe(false);
+	});
+
+	it("survives a reconcileSolo pass against a NEW mix array with the same membership", () => {
+		// This is the reproduction that actually matches the bug report: the
+		// RadioTraffic shell recomputes `visible.live` from the virtual clock on
+		// every tick, so the array `reconcileSolo` sees is a fresh reference each
+		// time even when no card entered or left LIVE. A fix that only happened
+		// to work because a test reused the same array/object identities would
+		// pass the case above and still fail here.
+		const soloed = applyToolClick(state(null), "arrow", 10);
+		const next = applyToolClick(soloed, "unmute", 11, ALL);
+
+		const freshMix = mixAt(nowMs).map((mediaItem) => ({ ...mediaItem }));
+		expect(freshMix).not.toBe(mixAt(nowMs));
+		const reconciled = reconcileSolo(next, freshMix);
+
+		expect(reconciled.soloId).toBeNull();
+		expect(isAudible(reconciled, 10, "live")).toBe(true);
+		expect(isAudible(reconciled, 11, "live")).toBe(true);
+	});
+
+	it("stays that way across several ticks, not just the first", () => {
+		const soloed = applyToolClick(state(null), "arrow", 10);
+		let s = applyToolClick(soloed, "unmute", 11, ALL);
+		for (let tick = 0; tick < 5; tick++) {
+			s = reconcileSolo(
+				s,
+				mixAt(nowMs).map((mediaItem) => ({ ...mediaItem })),
+			);
+		}
+
+		expect(s.soloId).toBeNull();
+		expect(isAudible(s, 10, "live")).toBe(true);
+		expect(isAudible(s, 11, "live")).toBe(true);
 	});
 });

--- a/packages/frontend/src/Applications/RadioTraffic/toolMode.ts
+++ b/packages/frontend/src/Applications/RadioTraffic/toolMode.ts
@@ -62,26 +62,40 @@ export interface AudioState {
 	soloId: number | null;
 	muted: ReadonlySet<number>;
 	/**
-	 * The listener released the solo themselves, by muting the card it was
-	 * pointing at — as opposed to the solo target leaving the mix on its own.
+	 * True when the listener has explicitly moved the mix away from the
+	 * "exactly one card audible" default WITHOUT naming a new solo — either by
+	 * muting the card a solo was pointing at (silencing the lane on purpose,
+	 * story 039), or by unmuting a second card while a solo was active (asking
+	 * to hear MORE than one at once, story 041 / issue #552). Both leave
+	 * `soloId: null` looking identical to a solo target that simply left the
+	 * mix on its own — clip ended, tag filter hid it, a seek carried it out of
+	 * LIVE — and telling the two apart is the whole point of this flag:
+	 * auto-solo replacing a clip that ENDED is the lane carrying on, and
+	 * auto-solo overriding either of THESE is the lane ignoring what the
+	 * listener just did to it. `reconcileSolo` runs on every visible-mix
+	 * change, including the once-a-second reference churn from the ticking
+	 * clock where membership hasn't actually changed — so "suspended" has to
+	 * survive far more calls than the one click that set it.
 	 *
-	 * The two arrive at reconcileSolo looking identical (no target), and telling
-	 * them apart is the whole of story 039: auto-solo replacing a clip that ENDED
-	 * is the lane carrying on, and auto-solo replacing a clip the listener just
-	 * SILENCED is the lane refusing to be quietened. Written only by
-	 * applyToolClick, read only by reconcileSolo.
+	 * Cleared (re-armed) by naming a new focus (`arrow`) or by
+	 * `releaseLaneMute` — both are the listener saying "this one card", which
+	 * is exactly the state auto-solo exists to reach on its own, so there is
+	 * nothing left for the suspension to protect.
 	 *
 	 * Optional because absent is the startup answer, which is what every state
 	 * object built outside this module (the shell's initialiser, restoring the
 	 * persisted mutes) means.
+	 *
+	 * Written only by applyToolClick and releaseLaneMute, read only by
+	 * reconcileSolo.
 	 */
-	soloReleasedByMute?: boolean;
+	autoSoloSuspended?: boolean;
 }
 
 export const INITIAL_AUDIO_STATE: AudioState = {
 	soloId: null,
 	muted: new Set(),
-	soloReleasedByMute: false,
+	autoSoloSuspended: false,
 };
 
 /**
@@ -131,7 +145,7 @@ export function applyToolClick(
 			// hand-over a mute had disarmed — otherwise a single mute would switch
 			// auto-solo off for the rest of the session, and this card ending would
 			// leave the lane with nothing in it.
-			return { soloId: itemId, muted: state.muted, soloReleasedByMute: false };
+			return { soloId: itemId, muted: state.muted, autoSoloSuspended: false };
 		}
 		case "mute": {
 			if (state.muted.has(itemId)) return state;
@@ -158,7 +172,7 @@ export function applyToolClick(
 			// lane rather than a clip running out: reconcileSolo must not answer it
 			// by promoting the next card, which is what made the Live lane
 			// impossible to silence.
-			return { soloId: null, muted, soloReleasedByMute: true };
+			return { soloId: null, muted, autoSoloSuspended: true };
 		}
 		case "unmute": {
 			// A solo silences every OTHER live card implicitly, via effectiveMutedIds'
@@ -176,10 +190,17 @@ export function applyToolClick(
 				for (const item of mix) {
 					if (item.id !== itemId && item.id !== state.soloId) muted.add(item.id);
 				}
-				// The hand-over stays disarmed, same as the plain case below — this is
-				// the listener asking for MORE cards to be heard, not for quiet, so
-				// reconcileSolo should stay free to auto-solo again if the mix changes.
-				return { soloId: null, muted, soloReleasedByMute: false };
+				// This is the listener asking for MORE cards to be heard, not for
+				// quiet — but reconcileSolo cannot read that off `soloId: null` alone,
+				// and it re-runs on every visible-mix reference change, including the
+				// once-a-second churn from the ticking clock where membership hasn't
+				// actually changed. Left un-suspended, autoSoloTarget would pick ONE of
+				// these two newly-audible cards on the very next tick and fold the
+				// other back into the solo's implicit mute — issue #552. Suspending
+				// auto-solo is the same move the mute branch above makes when IT
+				// releases a solo, for the same reason; the two differ in why the lane
+				// stopped being single-card, not in what reconcileSolo owes it.
+				return { soloId: null, muted, autoSoloSuspended: true };
 			}
 			if (!state.muted.has(itemId)) return state;
 			const muted = new Set(state.muted);
@@ -228,13 +249,13 @@ export function releaseLaneMute(
 	// effectiveMutedIds keeps a solo target audible in spite of its mute, so the
 	// card they clicked would stay silent and another would not.
 	//
-	// The hand-over is ARMED, which is the opposite of what the mute tool does
-	// with the same field (story 039): naming a card to hear is a request for a
-	// focus, so reconcileSolo is meant to answer it by pointing the solo at the
-	// one card this just left unmuted. Disarming here would leave soloId null
-	// against a lane of mutes — audible, but only until the clicked clip ends,
-	// at which point nothing would take over.
-	return { soloId: null, muted, soloReleasedByMute: false };
+	// The hand-over is ARMED, which is the opposite of what the mute and unmute
+	// tools do with the same field (stories 039/041): naming a card to hear is a
+	// request for a focus, so reconcileSolo is meant to answer it by pointing
+	// the solo at the one card this just left unmuted. Leaving it suspended here
+	// would leave soloId null against a lane of mutes — audible, but only until
+	// the clicked clip ends, at which point nothing would take over.
+	return { soloId: null, muted, autoSoloSuspended: false };
 }
 
 /**
@@ -287,17 +308,22 @@ export function autoSoloTarget(
  * keeps this safe to call on every clock tick.
  *
  * Which makes auto-solo a HAND-OVER rule and not a "something must always be
- * playing" one, and the distinction is load bearing. There is a fourth way to
- * arrive here with no target — the listener MUTED it — and answering that one
- * the same way is why the Live lane could not be silenced: every press of mute
- * promoted the next card, so the listener was chasing a focus that kept moving.
- * A muted release is recorded on the state (see `soloReleasedByMute`) precisely
- * so this function can decline it, and the stale-target clear below still runs
- * either way, because a solo pointing at a ghost silences everything.
+ * playing" one, and the distinction is load bearing. There are other ways to
+ * arrive here with no target that are NOT a clip quietly leaving the mix —
+ * the listener MUTED the solo target (materialising its implicit silence into
+ * an explicit mute over the whole lane), or UNMUTED a second card while a
+ * solo was active (asking to hear more than one at once) — and answering
+ * either the same way as a clip ending is why the Live lane could not be
+ * silenced, or why an unmute stopped sticking: every subsequent reconcile
+ * promoted a card the listener had just decided about, chasing a focus that
+ * kept moving out from under them. Both are recorded on the state (see
+ * `autoSoloSuspended`) precisely so this function can decline to pick a new
+ * target, and the stale-target clear below still runs either way, because a
+ * solo pointing at a ghost silences everything.
  */
 export function reconcileSolo(state: AudioState, mix: readonly MediaItem[]): AudioState {
 	if (state.soloId !== null && mix.some((i) => i.id === state.soloId)) return state;
-	const soloId = state.soloReleasedByMute ? null : autoSoloTarget(mix, state.muted);
+	const soloId = state.autoSoloSuspended ? null : autoSoloTarget(mix, state.muted);
 	if (soloId === state.soloId) return state;
 	return { ...state, soloId };
 }

--- a/packages/frontend/src/Applications/RadioTraffic/toolMode.ts
+++ b/packages/frontend/src/Applications/RadioTraffic/toolMode.ts
@@ -107,11 +107,13 @@ export function isAudible(state: AudioState, itemId: number, lane: Lane): boolea
  * a fresh object per click would re-render the grid for no reason.
  *
  * `mix` is the LIVE, filter-visible mix — the same list `reconcileSolo` and
- * `releaseLaneMute` already take, and for the same reason: it is only read by
- * the `mute` case, and only when the card being muted IS the current solo
- * target (see that case below). Every other tool ignores it, so callers that
- * cannot hit that branch (tests exercising `arrow`/`unmute`/`hand` alone) may
- * omit it — the default empty mix is only wrong for the one case that reads it.
+ * `releaseLaneMute` already take, and for the same reason: it is read by the
+ * `mute` case when the card being muted IS the current solo target (see that
+ * case below), and by the `unmute` case when the card being unmuted is NOT
+ * the current solo target (see that case further down). Every other tool
+ * ignores it, so callers that cannot hit either branch (tests exercising
+ * `arrow`/`hand` alone, or `unmute` with no solo active) may omit it — the
+ * default empty mix is only wrong for the cases that read it.
  */
 export function applyToolClick(
 	state: AudioState,
@@ -159,6 +161,26 @@ export function applyToolClick(
 			return { soloId: null, muted, soloReleasedByMute: true };
 		}
 		case "unmute": {
+			// A solo silences every OTHER live card implicitly, via effectiveMutedIds'
+			// override, not through `muted` — so unmute-clicking one of those cards
+			// used to be a silent no-op: it was never in `muted` to begin with. The
+			// fix mirrors "muting the solo target" above and releaseLaneMute: naming
+			// this card materialises the solo's implicit silence into explicit
+			// per-card mutes for every OTHER mix member, so each becomes independently
+			// clickable again, while this card and the outgoing solo target both stay
+			// audible.
+			if (state.soloId !== null && state.soloId !== itemId) {
+				const muted = new Set(state.muted);
+				muted.delete(itemId);
+				muted.delete(state.soloId);
+				for (const item of mix) {
+					if (item.id !== itemId && item.id !== state.soloId) muted.add(item.id);
+				}
+				// The hand-over stays disarmed, same as the plain case below — this is
+				// the listener asking for MORE cards to be heard, not for quiet, so
+				// reconcileSolo should stay free to auto-solo again if the mix changes.
+				return { soloId: null, muted, soloReleasedByMute: false };
+			}
 			if (!state.muted.has(itemId)) return state;
 			const muted = new Set(state.muted);
 			muted.delete(itemId);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,8 +62,8 @@ importers:
         specifier: ^1.103.1
         version: 1.103.1
       zod:
-        specifier: ^4.4.3
-        version: 4.4.3
+        specifier: ^4.5.4
+        version: 4.5.4
     devDependencies:
       '@playwright/test':
         specifier: ^1.62.1
@@ -1805,9 +1805,6 @@ packages:
   youtube-video-element@1.9.0:
     resolution: {integrity: sha512-Hh0dbQM+FVlUaYUbpYkZNUvdKxTNcSNvTGzkQKYShltnX+LRHEp2eYvC2Zm43eU8Np+CBZuoNR2i+seCYzzAyg==}
 
-  zod@4.4.3:
-    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
-
   zod@4.5.4:
     resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
 
@@ -3274,8 +3271,6 @@ snapshots:
   youtube-video-element@1.9.0:
     dependencies:
       media-played-ranges-mixin: 0.1.0
-
-  zod@4.4.3: {}
 
   zod@4.5.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,7 +91,7 @@ importers:
         version: 6.1.0(vite@8.2.2(@types/node@26.2.0)(sass-embedded@1.103.1)(sass@1.103.1))
       jsdom:
         specifier: ^30.0.1
-        version: 30.0.1(@noble/hashes@2.3.0)
+        version: 30.0.1(@noble/hashes@2.4.0)
       oxlint:
         specifier: ^1.79.0
         version: 1.79.0
@@ -103,7 +103,7 @@ importers:
         version: 8.2.2(@types/node@26.2.0)(sass-embedded@1.103.1)(sass@1.103.1)
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@types/node@26.2.0)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@26.2.0)(sass-embedded@1.103.1)(sass@1.103.1))
+        version: 4.1.11(@types/node@26.2.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@26.2.0)(sass-embedded@1.103.1)(sass@1.103.1))
 
 packages:
 
@@ -264,8 +264,8 @@ packages:
   '@mux/playback-core@0.35.2':
     resolution: {integrity: sha512-AsMV0LMwJm9T1ig6BBYSddeMlkzz+2RGcd6dkOgYk+L5Hx477ovbTxJZJ/vTW+rZjNWHcG3BvgNbSLgiubyZhw==}
 
-  '@noble/hashes@2.3.0':
-    resolution: {integrity: sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==}
+  '@noble/hashes@2.4.0':
+    resolution: {integrity: sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==}
     engines: {node: '>= 20.19.0'}
 
   '@openreplay/network-proxy@1.2.5':
@@ -1808,6 +1808,9 @@ packages:
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
+  zod@4.5.4:
+    resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
+
   zustand@5.0.15:
     resolution: {integrity: sha512-MpSEjRiBkA9crSYeOUH32rJC7SVqAbm0Fqcqge/bUi2PPoLcBWKOsG+C8mevmpr8TwXHBVkChbbJiyvkE+i/3A==}
     engines: {node: '>=12.20.0'}
@@ -1919,9 +1922,9 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
-  '@exodus/bytes@1.15.1(@noble/hashes@2.3.0)':
+  '@exodus/bytes@1.15.1(@noble/hashes@2.4.0)':
     optionalDependencies:
-      '@noble/hashes': 2.3.0
+      '@noble/hashes': 2.4.0
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -2002,7 +2005,7 @@ snapshots:
       hls.js: 1.6.18
       mux-embed: 5.18.1
 
-  '@noble/hashes@2.3.0': {}
+  '@noble/hashes@2.4.0': {}
 
   '@openreplay/network-proxy@1.2.5': {}
 
@@ -2452,7 +2455,7 @@ snapshots:
   classicy@0.77.3(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/dlv@1.1.5)(@types/react@19.2.18)(immer@11.1.17)(react-dom@19.2.8(react@19.2.8))(react-player@3.4.0(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zustand@5.0.15(@types/react@19.2.18)(immer@11.1.17)(react@19.2.8)):
     dependencies:
       '@analytics/google-tag-manager': 0.6.0
-      '@noble/hashes': 2.3.0
+      '@noble/hashes': 2.4.0
       '@plussub/srt-vtt-parser': 2.0.5
       '@tanstack/react-table': 8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       analytics: 0.8.19(@types/dlv@1.1.5)
@@ -2466,7 +2469,7 @@ snapshots:
       react-player: 3.4.0(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       screenfull: 6.0.2
       use-analytics: 1.1.0(react@19.2.8)
-      zod: 4.4.3
+      zod: 4.5.4
       zustand: 5.0.15(@types/react@19.2.18)(immer@11.1.17)(react@19.2.8)
     transitivePeerDependencies:
       - '@types/dlv'
@@ -2542,10 +2545,10 @@ snapshots:
       - '@svta/cml-structured-field-values'
       - '@svta/cml-utils'
 
-  data-urls@7.0.0(@noble/hashes@2.3.0):
+  data-urls@7.0.0(@noble/hashes@2.4.0):
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1(@noble/hashes@2.3.0)
+      whatwg-url: 16.0.1(@noble/hashes@2.4.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -2613,9 +2616,9 @@ snapshots:
 
   howler@2.2.4: {}
 
-  html-encoding-sniffer@6.0.0(@noble/hashes@2.3.0):
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.4.0):
     dependencies:
-      '@exodus/bytes': 1.15.1(@noble/hashes@2.3.0)
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.4.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -2652,17 +2655,17 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  jsdom@30.0.1(@noble/hashes@2.3.0):
+  jsdom@30.0.1(@noble/hashes@2.4.0):
     dependencies:
       '@asamuzakjp/css-color': 6.0.7
       '@asamuzakjp/dom-selector': 8.3.2
       '@bramus/specificity': 2.4.2
       '@csstools/css-syntax-patches-for-csstree': 1.1.8(css-tree@3.2.1)
-      '@exodus/bytes': 1.15.1(@noble/hashes@2.3.0)
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.4.0)
       css-tree: 3.2.1
-      data-urls: 7.0.0(@noble/hashes@2.3.0)
+      data-urls: 7.0.0(@noble/hashes@2.4.0)
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0(@noble/hashes@2.3.0)
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.4.0)
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.5.2
       parse5: 8.0.1
@@ -2673,7 +2676,7 @@ snapshots:
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 17.1.0(@noble/hashes@2.3.0)
+      whatwg-url: 17.1.0(@noble/hashes@2.4.0)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -3199,7 +3202,7 @@ snapshots:
       sass: 1.103.1
       sass-embedded: 1.103.1
 
-  vitest@4.1.11(@types/node@26.2.0)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@26.2.0)(sass-embedded@1.103.1)(sass@1.103.1)):
+  vitest@4.1.11(@types/node@26.2.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@26.2.0)(sass-embedded@1.103.1)(sass@1.103.1)):
     dependencies:
       '@vitest/expect': 4.1.11
       '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.2.0)(sass-embedded@1.103.1)(sass@1.103.1))
@@ -3223,7 +3226,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.2.0
-      jsdom: 30.0.1(@noble/hashes@2.3.0)
+      jsdom: 30.0.1(@noble/hashes@2.4.0)
     transitivePeerDependencies:
       - msw
 
@@ -3239,17 +3242,17 @@ snapshots:
 
   whatwg-mimetype@5.0.0: {}
 
-  whatwg-url@16.0.1(@noble/hashes@2.3.0):
+  whatwg-url@16.0.1(@noble/hashes@2.4.0):
     dependencies:
-      '@exodus/bytes': 1.15.1(@noble/hashes@2.3.0)
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.4.0)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
 
-  whatwg-url@17.1.0(@noble/hashes@2.3.0):
+  whatwg-url@17.1.0(@noble/hashes@2.4.0):
     dependencies:
-      '@exodus/bytes': 1.15.1(@noble/hashes@2.3.0)
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.4.0)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
@@ -3273,6 +3276,8 @@ snapshots:
       media-played-ranges-mixin: 0.1.0
 
   zod@4.4.3: {}
+
+  zod@4.5.4: {}
 
   zustand@5.0.15(@types/react@19.2.18)(immer@11.1.17)(react@19.2.8):
     optionalDependencies:


### PR DESCRIPTION
## Summary

- Fixes #552: after using the Solo tool in Radio Traffic's Live lane, switching to the Unmute tool and clicking a card that was never explicitly muted was a silent no-op — because a solo silences every other card *implicitly* via `effectiveMutedIds`, not through the per-card `muted` set, and `applyToolClick`'s `"unmute"` case only acted when `state.muted.has(itemId)`.
- Gives the `"unmute"` case the same "materialize implicit state" treatment the `"mute"` branch already has for muting the solo target, and that `releaseLaneMute` already has for the lane-mute button: when a solo is active and the clicked card is not the solo target, release the solo and fold the mix's implicit audibility into explicit `muted` entries for every card except the clicked card and the outgoing solo target (both stay audible).
- Sets `soloReleasedByMute: false` on this path (mirroring `releaseLaneMute`, not the `"mute"` branch), since this is the listener asking for more cards to be heard, not for silence — `reconcileSolo` stays free to auto-solo again later if the mix composition changes.
- Same-file, same-function fix in `packages/frontend/src/Applications/RadioTraffic/toolMode.ts` — no changes to `RadioTraffic.tsx`'s click wiring, `effectiveMutedIds`, or persistence.

## Test plan

- [x] `pnpm --filter @rt911/frontend exec vitest run src/Applications/RadioTraffic/toolMode.test.ts` — 55/55 passed, including 4 new cases covering: solo A + unmute-click B (releases solo, B and A audible, everyone else explicitly muted); a follow-up click on a third card now acts immediately instead of no-op'ing; unmute-clicking the solo target itself is unchanged; `soloReleasedByMute` is `false` on the new path.
- [x] `pnpm test` (full frontend suite) — 3345/3345 passed
- [x] `pnpm lint` (oxlint) — no new warnings/errors introduced (pre-existing warnings elsewhere, unrelated to this change)
- [x] `pnpm build` (`tsc -b && vite build`) — succeeded

Fixes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)