### PR TITLE
Add ground-ground as a valid parties.link type

### DIFF
--- a/packages/tools/video-grabber/tests/test_parties_identify.py
+++ b/packages/tools/video-grabber/tests/test_parties_identify.py
@@ -406,5 +406,5 @@ def test_wrong_typed_top_level_fields_do_not_crash(key, junk):
     cleaned, _ = validate_parties({**GOOD, key: junk}, TRANSCRIPT)
     assert cleaned["schema_version"] == SCHEMA_VERSION
     assert cleaned["confidence"] in {"high", "medium", "low"}
-    assert cleaned["link"] in {"air-ground", "landline", "internal",
-                               "conference", "unknown"}
+    assert cleaned["link"] in {"air-ground", "ground-ground", "landline",
+                               "internal", "conference", "unknown"}

--- a/packages/tools/video-grabber/video_grabber/parties/identify.py
+++ b/packages/tools/video-grabber/video_grabber/parties/identify.py
@@ -144,7 +144,7 @@ Return ONLY a JSON object:
  "participants":[{"facility":str|null,"position":str|null,"person":str|null,
                   "role":"atc"|"military"|"airline"|"emergency"|"aircraft"|"unknown",
                   "confidence":"high"|"medium"|"low"}],
- "link":"air-ground"|"landline"|"internal"|"conference"|"unknown",
+ "link":"air-ground"|"ground-ground"|"landline"|"internal"|"conference"|"unknown",
  "aircraft":[str],
  "mentions":{"facilities":[str],"aircraft":[str],"people":[str]},
  "subject":str|null,

--- a/packages/tools/video-grabber/video_grabber/parties/vocab.py
+++ b/packages/tools/video-grabber/video_grabber/parties/vocab.py
@@ -132,7 +132,7 @@ ROLES: frozenset[str] = frozenset({
 })
 
 LINKS: frozenset[str] = frozenset({
-    "air-ground", "landline", "internal", "conference", "unknown",
+    "air-ground", "ground-ground", "landline", "internal", "conference", "unknown",
 })
 
 


### PR DESCRIPTION
## Summary
- Adds `"ground-ground"` to `video_grabber/parties/vocab.py`'s `LINKS` set and to the `identify-parties` model prompt's schema, alongside `air-ground`, `landline`, `internal`, `conference`, `unknown`.
- Needed while hand-curating the FDNY Manhattan dispatch tape (rt911#377): dispatcher-to-mobile-unit fire radio doesn't fit any existing category — not `air-ground` (aircraft/ATC-specific), not `landline`, and not really `internal` (a facility's own voice loop, not a dispatch broadcast to units in the field).
- Updated `test_wrong_typed_top_level_fields_do_not_crash`'s allowed-`link`-values assertion to match the expanded set.

## Test plan
- [x] `uv run pytest tests/test_parties_identify.py -q` — 64 passed
- [x] `uv run ruff check video_grabber/parties/ tests/test_parties_identify.py` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYCRDCZo12uUfPfCg5uuyb