### PR TITLE
Radio Traffic: cap concurrent clips and add Split stereo panning

### DIFF
--- a/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.test.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.test.tsx
@@ -168,6 +168,22 @@ vi.mock("classicy", () => ({
 			onClick={() => onChangeFunc?.(0xff0000)}
 		/>
 	),
+	ClassicySlider: ({
+		id,
+		labelTitle,
+		value,
+		onChangeFunc,
+	}: {
+		id?: string;
+		labelTitle?: string;
+		value?: number;
+		onChangeFunc?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+	}) => (
+		<label htmlFor={id}>
+			{labelTitle}
+			<input id={id} type="range" value={value ?? 0} onChange={(e) => onChangeFunc?.(e)} />
+		</label>
+	),
 	MAC_OS_8_CRAYONS: [],
 	// The real packing, not a stand-in: the shell hands this straight to a CSS
 	// `color`, so a fake would let a broken conversion pass.

--- a/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/RadioTraffic.tsx
@@ -53,6 +53,7 @@ import { resolveAudioUrl } from "../radio-core/audioSource";
 import { BROADCAST_STATIONS, groupStations, startMs } from "../radio-core/stationGrouping";
 import appIconPng from "./app.png";
 import {
+	applySplitPanning,
 	clockMoved,
 	clockPauseChanged,
 	connectClock,
@@ -63,6 +64,7 @@ import {
 	setLevel,
 } from "./audioCoordinator";
 import { historyPool, type Lane, laneFor, rememberItems } from "./cardStatus";
+import { EMPTY_CLIP_QUEUE_STATE, reconcileClipQueue } from "./clipQueue";
 import { FilterTree } from "./FilterTree";
 import { LANES, type LaneOrder, reconcileLaneOrder, reorderLane } from "./laneOrder";
 import { LaneSection } from "./LaneSection";
@@ -291,6 +293,8 @@ export const RadioTraffic: React.FC = () => {
 		useThemeWaveformColor: restored.useThemeWaveformColor,
 		waveformColor: restored.waveformColor,
 		playOriginalAudio: restored.playOriginalAudio,
+		maxConcurrentClips: restored.maxConcurrentClips,
+		split: restored.split,
 	}));
 
 	// The Settings draft (the Tuner's pattern, and TimeMachine's before it):
@@ -619,6 +623,22 @@ export const RadioTraffic: React.FC = () => {
 		clockPauseChanged(clockPaused);
 	}, [clockPaused]);
 
+	// ── Issue #564: the concurrency cap ─────────────────────────────────────
+	// LIVE only (robbiebyrd's amendment) — a PREVIOUS clip the listener starts
+	// by hand is registered unconditionally below, same as before this issue.
+	// `visible.live` is already sorted earliest-start-first (partitionLanes),
+	// which doubles as clipQueue's arrival order.
+	const desiredLiveIds = useMemo(
+		() => visible.live.filter((item) => !stopped.has(item.id)).map((item) => item.id),
+		[visible.live, stopped],
+	);
+	const [clipQueue, setClipQueue] = useState(EMPTY_CLIP_QUEUE_STATE);
+	useEffect(() => {
+		setClipQueue((state) =>
+			reconcileClipQueue(state, desiredLiveIds, settings.maxConcurrentClips),
+		);
+	}, [desiredLiveIds, settings.maxConcurrentClips]);
+
 	// Which elements should exist, and WHICH COPY of each recording they play.
 	// FILTER visibility, NOT bare lane membership: a card the tag filter hides
 	// gets its <audio> released along with it, so a filtered-out item costs no
@@ -644,8 +664,14 @@ export const RadioTraffic: React.FC = () => {
 	useEffect(() => {
 		if (!isOpen) return;
 		const desired = new Map<number, string>();
+		// Issue #564: LIVE is gated on clipQueue's admission, not bare filter
+		// visibility — a pending id gets no element at all, which is the whole
+		// of "the number of clips should limit audio processing, as well as
+		// downloading." `stopped` is already excluded upstream, in
+		// `desiredLiveIds` feeding the queue above.
+		const admittedIds = new Set(clipQueue.admitted);
 		for (const item of visible.live) {
-			if (!stopped.has(item.id))
+			if (admittedIds.has(item.id))
 				desired.set(item.id, resolveAudioUrl(item, settings.playOriginalAudio));
 		}
 		for (const item of visible.previous) {
@@ -661,7 +687,25 @@ export const RadioTraffic: React.FC = () => {
 			ensure(itemId, url);
 			registeredRef.current.add(itemId);
 		}
-	}, [isOpen, visible.live, visible.previous, stopped, userStarted, settings.playOriginalAudio]);
+	}, [
+		isOpen,
+		visible.live,
+		visible.previous,
+		clipQueue.admitted,
+		userStarted,
+		settings.playOriginalAudio,
+	]);
+
+	// Issue #564's Split: pan admitted LIVE clips alternately left/right by
+	// their queue slot, or re-center all of them the instant Split is turned
+	// off (robbiebyrd's amendment — see applySplitPanning's own doc). A
+	// separate effect from the registration one above: this only needs to
+	// react to admission order and the Split flag, not the whole desired-set
+	// diff, and re-centering on toggle-off must fire even when nothing about
+	// admission itself changed this tick.
+	useEffect(() => {
+		applySplitPanning(clipQueue.admitted, settings.split);
+	}, [clipQueue.admitted, settings.split]);
 
 	// Story 050: the window closing is not an unmount — this component stays
 	// mounted for the desktop's whole lifetime — so nothing else stops the
@@ -706,7 +750,13 @@ export const RadioTraffic: React.FC = () => {
 			// they pressed play, and it is not part of the solo/mute mix at all.
 			setLevel(itemId, audibleIds.has(itemId) || userStarted.has(itemId));
 		}
-	}, [visible.live, audio, userStarted, liveLaneMuted]);
+		// clipQueue.admitted: issue #564's cap registers a LIVE element one
+		// render behind the mix that decides its level (reconcileClipQueue's own
+		// setState hop) — without this dependency, a card admitted on that later
+		// render would sit at whatever level `registeredRef` happened to hold
+		// nothing for the last time this effect's OTHER deps changed, i.e.
+		// unmuted by default, however the mix actually reads.
+	}, [visible.live, audio, userStarted, liveLaneMuted, clipQueue.admitted]);
 
 	const audioBlocked = useSyncExternalStore(subscribeAudioBlocked, isAudioBlocked);
 
@@ -723,6 +773,8 @@ export const RadioTraffic: React.FC = () => {
 				useThemeWaveformColor: settings.useThemeWaveformColor,
 				waveformColor: settings.waveformColor,
 				playOriginalAudio: settings.playOriginalAudio,
+				maxConcurrentClips: settings.maxConcurrentClips,
+				split: settings.split,
 			}),
 		);
 	}, [

--- a/packages/frontend/src/Applications/RadioTraffic/RadioTrafficContext.test.ts
+++ b/packages/frontend/src/Applications/RadioTraffic/RadioTrafficContext.test.ts
@@ -3,8 +3,11 @@ import { describe, expect, it } from "vitest";
 import {
 	classicyRadioTrafficEventHandler,
 	DEFAULT_CHECKED_TAGS,
+	DEFAULT_MAX_CONCURRENT_CLIPS,
 	DEFAULT_TOOL,
 	DEFAULT_WAVEFORM_COLOR,
+	MAX_CONCURRENT_CLIPS,
+	MIN_CONCURRENT_CLIPS,
 	radioTrafficSetState,
 	sanitizeRadioTrafficState,
 } from "./RadioTrafficContext";
@@ -36,6 +39,8 @@ describe("sanitizeRadioTrafficState", () => {
 			useThemeWaveformColor: true,
 			waveformColor: DEFAULT_WAVEFORM_COLOR,
 			playOriginalAudio: false,
+			maxConcurrentClips: DEFAULT_MAX_CONCURRENT_CLIPS,
+			split: false,
 		});
 	});
 
@@ -83,6 +88,8 @@ describe("sanitizeRadioTrafficState", () => {
 			useThemeWaveformColor: false,
 			waveformColor: 0x0000ff,
 			playOriginalAudio: true,
+			maxConcurrentClips: 8,
+			split: true,
 		};
 		expect(sanitizeRadioTrafficState(stored)).toEqual(stored);
 	});
@@ -229,6 +236,60 @@ describe("sanitizeRadioTrafficState", () => {
 			}
 		});
 	});
+
+	describe("the concurrent-clip cap", () => {
+		it("keeps every integer in the 2-24 range, including both ends", () => {
+			for (const n of [
+				MIN_CONCURRENT_CLIPS,
+				4,
+				12,
+				MAX_CONCURRENT_CLIPS,
+			]) {
+				expect(sanitizeRadioTrafficState({ maxConcurrentClips: n }).maxConcurrentClips).toBe(
+					n,
+				);
+			}
+		});
+
+		// A hand-edited or stale value could be anything, including a number a
+		// ClassicySlider (min 2, max 24) could never itself produce.
+		it("falls back to the default for anything outside 2-24 or not a number", () => {
+			for (const junk of [
+				MIN_CONCURRENT_CLIPS - 1,
+				MAX_CONCURRENT_CLIPS + 1,
+				0,
+				1.5,
+				Number.NaN,
+				"4",
+				null,
+				undefined,
+				{},
+			]) {
+				expect(
+					sanitizeRadioTrafficState({ maxConcurrentClips: junk }).maxConcurrentClips,
+				).toBe(DEFAULT_MAX_CONCURRENT_CLIPS);
+			}
+		});
+
+		it("defaults a state saved before the setting existed to 4", () => {
+			expect(
+				sanitizeRadioTrafficState({ tool: "mute" }).maxConcurrentClips,
+			).toBe(DEFAULT_MAX_CONCURRENT_CLIPS);
+		});
+	});
+
+	describe("Split", () => {
+		it("turns on only for an explicit true", () => {
+			expect(sanitizeRadioTrafficState({ split: true }).split).toBe(true);
+			for (const junk of [false, "true", 1, null, undefined, {}, []]) {
+				expect(sanitizeRadioTrafficState({ split: junk }).split).toBe(false);
+			}
+		});
+
+		it("defaults a state saved before the setting existed to off", () => {
+			expect(sanitizeRadioTrafficState({ tool: "mute" }).split).toBe(false);
+		});
+	});
 });
 
 describe("classicyRadioTrafficEventHandler", () => {
@@ -246,6 +307,8 @@ describe("classicyRadioTrafficEventHandler", () => {
 				useThemeWaveformColor: false,
 				waveformColor: 0xff6600,
 				playOriginalAudio: true,
+				maxConcurrentClips: 12,
+				split: true,
 			}),
 		);
 		expect(appData(next)).toEqual({
@@ -259,6 +322,8 @@ describe("classicyRadioTrafficEventHandler", () => {
 			useThemeWaveformColor: false,
 			waveformColor: 0xff6600,
 			playOriginalAudio: true,
+			maxConcurrentClips: 12,
+			split: true,
 		});
 	});
 
@@ -286,6 +351,8 @@ describe("classicyRadioTrafficEventHandler", () => {
 				useThemeWaveformColor: true,
 				waveformColor: DEFAULT_WAVEFORM_COLOR,
 				playOriginalAudio: false,
+				maxConcurrentClips: DEFAULT_MAX_CONCURRENT_CLIPS,
+				split: false,
 			})),
 		).toBe(ds);
 	});

--- a/packages/frontend/src/Applications/RadioTraffic/RadioTrafficContext.ts
+++ b/packages/frontend/src/Applications/RadioTraffic/RadioTrafficContext.ts
@@ -40,6 +40,11 @@ export const DEFAULT_TOOL: Tool = "arrow";
  */
 export const DEFAULT_WAVEFORM_COLOR = 0x00d25a;
 
+/** Issue #564: the concurrency cap's allowed range and its opening value. */
+export const MIN_CONCURRENT_CLIPS = 2;
+export const MAX_CONCURRENT_CLIPS = 24;
+export const DEFAULT_MAX_CONCURRENT_CLIPS = 4;
+
 /**
  * The slice of persisted state the Settings window edits.
  *
@@ -66,12 +71,31 @@ export interface RadioTrafficSettings {
 	 * renders, where it sat in front of broadcast stations it does not describe.
 	 */
 	playOriginalAudio: boolean;
+	/**
+	 * Issue #564: how many LIVE clips may hold an `<audio>` element (and
+	 * therefore a download and a decoder) at once — clipQueue.ts's admission
+	 * cap. `MIN_CONCURRENT_CLIPS`..`MAX_CONCURRENT_CLIPS`, default
+	 * `DEFAULT_MAX_CONCURRENT_CLIPS`. Scoped to the LIVE lane only: a
+	 * back-catalogue clip the listener starts by hand from PREVIOUS is not
+	 * counted against it (RadioTraffic.tsx's registration effect).
+	 */
+	maxConcurrentClips: number;
+	/**
+	 * Issue #564: hard-pan admitted LIVE clips alternately left/right by their
+	 * queue admission slot (slot 0 left, slot 1 right, slot 2 left, …) instead
+	 * of leaving every clip centered. Defaults false — the mix has always been
+	 * centered, and panning is an unusual enough listening mode that it should
+	 * be something a listener opts into, not discovers by accident.
+	 */
+	split: boolean;
 }
 
 export const DEFAULT_RADIO_TRAFFIC_SETTINGS: RadioTrafficSettings = {
 	useThemeWaveformColor: true,
 	waveformColor: DEFAULT_WAVEFORM_COLOR,
 	playOriginalAudio: false,
+	maxConcurrentClips: DEFAULT_MAX_CONCURRENT_CLIPS,
+	split: false,
 };
 
 /** Everything Radio Traffic persists, after sanitizing. */
@@ -210,6 +234,34 @@ function sanitizePlayOriginalAudio(value: unknown): boolean {
 	return value === true;
 }
 
+/**
+ * The concurrency cap, clamped to `MIN_CONCURRENT_CLIPS..MAX_CONCURRENT_CLIPS`.
+ *
+ * Mirrors `sanitizeWaveformColor`'s shape: a stored value outside the range a
+ * `ClassicySlider` can even produce (or not a number at all) falls back to the
+ * default rather than being clamped into range, because a silently-clamped
+ * number would leave the slider showing something the listener never chose.
+ */
+function sanitizeMaxConcurrentClips(value: unknown): number {
+	return typeof value === "number" &&
+		Number.isInteger(value) &&
+		value >= MIN_CONCURRENT_CLIPS &&
+		value <= MAX_CONCURRENT_CLIPS
+		? value
+		: DEFAULT_MAX_CONCURRENT_CLIPS;
+}
+
+/**
+ * Only an explicit `true` turns Split on.
+ *
+ * Mirrors `sanitizePlayOriginalAudio`: absent, `undefined` and garbage all mean
+ * the centered mix, which is both the default and what every session played
+ * before this setting existed — so nothing needs migrating.
+ */
+function sanitizeSplit(value: unknown): boolean {
+	return value === true;
+}
+
 function sanitizeLaneOrder(value: unknown): LaneOrder {
 	const stored = (value ?? {}) as Record<string, unknown>;
 	const out = {} as Record<Lane, readonly number[]>;
@@ -238,6 +290,8 @@ export function sanitizeRadioTrafficState(stored: unknown): RadioTrafficState {
 		useThemeWaveformColor: sanitizeUseThemeWaveformColor(data.useThemeWaveformColor),
 		waveformColor: sanitizeWaveformColor(data.waveformColor),
 		playOriginalAudio: sanitizePlayOriginalAudio(data.playOriginalAudio),
+		maxConcurrentClips: sanitizeMaxConcurrentClips(data.maxConcurrentClips),
+		split: sanitizeSplit(data.split),
 	};
 }
 
@@ -253,6 +307,8 @@ export const radioTrafficSetState = (state: RadioTrafficState): ActionMessage =>
 	useThemeWaveformColor: state.useThemeWaveformColor,
 	waveformColor: state.waveformColor,
 	playOriginalAudio: state.playOriginalAudio,
+	maxConcurrentClips: state.maxConcurrentClips,
+	split: state.split,
 });
 
 export const classicyRadioTrafficEventHandler = (
@@ -276,6 +332,8 @@ export const classicyRadioTrafficEventHandler = (
 				useThemeWaveformColor: action.useThemeWaveformColor,
 				waveformColor: action.waveformColor,
 				playOriginalAudio: action.playOriginalAudio,
+				maxConcurrentClips: action.maxConcurrentClips,
+				split: action.split,
 			};
 			return ds;
 		default:
@@ -338,6 +396,16 @@ export const RadioTrafficDataSchema = z.looseObject({
 		.describe(
 			"Whether cards play the original recording instead of the cleaned-up, noise-reduced one.",
 		),
+	maxConcurrentClips: z
+		.number()
+		.optional()
+		.describe(
+			"How many Live clips may play/download at once, 2-24 (default 4) — the rest wait their turn.",
+		),
+	split: z
+		.boolean()
+		.optional()
+		.describe("Whether admitted Live clips are hard-panned alternately left and right."),
 });
 
 export type RadioTrafficData = z.infer<typeof RadioTrafficDataSchema>;
@@ -351,7 +419,7 @@ registerApp({
 	actions: {
 		ClassicyAppRadioTrafficSetState: {
 			description:
-				"Persist the tag filters, the selected tool, the folded lanes, the manual card order, the per-card mutes, the Live lane mute, the waveform color and the original-recording choice.",
+				"Persist the tag filters, the selected tool, the folded lanes, the manual card order, the per-card mutes, the Live lane mute, the waveform color, the original-recording choice, the concurrent-clip cap and the Split setting.",
 			params: z.object({
 				checked: z.array(z.string()).describe("Ticked tag filters."),
 				tool: z.string().describe("Selected tool: arrow, mute, unmute or hand."),
@@ -366,6 +434,12 @@ registerApp({
 				playOriginalAudio: z
 					.boolean()
 					.describe("Whether to play the original recording rather than the enhanced one."),
+				maxConcurrentClips: z
+					.number()
+					.describe("How many Live clips may play/download at once, 2-24."),
+				split: z
+					.boolean()
+					.describe("Whether admitted Live clips are hard-panned alternately left and right."),
 			}),
 		},
 	},

--- a/packages/frontend/src/Applications/RadioTraffic/RadioTrafficSettingsWindow.test.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/RadioTrafficSettingsWindow.test.tsx
@@ -77,6 +77,27 @@ vi.mock("classicy", () => ({
 			onClick={() => onChangeFunc?.(0xff0000)}
 		/>
 	),
+	ClassicySlider: ({
+		id,
+		labelTitle,
+		value,
+		onChangeFunc,
+	}: {
+		id?: string;
+		labelTitle?: string;
+		value?: number;
+		onChangeFunc?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+	}) => (
+		<label htmlFor={id}>
+			{labelTitle}
+			<input
+				id={id}
+				type="range"
+				value={value ?? 0}
+				onChange={(e) => onChangeFunc?.(e)}
+			/>
+		</label>
+	),
 	ClassicyButton: ({
 		children,
 		onClickFunc,
@@ -155,9 +176,9 @@ describe("RadioTrafficSettingsWindow", () => {
 		fireEvent.click(picker() as HTMLElement);
 		fireEvent.click(screen.getByText("Save"));
 		expect(onSave).toHaveBeenCalledWith({
+			...DEFAULT_RADIO_TRAFFIC_SETTINGS,
 			useThemeWaveformColor: false,
 			waveformColor: 0xff0000,
-			playOriginalAudio: false,
 		});
 	});
 
@@ -190,9 +211,9 @@ describe("RadioTrafficSettingsWindow", () => {
 		render(
 			<Harness
 				initial={{
+					...DEFAULT_RADIO_TRAFFIC_SETTINGS,
 					useThemeWaveformColor: false,
 					waveformColor: 0x123456,
-					playOriginalAudio: false,
 				}}
 				onSave={() => {}}
 			/>,
@@ -242,6 +263,89 @@ describe("RadioTrafficSettingsWindow", () => {
 				/>,
 			);
 			expect(originalCheckbox().checked).toBe(true);
+		});
+	});
+
+	// Issue #564.
+	describe("the concurrent-clip cap", () => {
+		const slider = () =>
+			screen.getByLabelText("Max at once:") as HTMLInputElement;
+
+		it("opens on the documented default of 4", () => {
+			render(<Harness onSave={() => {}} />);
+			expect(slider().value).toBe("4");
+		});
+
+		it("hands the chosen cap back on Save", () => {
+			const onSave = vi.fn();
+			render(<Harness onSave={onSave} />);
+			fireEvent.change(slider(), { target: { value: "12" } });
+			fireEvent.click(screen.getByText("Save"));
+			expect(onSave).toHaveBeenCalledWith({
+				...DEFAULT_RADIO_TRAFFIC_SETTINGS,
+				maxConcurrentClips: 12,
+			});
+		});
+
+		it("dispatches nothing when the listener changes it and cancels", () => {
+			const onSave = vi.fn();
+			const onCancel = vi.fn();
+			render(<Harness onSave={onSave} onCancel={onCancel} />);
+			fireEvent.change(slider(), { target: { value: "20" } });
+			fireEvent.click(screen.getByText("Cancel"));
+			expect(onCancel).toHaveBeenCalled();
+			expect(onSave).not.toHaveBeenCalled();
+		});
+
+		it("opens showing the cap a previous session saved", () => {
+			render(
+				<Harness
+					initial={{ ...DEFAULT_RADIO_TRAFFIC_SETTINGS, maxConcurrentClips: 8 }}
+					onSave={() => {}}
+				/>,
+			);
+			expect(slider().value).toBe("8");
+		});
+	});
+
+	describe("Split", () => {
+		const splitCheckbox = () =>
+			screen.getByLabelText("Split — pan clips alternately left and right") as HTMLInputElement;
+
+		it("opens off by default", () => {
+			render(<Harness onSave={() => {}} />);
+			expect(splitCheckbox().checked).toBe(false);
+		});
+
+		it("hands the choice back on Save", () => {
+			const onSave = vi.fn();
+			render(<Harness onSave={onSave} />);
+			fireEvent.click(splitCheckbox());
+			fireEvent.click(screen.getByText("Save"));
+			expect(onSave).toHaveBeenCalledWith({
+				...DEFAULT_RADIO_TRAFFIC_SETTINGS,
+				split: true,
+			});
+		});
+
+		it("dispatches nothing when the listener ticks it and cancels", () => {
+			const onSave = vi.fn();
+			const onCancel = vi.fn();
+			render(<Harness onSave={onSave} onCancel={onCancel} />);
+			fireEvent.click(splitCheckbox());
+			fireEvent.click(screen.getByText("Cancel"));
+			expect(onCancel).toHaveBeenCalled();
+			expect(onSave).not.toHaveBeenCalled();
+		});
+
+		it("opens showing the choice a previous session saved", () => {
+			render(
+				<Harness
+					initial={{ ...DEFAULT_RADIO_TRAFFIC_SETTINGS, split: true }}
+					onSave={() => {}}
+				/>,
+			);
+			expect(splitCheckbox().checked).toBe(true);
 		});
 	});
 });

--- a/packages/frontend/src/Applications/RadioTraffic/RadioTrafficSettingsWindow.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/RadioTrafficSettingsWindow.tsx
@@ -3,13 +3,18 @@ import {
 	ClassicyCheckbox,
 	ClassicyColorPicker,
 	ClassicyControlGroup,
+	ClassicySlider,
 	ClassicyWindow,
 	MAC_OS_8_CRAYONS,
 } from "classicy";
 import type React from "react";
-import type { ComponentProps, Dispatch, SetStateAction } from "react";
+import type { ChangeEvent, ComponentProps, Dispatch, SetStateAction } from "react";
 import styles from "../radio-core/radio.module.scss";
-import type { RadioTrafficSettings } from "./RadioTrafficContext";
+import {
+	MAX_CONCURRENT_CLIPS,
+	MIN_CONCURRENT_CLIPS,
+	type RadioTrafficSettings,
+} from "./RadioTrafficContext";
 
 interface RadioTrafficSettingsWindowProps {
 	appId: string;
@@ -78,6 +83,34 @@ export const RadioTrafficSettingsWindow: React.FC<RadioTrafficSettingsWindowProp
 					onClickFunc={(checked: boolean) =>
 						setForm((f) => ({ ...f, playOriginalAudio: checked }))
 					}
+				/>
+			</ClassicyControlGroup>
+			<ClassicyControlGroup label="Concurrent Clips">
+				{/* Issue #564: caps how many Live clips may hold an <audio> element
+				    (and therefore a download and a decoder) at once — the rest wait
+				    their turn in clipQueue.ts rather than starting immediately. */}
+				<ClassicySlider
+					id="radiotraffic_settings_max_concurrent_clips"
+					labelTitle="Max at once:"
+					labelPosition="left"
+					labelSize="small"
+					value={form.maxConcurrentClips}
+					min={MIN_CONCURRENT_CLIPS}
+					max={MAX_CONCURRENT_CLIPS}
+					step={1}
+					valueLabel={`${form.maxConcurrentClips}`}
+					onChangeFunc={(e: ChangeEvent<HTMLInputElement>) =>
+						setForm((f) => ({
+							...f,
+							maxConcurrentClips: parseInt(e.target.value, 10),
+						}))
+					}
+				/>
+				<ClassicyCheckbox
+					id="radiotraffic_settings_split"
+					label="Split — pan clips alternately left and right"
+					checked={form.split}
+					onClickFunc={(checked: boolean) => setForm((f) => ({ ...f, split: checked }))}
 				/>
 			</ClassicyControlGroup>
 			<ClassicyControlGroup label="Waveform Color">

--- a/packages/frontend/src/Applications/RadioTraffic/audioCoordinator.test.ts
+++ b/packages/frontend/src/Applications/RadioTraffic/audioCoordinator.test.ts
@@ -12,8 +12,10 @@ import {
 } from "vitest";
 import type { MediaItem } from "../../Providers/MediaStream/MediaStreamContext";
 import { isAudioBlocked } from "../radio-core/audioBlocked";
+import { captureAudioElement } from "../radio-core/audioCapture";
 import { calcSeekSeconds } from "../radio-core/stationGrouping";
 import {
+	applySplitPanning,
 	type ClockSource,
 	clockMoved,
 	clockPauseChanged,
@@ -661,11 +663,20 @@ describe("audioCoordinator autoplay handling", () => {
 				.filter((type) =>
 					["click", "keydown", "pointerdown"].includes(type as string),
 				);
-		expect(registrations()).toEqual(["click", "keydown", "pointerdown"]);
+		// Loading the module graph registers each type twice, not once: this
+		// module's own retry listeners, plus radio-core/audioCapture's (issue
+		// #564's Split pulls it in as a static import) — each of those modules
+		// still registers its own set exactly once, which is what this test is
+		// actually pinning: neither set grows as more clips are ensure()'d.
+		const afterLoad = registrations();
+		expect(afterLoad).toHaveLength(6);
+		for (const type of ["click", "keydown", "pointerdown"]) {
+			expect(afterLoad.filter((t) => t === type)).toHaveLength(2);
+		}
 
 		fresh.connectClock(source);
 		for (let i = 0; i < 10; i++) fresh.ensure(i, `clip-${i}.mp3`);
-		expect(registrations()).toEqual(["click", "keydown", "pointerdown"]);
+		expect(registrations()).toEqual(afterLoad);
 
 		fresh.releaseAll();
 		addSpy.mockRestore();
@@ -1245,5 +1256,103 @@ describe("audioCoordinator clock-follow", () => {
 
 			expect(el.currentTime).toBe(10);
 		});
+	});
+});
+
+// Issue #564's Split feature. RadioTraffic never mounts radio-core's
+// WaveformVisualizer (its cards draw a static peaks envelope instead), so
+// nothing else in this app ever calls audioCapture's captureAudioElement —
+// applySplitPanning has to do it itself, on demand, the moment a clip
+// actually needs panning off-center.
+describe("audioCoordinator Split panning", () => {
+	class FakeGain {
+		gain = { value: 1 };
+		connect = vi.fn();
+	}
+	class FakePanner {
+		pan = { value: 0 };
+		connect = vi.fn();
+	}
+	class FakeSource {
+		connect = vi.fn();
+	}
+	class FakeAudioContext {
+		static instances = 0;
+		destination = { kind: "destination" };
+		createMediaElementSource = vi.fn(() => new FakeSource());
+		createStereoPanner = vi.fn(() => new FakePanner());
+		createGain = vi.fn(() => new FakeGain());
+		resume = vi.fn().mockResolvedValue(undefined);
+		constructor() {
+			FakeAudioContext.instances++;
+		}
+	}
+
+	beforeEach(() => {
+		FakeAudioContext.instances = 0;
+		vi.stubGlobal("AudioContext", FakeAudioContext);
+	});
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	/**
+	 * The pan value the capture chain actually holds for `el`. A second
+	 * `captureAudioElement` call is a documented no-op that returns the SAME
+	 * entry (audioCapture.test.ts's "returns the same entry on repeat
+	 * capture"), so this reads the live graph applySplitPanning already built
+	 * without audioCoordinator needing to expose its own captured entries.
+	 */
+	function panOf(el: HTMLAudioElement): number {
+		return captureAudioElement(el)?.panner.pan.value ?? Number.NaN;
+	}
+
+	it("pans even slots left and odd slots right when enabled", () => {
+		connect();
+		const one = ensure(1, "a.mp3");
+		const two = ensure(2, "b.mp3");
+		const three = ensure(3, "c.mp3");
+
+		applySplitPanning([1, 2, 3], true);
+
+		expect(panOf(one)).toBe(-1);
+		expect(panOf(two)).toBe(1);
+		expect(panOf(three)).toBe(-1);
+	});
+
+	it("does not capture an id that is not named in the order at all", () => {
+		connect();
+		ensure(1, "a.mp3");
+
+		applySplitPanning([], true);
+
+		expect(FakeAudioContext.instances).toBe(0);
+	});
+
+	it("re-centers every panned element immediately when Split turns off", () => {
+		// robbiebyrd's amendment: an already-panned clip must not wait for a
+		// fresh admission to come back to center.
+		connect();
+		const one = ensure(1, "a.mp3");
+		applySplitPanning([1], true);
+		expect(panOf(one)).toBe(-1);
+
+		applySplitPanning([1], false);
+
+		expect(panOf(one)).toBe(0);
+	});
+
+	it("never captures an element for the default, Split-off case", () => {
+		connect();
+		ensure(1, "a.mp3");
+
+		applySplitPanning([1], false);
+
+		expect(FakeAudioContext.instances).toBe(0);
+	});
+
+	it("skips an id with no registered element", () => {
+		connect();
+		expect(() => applySplitPanning([1, 2], true)).not.toThrow();
 	});
 });

--- a/packages/frontend/src/Applications/RadioTraffic/audioCoordinator.ts
+++ b/packages/frontend/src/Applications/RadioTraffic/audioCoordinator.ts
@@ -36,6 +36,7 @@
 
 import type { MediaItem } from "../../Providers/MediaStream/MediaStreamContext";
 import { clearAudioBlocked, markAudioBlocked } from "../radio-core/audioBlocked";
+import { captureAudioElement, setAudioLevel, setAudioPan } from "../radio-core/audioCapture";
 import { calcSeekSeconds } from "../radio-core/stationGrouping";
 
 /** A clock move larger than this is a scrub, not ordinary advance. */
@@ -222,6 +223,12 @@ function tryPlay(itemId: number, entry: Entry): void {
 			// silenced would shout the moment a retry succeeded.
 			entry.unlocked = true;
 			entry.el.muted = !entry.audible;
+			// Mirrored into the capture module's in-graph gain alongside el.muted,
+			// same pairing radio-core's StationPlayer already uses: Safari ignores
+			// volume AND muted once Split (issue #564) has captured this element
+			// for panning, and setAudioLevel is a documented no-op on an element
+			// that never gets captured, so this costs nothing the rest of the time.
+			setAudioLevel(entry.el, entry.audible ? 1 : 0);
 			notify(itemId);
 		})
 		.catch((err: unknown) => {
@@ -381,7 +388,46 @@ export function setLevel(itemId: number, audible: boolean): void {
 	// Before the gate opens the element must stay muted whatever the mix says;
 	// tryPlay applies the level the moment play() resolves.
 	if (entry.unlocked) entry.el.muted = !audible;
+	// Gain has no autoplay gate to wait for (setAudioLevel's own doc), so this
+	// applies immediately and unconditionally — the same mirroring tryPlay does
+	// on unlock, for the same Safari-captured-element reason.
+	setAudioLevel(entry.el, audible ? 1 : 0);
 	notify(itemId);
+}
+
+/**
+ * Issue #564's Split feature: hard-pan every registered id named in `order`
+ * by its position there (index 0 left, 1 right, 2 left, …), or re-center all
+ * of them when `enabled` is false.
+ *
+ * `order` is clipQueue.ts's admitted list — this function has no opinion
+ * about who gets to be in it, only where the ids that are get panned. An id
+ * with no registered element (still pending, released, filtered out) is
+ * silently skipped: there is no `<audio>` to pan, and it will get today's
+ * `enabled`/index answer applied the moment RadioTraffic.tsx registers it,
+ * same as every other per-element setting here.
+ *
+ * Capturing (via audioCapture's captureAudioElement) happens lazily, only for
+ * a pan that is actually off-center — the default, Split-off case therefore
+ * captures nothing and costs nothing beyond this loop and a `pan.value`
+ * write that setAudioPan already no-ops on an uncaptured element. Turning
+ * Split off after it was on still reaches every previously-captured element,
+ * because setAudioPan writes straight into an existing graph without asking
+ * this function to capture anything first — see the AMENDMENT below.
+ *
+ * AMENDMENT (robbiebyrd): re-centering on Split-off is immediate, not merely
+ * "the next admission" — every currently registered id in `order` gets
+ * `pan(0)` in the same call that turned Split off, whether or not it was ever
+ * actually panned off-center before.
+ */
+export function applySplitPanning(order: readonly number[], enabled: boolean): void {
+	order.forEach((itemId, index) => {
+		const entry = registry.get(itemId);
+		if (!entry) return;
+		const pan = enabled ? (index % 2 === 0 ? -1 : 1) : 0;
+		if (pan !== 0) captureAudioElement(entry.el);
+		setAudioPan(entry.el, pan);
+	});
 }
 
 /**

--- a/packages/frontend/src/Applications/RadioTraffic/clipQueue.test.ts
+++ b/packages/frontend/src/Applications/RadioTraffic/clipQueue.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+	admissionSlot,
+	type ClipQueueState,
+	EMPTY_CLIP_QUEUE_STATE,
+	reconcileClipQueue,
+} from "./clipQueue";
+
+describe("reconcileClipQueue", () => {
+	it("admits up to the cap and queues the rest", () => {
+		const state = reconcileClipQueue(EMPTY_CLIP_QUEUE_STATE, [1, 2, 3, 4, 5], 3);
+		expect(state.admitted).toEqual([1, 2, 3]);
+		expect(state.pending).toEqual([4, 5]);
+	});
+
+	it("admits everything when the cap is not reached", () => {
+		const state = reconcileClipQueue(EMPTY_CLIP_QUEUE_STATE, [1, 2], 4);
+		expect(state.admitted).toEqual([1, 2]);
+		expect(state.pending).toEqual([]);
+	});
+
+	it("admits the oldest pending id the instant a slot frees up", () => {
+		let state = reconcileClipQueue(EMPTY_CLIP_QUEUE_STATE, [1, 2, 3], 2);
+		expect(state.admitted).toEqual([1, 2]);
+		expect(state.pending).toEqual([3]);
+
+		// 1 finished (or scrolled out of LIVE) and is no longer desired.
+		state = reconcileClipQueue(state, [2, 3], 2);
+		expect(state.admitted).toEqual([2, 3]);
+		expect(state.pending).toEqual([]);
+	});
+
+	it("never evicts an admitted id merely because a newer one arrived", () => {
+		// The whole point of the feature: "always prefer playing out a clip
+		// before starting a new one to overtake the queue."
+		let state = reconcileClipQueue(EMPTY_CLIP_QUEUE_STATE, [1, 2], 2);
+		state = reconcileClipQueue(state, [1, 2, 3], 2);
+		expect(state.admitted).toEqual([1, 2]);
+		expect(state.pending).toEqual([3]);
+	});
+
+	it("drops an id from both lists the moment it stops being desired", () => {
+		let state = reconcileClipQueue(EMPTY_CLIP_QUEUE_STATE, [1, 2, 3], 1);
+		expect(state.admitted).toEqual([1]);
+		expect(state.pending).toEqual([2, 3]);
+
+		// 2 left the live lane (a tag filter hid it, or it scrolled out) while
+		// still pending — it must not linger waiting for a slot it will never
+		// get registered for.
+		state = reconcileClipQueue(state, [1, 3], 1);
+		expect(state.admitted).toEqual([1]);
+		expect(state.pending).toEqual([3]);
+	});
+
+	describe("a live change to the cap", () => {
+		it("admits more immediately when the cap is raised", () => {
+			let state = reconcileClipQueue(EMPTY_CLIP_QUEUE_STATE, [1, 2, 3, 4], 2);
+			expect(state.admitted).toEqual([1, 2]);
+
+			state = reconcileClipQueue(state, [1, 2, 3, 4], 4);
+			expect(state.admitted).toEqual([1, 2, 3, 4]);
+			expect(state.pending).toEqual([]);
+		});
+
+		it("does not evict an already-admitted id when the cap is lowered", () => {
+			let state = reconcileClipQueue(EMPTY_CLIP_QUEUE_STATE, [1, 2, 3, 4], 4);
+			expect(state.admitted).toEqual([1, 2, 3, 4]);
+
+			state = reconcileClipQueue(state, [1, 2, 3, 4], 2);
+			// Still all four playing — a lowered cap only throttles future
+			// admissions, it must never yank a clip out from under a listener.
+			expect(state.admitted).toEqual([1, 2, 3, 4]);
+			expect(state.pending).toEqual([]);
+		});
+
+		it("stops pulling from pending once the lowered cap is back in range", () => {
+			let state = reconcileClipQueue(EMPTY_CLIP_QUEUE_STATE, [1, 2, 3, 4], 4);
+			state = reconcileClipQueue(state, [1, 2, 3, 4], 2);
+			// 1 and 2 leave; only one new arrival (5) should be admitted, because
+			// the cap is now 2 and 3, 4 are still holding their slots.
+			state = reconcileClipQueue(state, [3, 4, 5], 2);
+			expect(state.admitted).toEqual([3, 4]);
+			expect(state.pending).toEqual([5]);
+		});
+	});
+
+	it("returns the same object when nothing changed", () => {
+		const state = reconcileClipQueue(EMPTY_CLIP_QUEUE_STATE, [1, 2, 3], 2);
+		const next = reconcileClipQueue(state, [1, 2, 3], 2);
+		expect(next).toBe(state);
+	});
+
+	it("is a fresh object when the pending order changed even if admitted did not", () => {
+		const state = reconcileClipQueue(EMPTY_CLIP_QUEUE_STATE, [1, 2, 3], 2);
+		const next = reconcileClipQueue(state, [1, 2, 4], 2);
+		expect(next).not.toBe(state);
+		expect(next.admitted).toEqual([1, 2]);
+		expect(next.pending).toEqual([4]);
+	});
+});
+
+describe("admissionSlot", () => {
+	const state: ClipQueueState = { admitted: [10, 20, 30], pending: [40] };
+
+	it("reports the index among currently-admitted ids", () => {
+		expect(admissionSlot(state, 10)).toBe(0);
+		expect(admissionSlot(state, 20)).toBe(1);
+		expect(admissionSlot(state, 30)).toBe(2);
+	});
+
+	it("reports undefined for a pending id", () => {
+		expect(admissionSlot(state, 40)).toBeUndefined();
+	});
+
+	it("reports undefined for an id the queue does not know at all", () => {
+		expect(admissionSlot(state, 999)).toBeUndefined();
+	});
+});

--- a/packages/frontend/src/Applications/RadioTraffic/clipQueue.ts
+++ b/packages/frontend/src/Applications/RadioTraffic/clipQueue.ts
@@ -1,0 +1,118 @@
+// Issue #564: cap how many LIVE clips may hold an `<audio>` element — and
+// therefore a download and a decoder — at once.
+//
+// This module decides ADMISSION only. It never touches audioCoordinator's
+// registry directly: RadioTraffic.tsx's registration effect (the one place
+// that already calls ensure()/release() over the FILTER-VISIBLE live lane)
+// reads `admitted` off the state this module returns and registers exactly
+// those ids, leaving every other desired id unregistered — no element, no
+// fetch, no decoder — until a slot frees up. That is the whole of "the number
+// of clips should limit audio processing, as well as downloading": a clip
+// that never gets an element never costs either.
+//
+// "Always prefer playing out a radio clip before starting a new one to
+// overtake the queue" is `reconcileClipQueue` never evicting an admitted id
+// on its own — the only way an id leaves `admitted` is that it stopped being
+// desired (it left the LIVE lane, the listener stopped it, or a tag filter
+// hid it), which is exactly the shell's existing release() trigger. A newly
+// arrived clip goes to the back of `pending` and waits, however long that
+// takes, rather than preempting whatever is already playing.
+//
+// A lowered cap does not evict anything either, for the same reason: it only
+// throttles how many NEW ids get pulled off `pending`, so turning the slider
+// down mid-session narrows admission going forward without yanking a clip a
+// listener is already hearing.
+//
+// Scoped to the LIVE lane only (robbiebyrd's amendment to the approved plan):
+// a back-catalogue clip the listener starts by hand from PREVIOUS bypasses
+// this module entirely and is registered unconditionally, the same as before
+// this issue — a listener who explicitly reaches for a specific clip should
+// not be told to wait behind the live mix.
+
+/** `admitted`'s order IS the queue's memory of arrival — see `admissionSlot`. */
+export interface ClipQueueState {
+	/** Ids currently allowed an `<audio>` element, oldest-admitted first. */
+	admitted: readonly number[];
+	/** Ids waiting for a slot, oldest-arrived first. */
+	pending: readonly number[];
+}
+
+export const EMPTY_CLIP_QUEUE_STATE: ClipQueueState = { admitted: [], pending: [] };
+
+/** Same two lists, whatever order arrived in — the no-op-is-the-same-object check. */
+function sameQueueState(a: ClipQueueState, b: ClipQueueState): boolean {
+	return (
+		a.admitted.length === b.admitted.length &&
+		a.pending.length === b.pending.length &&
+		a.admitted.every((id, i) => id === b.admitted[i]) &&
+		a.pending.every((id, i) => id === b.pending[i])
+	);
+}
+
+/**
+ * Recompute admission for this tick's desired LIVE ids.
+ *
+ * `desiredIds` is whatever the shell currently wants playing — filter-visible,
+ * un-stopped LIVE items, in the order RadioTraffic.tsx already sorts them
+ * (earliest start first), which doubles as this queue's arrival order. Three
+ * things happen, in order:
+ *
+ *   1. an id no longer in `desiredIds` drops out of both lists outright — it
+ *      left the LIVE lane, a tag filter hid it, or the listener stopped it,
+ *      and any of those already tells audioCoordinator to release its
+ *      element, so holding a queue slot for it here would be a second,
+ *      disagreeing answer to the same question.
+ *   2. a brand-new id — not already admitted or pending — joins the back of
+ *      `pending`.
+ *   3. `pending` is drained onto the back of `admitted` until `maxConcurrent`
+ *      is reached or nothing is left waiting.
+ *
+ * `maxConcurrent` is read fresh every call, so a listener dragging the
+ * Settings slider mid-session takes effect on the very next tick — up
+ * immediately pulls more off `pending`, down simply admits nothing further
+ * until enough already-admitted ids have left `desiredIds` on their own.
+ *
+ * Returns `state` itself when nothing changed, so a caller storing this in
+ * React state does not re-render the whole grid every tick for the common
+ * case of "the live mix is exactly what it was a second ago".
+ */
+export function reconcileClipQueue(
+	state: ClipQueueState,
+	desiredIds: readonly number[],
+	maxConcurrent: number,
+): ClipQueueState {
+	const desired = new Set(desiredIds);
+	const admitted = state.admitted.filter((id) => desired.has(id));
+	const pending = state.pending.filter((id) => desired.has(id));
+
+	const known = new Set([...admitted, ...pending]);
+	const arrivals = desiredIds.filter((id) => !known.has(id));
+
+	const nextAdmitted = [...admitted];
+	const nextPending = [...pending, ...arrivals];
+	while (nextAdmitted.length < maxConcurrent && nextPending.length > 0) {
+		// biome-ignore lint/style/noNonNullAssertion: bounded by the length check above
+		nextAdmitted.push(nextPending.shift()!);
+	}
+
+	const next: ClipQueueState = { admitted: nextAdmitted, pending: nextPending };
+	return sameQueueState(state, next) ? state : next;
+}
+
+/**
+ * Where `itemId` sits among the currently-admitted ids, or undefined if it
+ * holds no slot (it is pending, or not part of this queue at all).
+ *
+ * The Split feature's whole input: "the first audio player" is slot 0, "the
+ * second" is slot 1, and so on, alternating left/right as the caller pans by
+ * `index % 2`. Recomputed fresh from `admitted`'s current order rather than
+ * latched at the moment an id was admitted, so a slot number — and with it,
+ * which side a clip is panned to — can shift when an earlier slot frees up.
+ * That is a deliberate reading of "the first … the second … and so on" as a
+ * live ordinal among whoever is currently playing, not a permanent seat
+ * assigned once and held for the life of the clip.
+ */
+export function admissionSlot(state: ClipQueueState, itemId: number): number | undefined {
+	const index = state.admitted.indexOf(itemId);
+	return index === -1 ? undefined : index;
+}

--- a/packages/frontend/src/Applications/radio-core/audioCapture.test.ts
+++ b/packages/frontend/src/Applications/radio-core/audioCapture.test.ts
@@ -1,9 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { isAudioBlocked } from "./audioBlocked";
-import { captureAudioElement, setAudioLevel } from "./audioCapture";
+import { captureAudioElement, setAudioLevel, setAudioPan } from "./audioCapture";
 
 class FakeGain {
 	gain = { value: 1 };
+	connect = vi.fn();
+	disconnect = vi.fn();
+}
+class FakePanner {
+	pan = { value: 0 };
 	connect = vi.fn();
 	disconnect = vi.fn();
 }
@@ -13,6 +18,7 @@ class FakeSource {
 class FakeAudioContext {
 	destination = { kind: "destination" };
 	createMediaElementSource = vi.fn(() => new FakeSource());
+	createStereoPanner = vi.fn(() => new FakePanner());
 	createGain = vi.fn(() => new FakeGain());
 	resume = vi.fn().mockResolvedValue(undefined);
 }
@@ -24,13 +30,14 @@ afterEach(() => {
 const el = () => document.createElement("audio");
 
 describe("captureAudioElement", () => {
-	it("builds the permanent source → gain → destination chain", () => {
+	it("builds the permanent source → panner → gain → destination chain", () => {
 		vi.stubGlobal("AudioContext", FakeAudioContext);
 		const a = el();
 		const entry = captureAudioElement(a);
 		expect(entry).not.toBeNull();
 		expect(entry?.ctx.createMediaElementSource).toHaveBeenCalledWith(a);
-		expect(entry?.source.connect).toHaveBeenCalledWith(entry?.gain);
+		expect(entry?.source.connect).toHaveBeenCalledWith(entry?.panner);
+		expect(entry?.panner.connect).toHaveBeenCalledWith(entry?.gain);
 		expect(entry?.gain.connect).toHaveBeenCalledWith(entry?.ctx.destination);
 	});
 
@@ -162,5 +169,35 @@ describe("setAudioLevel", () => {
 
 	it("is safe on an element that never gets captured", () => {
 		expect(() => setAudioLevel(el(), 0.5)).not.toThrow();
+	});
+});
+
+describe("setAudioPan", () => {
+	it("drives the pan of an already-captured element to the exact value", () => {
+		vi.stubGlobal("AudioContext", FakeAudioContext);
+		const a = el();
+		const entry = captureAudioElement(a);
+		setAudioPan(a, -1);
+		expect(entry?.panner.pan.value).toBe(-1);
+		setAudioPan(a, 1);
+		expect(entry?.panner.pan.value).toBe(1);
+	});
+
+	it("is remembered by a later capture (pan set before primary)", () => {
+		vi.stubGlobal("AudioContext", FakeAudioContext);
+		const a = el();
+		setAudioPan(a, -1);
+		const entry = captureAudioElement(a);
+		expect(entry?.panner.pan.value).toBe(-1);
+	});
+
+	it("is safe on an element that never gets captured", () => {
+		expect(() => setAudioPan(el(), -1)).not.toThrow();
+	});
+
+	it("defaults an uncaptured element's panner to centered", () => {
+		vi.stubGlobal("AudioContext", FakeAudioContext);
+		const entry = captureAudioElement(el());
+		expect(entry?.panner.pan.value).toBe(0);
 	});
 });

--- a/packages/frontend/src/Applications/radio-core/audioCapture.ts
+++ b/packages/frontend/src/Applications/radio-core/audioCapture.ts
@@ -9,14 +9,20 @@
 //
 // This module owns the capture. WaveformVisualizer asks for an element's
 // entry to attach its analyser; StationPlayer drives the gain level in lockstep
-// with its el.volume/el.muted handling. The WeakMaps let entries be collected
-// with their audio elements.
+// with its el.volume/el.muted handling. Issue #564's Split feature is a third
+// consumer, and the odd one out: RadioTraffic never mounts WaveformVisualizer
+// (its cards draw a static peaks envelope instead — see PeaksWaveform.tsx), so
+// nothing here captures its elements today. audioCoordinator.ts calls
+// captureAudioElement itself, on demand, the moment a clip actually needs to be
+// panned off-center — see that module's `applySplitPanning`. The WeakMaps let
+// entries be collected with their audio elements.
 
 import { clearAudioBlocked, markAudioBlocked } from "./audioBlocked";
 
 export interface CapturedAudio {
 	ctx: AudioContext;
 	source: MediaElementAudioSourceNode;
+	panner: StereoPannerNode;
 	gain: GainNode;
 }
 
@@ -25,6 +31,10 @@ const captured = new WeakMap<HTMLAudioElement, CapturedAudio>();
 // level was set while native (never yet primary) must come up at that level
 // if it later gets captured. 0 = silenced.
 const desiredVolume = new WeakMap<HTMLAudioElement, number>();
+// Desired stereo position (-1 full left .. 0 center .. 1 full right),
+// remembered the same way and for the same reason — Split can be toggled on
+// before an element has ever needed capturing.
+const desiredPan = new WeakMap<HTMLAudioElement, number>();
 
 // A context created before the page's first user gesture (e.g. a restored
 // session autoplaying on load) starts out suspended in Safari, and resume()
@@ -59,21 +69,24 @@ if (typeof document !== "undefined") {
 	document.addEventListener("pointerdown", resumeAwaitingContexts, true);
 }
 
-/** Get or create the permanent capture chain (source → gain → destination). */
+/** Get or create the permanent capture chain (source → panner → gain → destination). */
 export function captureAudioElement(el: HTMLAudioElement): CapturedAudio | null {
 	let entry = captured.get(el);
 	if (!entry) {
 		try {
 			const ctx = new AudioContext();
 			const source = ctx.createMediaElementSource(el);
+			const panner = ctx.createStereoPanner();
 			const gain = ctx.createGain();
-			source.connect(gain);
+			source.connect(panner);
+			panner.connect(gain);
 			gain.connect(ctx.destination);
-			entry = { ctx, source, gain };
+			entry = { ctx, source, panner, gain };
 		} catch {
 			return null;
 		}
 		entry.gain.gain.value = desiredVolume.get(el) ?? 1;
+		entry.panner.pan.value = desiredPan.get(el) ?? 0;
 		captured.set(el, entry);
 		// Track the suspended state via statechange, not just a creation-time
 		// snapshot: Safari can report a fresh context as running and only settle
@@ -104,5 +117,19 @@ export function setAudioLevel(el: HTMLAudioElement, volume: number): void {
 	desiredVolume.set(el, volume);
 	const entry = captured.get(el);
 	if (entry) entry.gain.gain.value = volume;
+}
+
+/**
+ * Record the stereo position `el` should play at (-1 full left .. 0 center ..
+ * 1 full right) and, if it is (or later becomes) captured, apply it in-graph.
+ * Mirrors {@link setAudioLevel} exactly: safe to call on an element that has
+ * never been captured (it just remembers the value for when it is), and
+ * writes straight to the live `StereoPannerNode` — no gesture gating, the same
+ * as gain — when it already has been.
+ */
+export function setAudioPan(el: HTMLAudioElement, value: number): void {
+	desiredPan.set(el, value);
+	const entry = captured.get(el);
+	if (entry) entry.panner.pan.value = value;
 }
 


### PR DESCRIPTION
## Summary

- Adds a concurrency cap (2-24 clips, default 4) on how many **LIVE** Radio Traffic clips may hold an `<audio>` element — and therefore a download and a decoder — at once. New `clipQueue.ts` module owns pure admission/queueing logic: an admitted clip always finishes before a newer arrival gets a slot ("always prefer playing out a clip before starting a new one"), and a listener-started PREVIOUS clip bypasses the cap entirely (unchanged behavior).
- Adds an opt-in "Split" setting (off by default) that hard-pans admitted LIVE clips alternately left/right by their queue slot. Built on a new `StereoPannerNode` inserted into `radio-core/audioCapture.ts`'s shared `source → gain → destination` chain (now `source → panner → gain → destination`), plus a new `setAudioPan` mirroring `setAudioLevel`.
- Both settings are exposed in the Radio Traffic Settings window (`ClassicySlider` for the cap, `ClassicyCheckbox` for Split), persisted through the existing `RadioTrafficContext` sanitizer/reducer/manifest pattern.

## Design note (deviation from the plan's assumption)

The approved plan assumed every admitted card mounts radio-core's `WaveformVisualizer`, which is what normally triggers `captureAudioElement`. That's not true for Radio Traffic — its cards draw a static peaks envelope (`PeaksWaveform`) instead, so nothing there ever calls `captureAudioElement`. Per the plan's own contingency, panning is instead driven directly from `audioCoordinator.ts`'s new `applySplitPanning`, which calls `captureAudioElement` itself, lazily, only when a pan is actually off-center — so the default (Split off) case creates no `AudioContext` and costs nothing. Because capturing an element makes Safari ignore `el.muted`/`el.volume` (documented in `audioCapture.ts`), `audioCoordinator`'s existing mute path (`setLevel`/`tryPlay`) now also mirrors into the in-graph gain via `setAudioLevel`, the same defensive pairing `radio-core/StationPlayer.tsx` already uses — so muting stays correct even once Split has captured an element.

Per robbiebyrd's amendments: the concurrency cap applies to the LIVE lane only, and turning Split off re-centers every currently-admitted clip immediately rather than waiting for the next admission.

## Test plan

- [x] `pnpm --filter @rt911/frontend exec tsc -b` — clean
- [x] `pnpm --filter @rt911/frontend exec vitest run` — 303 files / 3383 tests passed
- [x] `pnpm lint` — no new warnings/errors in touched files
- New unit coverage: `clipQueue.test.ts` (admission/queueing/live cap changes), `audioCapture.test.ts` (panner chain + `setAudioPan`), `audioCoordinator.test.ts` (`applySplitPanning`), `RadioTrafficContext.test.ts` (new sanitizers), `RadioTrafficSettingsWindow.test.tsx` (new controls). Existing `RadioTraffic.test.tsx` suite extended/still green.

Fixes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)