### PR TITLE
RadioTraffic: hide tab strip on "tape" tier audio cards

### DIFF
--- a/packages/frontend/src/Applications/RadioTraffic/TrafficCard.test.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/TrafficCard.test.tsx
@@ -757,6 +757,34 @@ describe("TrafficCard tabs", () => {
 	});
 });
 
+describe("TrafficCard tape tier (issue #565)", () => {
+	it("renders Details' own content with no tab strip for a tier:tape item", () => {
+		const { queryByRole, container } = renderCard({
+			meta: makeMeta({
+				tags: [{ tag: "tier:tape", namespace: "tier", value: "Tape" }],
+			}),
+		});
+		expect(queryByRole("tablist")).toBeNull();
+		expect(queryByRole("tab")).toBeNull();
+		expect(container.querySelector('[data-tab="details"]')).not.toBeNull();
+	});
+
+	it("still shows the tab strip for a tier:clip item", () => {
+		const { getAllByRole, container } = renderCard({
+			meta: makeMeta({
+				tags: [{ tag: "tier:clip", namespace: "tier", value: "Clip" }],
+			}),
+		});
+		expect(getAllByRole("tab")).toHaveLength(6);
+		expect(container.querySelector('[data-tab="details"]')).not.toBeNull();
+	});
+
+	it("still shows the tab strip for an item with no tier tag at all", () => {
+		const { getAllByRole } = renderCard({ meta: makeMeta() });
+		expect(getAllByRole("tab")).toHaveLength(6);
+	});
+});
+
 describe("TrafficCard control bar", () => {
 	it("toggles the pause button", () => {
 		const onTogglePause = vi.fn();

--- a/packages/frontend/src/Applications/RadioTraffic/TrafficCard.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/TrafficCard.tsx
@@ -48,6 +48,8 @@ import {
 import { type Badge, badgeFor, countdownFor, type Lane } from "./cardStatus";
 import { isSilentAt } from "./silence";
 import { CARD_TABS, CardTabBar, visibleCardTabs } from "./CardTabBar";
+import { isTapeTier } from "./tagFilter";
+import { DetailsTab } from "./tabs/DetailsTab";
 import { itemTiming } from "./tabs/itemTiming";
 import styles from "./trafficCard.module.scss";
 
@@ -390,6 +392,12 @@ const TrafficCardImpl: React.FC<TrafficCardProps> = ({
 	// highlighted instead of showing a panel with nothing selected.
 	const tabs = useMemo(() => visibleCardTabs(meta), [meta]);
 	const panel = tabs.find((tab) => tab.id === active) ?? tabs[0];
+	// Issue #565: a tape is one long continuous recording — the tab strip
+	// (Details, Summary, Mentions, ...) offers nothing to switch between, so it
+	// is skipped entirely in favor of Details' content alone, bypassing the
+	// tab-selection state above rather than pinning `active` to "details" (which
+	// would still render a CardTabBar with one, meaningless, button on it).
+	const tape = isTapeTier(meta);
 
 	// The existing panel switch, plus Story 045's touch signal alongside it —
 	// see onTabSelect above.
@@ -546,16 +554,22 @@ const TrafficCardImpl: React.FC<TrafficCardProps> = ({
 			</div>
 
 			<div className={styles.rtCardTabs}>
-				<CardTabBar tabs={tabs} active={panel.id} onSelect={handleTabSelect} />
+				{!tape && (
+					<CardTabBar tabs={tabs} active={panel.id} onSelect={handleTabSelect} />
+				)}
 				<div className={styles.rtCardPanel}>
-					<panel.Panel
-						item={item}
-						meta={meta}
-						tzOffsetHours={tzOffsetHours}
-						// The element's own position, not the clock's: a drifting card
-						// must caption the words it is actually saying.
-						currentTimeSec={currentMs === undefined ? undefined : currentMs / 1000}
-					/>
+					{tape ? (
+						<DetailsTab item={item} meta={meta} tzOffsetHours={tzOffsetHours} />
+					) : (
+						<panel.Panel
+							item={item}
+							meta={meta}
+							tzOffsetHours={tzOffsetHours}
+							// The element's own position, not the clock's: a drifting card
+							// must caption the words it is actually saying.
+							currentTimeSec={currentMs === undefined ? undefined : currentMs / 1000}
+						/>
+					)}
 				</div>
 			</div>
 		</article>

--- a/packages/frontend/src/Applications/RadioTraffic/tagFilter.test.ts
+++ b/packages/frontend/src/Applications/RadioTraffic/tagFilter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { TagDef } from "../../Providers/MediaStream/MediaStreamContext";
 import {
 	groupVocabulary,
+	isTapeTier,
 	LARGE_NAMESPACES,
 	matchesFilter,
 	UNKNOWN_TIER_TAG,
@@ -257,5 +258,27 @@ describe("withUnknownTier", () => {
 
 	it("does nothing to an empty vocabulary", () => {
 		expect(withUnknownTier(groupVocabulary([]))).toEqual([]);
+	});
+});
+
+describe("isTapeTier", () => {
+	it("is true for an item carrying tier:tape", () => {
+		expect(isTapeTier({ tags: [def("tier:tape")] })).toBe(true);
+	});
+
+	it("is false for an item carrying tier:clip", () => {
+		expect(isTapeTier({ tags: [def("tier:clip")] })).toBe(false);
+	});
+
+	it("is false for an item with no tier tag at all", () => {
+		expect(isTapeTier({ tags: [def("topic:hijack")] })).toBe(false);
+	});
+
+	it("is false for an item with no tags", () => {
+		expect(isTapeTier({ tags: [] })).toBe(false);
+	});
+
+	it("is false for undefined meta", () => {
+		expect(isTapeTier(undefined)).toBe(false);
 	});
 });

--- a/packages/frontend/src/Applications/RadioTraffic/tagFilter.ts
+++ b/packages/frontend/src/Applications/RadioTraffic/tagFilter.ts
@@ -96,6 +96,22 @@ export const TIER_NAMESPACE = "tier";
  */
 export const UNKNOWN_TIER_TAG = `${TIER_NAMESPACE}:unknown`;
 
+/** The tag `tier_for` (video-grabber's `parties/identify.py`) writes for a long-form recording. */
+export const TAPE_TIER_TAG = `${TIER_NAMESPACE}:tape`;
+
+/**
+ * A tape (as opposed to a clip): one of the long continuous position
+ * recordings, where the per-item tab strip (Details, Summary, Mentions, ...)
+ * adds nothing a listener needs — see issue #565. Reads the tier straight off
+ * `meta.tags`, the same field `matchesFilter` reads it from above, rather
+ * than `ItemMeta.tier`: nothing populates that scalar today, and adding a
+ * second reader of a field the pipeline doesn't write would just be a second
+ * place for the two to disagree.
+ */
+export function isTapeTier(meta: { tags?: TagDef[] } | undefined): boolean {
+	return (meta?.tags ?? []).some((t) => t.tag === TAPE_TIER_TAG);
+}
+
 /**
  * Does `tags` survive `checked`? OR within a namespace, AND across namespaces.
  *


### PR DESCRIPTION
## Summary
- Audio Player cards for long-form "tape" recordings (tagged `tier:tape` in `meta.tags`) no longer render the tab strip (Details, Summary, Transcript, Parties, Mentions, Source) — instead they render only the Details tab's content directly.
- Adds `isTapeTier(meta)` to `packages/frontend/src/Applications/RadioTraffic/tagFilter.ts`, reading the tier off `meta.tags` the same way `matchesFilter` does (namespace `"tier"`, value `"tape"`), rather than introducing a new field.
- `TrafficCard.tsx` branches at the tab-strip/panel render site: when `isTapeTier(meta)` is true, it skips `<CardTabBar>` and renders `<DetailsTab item={item} meta={meta} tzOffsetHours={tzOffsetHours} />` directly, bypassing the tab-selection state entirely since there's nothing to select between. Non-tape cards ("clip" tier or untagged) are unaffected.

Fixes #565

## Test plan
- [x] `pnpm --filter @rt911/frontend exec tsc -b` — passes, no errors
- [x] `pnpm lint` (oxlint) — passes, only pre-existing warnings in unrelated files
- [x] `pnpm test` (vitest run, full suite) — 303 files / 3391 tests pass
- [x] New unit tests in `tagFilter.test.ts` for `isTapeTier` (tape/clip/no-tier/no-tags/undefined-meta cases)
- [x] New cases in `TrafficCard.test.tsx`: a `tier:tape` card renders Details content with no tab strip/tablist; a `tier:clip` card and an untagged card still show all 6 tabs (regression coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)