### PR TITLE
HyperCard: multi-select pickers for TV/News/Pager/Weather/Flight embeds

### DIFF
--- a/packages/frontend/src/Applications/HyperCard/README.md
+++ b/packages/frontend/src/Applications/HyperCard/README.md
@@ -22,23 +22,43 @@ result into its authored `rect`.
   is the registry of embeddable collections + the fields each needs.
 - `extensions/DirectusAudioPart.tsx` — the `directusAudio` part: embeds one
   clip from the `mp3_items` collection (by `itemId`, or a direct `url`).
-- `extensions/DirectusVideoPart.tsx` — the `directusVideo` part: embeds one TV
-  channel stream from `tv_channels`, optionally limited to a start/end segment,
-  using classicy's `QuickTimeVideoEmbed` (HLS) for controls/autoplay/captions.
+- `extensions/DirectusVideoPart.tsx` — the `directusVideo` part: embeds one or
+  more TV channel streams from `tv_channels` (a grid when `channelId` holds
+  more than one id), each optionally limited to a start/end segment, using
+  classicy's `QuickTimeVideoEmbed` (HLS) for controls/autoplay/captions.
   Exports the reusable `DirectusVideo` body.
 - `extensions/DirectusMultiviewPart.tsx` — the `directusMultiview` part: a grid
   ("video wall") of `DirectusVideo` tiles with solo/mute/all audio modes.
-- `extensions/DirectusNewsPart.tsx` — the `directusNews` part: one article from
-  `news_items` (headline, dateline, image, HTML body).
-- `extensions/DirectusPagerPart.tsx` — the `directusPager` part: one instant
-  message from `pager_items`, styled as a pager readout.
+- `extensions/DirectusNewsPart.tsx` — the `directusNews` part: one or more
+  articles from `news_items` (headline, dateline, image, HTML body), stacked
+  vertically when `itemId` holds more than one id.
+- `extensions/DirectusPagerPart.tsx` — the `directusPager` part: one or more
+  instant messages from `pager_items`, styled as pager readouts, stacked
+  vertically when `itemId` holds more than one id.
 - `extensions/useDirectusItem.ts` — shared id-resolution + fetch/load-state hook
-  used by the news/pager parts.
+  used by the news/pager parts; `resolveItemIds` is the array-aware id
+  resolution the video/weather/flight-map parts also use.
 - `extensions/DirectusWeatherPart.tsx` — the `directusWeatherStation` part: one
-  station's live conditions/forecast/almanac, reusing the Weather app's
-  `WeatherStationPanel` (extracted from `Weather.tsx`).
-- `extensions/DirectusFlightMapPart.tsx` — the `directusFlightMap` part: a live
-  plane map reusing the Flight Tracker's `FlightMap` (maplibre/WebGL).
+  or more stations' live conditions/forecast/almanac (a grid when `station`
+  holds more than one id), reusing the Weather app's `WeatherStationPanel`
+  (extracted from `Weather.tsx`).
+- `extensions/DirectusFlightMapPart.tsx` — the `directusFlightMap` part: one or
+  more live plane maps reusing the Flight Tracker's `FlightMap`
+  (maplibre/WebGL) — a grid, one map per focused callsign, when `flight` holds
+  more than one.
+- `extensions/HyperCardPartGrid.tsx` — the shared "video wall" grid layout the
+  video/weather/flight-map parts above lay their multiple tiles out in;
+  generalizes `DirectusMultiviewPart.tsx`'s own grid, which predates it.
+- `extensions/editorMetadata.ts` — registers each part's `optionsSchema` (what
+  the stack editor's inspector shows) and, for every id/array field, a
+  `picker`-kind field bound to a concrete `registerHyperCardOptionPicker`
+  component.
+- `extensions/HyperCardItemPicker.tsx` — the shared searchable/filterable,
+  checkbox-multi-select picker window every concrete picker
+  (`TVClipPicker.tsx`, `TVMultiviewPicker.tsx`, `NewsItemPicker.tsx`,
+  `PagerMessagePicker.tsx`, `WeatherStationPicker.tsx`, `FlightMapPicker.tsx`,
+  and audio's pre-existing `RadioTrafficClipPicker.tsx`) opens from its
+  inspector field, plus the `HyperCardOptionPickerField` shell those six share.
 - `extensions/HyperCardClockBridge.tsx` + `extensions/dateRange.ts` — the
   `setDateTime` *action*: a command queues an effect, the mounted bridge applies
   it through the sanctioned `setDateTimeFromUtc` seam, clamped to the canonical
@@ -75,7 +95,10 @@ variable/field (`"options": { "itemId": "clip" }` tracks the `clip` variable).
   "type": "directusVideo",
   "rect": [12, 40, 416, 232],
   "options": {
-    "channelId": 3,          // a row in tv_channels (or a direct HLS "url")
+    "channelId": [3],        // row(s) in tv_channels (or a direct HLS "url");
+                             // the inspector's TV Channels picker always
+                             // writes an array — two or more ids lay out as a
+                             // grid, sharing every other option below
     "start": 60, "end": 180, // stream-offset seconds, "M:SS", or a
                              // date-bearing wall-clock ("2001-09-11T12:46:00")
     "controls": true,        // native transport (default true); false = chromeless
@@ -113,32 +136,41 @@ the part's own `script` (e.g. `go next`), so clips can chain.
 }
 ```
 
-Each tile takes the full `directusVideo` option set.
+Each tile takes the full `directusVideo` option set. The inspector's Videos
+picker (`TVMultiviewPicker.tsx`) manages each tile's `channelId`, preserving
+whatever other settings (`start`/`autoPlay`/…) are already on a kept tile
+rather than resetting them.
 
 ## Authoring news / pager embeds
 
 ```jsonc
-{ "id": "story", "type": "directusNews",  "rect": [12, 12, 396, 232], "options": { "itemId": 42 } }
-{ "id": "page",  "type": "directusPager", "rect": [12, 40, 396, 150], "options": { "itemId": 128 } }
+{ "id": "story", "type": "directusNews",  "rect": [12, 12, 396, 232], "options": { "itemId": [42] } }
+{ "id": "page",  "type": "directusPager", "rect": [12, 40, 396, 150], "options": { "itemId": [128] } }
 ```
 
-Both take an `itemId` (a `news_items` / `pager_items` row, resolved through the
-stack expression engine). News accepts `showImage`/`showDate`; pager accepts
-`showMeta`.
+Both take an `itemId` array (each entry a `news_items` / `pager_items` row,
+resolved through the stack expression engine) — the inspector's News
+Items/Pager Messages pickers always write an array, and two or more ids
+render as a scrollable vertical list rather than a single article/readout.
+News accepts `showImage`/`showDate`; pager accepts `showMeta`.
 
 ## Authoring weather / flight embeds
 
 ```jsonc
-{ "id": "wx",  "type": "directusWeatherStation", "rect": [12, 40, 396, 210], "options": { "station": "KJFK" } }
-{ "id": "map", "type": "directusFlightMap",      "rect": [12, 44, 396, 206], "options": { "notablesOnly": true, "flight": "AA11", "mapStyle": "radar" } }
+{ "id": "wx",  "type": "directusWeatherStation", "rect": [12, 40, 396, 210], "options": { "station": ["KJFK"] } }
+{ "id": "map", "type": "directusFlightMap",      "rect": [12, 44, 396, 206], "options": { "notablesOnly": true, "flight": ["AA11"], "mapStyle": "radar" } }
 ```
 
 Both read the shared virtual clock and the streamed flight/weather channels via
 `MediaStreamContext` (ref-counted `subscribe*`), so they stay in lockstep with
 the desktop. The weather station reuses `Weather/WeatherStationPanel`; the flight
 map reuses `FlightTracker/FlightMap` and **requires WebGL + a sized card**.
-`station`/`flight` resolve through the stack expression engine (variable-driven
-selection). Flight options: `notablesOnly`, `flight` (focus a callsign),
+`station`/`flight` are arrays (the inspector's Weather Stations/Flights pickers
+always write one, filtered to whatever's *currently* live on the shared
+channel rather than the full historical list) whose entries resolve through
+the stack expression engine (variable-driven selection); two or more ids lay
+out as a grid, one panel/map per id. Flight options: `notablesOnly`, `flight`
+(focus callsign(s), one map per focused flight when there's more than one),
 `mapStyle`/`darkMap`/`radarSweep`/`trailMultiplier`, pin-color overrides.
 
 ## The `setDateTime` action

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusFlightMapPart.test.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusFlightMapPart.test.tsx
@@ -83,6 +83,19 @@ describe("DirectusFlightMapPart", () => {
 		);
 		expect(ctx.subscribeFlights).toHaveBeenCalledTimes(1);
 	});
+
+	// issue #560 — flight widened from a scalar to an array.
+	it("renders a single, unfocused map for an empty flight array (same as no option)", () => {
+		renderPart({ flight: [] });
+		expect(mapProps).toHaveLength(1);
+		expect((last().positions as unknown[]).length).toBe(2);
+	});
+
+	it("renders one map per callsign, in a grid, when flight holds more than one", () => {
+		renderPart({ flight: ["AA11", "DAL123"] });
+		expect(mapProps).toHaveLength(2);
+		expect(mapProps.every((p) => (p.positions as unknown[]).length === 2)).toBe(true);
+	});
 });
 
 function partProps(options: Record<string, unknown>): HyperCardPartProps {

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusFlightMapPart.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusFlightMapPart.tsx
@@ -1,11 +1,13 @@
 import type { HyperCardPartProps } from "classicy";
 import { useClassicyDateTime } from "classicy";
 import { useCallback, useContext, useEffect, useMemo, useRef } from "react";
-import { MediaStreamContext } from "../../../Providers/MediaStream/MediaStreamContext";
+import { MediaStreamContext, type FlightPosition } from "../../../Providers/MediaStream/MediaStreamContext";
 import { virtualUtcMs } from "../../../Providers/MediaStream/virtualClock";
 import { BASEMAP_URLS, type BasemapStyleId } from "../../../lib/basemap/basemapStyles";
 import { FlightMap, type FlightMapHandle } from "../../FlightTracker/FlightMap";
 import { isNotable } from "../../FlightTracker/notableFlights";
+import { HyperCardPartGrid } from "./HyperCardPartGrid";
+import { resolveItemIds } from "./useDirectusItem";
 import "./DirectusFlightMapPart.css";
 
 /**
@@ -15,14 +17,19 @@ import "./DirectusFlightMapPart.css";
  * virtual clock, so planes move in lockstep with the rest of the desktop.
  *
  *   { "id": "map", "type": "directusFlightMap", "rect": [8, 32, 404, 240],
- *     "options": { "notablesOnly": true, "flight": "AA11", "mapStyle": "radar" } }
+ *     "options": { "notablesOnly": true, "flight": ["AA11"], "mapStyle": "radar" } }
  *
- * Options: `notablesOnly` curates to the four hijacked flights; `flight` focuses
- * the camera on a callsign; `mapStyle`/`darkMap`/`radarSweep`/`trailMultiplier`
- * mirror the app's map settings; `pinColor`/`notablePinColor`/`observerPinColor`
- * override the pin colors; `buildingHeroColorLight`/`buildingHeroColorDark`
- * (packed 0xRRGGBB numbers) override the hero-landmark tint. Requires WebGL
- * and a sized card.
+ * Options: `notablesOnly` curates to the four hijacked flights; `flight` is an
+ * array of callsigns to focus (issue #560's `FlightMapPicker` always writes
+ * one), but a bare scalar/variable callsign is still accepted for a part
+ * authored before that change. Zero or one resolved callsign renders exactly
+ * as before — a single map, optionally focused; two or more lay out as a
+ * `DirectusMultiviewPart`-style grid, one map per focused callsign, each
+ * still showing every position on the shared channel.
+ * `mapStyle`/`darkMap`/`radarSweep`/`trailMultiplier` mirror the app's map
+ * settings; `pinColor`/`notablePinColor`/`observerPinColor` override the pin
+ * colors; `buildingHeroColorLight`/`buildingHeroColorDark` (packed 0xRRGGBB
+ * numbers) override the hero-landmark tint. Requires WebGL and a sized card.
  */
 
 const DEFAULT_PIN = "#f5a623";
@@ -37,12 +44,74 @@ function readMapStyle(v: unknown): BasemapStyleId {
 	return v === "radar" || v === "satellite" ? v : "classic";
 }
 
+/** Resolves `flight` into a list of callsigns to focus — array-valued per issue #560, with a single legacy scalar/variable still accepted; unset/empty means "no focus". */
+function readFocusFlights(
+	options: Record<string, unknown>,
+	value: string,
+	resolve: (expr: string) => string,
+): string[] {
+	return resolveItemIds(options.flight, value, resolve)
+		.map((f) => f.toUpperCase())
+		.filter((f) => f !== "");
+}
+
+interface FlightMapTileProps {
+	focusFlight: string | undefined;
+	positions: FlightPosition[];
+	nowMs: number;
+	playing: boolean;
+	mapStyle: BasemapStyleId;
+	darkMap: boolean;
+	pinColor: string;
+	notablePinColor: string;
+	anonPinColor: string;
+	observerPinColor: string;
+	buildingHeroColorLight: number;
+	buildingHeroColorDark: number;
+	radarSweep: boolean;
+	trailMultiplier: number;
+}
+
+/** One map instance — split out so a multi-flight embed can render several, each flying to its own focused callsign. */
+function FlightMapTile({ focusFlight, positions, ...mapSettings }: FlightMapTileProps) {
+	// Fly the camera to a focused callsign once it first appears on the map.
+	const mapApi = useRef<FlightMapHandle>(null);
+	const flownFor = useRef<string | undefined>(undefined);
+	useEffect(() => {
+		if (!focusFlight) {
+			flownFor.current = undefined;
+			return;
+		}
+		if (flownFor.current === focusFlight) return;
+		const pos = positions.find((p) => p.flight === focusFlight);
+		if (pos) {
+			mapApi.current?.flyTo([pos.lon, pos.lat], 7);
+			flownFor.current = focusFlight;
+		}
+	}, [focusFlight, positions]);
+
+	const noop = useCallback(() => {}, []);
+
+	return (
+		<FlightMap
+			ref={mapApi}
+			positions={positions}
+			basemapUrls={BASEMAP_URLS}
+			trackGeoJSON={null}
+			{...mapSettings}
+			onSelectFlight={noop}
+			onClearSelection={noop}
+		/>
+	);
+}
+
+/**
+ * Zero or one resolved `flight` renders exactly as before (a single map,
+ * optionally focused); two or more lay out as a grid of maps, one per focused
+ * callsign, all sharing the same position feed and map settings (issue #560).
+ */
 export const DirectusFlightMapPart = ({ options, resolve, value, partId, stackId }: HyperCardPartProps) => {
-	const focusFlight = useMemo(() => {
-		const raw = typeof options.flight === "string" ? options.flight : value;
-		const r = raw ? resolve(String(raw)).trim().toUpperCase() : "";
-		return r || undefined;
-	}, [options.flight, value, resolve]);
+	const focusFlights = useMemo(() => readFocusFlights(options, value, resolve), [options, value, resolve]);
 	const notablesOnly = options.notablesOnly === true;
 	const mapStyle = readMapStyle(options.mapStyle);
 	const darkMap = options.darkMap === true;
@@ -79,46 +148,36 @@ export const DirectusFlightMapPart = ({ options, resolve, value, partId, stackId
 		[flightPositions, notablesOnly],
 	);
 
-	// Fly the camera to a focused callsign once it first appears on the map.
-	const mapApi = useRef<FlightMapHandle>(null);
-	const flownFor = useRef<string | undefined>(undefined);
-	useEffect(() => {
-		if (!focusFlight) {
-			flownFor.current = undefined;
-			return;
-		}
-		if (flownFor.current === focusFlight) return;
-		const pos = flightPositions.find((p) => p.flight === focusFlight);
-		if (pos) {
-			mapApi.current?.flyTo([pos.lon, pos.lat], 7);
-			flownFor.current = focusFlight;
-		}
-	}, [focusFlight, flightPositions]);
+	const mapSettings = {
+		positions,
+		nowMs,
+		playing: !paused,
+		mapStyle,
+		darkMap,
+		pinColor,
+		notablePinColor,
+		anonPinColor,
+		observerPinColor,
+		buildingHeroColorLight,
+		buildingHeroColorDark,
+		radarSweep,
+		trailMultiplier,
+	};
 
-	const noop = useCallback(() => {}, []);
+	if (focusFlights.length <= 1) {
+		return (
+			<div className="classicyHyperCardFlightMap">
+				<FlightMapTile focusFlight={focusFlights[0]} {...mapSettings} />
+			</div>
+		);
+	}
 
 	return (
-		<div className="classicyHyperCardFlightMap">
-			<FlightMap
-				ref={mapApi}
-				positions={positions}
-				basemapUrls={BASEMAP_URLS}
-				trackGeoJSON={null}
-				nowMs={nowMs}
-				playing={!paused}
-				mapStyle={mapStyle}
-				darkMap={darkMap}
-				pinColor={pinColor}
-				notablePinColor={notablePinColor}
-				observerPinColor={observerPinColor}
-			anonPinColor={anonPinColor}
-				buildingHeroColorLight={buildingHeroColorLight}
-				buildingHeroColorDark={buildingHeroColorDark}
-				radarSweep={radarSweep}
-				trailMultiplier={trailMultiplier}
-				onSelectFlight={noop}
-				onClearSelection={noop}
-			/>
-		</div>
+		<HyperCardPartGrid
+			className="classicyHyperCardFlightMap"
+			items={focusFlights}
+			getKey={(flight, i) => `${flight}-${i}`}
+			renderItem={(flight) => <FlightMapTile focusFlight={flight} {...mapSettings} />}
+		/>
 	);
 };

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusNewsPart.css
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusNewsPart.css
@@ -49,6 +49,29 @@
 	height: auto;
 }
 
+/* Wrapper when `itemId` resolves to more than one article (issue #560) — a
+   scrollable stack, each article divided from the next. */
+.classicyHyperCardNewsList {
+	width: 100%;
+	height: 100%;
+	overflow-y: auto;
+	box-sizing: border-box;
+	background: #fff;
+}
+
+.classicyHyperCardNewsListItem {
+	border-bottom: 2px solid #ccc;
+}
+
+.classicyHyperCardNewsListItem:last-child {
+	border-bottom: none;
+}
+
+.classicyHyperCardNewsListItem .classicyHyperCardNews {
+	height: auto;
+	overflow-y: visible;
+}
+
 .classicyHyperCardNewsMessage {
 	display: flex;
 	align-items: center;

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusNewsPart.test.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusNewsPart.test.tsx
@@ -71,4 +71,22 @@ describe("DirectusNewsPart", () => {
 		expect(await screen.findByRole("alert")).toBeTruthy();
 		expect(screen.getByText(/Could not load article/)).toBeTruthy();
 	});
+
+	// issue #560 — itemId widened from a scalar to an array.
+	it("shows a placeholder for an empty itemId array", () => {
+		render(<DirectusNewsPart {...partProps({ itemId: [] })} />);
+		expect(screen.getByText("No article selected")).toBeTruthy();
+	});
+
+	it("renders a list of articles when itemId holds more than one id", async () => {
+		vi.spyOn(globalThis, "fetch").mockImplementation((url) => {
+			const isNine = String(url).includes("/9?");
+			return Promise.resolve(
+				jsonResponse({ data: { id: isNine ? 9 : 10, title: isNine ? "Nine" : "Ten" } }),
+			);
+		});
+		render(<DirectusNewsPart {...partProps({ itemId: [9, 10] })} />);
+		expect(await screen.findByText("Nine")).toBeTruthy();
+		expect(screen.getByText("Ten")).toBeTruthy();
+	});
 });

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusNewsPart.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusNewsPart.tsx
@@ -1,32 +1,38 @@
 import type { HyperCardPartProps } from "classicy";
 import { useMemo } from "react";
 import { fetchDirectusNewsItem } from "./directusCollections";
-import { resolveItemId, useDirectusItem } from "./useDirectusItem";
+import { resolveItemIds, useDirectusItem } from "./useDirectusItem";
 import "./DirectusNewsPart.css";
 
 /**
- * `directusNews` HyperCard part — embeds one article from the `news_items`
- * Directus collection (History Commons news entries).
+ * `directusNews` HyperCard part — embeds one or more articles from the
+ * `news_items` Directus collection (History Commons news entries).
  *
  *   { "id": "story", "type": "directusNews", "rect": [16, 40, 388, 220],
- *     "options": { "itemId": 42, "showImage": true } }
+ *     "options": { "itemId": [42], "showImage": true } }
  *
- * `itemId` resolves through the stack expression engine (so it may reference a
- * variable/field). The article's `content` is first-party HTML authored in
- * Directus — rendered the same way the News app renders it.
+ * `itemId` is an array (issue #560's `NewsItemPicker` always writes one), but
+ * a bare scalar/variable-name id is still accepted for a part authored before
+ * that change, and each entry resolves through the stack expression engine
+ * (so it may reference a variable/field). Two or more ids render as a
+ * vertical list of articles; the article's `content` is first-party HTML
+ * authored in Directus — rendered the same way the News app renders it.
  */
 
 interface DirectusNewsOptions {
-	itemId?: string | number;
+	itemIds: string[];
 	showImage: boolean;
 	showDate: boolean;
 }
 
-function readOptions(options: Record<string, unknown>): DirectusNewsOptions {
+function readOptions(
+	options: Record<string, unknown>,
+	value: string,
+	resolve: (expr: string) => string,
+): DirectusNewsOptions {
 	const o = options;
 	return {
-		itemId:
-			typeof o.itemId === "string" || typeof o.itemId === "number" ? o.itemId : undefined,
+		itemIds: resolveItemIds(o.itemId, value, resolve),
 		showImage: o.showImage !== false,
 		showDate: o.showDate !== false,
 	};
@@ -48,10 +54,17 @@ function formatDate(iso: string | null | undefined): string {
 	});
 }
 
-export const DirectusNewsPart = ({ options, value, resolve }: HyperCardPartProps) => {
-	const opts = useMemo(() => readOptions(options), [options]);
-	const id = resolveItemId(opts.itemId, value, resolve);
-	const state = useDirectusItem(id, fetchDirectusNewsItem);
+/** One article's body — split out so `DirectusNewsPart` can render several, each with its own load state. */
+function NewsArticle({
+	itemId,
+	showImage,
+	showDate,
+}: {
+	itemId: string;
+	showImage: boolean;
+	showDate: boolean;
+}) {
+	const state = useDirectusItem(itemId, fetchDirectusNewsItem);
 
 	if (state.status === "error") {
 		return (
@@ -71,10 +84,10 @@ export const DirectusNewsPart = ({ options, value, resolve }: HyperCardPartProps
 	return (
 		<article className="classicyHyperCardNews">
 			<h1 className="classicyHyperCardNewsHeadline">{item.full_title || item.title}</h1>
-			{opts.showDate && item.start_date && (
+			{showDate && item.start_date && (
 				<p className="classicyHyperCardNewsDate">{formatDate(item.start_date)}</p>
 			)}
-			{opts.showImage && item.image && (
+			{showImage && item.image && (
 				<figure className="classicyHyperCardNewsFigure">
 					<img src={item.image} alt={item.image_caption || item.title} />
 					{item.image_caption && <figcaption>{item.image_caption}</figcaption>}
@@ -89,5 +102,31 @@ export const DirectusNewsPart = ({ options, value, resolve }: HyperCardPartProps
 				/>
 			)}
 		</article>
+	);
+}
+
+/**
+ * Zero resolved ids renders the same "No article selected" message as
+ * before; one id renders exactly as before (a single `.classicyHyperCardNews`
+ * article, no extra wrapper); two or more render as a scrollable list of
+ * articles (issue #560).
+ */
+export const DirectusNewsPart = ({ options, value, resolve }: HyperCardPartProps) => {
+	const opts = useMemo(() => readOptions(options, value, resolve), [options, value, resolve]);
+
+	if (opts.itemIds.length === 0) {
+		return <div className="classicyHyperCardNews classicyHyperCardNewsMessage">No article selected</div>;
+	}
+	if (opts.itemIds.length === 1) {
+		return <NewsArticle itemId={opts.itemIds[0]} showImage={opts.showImage} showDate={opts.showDate} />;
+	}
+	return (
+		<div className="classicyHyperCardNewsList">
+			{opts.itemIds.map((id, i) => (
+				<div className="classicyHyperCardNewsListItem" key={`${id}-${i}`}>
+					<NewsArticle itemId={id} showImage={opts.showImage} showDate={opts.showDate} />
+				</div>
+			))}
+		</div>
 	);
 };

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusPagerPart.css
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusPagerPart.css
@@ -47,6 +47,29 @@
 	padding-top: 2px;
 }
 
+/* Wrapper when `itemId` resolves to more than one message (issue #560) — a
+   scrollable stack, each readout sized to its own content. */
+.classicyHyperCardPagerList {
+	width: 100%;
+	height: 100%;
+	overflow-y: auto;
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	padding: 6px;
+	box-sizing: border-box;
+	background: #b6b6a8;
+}
+
+.classicyHyperCardPagerList .classicyHyperCardPager {
+	height: auto;
+	padding: 0;
+}
+
+.classicyHyperCardPagerList .classicyHyperCardPagerScreen {
+	overflow-y: visible;
+}
+
 .classicyHyperCardPagerMessage {
 	display: flex;
 	align-items: center;

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusPagerPart.test.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusPagerPart.test.tsx
@@ -67,4 +67,22 @@ describe("DirectusPagerPart", () => {
 		expect(await screen.findByRole("alert")).toBeTruthy();
 		expect(screen.getByText(/Could not load page/)).toBeTruthy();
 	});
+
+	// issue #560 — itemId widened from a scalar to an array.
+	it("shows a placeholder for an empty itemId array", () => {
+		render(<DirectusPagerPart {...partProps({ itemId: [] })} />);
+		expect(screen.getByText("No page selected")).toBeTruthy();
+	});
+
+	it("renders a stack of readouts when itemId holds more than one id", async () => {
+		vi.spyOn(globalThis, "fetch").mockImplementation((url) => {
+			const isFive = String(url).includes("/5?");
+			return Promise.resolve(
+				jsonResponse({ data: { id: isFive ? 5 : 6, message: isFive ? "PAGE FIVE" : "PAGE SIX" } }),
+			);
+		});
+		render(<DirectusPagerPart {...partProps({ itemId: [5, 6] })} />);
+		expect(await screen.findByText("PAGE FIVE")).toBeTruthy();
+		expect(screen.getByText("PAGE SIX")).toBeTruthy();
+	});
 });

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusPagerPart.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusPagerPart.tsx
@@ -1,31 +1,37 @@
 import type { HyperCardPartProps } from "classicy";
 import { useMemo } from "react";
 import { fetchDirectusPagerItem } from "./directusCollections";
-import { resolveItemId, useDirectusItem } from "./useDirectusItem";
+import { resolveItemIds, useDirectusItem } from "./useDirectusItem";
 import "./DirectusPagerPart.css";
 
 /**
- * `directusPager` HyperCard part — embeds one instant pager message from the
- * `pager_items` Directus collection, styled as a pager readout.
+ * `directusPager` HyperCard part — embeds one or more instant pager messages
+ * from the `pager_items` Directus collection, styled as a pager readout.
  *
  *   { "id": "page", "type": "directusPager", "rect": [16, 40, 388, 140],
- *     "options": { "itemId": 128 } }
+ *     "options": { "itemId": [128] } }
  *
- * `itemId` resolves through the stack expression engine (so it may reference a
- * variable/field).
+ * `itemId` is an array (issue #560's `PagerMessagePicker` always writes one),
+ * but a bare scalar/variable-name id is still accepted for a part authored
+ * before that change, and each entry resolves through the stack expression
+ * engine (so it may reference a variable/field). Two or more ids render as a
+ * vertical list of pager readouts.
  */
 
 interface DirectusPagerOptions {
-	itemId?: string | number;
+	itemIds: string[];
 	/** Show the provider/recipient/mode metadata row (default true). */
 	showMeta: boolean;
 }
 
-function readOptions(options: Record<string, unknown>): DirectusPagerOptions {
+function readOptions(
+	options: Record<string, unknown>,
+	value: string,
+	resolve: (expr: string) => string,
+): DirectusPagerOptions {
 	const o = options;
 	return {
-		itemId:
-			typeof o.itemId === "string" || typeof o.itemId === "number" ? o.itemId : undefined,
+		itemIds: resolveItemIds(o.itemId, value, resolve),
 		showMeta: o.showMeta !== false,
 	};
 }
@@ -45,10 +51,9 @@ function formatTimestamp(iso: string | null | undefined): string {
 	});
 }
 
-export const DirectusPagerPart = ({ options, value, resolve }: HyperCardPartProps) => {
-	const opts = useMemo(() => readOptions(options), [options]);
-	const id = resolveItemId(opts.itemId, value, resolve);
-	const state = useDirectusItem(id, fetchDirectusPagerItem);
+/** One pager readout — split out so `DirectusPagerPart` can render several, each with its own load state. */
+function PagerMessage({ itemId, showMeta }: { itemId: string; showMeta: boolean }) {
+	const state = useDirectusItem(itemId, fetchDirectusPagerItem);
 
 	if (state.status === "error") {
 		return (
@@ -76,8 +81,32 @@ export const DirectusPagerPart = ({ options, value, resolve }: HyperCardPartProp
 					<span className="classicyHyperCardPagerTime">{formatTimestamp(item.start_date)}</span>
 				</div>
 				<p className="classicyHyperCardPagerBody">{item.message}</p>
-				{opts.showMeta && meta && <div className="classicyHyperCardPagerMeta">{meta}</div>}
+				{showMeta && meta && <div className="classicyHyperCardPagerMeta">{meta}</div>}
 			</div>
+		</div>
+	);
+}
+
+/**
+ * Zero resolved ids renders the same "No page selected" message as before;
+ * one id renders exactly as before (a single pager readout, no extra
+ * wrapper); two or more render as a scrollable stack of readouts (issue
+ * #560).
+ */
+export const DirectusPagerPart = ({ options, value, resolve }: HyperCardPartProps) => {
+	const opts = useMemo(() => readOptions(options, value, resolve), [options, value, resolve]);
+
+	if (opts.itemIds.length === 0) {
+		return <div className="classicyHyperCardPager classicyHyperCardPagerMessage">No page selected</div>;
+	}
+	if (opts.itemIds.length === 1) {
+		return <PagerMessage itemId={opts.itemIds[0]} showMeta={opts.showMeta} />;
+	}
+	return (
+		<div className="classicyHyperCardPagerList">
+			{opts.itemIds.map((id, i) => (
+				<PagerMessage key={`${id}-${i}`} itemId={id} showMeta={opts.showMeta} />
+			))}
 		</div>
 	);
 };

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusVideoPart.css
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusVideoPart.css
@@ -15,6 +15,11 @@
 	height: 100%;
 }
 
+/* Grid of tiles when `channelId` resolves to more than one id (issue #560). */
+.classicyHyperCardDirectusVideoGrid {
+	background: #000;
+}
+
 .classicyHyperCardDirectusVideoMessage {
 	display: flex;
 	align-items: center;

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusVideoPart.test.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusVideoPart.test.tsx
@@ -117,6 +117,29 @@ describe("DirectusVideoPart", () => {
 		expect(await screen.findByRole("alert")).toBeTruthy();
 		expect(screen.getByText(/Could not load video/)).toBeTruthy();
 	});
+
+	// issue #560 — channelId widened from a scalar to an array.
+	it("shows 'No video source' for an empty channelId array", () => {
+		render(<DirectusVideoPart {...partProps({ channelId: [] })} />);
+		expect(screen.getByText("No video source")).toBeTruthy();
+	});
+
+	it("renders one tile per id in a grid when channelId holds more than one", async () => {
+		vi.spyOn(globalThis, "fetch").mockImplementation((url) =>
+			Promise.resolve(
+				jsonResponse({
+					data: { id: 1, title: "T1", url: String(url).includes("/1?") ? "https://x/ch1.m3u8" : "https://x/ch2.m3u8" },
+				}),
+			),
+		);
+		render(<DirectusVideoPart {...partProps({ channelId: [1, 2] })} />);
+		const embeds = await screen.findAllByTestId("qt-embed");
+		expect(embeds).toHaveLength(2);
+		expect(embeds.map((e) => e.getAttribute("data-url")).sort()).toEqual([
+			"https://x/ch1.m3u8",
+			"https://x/ch2.m3u8",
+		]);
+	});
 });
 
 describe("DirectusVideo segment enforcement", () => {

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusVideoPart.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusVideoPart.tsx
@@ -6,24 +6,32 @@ import {
 	type DirectusVideoItem,
 	fetchDirectusVideoItem,
 } from "./directusCollections";
+import { HyperCardPartGrid } from "./HyperCardPartGrid";
+import { resolveItemIds } from "./useDirectusItem";
 import { type DirectusVideoOptions, readVideoOptions } from "./videoOptions";
 import { resolveSegment, toUtcMs } from "./videoSegment";
 import "./DirectusVideoPart.css";
 
 /**
- * `directusVideo` HyperCard part — embeds one TV channel stream from the
- * `tv_channels` Directus collection, optionally limited to a start/end segment.
+ * `directusVideo` HyperCard part — embeds one or more TV channel streams from
+ * the `tv_channels` Directus collection, each optionally limited to a
+ * start/end segment.
  *
  * Authored in a stack's JSON:
  *
  *   { "id": "tv", "type": "directusVideo", "rect": [16, 40, 388, 220],
- *     "options": { "channelId": 3, "start": 120, "end": 240,
+ *     "options": { "channelId": [3], "start": 120, "end": 240,
  *                  "controls": true, "loop": true, "captions": true } }
  *
- * `channelId` picks the `tv_channels` row (or pass a direct HLS `url`).
- * `start`/`end` bound the playback window — a number/"M:SS" is a stream offset,
- * a date-bearing time (e.g. "2001-09-11T12:46:00") is a wall-clock instant
- * mapped via the channel's `start_date` (see videoSegment.ts).
+ * `channelId` picks the `tv_channels` row(s) (or pass a direct HLS `url` for a
+ * single embed). It's an array (issue #560's HyperCard item picker stores a
+ * multi-select, and `TVClipPicker` always writes one) but a bare scalar id is
+ * still accepted for a part authored before that change. Two or more ids lay
+ * out as a `DirectusMultiviewPart`-style grid; `start`/`end`/`controls`/etc.
+ * are shared across every tile. `start`/`end` bound the playback window — a
+ * number/"M:SS" is a stream offset, a date-bearing time (e.g.
+ * "2001-09-11T12:46:00") is a wall-clock instant mapped via the channel's
+ * `start_date` (see videoSegment.ts).
  */
 
 type SourceState =
@@ -202,16 +210,51 @@ export function DirectusVideo(props: DirectusVideoProps) {
 	);
 }
 
-/** The registered HyperCard part: adapts part props to {@link DirectusVideo}. */
-export const DirectusVideoPart = ({ options, partId, stackId, fire }: HyperCardPartProps) => {
+/** Resolves `channelId` (or its `itemId` alias) into a list of ids — array-valued per issue #560, with a single legacy scalar still accepted. */
+function readChannelIds(
+	options: Record<string, unknown>,
+	value: string,
+	resolve: (expr: string) => string,
+): string[] {
+	return resolveItemIds(options.channelId ?? options.itemId, value, resolve);
+}
+
+/**
+ * The registered HyperCard part: adapts part props to {@link DirectusVideo}.
+ * Zero or one resolved `channelId` renders exactly as before (a single embed,
+ * falling back to a direct `url`); two or more lay out as a grid of tiles,
+ * one `DirectusVideo` per id, sharing every other option (issue #560).
+ */
+export const DirectusVideoPart = ({ options, value, resolve, partId, stackId, fire }: HyperCardPartProps) => {
 	const opts = useMemo(() => readVideoOptions(options), [options]);
+	const channelIds = useMemo(() => readChannelIds(options, value, resolve), [options, value, resolve]);
 	// Non-looping segment end fires the part's own script (e.g. `go next`).
 	const onSegmentEnd = useCallback(() => fire(), [fire]);
+
+	if (channelIds.length <= 1) {
+		return (
+			<DirectusVideo
+				{...opts}
+				channelId={channelIds[0] ?? opts.channelId}
+				appId={`hc-${stackId}-${partId}`}
+				onSegmentEnd={opts.loop ? undefined : onSegmentEnd}
+			/>
+		);
+	}
+
 	return (
-		<DirectusVideo
-			{...opts}
-			appId={`hc-${stackId}-${partId}`}
-			onSegmentEnd={opts.loop ? undefined : onSegmentEnd}
+		<HyperCardPartGrid
+			className="classicyHyperCardDirectusVideoGrid"
+			items={channelIds}
+			getKey={(id, i) => `${id}-${i}`}
+			renderItem={(id, i) => (
+				<DirectusVideo
+					{...opts}
+					channelId={id}
+					appId={`hc-${stackId}-${partId}-${i}`}
+					onSegmentEnd={opts.loop ? undefined : onSegmentEnd}
+				/>
+			)}
 		/>
 	);
 };

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusWeatherPart.test.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusWeatherPart.test.tsx
@@ -25,11 +25,11 @@ afterEach(() => {
 	vi.restoreAllMocks();
 });
 
-function renderPart(options: Record<string, unknown>, obs?: Record<string, unknown>) {
+function renderPart(options: Record<string, unknown>, obs?: Record<string, Record<string, unknown>>) {
 	// Almanac is fetched from the network; keep it absent in tests.
 	vi.spyOn(globalThis, "fetch").mockResolvedValue({ ok: false, status: 404 } as Response);
 	const ctx = {
-		weatherObservations: obs ? { KJFK: obs } : {},
+		weatherObservations: obs ?? {},
 		weatherForecastByZone: {},
 		subscribeWeather: vi.fn(),
 		unsubscribeWeather: vi.fn(),
@@ -47,7 +47,7 @@ describe("DirectusWeatherPart", () => {
 	it("renders the requested station's conditions", () => {
 		renderPart(
 			{ station: "KJFK" },
-			{ id: 1, station_id: "KJFK", start_date: "2001-09-11T12:46:00Z", temp_c: 20 },
+			{ KJFK: { id: 1, station_id: "KJFK", start_date: "2001-09-11T12:46:00Z", temp_c: 20 } },
 		);
 		// 20°C → 68°F via cToF, rendered in the Conditions group.
 		expect(screen.getByText("68°F")).toBeTruthy();
@@ -57,13 +57,35 @@ describe("DirectusWeatherPart", () => {
 	it("defaults to KJFK when no station option is given", () => {
 		renderPart(
 			{},
-			{ id: 1, station_id: "KJFK", start_date: "2001-09-11T12:46:00Z", temp_c: 0 },
+			{ KJFK: { id: 1, station_id: "KJFK", start_date: "2001-09-11T12:46:00Z", temp_c: 0 } },
 		);
 		expect(screen.getByText("32°F")).toBeTruthy();
 	});
 
-	it("subscribes to the weather channel on mount", () => {
+	it("subscribes to the weather channel exactly once regardless of station count", () => {
 		const ctx = renderPart({ station: "KJFK" });
+		expect(ctx.subscribeWeather).toHaveBeenCalledTimes(1);
+	});
+
+	// issue #560 — station widened from a scalar to an array.
+	it("defaults to KJFK for an empty station array", () => {
+		renderPart(
+			{ station: [] },
+			{ KJFK: { id: 1, station_id: "KJFK", start_date: "2001-09-11T12:46:00Z", temp_c: 0 } },
+		);
+		expect(screen.getByText("32°F")).toBeTruthy();
+	});
+
+	it("renders a tile per station, and still subscribes only once, when station holds more than one id", () => {
+		const ctx = renderPart(
+			{ station: ["KJFK", "KBOS"] },
+			{
+				KJFK: { id: 1, station_id: "KJFK", start_date: "2001-09-11T12:46:00Z", temp_c: 20 },
+				KBOS: { id: 2, station_id: "KBOS", start_date: "2001-09-11T12:46:00Z", temp_c: 0 },
+			},
+		);
+		expect(screen.getByText("68°F")).toBeTruthy();
+		expect(screen.getByText("32°F")).toBeTruthy();
 		expect(ctx.subscribeWeather).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/frontend/src/Applications/HyperCard/extensions/DirectusWeatherPart.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/DirectusWeatherPart.tsx
@@ -6,54 +6,36 @@ import stationsRaw from "../../Weather/stations.json";
 import { ALMANAC_DAYS, useAlmanac } from "../../Weather/useAlmanac";
 import type { WeatherStation } from "../../Weather/WeatherMap";
 import { WeatherStationPanel } from "../../Weather/WeatherStationPanel";
+import { HyperCardPartGrid } from "./HyperCardPartGrid";
+import { resolveItemIds } from "./useDirectusItem";
 import "./DirectusWeatherPart.css";
 
 /**
- * `directusWeatherStation` HyperCard part — embeds one weather station's live
- * readout (conditions, forecast, almanac) using the same `WeatherStationPanel`
- * the Weather app renders. Reads the shared virtual clock and the streamed
- * weather channel (via `MediaStreamContext`), so it stays in lockstep with the
- * desktop like every other app.
+ * `directusWeatherStation` HyperCard part — embeds one or more weather
+ * stations' live readouts (conditions, forecast, almanac) using the same
+ * `WeatherStationPanel` the Weather app renders. Reads the shared virtual
+ * clock and the streamed weather channel (via `MediaStreamContext`), so it
+ * stays in lockstep with the desktop like every other app.
  *
  *   { "id": "wx", "type": "directusWeatherStation", "rect": [12, 12, 260, 300],
- *     "options": { "station": "KJFK" } }
+ *     "options": { "station": ["KJFK"] } }
  *
- * `station` is an ICAO station id from the app's static station list; it
- * resolves through the stack expression engine (so it may track a variable).
+ * `station` is an array of ICAO station ids from the app's static station
+ * list (issue #560's `WeatherStationPicker` always writes one), but a bare
+ * scalar/variable id is still accepted for a part authored before that
+ * change; each entry resolves through the stack expression engine (so it may
+ * track a variable). No usable id falls back to a single default station, as
+ * before. Two or more ids lay out as a `DirectusMultiviewPart`-style grid of
+ * station panels.
  */
 
 const STATIONS = stationsRaw as WeatherStation[];
 const DEFAULT_STATION_ID = "KJFK";
 
-export const DirectusWeatherPart = ({ options, value, resolve, partId, stackId }: HyperCardPartProps) => {
-	const stationId = useMemo(() => {
-		const raw = (typeof options.station === "string" || typeof options.station === "number"
-			? options.station
-			: undefined) ?? value;
-		const resolved = raw ? resolve(String(raw)).trim() : "";
-		return resolved || DEFAULT_STATION_ID;
-	}, [options.station, value, resolve]);
-
-	const station = useMemo(
-		() => STATIONS.find((s) => s.station_id === stationId) ?? null,
-		[stationId],
-	);
-
-	const {
-		weatherObservations,
-		weatherForecastByZone,
-		subscribeWeather,
-		unsubscribeWeather,
-		requestWeatherForecast,
-	} = useContext(MediaStreamContext);
-
-	// Ref-counted subscription to the shared weather channel (one appId per
-	// embed), released on unmount — the same pattern the Weather app uses.
-	const appId = `hc-weather-${stackId}-${partId}`;
-	useEffect(() => {
-		subscribeWeather(appId);
-		return () => unsubscribeWeather(appId);
-	}, [subscribeWeather, unsubscribeWeather, appId]);
+/** One station's panel — split out so `DirectusWeatherPart` can render several, each with its own almanac/forecast lookups. */
+function WeatherStationTile({ stationId }: { stationId: string }) {
+	const station = useMemo(() => STATIONS.find((s) => s.station_id === stationId) ?? null, [stationId]);
+	const { weatherObservations, weatherForecastByZone, requestWeatherForecast } = useContext(MediaStreamContext);
 
 	useEffect(() => {
 		if (station?.nws_zone) requestWeatherForecast(station.nws_zone);
@@ -78,5 +60,34 @@ export const DirectusWeatherPart = ({ options, value, resolve, partId, stackId }
 				showAlmanac={ALMANAC_DAYS.has(currentMMDD)}
 			/>
 		</div>
+	);
+}
+
+export const DirectusWeatherPart = ({ options, value, resolve, partId, stackId }: HyperCardPartProps) => {
+	const stationIds = useMemo(() => {
+		const ids = resolveItemIds(options.station, value, resolve);
+		return ids.length > 0 ? ids : [DEFAULT_STATION_ID];
+	}, [options.station, value, resolve]);
+
+	// Ref-counted subscription to the shared weather channel (one appId per
+	// embed, regardless of how many stations it shows), released on unmount —
+	// the same pattern the Weather app uses.
+	const { subscribeWeather, unsubscribeWeather } = useContext(MediaStreamContext);
+	const appId = `hc-weather-${stackId}-${partId}`;
+	useEffect(() => {
+		subscribeWeather(appId);
+		return () => unsubscribeWeather(appId);
+	}, [subscribeWeather, unsubscribeWeather, appId]);
+
+	if (stationIds.length === 1) {
+		return <WeatherStationTile stationId={stationIds[0]} />;
+	}
+
+	return (
+		<HyperCardPartGrid
+			items={stationIds}
+			getKey={(id, i) => `${id}-${i}`}
+			renderItem={(id) => <WeatherStationTile stationId={id} />}
+		/>
 	);
 };

--- a/packages/frontend/src/Applications/HyperCard/extensions/FlightMapPicker.test.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/FlightMapPicker.test.tsx
@@ -1,0 +1,88 @@
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import {
+	MediaStreamContext,
+	type MediaStreamContextValue,
+} from "../../../Providers/MediaStream/MediaStreamContext";
+
+vi.mock("classicy", async (importOriginal) => ({
+	...(await importOriginal<typeof import("classicy")>()),
+	ClassicyWindow: ({ children, id, title }: { children?: ReactNode; id?: string; title?: string }) => (
+		<div data-testid={`win-${id}`} data-title={title}>
+			{children}
+		</div>
+	),
+}));
+
+import { FlightMapPicker } from "./FlightMapPicker";
+
+afterEach(cleanup);
+
+const POSITIONS = [
+	{ id: 1, flight: "AA11", carrier: "American", start_date: "x", lat: 42, lon: -71, alt_ft: 30000 },
+	{ id: 2, flight: "DAL123", start_date: "x", lat: 40, lon: -75, alt_ft: 35000 },
+];
+
+function renderPicker(flightPositions: unknown[], onChange = vi.fn()) {
+	const ctx = {
+		flightPositions,
+		subscribeFlights: vi.fn(),
+		unsubscribeFlights: vi.fn(),
+	} as unknown as MediaStreamContextValue;
+	render(
+		<MediaStreamContext.Provider value={ctx}>
+			<FlightMapPicker value={[]} onChange={onChange} />
+		</MediaStreamContext.Provider>,
+	);
+	return ctx;
+}
+
+describe("FlightMapPicker", () => {
+	it("subscribes to the flight channel on mount", () => {
+		const ctx = renderPicker(POSITIONS);
+		expect(ctx.subscribeFlights).toHaveBeenCalledTimes(1);
+	});
+
+	it("lists every flight currently on the map, with carrier when known", async () => {
+		renderPicker(POSITIONS);
+		fireEvent.click(screen.getByRole("button", { name: /browse/i }));
+		expect(await screen.findByLabelText("AA11 (American)")).toBeTruthy();
+		expect(screen.getByLabelText("DAL123")).toBeTruthy();
+	});
+
+	it("shows an empty-state message with nothing on the map", async () => {
+		renderPicker([]);
+		fireEvent.click(screen.getByRole("button", { name: /browse/i }));
+		expect(await screen.findByText("No flights are currently on the map.")).toBeTruthy();
+	});
+
+	it("confirms the selected callsigns", async () => {
+		const onChange = vi.fn();
+		renderPicker(POSITIONS, onChange);
+		fireEvent.click(screen.getByRole("button", { name: /browse/i }));
+		fireEvent.click(await screen.findByLabelText("AA11 (American)"));
+		fireEvent.click(screen.getByRole("button", { name: /confirm/i }));
+		expect(onChange).toHaveBeenCalledWith(["AA11"]);
+	});
+
+	it("filters to notable flights only via the checkbox", async () => {
+		renderPicker(POSITIONS);
+		fireEvent.click(screen.getByRole("button", { name: /browse/i }));
+		await screen.findByLabelText("AA11 (American)");
+		fireEvent.click(screen.getByLabelText("Notable flights only"));
+		await screen.findByLabelText("AA11 (American)");
+		expect(screen.queryByLabelText("DAL123")).toBeNull();
+	});
+
+	it("does not call onChange on Cancel", async () => {
+		const onChange = vi.fn();
+		renderPicker(POSITIONS, onChange);
+		fireEvent.click(screen.getByRole("button", { name: /browse/i }));
+		await screen.findByLabelText("AA11 (American)");
+		act(() => {
+			fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+		});
+		expect(onChange).not.toHaveBeenCalled();
+	});
+});

--- a/packages/frontend/src/Applications/HyperCard/extensions/FlightMapPicker.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/FlightMapPicker.tsx
@@ -1,0 +1,65 @@
+/**
+ * The HyperCard inspector's picker for directusFlightMap's `flight` field
+ * (issue #560) — checks off the flight(s) to focus from whatever's
+ * *currently* on the live flight channel (resolved open question: live data
+ * only, not historical/replay positions), the same `MediaStreamContext` read
+ * `DirectusFlightMapPart.tsx` itself uses, with the same "notable flights
+ * only" toggle `FlightTracker.tsx` exposes. `flight` stores an array, so this
+ * picker always runs in multi-select mode.
+ */
+import { ClassicyCheckbox } from "classicy";
+import { useCallback, useContext, useEffect } from "react";
+import { MediaStreamContext } from "../../../Providers/MediaStream/MediaStreamContext";
+import { isNotable } from "../../FlightTracker/notableFlights";
+import { filterRowsByQuery, HyperCardOptionPickerField, type HyperCardItemPickerFilters, type HyperCardItemPickerRow } from "./HyperCardItemPicker";
+
+const PICKER_APP_ID = "hypercard-flight-map-picker";
+
+export function FlightMapPicker({ value, onChange }: { value: unknown; onChange: (value: unknown) => void }) {
+	// Subscribing here (ref-counted, same as the part itself) means the live
+	// flight list is populated for authoring even if no other app currently
+	// has the flight channel open.
+	const { flightPositions, subscribeFlights, unsubscribeFlights } = useContext(MediaStreamContext);
+	useEffect(() => {
+		subscribeFlights(PICKER_APP_ID);
+		return () => unsubscribeFlights(PICKER_APP_ID);
+	}, [subscribeFlights, unsubscribeFlights]);
+
+	const fetchItems = useCallback(
+		(query: string, filters: HyperCardItemPickerFilters) => {
+			const notablesOnly = filters.notablesOnly === true;
+			const seen = new Set<string>();
+			const rows: HyperCardItemPickerRow[] = [];
+			for (const p of flightPositions) {
+				if (notablesOnly && !isNotable(p.flight)) continue;
+				if (seen.has(p.flight)) continue;
+				seen.add(p.flight);
+				rows.push({ id: p.flight, label: p.carrier ? `${p.flight} (${p.carrier})` : p.flight });
+			}
+			return filterRowsByQuery(rows, query);
+		},
+		[flightPositions],
+	);
+
+	return (
+		<HyperCardOptionPickerField
+			label="Flights"
+			value={value}
+			onChange={onChange}
+			pickerKey="flight_map"
+			title="Choose Flights"
+			fetchItems={fetchItems}
+			initialFilters={{ notablesOnly: false }}
+			searchPlaceholder="Search callsign"
+			emptyMessage="No flights are currently on the map."
+			renderFilterBar={(filters, setFilters) => (
+				<ClassicyCheckbox
+					id="flight_map_picker_notables_only"
+					label="Notable flights only"
+					checked={filters.notablesOnly === true}
+					onClickFunc={(checked) => setFilters({ notablesOnly: checked })}
+				/>
+			)}
+		/>
+	);
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/HyperCardItemPicker.css
+++ b/packages/frontend/src/Applications/HyperCard/extensions/HyperCardItemPicker.css
@@ -1,0 +1,54 @@
+/* Shared item-picker dialog for the six Directus embed types (issue #560).
+   Same list-scrolls-not-the-window shape as RadioTraffic's tag picker. */
+.classicyHyperCardItemPicker {
+	display: flex;
+	flex-direction: column;
+	gap: var(--window-padding-size, 8px);
+	padding: var(--window-padding-size, 8px);
+	font-family: var(--ui-font);
+	font-size: var(--ui-font-size);
+}
+
+.classicyHyperCardItemPickerList {
+	overflow-y: auto;
+	height: 220px;
+	padding: 6px;
+	background: var(--color-white, #fff);
+	border: 1px inset var(--color-system-05, #888);
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.classicyHyperCardItemPickerRow {
+	display: flex;
+	align-items: flex-start;
+	gap: 6px;
+	padding: 2px 4px;
+	cursor: pointer;
+}
+
+.classicyHyperCardItemPickerRowLabel {
+	flex: 1;
+	min-width: 0;
+}
+
+.classicyHyperCardItemPickerStatus {
+	padding: 4px;
+	color: var(--color-system-05, #666);
+	font-style: italic;
+}
+
+.classicyHyperCardItemPickerButtons {
+	display: flex;
+	flex-direction: row;
+	justify-content: flex-end;
+	gap: var(--window-padding-size, 8px);
+}
+
+/* The inspector-field summary line ahead of a picker field's Browse button
+   (HyperCardOptionPickerField) — e.g. "3 selected" or "(none)". */
+.classicyHyperCardItemPickerFieldSummary {
+	font-size: 11px;
+	color: var(--color-system-05, #666);
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/HyperCardItemPicker.test.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/HyperCardItemPicker.test.tsx
@@ -1,0 +1,261 @@
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// ClassicyWindow needs the app-manager store to mount — stub the two things
+// the shell is responsible for (same shape as TagPickerWindow.test.tsx).
+vi.mock("classicy", async (importOriginal) => ({
+	...(await importOriginal<typeof import("classicy")>()),
+	ClassicyWindow: ({
+		children,
+		id,
+		title,
+		onCloseFunc,
+	}: {
+		children?: React.ReactNode;
+		id?: string;
+		title?: string;
+		onCloseFunc?: (id: string) => void;
+	}) => (
+		<div data-testid={`win-${id}`} data-title={title}>
+			<button type="button" data-testid="close-box" onClick={() => onCloseFunc?.(id ?? "")}>
+				close
+			</button>
+			{children}
+		</div>
+	),
+}));
+
+import {
+	filterRowsByQuery,
+	HyperCardItemPicker,
+	HyperCardItemPickerForm,
+	type HyperCardItemPickerRow,
+} from "./HyperCardItemPicker";
+
+afterEach(cleanup);
+
+interface Row extends HyperCardItemPickerRow {
+	extra?: string;
+}
+
+const ROWS: Row[] = [
+	{ id: "1", label: "AAL11" },
+	{ id: "2", label: "UAL175" },
+	{ id: "3", label: "AAL77" },
+	{ id: "4", label: "UAL93" },
+];
+
+const onConfirm = vi.fn();
+const onCancel = vi.fn();
+afterEach(() => {
+	onConfirm.mockReset();
+	onCancel.mockReset();
+});
+
+const box = (label: string) => screen.getByLabelText(label) as HTMLInputElement;
+// Mode varies test-to-test (checkbox in multi mode, radio in single mode);
+// getByRole only accepts one literal role, so query the raw <input> elements.
+const boxes = () => Array.from(document.querySelectorAll<HTMLInputElement>("input[type=checkbox], input[type=radio]"));
+const click = (name: string) => fireEvent.click(screen.getByRole("button", { name }));
+const type = (query: string) =>
+	fireEvent.change(screen.getByLabelText("Search"), { target: { value: query } });
+
+function renderForm(overrides: Partial<Parameters<typeof HyperCardItemPickerForm<Row>>[0]> = {}) {
+	const fetchItems = vi.fn((query: string) => filterRowsByQuery(ROWS, query));
+	render(
+		<HyperCardItemPickerForm
+			pickerKey="test"
+			title="Test Picker"
+			selectionMode="multi"
+			selected={[]}
+			fetchItems={fetchItems}
+			onConfirm={onConfirm}
+			onCancel={onCancel}
+			{...overrides}
+		/>,
+	);
+	return fetchItems;
+}
+
+describe("filterRowsByQuery", () => {
+	it("ranks prefix matches before substring matches, case-insensitively", () => {
+		expect(filterRowsByQuery(ROWS, "ual").map((r) => r.id)).toEqual(["2", "4"]);
+	});
+
+	it("returns everything unfiltered for a blank query", () => {
+		expect(filterRowsByQuery(ROWS, "")).toEqual(ROWS);
+	});
+
+	it("returns nothing for a query matching no label", () => {
+		expect(filterRowsByQuery(ROWS, "zzz")).toEqual([]);
+	});
+});
+
+describe("HyperCardItemPickerForm", () => {
+	it("lists every row fetchItems returns", async () => {
+		renderForm();
+		expect(await screen.findByLabelText("AAL11")).toBeTruthy();
+		expect(boxes()).toHaveLength(ROWS.length);
+	});
+
+	it("re-queries fetchItems as the search box changes", async () => {
+		const fetchItems = renderForm();
+		await screen.findByLabelText("AAL11");
+		type("ual");
+		await screen.findByLabelText("UAL175");
+		expect(boxes()).toHaveLength(2);
+		expect(fetchItems).toHaveBeenLastCalledWith("ual", {});
+	});
+
+	it("keeps a row checked after a new query filters it out of view (multi)", async () => {
+		renderForm();
+		await screen.findByLabelText("AAL11");
+		fireEvent.click(box("AAL11"));
+		type("ual");
+		await screen.findByLabelText("UAL175");
+		expect(screen.queryByLabelText("AAL11")).toBeNull();
+		fireEvent.click(box("UAL93"));
+
+		type("");
+		await screen.findByLabelText("AAL11");
+		expect(box("AAL11").checked).toBe(true);
+		expect(box("UAL93").checked).toBe(true);
+
+		click("Confirm");
+		expect(onConfirm).toHaveBeenCalledWith(expect.arrayContaining(["1", "4"]));
+		expect((onConfirm.mock.calls[0][0] as string[]).sort()).toEqual(["1", "4"]);
+	});
+
+	it("seeds pending selection from `selected`", async () => {
+		renderForm({ selected: ["1", "3"] });
+		await screen.findByLabelText("AAL11");
+		expect(box("AAL11").checked).toBe(true);
+		expect(box("AAL77").checked).toBe(true);
+		expect(box("UAL175").checked).toBe(false);
+	});
+
+	it("caps selection at one row in single mode", async () => {
+		renderForm({ selectionMode: "single" });
+		await screen.findByLabelText("AAL11");
+		fireEvent.click(box("AAL11"));
+		fireEvent.click(box("UAL175"));
+		click("Confirm");
+		expect(onConfirm).toHaveBeenCalledWith(["2"]);
+	});
+
+	it("discards pending changes on Cancel", async () => {
+		renderForm();
+		await screen.findByLabelText("AAL11");
+		fireEvent.click(box("AAL11"));
+		click("Cancel");
+		expect(onCancel).toHaveBeenCalledTimes(1);
+		expect(onConfirm).not.toHaveBeenCalled();
+	});
+
+	it("shows an empty-state message rather than a blank panel", async () => {
+		renderForm();
+		type("zzz");
+		expect(await screen.findByText(/no matches/i)).toBeTruthy();
+	});
+
+	it("shows a custom empty message when given one", async () => {
+		renderForm({ emptyMessage: "No flights right now." });
+		type("zzz");
+		expect(await screen.findByText("No flights right now.")).toBeTruthy();
+	});
+
+	it("shows an error state when fetchItems rejects", async () => {
+		render(
+			<HyperCardItemPickerForm
+				pickerKey="test"
+				title="Test Picker"
+				selectionMode="multi"
+				selected={[]}
+				fetchItems={() => Promise.reject(new Error("boom"))}
+				onConfirm={onConfirm}
+				onCancel={onCancel}
+			/>,
+		);
+		expect(await screen.findByRole("alert")).toBeTruthy();
+	});
+
+	it("uses renderRow for custom row content instead of the bare label", async () => {
+		renderForm({
+			renderRow: (row) => <span data-testid={`row-${row.id}`}>Flight {row.label}</span>,
+		});
+		expect((await screen.findByTestId("row-1")).textContent).toBe("Flight AAL11");
+	});
+
+	it("passes filter state through to fetchItems and lets renderFilterBar update it", async () => {
+		const fetchItems = vi.fn((_query: string, filters: Record<string, unknown>) =>
+			ROWS.filter((r) => !filters.onlyUal || r.label.startsWith("UAL")),
+		);
+		render(
+			<HyperCardItemPickerForm
+				pickerKey="test"
+				title="Test Picker"
+				selectionMode="multi"
+				selected={[]}
+				initialFilters={{ onlyUal: false }}
+				fetchItems={fetchItems}
+				renderFilterBar={(filters, setFilters) => (
+					<button
+						type="button"
+						onClick={() => setFilters({ onlyUal: !filters.onlyUal })}
+					>
+						Toggle UAL-only
+					</button>
+				)}
+				onConfirm={onConfirm}
+				onCancel={onCancel}
+			/>,
+		);
+		await screen.findByLabelText("AAL11");
+		expect(boxes()).toHaveLength(4);
+		click("Toggle UAL-only");
+		await screen.findByLabelText("UAL175");
+		expect(boxes()).toHaveLength(2);
+		expect(fetchItems).toHaveBeenLastCalledWith("", { onlyUal: true });
+	});
+});
+
+describe("HyperCardItemPicker", () => {
+	it("mounts the form inside a window scoped by pickerKey", async () => {
+		render(
+			<HyperCardItemPicker
+				appId="HyperCard.app"
+				pickerKey="tv_clip"
+				title="Choose TV Channels"
+				selectionMode="multi"
+				selected={[]}
+				fetchItems={() => ROWS}
+				onConfirm={onConfirm}
+				onCancel={onCancel}
+			/>,
+		);
+		const win = screen.getByTestId("win-HyperCard.app_item_picker_tv_clip");
+		expect(win.getAttribute("data-title")).toBe("Choose TV Channels");
+		expect(await screen.findByLabelText("AAL11")).toBeTruthy();
+	});
+
+	it("treats the close box as Cancel, not as Confirm", async () => {
+		render(
+			<HyperCardItemPicker
+				appId="HyperCard.app"
+				pickerKey="tv_clip"
+				title="Choose TV Channels"
+				selectionMode="multi"
+				selected={[]}
+				fetchItems={() => ROWS}
+				onConfirm={onConfirm}
+				onCancel={onCancel}
+			/>,
+		);
+		await screen.findByLabelText("AAL11");
+		act(() => {
+			fireEvent.click(screen.getByTestId("close-box"));
+		});
+		expect(onCancel).toHaveBeenCalledTimes(1);
+		expect(onConfirm).not.toHaveBeenCalled();
+	});
+});

--- a/packages/frontend/src/Applications/HyperCard/extensions/HyperCardItemPicker.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/HyperCardItemPicker.tsx
@@ -1,0 +1,385 @@
+import { ClassicyBevelButton, ClassicyButton, ClassicyControlLabel, ClassicyInput, ClassicyWindow } from "classicy";
+import type { ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import "./HyperCardItemPicker.css";
+
+/**
+ * Shared reusable picker for HyperCard's six Directus-backed embeds (TV Clip,
+ * TV Multiview, News Item, Pager Message, Weather Station, Flight Map) — see
+ * issue #560. Modeled on `RadioTraffic/TagPickerWindow.tsx` +
+ * `RadioTraffic/tagSearch.ts`: a search box above a filtered, checkable list,
+ * Confirm/Cancel buttons, and the pending selection living above the rendered
+ * rows (so narrowing the query never silently drops a tick — see
+ * `TagPickerForm`'s own comment on this).
+ *
+ * Unlike the tag picker, the vocabulary here isn't a small fixed list handed
+ * in as a prop — each concrete embed's data source differs (a Directus
+ * collection, a static JSON file, or the live flight/weather channel), so this
+ * component takes a `fetchItems(query, filters)` callback instead and stays
+ * agnostic about where rows come from. `renderRow` likewise lets each concrete
+ * picker show whatever fields matter for that row (a date, a provider, a
+ * callsign) without this component knowing the row shape beyond `id`/`label`.
+ */
+
+/** One row in the list: `id` is what gets stored, `label` is the fallback text. */
+export interface HyperCardItemPickerRow {
+	id: string;
+	label: string;
+}
+
+/** Free-form extra filter state a concrete picker layers on top of the search box. */
+export type HyperCardItemPickerFilters = Record<string, unknown>;
+
+export interface HyperCardItemPickerFormProps<Row extends HyperCardItemPickerRow = HyperCardItemPickerRow> {
+	/** Namespaces every control id — lets several pickers exist without DOM id collisions. */
+	pickerKey: string;
+	title: string;
+	selectionMode: "single" | "multi";
+	/** Ids already selected when the picker opens. */
+	selected: string[];
+	initialFilters?: HyperCardItemPickerFilters;
+	/**
+	 * Resolves the visible rows for the current search text and filter state.
+	 * May run a real query (Directus, live channel) or filter an in-memory
+	 * list — either a plain array or a promise is accepted.
+	 */
+	fetchItems: (query: string, filters: HyperCardItemPickerFilters) => Row[] | Promise<Row[]>;
+	/** Row content beyond the plain label; defaults to `row.label`. */
+	renderRow?: (row: Row) => ReactNode;
+	/** Extra filter controls (e.g. a provider pop-up) rendered above the list. */
+	renderFilterBar?: (filters: HyperCardItemPickerFilters, setFilters: (patch: HyperCardItemPickerFilters) => void) => ReactNode;
+	/** Shown in place of the list when a query/filter combination matches nothing. */
+	emptyMessage?: string;
+	searchPlaceholder?: string;
+	onConfirm: (ids: string[]) => void;
+	onCancel: () => void;
+}
+
+/**
+ * The picker's contents, split from the window shell so behaviour is testable
+ * without classicy window chrome (the same split `TagPickerForm`/
+ * `TagPickerWindow` use).
+ */
+export function HyperCardItemPickerForm<Row extends HyperCardItemPickerRow>({
+	pickerKey,
+	title,
+	selectionMode,
+	selected,
+	initialFilters,
+	fetchItems,
+	renderRow,
+	renderFilterBar,
+	emptyMessage,
+	searchPlaceholder,
+	onConfirm,
+	onCancel,
+}: HyperCardItemPickerFormProps<Row>) {
+	const [query, setQuery] = useState("");
+	const [filters, setFiltersState] = useState<HyperCardItemPickerFilters>(() => initialFilters ?? {});
+	// Pending ticks live above the rendered rows — narrowing the query/filters
+	// unmounts rows, and a tick stored ON a row would go with it.
+	const [pending, setPending] = useState<ReadonlySet<string>>(() => new Set(selected));
+	const [rows, setRows] = useState<Row[]>([]);
+	const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
+
+	// Guards against a stale, slower-to-resolve request overwriting a newer one.
+	const requestId = useRef(0);
+	useEffect(() => {
+		const id = ++requestId.current;
+		setStatus("loading");
+		Promise.resolve(fetchItems(query, filters))
+			.then((result) => {
+				if (requestId.current !== id) return;
+				setRows(result);
+				setStatus("ready");
+			})
+			.catch(() => {
+				if (requestId.current !== id) return;
+				setRows([]);
+				setStatus("error");
+			});
+	}, [query, filters, fetchItems]);
+
+	const setFilters = (patch: HyperCardItemPickerFilters) =>
+		setFiltersState((prev) => ({ ...prev, ...patch }));
+
+	const toggle = (id: string, on: boolean) =>
+		setPending((prev) => {
+			if (selectionMode === "single") return on ? new Set([id]) : new Set();
+			const next = new Set(prev);
+			if (on) next.add(id);
+			else next.delete(id);
+			return next;
+		});
+
+	const inputType = selectionMode === "single" ? "radio" : "checkbox";
+	const groupName = `hc_item_picker_${pickerKey}_group`;
+
+	return (
+		<div className="classicyHyperCardItemPicker">
+			<ClassicyInput
+				id={`hc_item_picker_${pickerKey}_search`}
+				labelTitle="Search"
+				labelPosition="left"
+				placeholder={searchPlaceholder ?? "Search"}
+				onChangeFunc={(e) => setQuery(e.target.value)}
+			/>
+			{renderFilterBar?.(filters, setFilters)}
+			<div className="classicyHyperCardItemPickerList" role="group" aria-label={title}>
+				{status === "loading" && <p className="classicyHyperCardItemPickerStatus">Loading…</p>}
+				{status === "error" && (
+					<p className="classicyHyperCardItemPickerStatus" role="alert">
+						Could not load items.
+					</p>
+				)}
+				{status === "ready" && rows.length === 0 && (
+					<p className="classicyHyperCardItemPickerStatus">{emptyMessage ?? "No matches."}</p>
+				)}
+				{status === "ready" &&
+					rows.map((row) => {
+						const inputId = `hc_item_picker_${pickerKey}_${row.id}`;
+						return (
+							<label key={row.id} className="classicyHyperCardItemPickerRow" htmlFor={inputId}>
+								<input
+									id={inputId}
+									type={inputType}
+									name={inputType === "radio" ? groupName : undefined}
+									checked={pending.has(row.id)}
+									onChange={(e) => toggle(row.id, e.target.checked)}
+								/>
+								<span className="classicyHyperCardItemPickerRowLabel">
+									{renderRow ? renderRow(row) : row.label}
+								</span>
+							</label>
+						);
+					})}
+			</div>
+			<div className="classicyHyperCardItemPickerButtons">
+				<ClassicyButton onClickFunc={onCancel}>Cancel</ClassicyButton>
+				<ClassicyButton isDefault={true} onClickFunc={() => onConfirm([...pending])}>
+					Confirm
+				</ClassicyButton>
+			</div>
+		</div>
+	);
+}
+
+export interface HyperCardItemPickerProps<Row extends HyperCardItemPickerRow = HyperCardItemPickerRow>
+	extends HyperCardItemPickerFormProps<Row> {
+	appId: string;
+	icon?: string;
+}
+
+/**
+ * The form wrapped in its own modal window — one per concrete picker's Browse
+ * button, opened/closed by that picker (see `TVClipPicker.tsx` and friends).
+ */
+export function HyperCardItemPicker<Row extends HyperCardItemPickerRow>({
+	appId,
+	icon,
+	...form
+}: HyperCardItemPickerProps<Row>) {
+	return (
+		<ClassicyWindow
+			id={`${appId}_item_picker_${form.pickerKey}`}
+			appId={appId}
+			title={form.title}
+			icon={icon}
+			modal={true}
+			closable={true}
+			resizable={false}
+			zoomable={false}
+			collapsable={false}
+			scrollable={false}
+			initialSize={[320, 0]}
+			initialPosition={["center", "center"]}
+			// The close box is a way out, not a way to apply — anything else would
+			// let the field gain a selection the user never confirmed.
+			onCloseFunc={form.onCancel}
+		>
+			<HyperCardItemPickerForm {...form} />
+		</ClassicyWindow>
+	);
+}
+
+/**
+ * Prefix-then-substring ranking over a row's `label`, case-insensitive — same
+ * shape as `RadioTraffic/tagSearch.ts`'s `searchTags`, generalized to any row
+ * with a `label`. An empty query returns every row unfiltered.
+ */
+export function filterRowsByQuery<Row extends HyperCardItemPickerRow>(rows: Row[], query: string): Row[] {
+	const needle = query.trim().toLowerCase();
+	if (needle === "") return rows;
+	const prefix: Row[] = [];
+	const substring: Row[] = [];
+	for (const row of rows) {
+		const at = row.label.toLowerCase().indexOf(needle);
+		if (at === 0) prefix.push(row);
+		else if (at > 0) substring.push(row);
+	}
+	return prefix.concat(substring);
+}
+
+/**
+ * Load a full row list once (memoized across calls for the same loader
+ * identity) and filter it in-memory per keystroke — the shape
+ * `TVClipPicker`/`NewsItemPicker` use for their Directus-backed lists, since
+ * each collection is small enough to fetch whole (same reasoning as
+ * `tagSearch.ts`'s "build once, filter every keystroke").
+ */
+export function useCachedListSearch<Row extends HyperCardItemPickerRow>(
+	loadAll: () => Promise<Row[]>,
+): (query: string) => Promise<Row[]> {
+	const cache = useRef<Promise<Row[]> | null>(null);
+	// A new `loadAll` identity (e.g. the fetch fn changed in a test) invalidates
+	// the cache; the ref keeps the fetch itself to exactly once per identity.
+	const loaderRef = useRef(loadAll);
+	if (loaderRef.current !== loadAll) {
+		loaderRef.current = loadAll;
+		cache.current = null;
+	}
+	return useMemo(
+		() => async (query: string) => {
+			cache.current ??= loaderRef.current();
+			const all = await cache.current;
+			return filterRowsByQuery(all, query);
+		},
+		[loadAll],
+	);
+}
+
+/**
+ * Like {@link useCachedListSearch}, but for a picker whose `renderFilterBar`
+ * needs server-shaped rows filtered *before* they're mapped down to
+ * `{id, label}` — `PagerMessagePicker`'s provider pop-up is the model case: the
+ * full row set is fetched and cached once, `toRows` narrows it by the current
+ * filter state and produces the picker rows, and the query still narrows by
+ * label on top of that (same ranked prefix/substring match every picker uses).
+ */
+export function useCachedFilteredListSearch<T, Row extends HyperCardItemPickerRow>(
+	loadAll: () => Promise<T[]>,
+	toRows: (all: T[], filters: HyperCardItemPickerFilters) => Row[],
+): (query: string, filters: HyperCardItemPickerFilters) => Promise<Row[]> {
+	const cache = useRef<Promise<T[]> | null>(null);
+	const loaderRef = useRef(loadAll);
+	if (loaderRef.current !== loadAll) {
+		loaderRef.current = loadAll;
+		cache.current = null;
+	}
+	const toRowsRef = useRef(toRows);
+	toRowsRef.current = toRows;
+	return useMemo(
+		() => async (query: string, filters: HyperCardItemPickerFilters) => {
+			cache.current ??= loaderRef.current();
+			const all = await cache.current;
+			return filterRowsByQuery(toRowsRef.current(all, filters), query);
+		},
+		[loadAll],
+	);
+}
+
+/**
+ * Coerce a HyperCard option field's raw `value` into the id list a picker's
+ * `selected` prop expects — an array (the shape every widened field now
+ * stores, per issue #560), or a single legacy scalar id for a field that
+ * hasn't been re-saved yet. Anything else (undefined/null/an unrelated shape)
+ * is "nothing selected".
+ */
+export function toSelectedIds(value: unknown): string[] {
+	if (Array.isArray(value)) {
+		return value
+			.filter((v): v is string | number => typeof v === "string" || typeof v === "number")
+			.map(String);
+	}
+	if (typeof value === "string" && value !== "") return [value];
+	if (typeof value === "number") return [String(value)];
+	return [];
+}
+
+export interface HyperCardOptionPickerFieldProps<Row extends HyperCardItemPickerRow = HyperCardItemPickerRow> {
+	/** The bare-input label this replaces (kind:"picker" fields render only this component). */
+	label: string;
+	value: unknown;
+	onChange: (value: unknown) => void;
+	pickerKey: string;
+	title: string;
+	fetchItems: HyperCardItemPickerFormProps<Row>["fetchItems"];
+	renderRow?: HyperCardItemPickerFormProps<Row>["renderRow"];
+	renderFilterBar?: HyperCardItemPickerFormProps<Row>["renderFilterBar"];
+	initialFilters?: HyperCardItemPickerFormProps<Row>["initialFilters"];
+	emptyMessage?: string;
+	searchPlaceholder?: string;
+	/** Custom "N selected" summary text; defaults to a plain count. */
+	summary?: (selected: string[]) => string;
+	/**
+	 * Overrides how `value` becomes the picker's pending selection; defaults to
+	 * {@link toSelectedIds}. Needed by `TVMultiviewPicker`, whose field stores
+	 * full video-option objects rather than bare ids — it reads ids out of
+	 * those objects here, and does its own id-to-object mapping (preserving
+	 * each kept object's other settings) around the `onChange` it passes in.
+	 */
+	valueToIds?: (value: unknown) => string[];
+}
+
+/**
+ * The inspector-field half of a `HyperCardOptionPickerComponent`: a summary of
+ * the current selection, a Browse button, and the shared picker window,
+ * opened/closed locally. Every one of issue #560's six concrete pickers
+ * (`TVClipPicker`, `TVMultiviewPicker`, `NewsItemPicker`,
+ * `PagerMessagePicker`, `WeatherStationPicker`, `FlightMapPicker`) is this
+ * shell plus its own `fetchItems`/filter bar — see those files for the parts
+ * that actually differ.
+ */
+export function HyperCardOptionPickerField<Row extends HyperCardItemPickerRow>({
+	label,
+	value,
+	onChange,
+	pickerKey,
+	title,
+	fetchItems,
+	renderRow,
+	renderFilterBar,
+	initialFilters,
+	emptyMessage,
+	searchPlaceholder,
+	summary,
+	valueToIds,
+}: HyperCardOptionPickerFieldProps<Row>) {
+	const [open, setOpen] = useState(false);
+	const selected = (valueToIds ?? toSelectedIds)(value);
+	const summaryText = summary
+		? summary(selected)
+		: selected.length === 0
+			? "(none)"
+			: `${selected.length} selected`;
+
+	return (
+		<>
+			<ClassicyControlLabel label={label} />
+			<div className="classicyHyperCardItemPickerFieldSummary">{summaryText}</div>
+			<ClassicyBevelButton bevelWidth="small" onClickFunc={() => setOpen(true)}>
+				Browse…
+			</ClassicyBevelButton>
+			{open && (
+				<HyperCardItemPicker
+					appId="HyperCard.app"
+					pickerKey={pickerKey}
+					title={title}
+					selectionMode="multi"
+					selected={selected}
+					initialFilters={initialFilters}
+					fetchItems={fetchItems}
+					renderRow={renderRow}
+					renderFilterBar={renderFilterBar}
+					emptyMessage={emptyMessage}
+					searchPlaceholder={searchPlaceholder}
+					onConfirm={(ids) => {
+						onChange(ids);
+						setOpen(false);
+					}}
+					onCancel={() => setOpen(false)}
+				/>
+			)}
+		</>
+	);
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/HyperCardPartGrid.css
+++ b/packages/frontend/src/Applications/HyperCard/extensions/HyperCardPartGrid.css
@@ -1,0 +1,19 @@
+/* Shared "video wall"-style grid for a Directus*Part that now embeds several
+   items (issue #560 — array-valued options). Mirrors DirectusMultiviewPart's
+   own grid exactly, generalized for reuse by the video/weather/flight-map
+   parts, which grew multi-select pickers alongside Multiview's existing
+   array support. */
+.classicyHyperCardPartGrid {
+	display: grid;
+	gap: 3px;
+	width: 100%;
+	height: 100%;
+	grid-auto-rows: 1fr;
+}
+
+.classicyHyperCardPartGridTile {
+	position: relative;
+	min-width: 0;
+	min-height: 0;
+	overflow: hidden;
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/HyperCardPartGrid.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/HyperCardPartGrid.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react";
+import "./HyperCardPartGrid.css";
+
+/**
+ * Shared grid layout for a Directus*Part rendering more than one embedded
+ * item (issue #560 — TV Video's `channelId`, Weather Station's `station` and
+ * Flight Map's `flight` all widened from a single scalar to an array). Mirrors
+ * `DirectusMultiviewPart.tsx`'s own "video wall" grid — that component is the
+ * template this generalizes, since it already rendered an array of tiles end
+ * to end before this issue.
+ */
+
+/** Balanced column count for `n` tiles when the author doesn't set one. */
+export function autoGridColumns(n: number): number {
+	return n <= 1 ? 1 : Math.ceil(Math.sqrt(n));
+}
+
+export interface HyperCardPartGridProps<T> {
+	items: readonly T[];
+	renderItem: (item: T, index: number) => ReactNode;
+	getKey: (item: T, index: number) => string | number;
+	columns?: number;
+	/** Extra class(es) appended to the grid container, e.g. to inherit a part's own background. */
+	className?: string;
+}
+
+export function HyperCardPartGrid<T>({ items, renderItem, getKey, columns, className }: HyperCardPartGridProps<T>) {
+	const cols = Math.min(columns ?? autoGridColumns(items.length), items.length || 1);
+	return (
+		<div
+			className={["classicyHyperCardPartGrid", className].filter(Boolean).join(" ")}
+			style={{ gridTemplateColumns: `repeat(${cols}, 1fr)` }}
+		>
+			{items.map((item, i) => (
+				<div key={getKey(item, i)} className="classicyHyperCardPartGridTile">
+					{renderItem(item, i)}
+				</div>
+			))}
+		</div>
+	);
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/NewsItemPicker.test.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/NewsItemPicker.test.tsx
@@ -1,0 +1,75 @@
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+vi.mock("classicy", async (importOriginal) => ({
+	...(await importOriginal<typeof import("classicy")>()),
+	ClassicyWindow: ({ children, id, title }: { children?: ReactNode; id?: string; title?: string }) => (
+		<div data-testid={`win-${id}`} data-title={title}>
+			{children}
+		</div>
+	),
+}));
+
+const listRows = [
+	{ id: 9, title: "Short", full_title: "A Fuller Headline", start_date: "2001-09-11T12:46:00" },
+	{ id: 10, title: "Ten", full_title: null, start_date: "2001-09-11T13:00:00" },
+];
+const fetchDirectusNewsList = vi.hoisted(() => vi.fn());
+vi.mock("./directusCollections", () => ({ fetchDirectusNewsList }));
+
+import { NewsItemPicker } from "./NewsItemPicker";
+
+afterEach(() => {
+	cleanup();
+	fetchDirectusNewsList.mockReset();
+});
+
+describe("NewsItemPicker", () => {
+	it("shows '(none)' with no value", () => {
+		fetchDirectusNewsList.mockResolvedValue(listRows);
+		render(<NewsItemPicker value={undefined} onChange={vi.fn()} />);
+		expect(screen.getByText("(none)")).toBeTruthy();
+	});
+
+	it("lists every article, falling back to the bare title when full_title is unset", async () => {
+		fetchDirectusNewsList.mockResolvedValue(listRows);
+		render(<NewsItemPicker value={[]} onChange={vi.fn()} />);
+		fireEvent.click(screen.getByRole("button", { name: /browse/i }));
+		expect(await screen.findByLabelText("A Fuller Headline")).toBeTruthy();
+		expect(screen.getByLabelText("Ten")).toBeTruthy();
+	});
+
+	it("narrows the list via the search box", async () => {
+		fetchDirectusNewsList.mockResolvedValue(listRows);
+		render(<NewsItemPicker value={[]} onChange={vi.fn()} />);
+		fireEvent.click(screen.getByRole("button", { name: /browse/i }));
+		await screen.findByLabelText("A Fuller Headline");
+		fireEvent.change(screen.getByLabelText("Search"), { target: { value: "Ten" } });
+		await screen.findByLabelText("Ten");
+		expect(screen.queryByLabelText("A Fuller Headline")).toBeNull();
+	});
+
+	it("confirms the selected ids", async () => {
+		fetchDirectusNewsList.mockResolvedValue(listRows);
+		const onChange = vi.fn();
+		render(<NewsItemPicker value={[]} onChange={onChange} />);
+		fireEvent.click(screen.getByRole("button", { name: /browse/i }));
+		fireEvent.click(await screen.findByLabelText("A Fuller Headline"));
+		fireEvent.click(screen.getByLabelText("Ten"));
+		fireEvent.click(screen.getByRole("button", { name: /confirm/i }));
+		expect((onChange.mock.calls[0][0] as string[]).sort()).toEqual(["10", "9"]);
+	});
+
+	it("does not call onChange on Cancel", async () => {
+		fetchDirectusNewsList.mockResolvedValue(listRows);
+		const onChange = vi.fn();
+		render(<NewsItemPicker value={[]} onChange={onChange} />);
+		fireEvent.click(screen.getByRole("button", { name: /browse/i }));
+		await screen.findByLabelText("A Fuller Headline");
+		act(() => {
+			fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+		});
+		expect(onChange).not.toHaveBeenCalled();
+	});
+});

--- a/packages/frontend/src/Applications/HyperCard/extensions/NewsItemPicker.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/NewsItemPicker.tsx
@@ -1,0 +1,31 @@
+/**
+ * The HyperCard inspector's picker for directusNews's `itemId` field (issue
+ * #560) — browse every `news_items` row and check off the article(s) to
+ * embed. `itemId` stores an array (see `DirectusNewsPart.tsx`), so this
+ * picker always runs in multi-select mode.
+ */
+import { useCallback } from "react";
+import { fetchDirectusNewsList, type DirectusNewsListItem } from "./directusCollections";
+import { HyperCardOptionPickerField, type HyperCardItemPickerRow, useCachedListSearch } from "./HyperCardItemPicker";
+
+function toRow(item: DirectusNewsListItem): HyperCardItemPickerRow {
+	return { id: String(item.id), label: item.full_title || item.title };
+}
+
+export function NewsItemPicker({ value, onChange }: { value: unknown; onChange: (value: unknown) => void }) {
+	const loadAll = useCallback(async () => (await fetchDirectusNewsList()).map(toRow), []);
+	const fetchItems = useCachedListSearch(loadAll);
+
+	return (
+		<HyperCardOptionPickerField
+			label="News Items"
+			value={value}
+			onChange={onChange}
+			pickerKey="news_item"
+			title="Choose News Items"
+			fetchItems={fetchItems}
+			searchPlaceholder="Search headline"
+			emptyMessage="No news items match."
+		/>
+	);
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/PagerMessagePicker.test.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/PagerMessagePicker.test.tsx
@@ -1,0 +1,104 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChangeEvent, ReactNode } from "react";
+
+vi.mock("classicy", async (importOriginal) => ({
+	...(await importOriginal<typeof import("classicy")>()),
+	ClassicyWindow: ({ children, id, title }: { children?: ReactNode; id?: string; title?: string }) => (
+		<div data-testid={`win-${id}`} data-title={title}>
+			{children}
+		</div>
+	),
+	ClassicyPopUpMenu: ({
+		id,
+		label,
+		options,
+		selected,
+		onChangeFunc,
+	}: {
+		id: string;
+		label?: string;
+		options: Array<{ value: string; label: string }>;
+		selected?: string;
+		onChangeFunc?: (e: ChangeEvent<HTMLSelectElement>) => void;
+	}) => (
+		<label>
+			{label}
+			<select id={id} value={selected} onChange={(e) => onChangeFunc?.(e)}>
+				{options.map((o) => (
+					<option key={o.value} value={o.value}>
+						{o.label}
+					</option>
+				))}
+			</select>
+		</label>
+	),
+}));
+
+const fetchDirectusPagerList = vi.hoisted(() => vi.fn());
+const fetchDirectusPagerProviders = vi.hoisted(() => vi.fn());
+vi.mock("./directusCollections", () => ({ fetchDirectusPagerList, fetchDirectusPagerProviders }));
+
+import { PagerMessagePicker } from "./PagerMessagePicker";
+
+afterEach(() => {
+	cleanup();
+	fetchDirectusPagerList.mockReset();
+	fetchDirectusPagerProviders.mockReset();
+});
+
+describe("PagerMessagePicker", () => {
+	it("lists rows with a provider prefix", async () => {
+		fetchDirectusPagerProviders.mockResolvedValue(["SkyTel"]);
+		fetchDirectusPagerList.mockResolvedValue([{ id: 5, message: "CALL OPS CENTER", provider: "SkyTel" }]);
+		render(<PagerMessagePicker value={[]} onChange={vi.fn()} />);
+		fireEvent.click(screen.getByRole("button", { name: /browse/i }));
+		expect(await screen.findByLabelText("SkyTel — CALL OPS CENTER")).toBeTruthy();
+		expect(fetchDirectusPagerList).toHaveBeenCalledWith(
+			{ provider: undefined, recipient: undefined, message: undefined },
+		);
+	});
+
+	it("passes the search box text through as a server-side message filter", async () => {
+		fetchDirectusPagerProviders.mockResolvedValue([]);
+		fetchDirectusPagerList.mockResolvedValue([]);
+		render(<PagerMessagePicker value={[]} onChange={vi.fn()} />);
+		fireEvent.click(screen.getByRole("button", { name: /browse/i }));
+		await screen.findByText("No pager messages match.");
+		fireEvent.change(screen.getByLabelText("Search"), { target: { value: "OPS" } });
+		await vi.waitFor(() =>
+			expect(fetchDirectusPagerList).toHaveBeenLastCalledWith({
+				provider: undefined,
+				recipient: undefined,
+				message: "OPS",
+			}),
+		);
+	});
+
+	it("filters by provider via the pop-up", async () => {
+		fetchDirectusPagerProviders.mockResolvedValue(["SkyTel", "PageNet"]);
+		fetchDirectusPagerList.mockResolvedValue([]);
+		render(<PagerMessagePicker value={[]} onChange={vi.fn()} />);
+		fireEvent.click(screen.getByRole("button", { name: /browse/i }));
+		await screen.findByLabelText("Provider");
+		fireEvent.change(screen.getByLabelText("Provider"), { target: { value: "PageNet" } });
+		await vi.waitFor(() =>
+			expect(fetchDirectusPagerList).toHaveBeenLastCalledWith({
+				provider: "PageNet",
+				recipient: undefined,
+				message: undefined,
+			}),
+		);
+	});
+
+	it("confirms the selected ids", async () => {
+		fetchDirectusPagerProviders.mockResolvedValue([]);
+		fetchDirectusPagerList.mockResolvedValue([{ id: 5, message: "PAGE", provider: null }]);
+		const onChange = vi.fn();
+		render(<PagerMessagePicker value={[]} onChange={onChange} />);
+		fireEvent.click(screen.getByRole("button", { name: /browse/i }));
+		fireEvent.click(await screen.findByLabelText("PAGE"));
+		fireEvent.click(screen.getByRole("button", { name: /confirm/i }));
+		expect(onChange).toHaveBeenCalledWith(["5"]);
+	});
+});

--- a/packages/frontend/src/Applications/HyperCard/extensions/PagerMessagePicker.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/PagerMessagePicker.tsx
@@ -1,0 +1,78 @@
+/**
+ * The HyperCard inspector's picker for directusPager's `itemId` field (issue
+ * #560) — browse `pager_items`, filtered server-side the same way
+ * `PagerDecoder.tsx`'s own filter bar works (provider exact-match, recipient
+ * substring), with the search box driving a message-text substring filter.
+ * `itemId` stores an array (see `DirectusPagerPart.tsx`), so this picker
+ * always runs in multi-select mode.
+ */
+import { ClassicyInput, ClassicyPopUpMenu } from "classicy";
+import { useCallback, useEffect, useState } from "react";
+import {
+	fetchDirectusPagerList,
+	fetchDirectusPagerProviders,
+	type DirectusPagerListItem,
+} from "./directusCollections";
+import { HyperCardOptionPickerField, type HyperCardItemPickerFilters, type HyperCardItemPickerRow } from "./HyperCardItemPicker";
+
+function toRow(item: DirectusPagerListItem): HyperCardItemPickerRow {
+	const prefix = item.provider ? `${item.provider} — ` : "";
+	return { id: String(item.id), label: `${prefix}${item.message}` };
+}
+
+export function PagerMessagePicker({ value, onChange }: { value: unknown; onChange: (value: unknown) => void }) {
+	const [providers, setProviders] = useState<string[]>([]);
+	useEffect(() => {
+		let cancelled = false;
+		fetchDirectusPagerProviders().then((p) => {
+			if (!cancelled) setProviders(p);
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	const fetchItems = useCallback(async (query: string, filters: HyperCardItemPickerFilters) => {
+		const provider = typeof filters.provider === "string" && filters.provider !== "" ? filters.provider : undefined;
+		const recipient =
+			typeof filters.recipient === "string" && filters.recipient !== "" ? filters.recipient : undefined;
+		const rows = await fetchDirectusPagerList({ provider, recipient, message: query || undefined });
+		return rows.map(toRow);
+	}, []);
+
+	return (
+		<HyperCardOptionPickerField
+			label="Pager Messages"
+			value={value}
+			onChange={onChange}
+			pickerKey="pager_message"
+			title="Choose Pager Messages"
+			fetchItems={fetchItems}
+			initialFilters={{ provider: "", recipient: "" }}
+			searchPlaceholder="Search message text"
+			emptyMessage="No pager messages match."
+			renderFilterBar={(filters, setFilters) => (
+				<>
+					<ClassicyPopUpMenu
+						id="pager_message_picker_provider"
+						label="Provider"
+						labelPosition="left"
+						size="mini"
+						placeholder="All providers"
+						options={[{ value: "", label: "All providers" }, ...providers.map((p) => ({ value: p, label: p }))]}
+						selected={typeof filters.provider === "string" ? filters.provider : ""}
+						onChangeFunc={(e) => setFilters({ provider: e.target.value })}
+					/>
+					<ClassicyInput
+						id="pager_message_picker_recipient"
+						labelTitle="Recipient"
+						labelPosition="left"
+						placeholder="Recipient id"
+						prefillValue={typeof filters.recipient === "string" ? filters.recipient : ""}
+						onChangeFunc={(e) => setFilters({ recipient: e.target.value })}
+					/>
+				</>
+			)}
+		/>
+	);
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/TVClipPicker.test.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/TVClipPicker.test.tsx
@@ -1,0 +1,111 @@
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChangeEvent, ReactNode } from "react";
+
+// ClassicyWindow needs the app-manager store to mount — stub it the same way
+// HyperCardItemPicker.test.tsx does. ClassicyPopUpMenu's real implementation
+// is a custom listbox, not a native <select> — Weather.test.tsx's own stub
+// (a real <select>) is the established, simpler-to-drive-in-tests shape.
+vi.mock("classicy", async (importOriginal) => ({
+	...(await importOriginal<typeof import("classicy")>()),
+	ClassicyWindow: ({ children, id, title }: { children?: ReactNode; id?: string; title?: string }) => (
+		<div data-testid={`win-${id}`} data-title={title}>
+			{children}
+		</div>
+	),
+	ClassicyPopUpMenu: ({
+		id,
+		label,
+		options,
+		selected,
+		onChangeFunc,
+	}: {
+		id: string;
+		label?: string;
+		options: Array<{ value: string; label: string }>;
+		selected?: string;
+		onChangeFunc?: (e: ChangeEvent<HTMLSelectElement>) => void;
+	}) => (
+		<label>
+			{label}
+			<select id={id} value={selected} onChange={(e) => onChangeFunc?.(e)}>
+				{options.map((o) => (
+					<option key={o.value} value={o.value}>
+						{o.label}
+					</option>
+				))}
+			</select>
+		</label>
+	),
+}));
+
+const listRows = [
+	{ id: 1, title: "WNYW", full_title: "WNYW Fox 5", source: "fox" },
+	{ id: 2, title: "WCBS", full_title: "WCBS CBS 2", source: "cbs" },
+	{ id: 3, title: "WABC", full_title: "WABC ABC 7", source: "abc" },
+];
+const fetchDirectusVideoList = vi.hoisted(() => vi.fn());
+vi.mock("./directusCollections", () => ({ fetchDirectusVideoList }));
+
+import { TVClipPicker } from "./TVClipPicker";
+
+afterEach(() => {
+	cleanup();
+	fetchDirectusVideoList.mockReset();
+});
+
+describe("TVClipPicker", () => {
+	it("shows '(none)' with no value, and the Browse control", () => {
+		fetchDirectusVideoList.mockResolvedValue(listRows);
+		render(<TVClipPicker value={undefined} onChange={vi.fn()} />);
+		expect(screen.getByText("(none)")).toBeTruthy();
+		expect(screen.getByRole("button", { name: /browse/i })).toBeTruthy();
+	});
+
+	it("shows a count summary for an existing array value", () => {
+		fetchDirectusVideoList.mockResolvedValue(listRows);
+		render(<TVClipPicker value={["1", "2"]} onChange={vi.fn()} />);
+		expect(screen.getByText("2 selected")).toBeTruthy();
+	});
+
+	it("opens the picker, lists every channel, and confirms the selected ids", async () => {
+		fetchDirectusVideoList.mockResolvedValue(listRows);
+		const onChange = vi.fn();
+		render(<TVClipPicker value={[]} onChange={onChange} />);
+		fireEvent.click(screen.getByRole("button", { name: /browse/i }));
+		expect(await screen.findByLabelText("WNYW Fox 5")).toBeTruthy();
+		expect(screen.getByLabelText("WCBS CBS 2")).toBeTruthy();
+		expect(screen.getByLabelText("WABC ABC 7")).toBeTruthy();
+
+		fireEvent.click(screen.getByLabelText("WNYW Fox 5"));
+		fireEvent.click(screen.getByLabelText("WABC ABC 7"));
+		fireEvent.click(screen.getByRole("button", { name: /confirm/i }));
+
+		expect(onChange).toHaveBeenCalledTimes(1);
+		expect((onChange.mock.calls[0][0] as string[]).sort()).toEqual(["1", "3"]);
+	});
+
+	it("filters the list by network via the pop-up", async () => {
+		fetchDirectusVideoList.mockResolvedValue(listRows);
+		render(<TVClipPicker value={[]} onChange={vi.fn()} />);
+		fireEvent.click(screen.getByRole("button", { name: /browse/i }));
+		await screen.findByLabelText("WNYW Fox 5");
+
+		fireEvent.change(screen.getByLabelText("Network"), { target: { value: "cbs" } });
+		await screen.findByLabelText("WCBS CBS 2");
+		expect(screen.queryByLabelText("WNYW Fox 5")).toBeNull();
+		expect(screen.queryByLabelText("WABC ABC 7")).toBeNull();
+	});
+
+	it("does not call onChange on Cancel", async () => {
+		fetchDirectusVideoList.mockResolvedValue(listRows);
+		const onChange = vi.fn();
+		render(<TVClipPicker value={[]} onChange={onChange} />);
+		fireEvent.click(screen.getByRole("button", { name: /browse/i }));
+		await screen.findByLabelText("WNYW Fox 5");
+		act(() => {
+			fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+		});
+		expect(onChange).not.toHaveBeenCalled();
+	});
+});

--- a/packages/frontend/src/Applications/HyperCard/extensions/TVClipPicker.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/TVClipPicker.tsx
@@ -1,0 +1,80 @@
+/**
+ * The HyperCard inspector's picker for directusVideo's `channelId` field
+ * (issue #560) — browse every `tv_channels` row, filter by network, and check
+ * off the channel(s) to embed. `channelId` stores an array (see
+ * `DirectusVideoPart.tsx`), so this picker always runs in multi-select mode.
+ */
+import { ClassicyPopUpMenu } from "classicy";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { fetchDirectusVideoList, type DirectusVideoListItem } from "./directusCollections";
+import {
+	HyperCardOptionPickerField,
+	type HyperCardItemPickerFilters,
+	type HyperCardItemPickerRow,
+	useCachedFilteredListSearch,
+} from "./HyperCardItemPicker";
+
+function toRow(item: DirectusVideoListItem): HyperCardItemPickerRow {
+	return { id: String(item.id), label: item.full_title || item.title };
+}
+
+function applyNetworkFilter(rows: DirectusVideoListItem[], filters: HyperCardItemPickerFilters): DirectusVideoListItem[] {
+	const network = typeof filters.network === "string" ? filters.network : "";
+	return network ? rows.filter((r) => r.source === network) : rows;
+}
+
+/** Loads the (small, fetch-whole) `tv_channels` list once and maps/filters it into picker rows. */
+function useVideoRows(): [(rows: DirectusVideoListItem[], filters: HyperCardItemPickerFilters) => HyperCardItemPickerRow[], () => Promise<DirectusVideoListItem[]>] {
+	const cache = useRef<Promise<DirectusVideoListItem[]> | null>(null);
+	const loadAll = useCallback(() => (cache.current ??= fetchDirectusVideoList()), []);
+	const toRows = useCallback(
+		(rows: DirectusVideoListItem[], filters: HyperCardItemPickerFilters) => applyNetworkFilter(rows, filters).map(toRow),
+		[],
+	);
+	return [toRows, loadAll];
+}
+
+export function TVClipPicker({ value, onChange }: { value: unknown; onChange: (value: unknown) => void }) {
+	const [toRows, loadAll] = useVideoRows();
+	const fetchItems = useCachedFilteredListSearch(loadAll, toRows);
+
+	// Populates the network pop-up; shares `loadAll`'s cached promise, so this
+	// doesn't cost a second request beyond the one `fetchItems` triggers.
+	const [networks, setNetworks] = useState<string[]>([]);
+	useEffect(() => {
+		let cancelled = false;
+		loadAll().then((rows) => {
+			if (cancelled) return;
+			setNetworks([...new Set(rows.map((r) => r.source).filter((s): s is string => !!s))].sort());
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, [loadAll]);
+
+	return (
+		<HyperCardOptionPickerField
+			label="TV Channels"
+			value={value}
+			onChange={onChange}
+			pickerKey="tv_clip"
+			title="Choose TV Channels"
+			fetchItems={fetchItems}
+			initialFilters={{ network: "" }}
+			searchPlaceholder="Search channel"
+			emptyMessage="No TV channels match."
+			renderFilterBar={(filters, setFilters) => (
+				<ClassicyPopUpMenu
+					id="tv_clip_picker_network"
+					label="Network"
+					labelPosition="left"
+					size="mini"
+					placeholder="All networks"
+					options={[{ value: "", label: "All networks" }, ...networks.map((n) => ({ value: n, label: n }))]}
+					selected={typeof filters.network === "string" ? filters.network : ""}
+					onChangeFunc={(e) => setFilters({ network: e.target.value })}
+				/>
+			)}
+		/>
+	);
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/TVMultiviewPicker.test.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/TVMultiviewPicker.test.tsx
@@ -1,0 +1,108 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChangeEvent, ReactNode } from "react";
+
+vi.mock("classicy", async (importOriginal) => ({
+	...(await importOriginal<typeof import("classicy")>()),
+	ClassicyWindow: ({ children, id, title }: { children?: ReactNode; id?: string; title?: string }) => (
+		<div data-testid={`win-${id}`} data-title={title}>
+			{children}
+		</div>
+	),
+	ClassicyPopUpMenu: ({
+		id,
+		label,
+		options,
+		selected,
+		onChangeFunc,
+	}: {
+		id: string;
+		label?: string;
+		options: Array<{ value: string; label: string }>;
+		selected?: string;
+		onChangeFunc?: (e: ChangeEvent<HTMLSelectElement>) => void;
+	}) => (
+		<label>
+			{label}
+			<select id={id} value={selected} onChange={(e) => onChangeFunc?.(e)}>
+				{options.map((o) => (
+					<option key={o.value} value={o.value}>
+						{o.label}
+					</option>
+				))}
+			</select>
+		</label>
+	),
+}));
+
+const listRows = [
+	{ id: 1, title: "WNYW", full_title: "WNYW Fox 5", source: "fox" },
+	{ id: 2, title: "WCBS", full_title: "WCBS CBS 2", source: "cbs" },
+];
+const fetchDirectusVideoList = vi.hoisted(() => vi.fn());
+vi.mock("./directusCollections", () => ({ fetchDirectusVideoList }));
+
+import { TVMultiviewPicker } from "./TVMultiviewPicker";
+
+afterEach(() => {
+	cleanup();
+	fetchDirectusVideoList.mockReset();
+});
+
+describe("TVMultiviewPicker", () => {
+	it("reads the pending selection from the videos array's channelId fields", async () => {
+		fetchDirectusVideoList.mockResolvedValue(listRows);
+		render(
+			<TVMultiviewPicker
+				value={[{ channelId: "1", start: 10 }]}
+				onChange={vi.fn()}
+			/>,
+		);
+		expect(screen.getByText("1 selected")).toBeTruthy();
+		fireEvent.click(screen.getByRole("button", { name: /browse/i }));
+		await screen.findByLabelText("WNYW Fox 5");
+		expect((screen.getByLabelText("WNYW Fox 5") as HTMLInputElement).checked).toBe(true);
+	});
+
+	it("preserves a kept channel's other settings and adds a bare object for a new one", async () => {
+		fetchDirectusVideoList.mockResolvedValue(listRows);
+		const onChange = vi.fn();
+		render(
+			<TVMultiviewPicker
+				value={[{ channelId: "1", start: 10, autoPlay: true }]}
+				onChange={onChange}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: /browse/i }));
+		await screen.findByLabelText("WNYW Fox 5");
+		// Channel 1 stays checked (seeded from `value`); also check channel 2.
+		fireEvent.click(screen.getByLabelText("WCBS CBS 2"));
+		fireEvent.click(screen.getByRole("button", { name: /confirm/i }));
+
+		expect(onChange).toHaveBeenCalledTimes(1);
+		const result = onChange.mock.calls[0][0] as Array<Record<string, unknown>>;
+		expect(result).toHaveLength(2);
+		expect(result.find((v) => v.channelId === "1")).toEqual({ channelId: "1", start: 10, autoPlay: true });
+		expect(result.find((v) => v.channelId === "2")).toEqual({ channelId: "2" });
+	});
+
+	it("drops a channel that's unchecked, discarding its settings", async () => {
+		fetchDirectusVideoList.mockResolvedValue(listRows);
+		const onChange = vi.fn();
+		render(
+			<TVMultiviewPicker
+				value={[
+					{ channelId: "1", start: 10 },
+					{ channelId: "2" },
+				]}
+				onChange={onChange}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: /browse/i }));
+		await screen.findByLabelText("WNYW Fox 5");
+		fireEvent.click(screen.getByLabelText("WNYW Fox 5")); // uncheck channel 1
+		fireEvent.click(screen.getByRole("button", { name: /confirm/i }));
+
+		expect(onChange).toHaveBeenCalledWith([{ channelId: "2" }]);
+	});
+});

--- a/packages/frontend/src/Applications/HyperCard/extensions/TVMultiviewPicker.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/TVMultiviewPicker.tsx
@@ -1,0 +1,105 @@
+/**
+ * The HyperCard inspector's picker for directusMultiview's `videos` field
+ * (issue #560) — same `tv_channels` browse/filter as `TVClipPicker`, but the
+ * field stores an array of full video-option objects (`{ channelId, ... }`,
+ * see `DirectusMultiviewPart.tsx`) rather than bare ids, so this picker
+ * supplies `valueToIds`/`idsToValue` adapters instead of using
+ * `HyperCardOptionPickerField`'s default array-of-ids behaviour. Selecting
+ * channels here only ever sets `channelId` on each tile; per-tile settings
+ * (`start`, `end`, `autoPlay`, …) are still hand-authored in the part's own
+ * JSON, same as today.
+ */
+import { ClassicyPopUpMenu } from "classicy";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { fetchDirectusVideoList, type DirectusVideoListItem } from "./directusCollections";
+import {
+	HyperCardOptionPickerField,
+	type HyperCardItemPickerFilters,
+	type HyperCardItemPickerRow,
+	useCachedFilteredListSearch,
+} from "./HyperCardItemPicker";
+
+function toRow(item: DirectusVideoListItem): HyperCardItemPickerRow {
+	return { id: String(item.id), label: item.full_title || item.title };
+}
+
+function applyNetworkFilter(rows: DirectusVideoListItem[], filters: HyperCardItemPickerFilters): DirectusVideoListItem[] {
+	const network = typeof filters.network === "string" ? filters.network : "";
+	return network ? rows.filter((r) => r.source === network) : rows;
+}
+
+/** A `videos` array entry's `channelId`, as a string, or undefined if it's not a recognizable video-option object. */
+function channelIdOf(entry: unknown): string | undefined {
+	if (entry && typeof entry === "object" && "channelId" in entry) {
+		const id = (entry as { channelId: unknown }).channelId;
+		if (typeof id === "string" || typeof id === "number") return String(id);
+	}
+	return undefined;
+}
+
+export function TVMultiviewPicker({ value, onChange }: { value: unknown; onChange: (value: unknown) => void }) {
+	// Confirm hands back a bare id list; map it back to full video-option
+	// objects, preserving each *kept* channel's other settings (start/end/
+	// autoPlay/…) rather than clobbering them with a bare `{ channelId }`.
+	const handleConfirm = useCallback(
+		(next: unknown) => {
+			const ids = Array.isArray(next) ? next.filter((id): id is string => typeof id === "string") : [];
+			const previousById = new Map<string, unknown>();
+			if (Array.isArray(value)) {
+				for (const entry of value) {
+					const id = channelIdOf(entry);
+					if (id !== undefined) previousById.set(id, entry);
+				}
+			}
+			onChange(ids.map((id) => previousById.get(id) ?? { channelId: id }));
+		},
+		[value, onChange],
+	);
+
+	const cache = useRef<Promise<DirectusVideoListItem[]> | null>(null);
+	const loadAll = useCallback(() => (cache.current ??= fetchDirectusVideoList()), []);
+	const toRows = useCallback(
+		(rows: DirectusVideoListItem[], filters: HyperCardItemPickerFilters) => applyNetworkFilter(rows, filters).map(toRow),
+		[],
+	);
+	const fetchItems = useCachedFilteredListSearch(loadAll, toRows);
+
+	const [networks, setNetworks] = useState<string[]>([]);
+	useEffect(() => {
+		let cancelled = false;
+		loadAll().then((rows) => {
+			if (cancelled) return;
+			setNetworks([...new Set(rows.map((r) => r.source).filter((s): s is string => !!s))].sort());
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, [loadAll]);
+
+	return (
+		<HyperCardOptionPickerField
+			label="Videos"
+			value={value}
+			onChange={handleConfirm}
+			pickerKey="tv_multiview_videos"
+			title="Choose TV Channels"
+			fetchItems={fetchItems}
+			initialFilters={{ network: "" }}
+			searchPlaceholder="Search channel"
+			emptyMessage="No TV channels match."
+			valueToIds={(v) => (Array.isArray(v) ? v.map(channelIdOf).filter((id): id is string => id !== undefined) : [])}
+			renderFilterBar={(filters, setFilters) => (
+				<ClassicyPopUpMenu
+					id="tv_multiview_picker_network"
+					label="Network"
+					labelPosition="left"
+					size="mini"
+					placeholder="All networks"
+					options={[{ value: "", label: "All networks" }, ...networks.map((n) => ({ value: n, label: n }))]}
+					selected={typeof filters.network === "string" ? filters.network : ""}
+					onChangeFunc={(e) => setFilters({ network: e.target.value })}
+				/>
+			)}
+		/>
+	);
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/WeatherStationPicker.test.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/WeatherStationPicker.test.tsx
@@ -1,0 +1,77 @@
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import {
+	MediaStreamContext,
+	type MediaStreamContextValue,
+} from "../../../Providers/MediaStream/MediaStreamContext";
+
+vi.mock("classicy", async (importOriginal) => ({
+	...(await importOriginal<typeof import("classicy")>()),
+	ClassicyWindow: ({ children, id, title }: { children?: ReactNode; id?: string; title?: string }) => (
+		<div data-testid={`win-${id}`} data-title={title}>
+			{children}
+		</div>
+	),
+}));
+
+import { WeatherStationPicker } from "./WeatherStationPicker";
+
+afterEach(cleanup);
+
+function renderPicker(observations: Record<string, unknown>, onChange = vi.fn()) {
+	const ctx = {
+		weatherObservations: observations,
+		subscribeWeather: vi.fn(),
+		unsubscribeWeather: vi.fn(),
+	} as unknown as MediaStreamContextValue;
+	render(
+		<MediaStreamContext.Provider value={ctx}>
+			<WeatherStationPicker value={[]} onChange={onChange} />
+		</MediaStreamContext.Provider>,
+	);
+	return ctx;
+}
+
+describe("WeatherStationPicker", () => {
+	it("subscribes to the weather channel on mount", () => {
+		const ctx = renderPicker({});
+		expect(ctx.subscribeWeather).toHaveBeenCalledTimes(1);
+	});
+
+	it("lists only stations currently reporting a live observation", async () => {
+		renderPicker({ KJFK: {}, KBOS: {}, ZZZZ: {} });
+		fireEvent.click(screen.getByRole("button", { name: /browse/i }));
+		expect(await screen.findByLabelText(/KJFK/)).toBeTruthy();
+		expect(screen.getByLabelText(/KBOS/)).toBeTruthy();
+		// ZZZZ isn't a real station in stations.json, so it's dropped even
+		// though it has a live observation.
+		expect(screen.queryByLabelText(/ZZZZ/)).toBeNull();
+	});
+
+	it("shows an empty-state message when nothing is currently reporting", async () => {
+		renderPicker({});
+		fireEvent.click(screen.getByRole("button", { name: /browse/i }));
+		expect(await screen.findByText("No stations are currently reporting.")).toBeTruthy();
+	});
+
+	it("confirms the selected station ids", async () => {
+		const onChange = vi.fn();
+		renderPicker({ KJFK: {}, KBOS: {} }, onChange);
+		fireEvent.click(screen.getByRole("button", { name: /browse/i }));
+		fireEvent.click(await screen.findByLabelText(/KJFK/));
+		fireEvent.click(screen.getByRole("button", { name: /confirm/i }));
+		expect(onChange).toHaveBeenCalledWith(["KJFK"]);
+	});
+
+	it("does not call onChange on Cancel", async () => {
+		const onChange = vi.fn();
+		renderPicker({ KJFK: {} }, onChange);
+		fireEvent.click(screen.getByRole("button", { name: /browse/i }));
+		await screen.findByLabelText(/KJFK/);
+		act(() => {
+			fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+		});
+		expect(onChange).not.toHaveBeenCalled();
+	});
+});

--- a/packages/frontend/src/Applications/HyperCard/extensions/WeatherStationPicker.tsx
+++ b/packages/frontend/src/Applications/HyperCard/extensions/WeatherStationPicker.tsx
@@ -1,0 +1,49 @@
+/**
+ * The HyperCard inspector's picker for directusWeatherStation's `station`
+ * field (issue #560) — checks off the station(s) to embed from whatever's
+ * *currently* reporting on the live weather channel (resolved open question:
+ * live data only, not the full static station list), the same
+ * `MediaStreamContext` reads `DirectusWeatherPart.tsx` itself uses. `station`
+ * stores an array, so this picker always runs in multi-select mode.
+ */
+import { useContext, useEffect, useMemo } from "react";
+import { MediaStreamContext } from "../../../Providers/MediaStream/MediaStreamContext";
+import stationsRaw from "../../Weather/stations.json";
+import type { WeatherStation } from "../../Weather/WeatherMap";
+import { filterRowsByQuery, HyperCardOptionPickerField, type HyperCardItemPickerRow } from "./HyperCardItemPicker";
+
+const STATIONS = stationsRaw as WeatherStation[];
+const PICKER_APP_ID = "hypercard-weather-station-picker";
+
+export function WeatherStationPicker({ value, onChange }: { value: unknown; onChange: (value: unknown) => void }) {
+	// Subscribing here (ref-counted, same as the part itself) means the live
+	// station list is populated for authoring even if no other app currently
+	// has the weather channel open.
+	const { weatherObservations, subscribeWeather, unsubscribeWeather } = useContext(MediaStreamContext);
+	useEffect(() => {
+		subscribeWeather(PICKER_APP_ID);
+		return () => unsubscribeWeather(PICKER_APP_ID);
+	}, [subscribeWeather, unsubscribeWeather]);
+
+	const rows = useMemo<HyperCardItemPickerRow[]>(() => {
+		return Object.keys(weatherObservations)
+			.map((id) => STATIONS.find((s) => s.station_id === id))
+			.filter((s): s is WeatherStation => !!s)
+			.map((s) => ({ id: s.station_id, label: `${s.station_id} — ${s.name}` }));
+	}, [weatherObservations]);
+
+	const fetchItems = useMemo(() => (query: string) => filterRowsByQuery(rows, query), [rows]);
+
+	return (
+		<HyperCardOptionPickerField
+			label="Weather Stations"
+			value={value}
+			onChange={onChange}
+			pickerKey="weather_station"
+			title="Choose Weather Stations"
+			fetchItems={fetchItems}
+			searchPlaceholder="Search station id or name"
+			emptyMessage="No stations are currently reporting."
+		/>
+	);
+}

--- a/packages/frontend/src/Applications/HyperCard/extensions/directusCollections.test.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/directusCollections.test.ts
@@ -5,8 +5,12 @@ import {
 	fetchDirectusAudioItem,
 	fetchDirectusItem,
 	fetchDirectusNewsItem,
+	fetchDirectusNewsList,
 	fetchDirectusPagerItem,
+	fetchDirectusPagerList,
+	fetchDirectusPagerProviders,
 	fetchDirectusVideoItem,
+	fetchDirectusVideoList,
 } from "./directusCollections";
 
 function jsonResponse(body: unknown, ok = true, status = 200): Response {
@@ -114,5 +118,73 @@ describe("fetchDirectusPagerItem", () => {
 		for (const field of DIRECTUS_COLLECTIONS.pager.fields) {
 			expect(url).toContain(field);
 		}
+	});
+});
+
+// --- List/search fetchers (issue #560 — HyperCard item pickers) -----------
+
+describe("fetchDirectusVideoList", () => {
+	it("requests every tv_channels row, sorted by source/title, and returns the data array", async () => {
+		const rows = [{ id: 1, title: "WNYW", full_title: "WNYW Fox 5", source: "fox" }];
+		const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ data: rows }));
+		const result = await fetchDirectusVideoList(fetchFn);
+		expect(result).toEqual(rows);
+		const url = fetchFn.mock.calls[0][0] as string;
+		expect(url).toContain("/items/tv_channels?");
+		expect(url).toContain("fields=id,title,full_title,source");
+		expect(url).toContain("sort=source,title");
+	});
+
+	it("throws when the request fails", async () => {
+		const fetchFn = vi.fn().mockResolvedValue(jsonResponse({}, false, 500));
+		await expect(fetchDirectusVideoList(fetchFn)).rejects.toThrow("500");
+	});
+});
+
+describe("fetchDirectusNewsList", () => {
+	it("requests every news_items row, newest first", async () => {
+		const rows = [{ id: 9, title: "Headline", full_title: "A Fuller Headline", start_date: "2001-09-11T12:46:00" }];
+		const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ data: rows }));
+		const result = await fetchDirectusNewsList(fetchFn);
+		expect(result).toEqual(rows);
+		const url = fetchFn.mock.calls[0][0] as string;
+		expect(url).toContain("/items/news_items?");
+		expect(url).toContain("fields=id,title,full_title,start_date");
+		expect(url).toContain("sort=-start_date");
+	});
+});
+
+describe("fetchDirectusPagerProviders", () => {
+	it("returns the distinct, sorted, non-empty provider values", async () => {
+		const fetchFn = vi.fn().mockResolvedValue(
+			jsonResponse({ data: [{ provider: "SkyTel" }, { provider: "PageNet" }, { provider: null }] }),
+		);
+		const providers = await fetchDirectusPagerProviders(fetchFn);
+		expect(providers).toEqual(["PageNet", "SkyTel"]);
+		const url = fetchFn.mock.calls[0][0] as string;
+		expect(url).toContain("/items/pager_items?");
+		expect(url).toContain("groupBy=provider");
+	});
+});
+
+describe("fetchDirectusPagerList", () => {
+	it("requests every pager_items row, newest first, with no filters applied", async () => {
+		const rows = [{ id: 5, message: "CALL OPS", provider: "SkyTel", recipient_id: "123", start_date: "x" }];
+		const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ data: rows }));
+		const result = await fetchDirectusPagerList({}, fetchFn);
+		expect(result).toEqual(rows);
+		const url = fetchFn.mock.calls[0][0] as string;
+		expect(url).toContain("/items/pager_items?");
+		expect(url).toContain("sort=-start_date");
+		expect(url).not.toContain("filter%5B");
+	});
+
+	it("applies provider (exact), recipient and message (substring) filters", async () => {
+		const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ data: [] }));
+		await fetchDirectusPagerList({ provider: "SkyTel", recipient: "123", message: "OPS" }, fetchFn);
+		const url = fetchFn.mock.calls[0][0] as string;
+		expect(url).toContain("filter%5Bprovider%5D%5B_eq%5D=SkyTel");
+		expect(url).toContain("filter%5Brecipient_id%5D%5B_icontains%5D=123");
+		expect(url).toContain("filter%5Bmessage%5D%5B_icontains%5D=OPS");
 	});
 });

--- a/packages/frontend/src/Applications/HyperCard/extensions/directusCollections.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/directusCollections.ts
@@ -11,6 +11,7 @@
 // Same env seam every other Directus caller uses; re-exported for parts.
 export { DIRECTUS_URL } from "../../../lib/endpoints";
 import { DIRECTUS_URL } from "../../../lib/endpoints";
+import { directusGet } from "../../../lib/directusQueue";
 
 /**
  * A minimal registry describing which Directus collections HyperCard stacks may
@@ -208,4 +209,93 @@ export function fetchDirectusPagerItem(
 ): Promise<DirectusPagerItem> {
 	const { collection, fields } = DIRECTUS_COLLECTIONS.pager;
 	return fetchDirectusItem<DirectusPagerItem>(collection, id, fields, fetchFn, signal);
+}
+
+// --- List/search fetchers (issue #560 — HyperCard item pickers) -----------
+//
+// Every id-lookup fetcher above answers "give me item N"; the pickers instead
+// need "give me every row I could pick from" so the user can search and
+// multi-select. These go through the same serialized `directusGet` queue
+// PlaylistEditor/radio-core already use for collection LISTS (as opposed to
+// the single-item GETs above, which have always been safe unserialized single
+// requests) — see lib/directusQueue.ts's own comment on why concurrent same-
+// path Directus requests can't be trusted to keep their response bodies apart.
+
+const LIST_LIMIT = 1000;
+
+/** A `tv_channels` row as the TV Clip / TV Multiview pickers list it. */
+export interface DirectusVideoListItem {
+	id: number;
+	title: string;
+	full_title?: string | null;
+	source?: string | null;
+}
+
+/** Every `tv_channels` row (id/title/callsign only) — small enough to fetch whole. */
+export async function fetchDirectusVideoList(
+	fetchFn: typeof fetch = fetch,
+): Promise<DirectusVideoListItem[]> {
+	const rows = await directusGet(
+		"/items/tv_channels?fields=id,title,full_title,source&sort=source,title&limit=" + LIST_LIMIT,
+		fetchFn,
+	);
+	return rows as DirectusVideoListItem[];
+}
+
+/** A `news_items` row as the News Item picker lists it. */
+export interface DirectusNewsListItem {
+	id: number;
+	title: string;
+	full_title?: string | null;
+	start_date?: string | null;
+}
+
+/** Every `news_items` row (id/title/date only), newest first. */
+export async function fetchDirectusNewsList(
+	fetchFn: typeof fetch = fetch,
+): Promise<DirectusNewsListItem[]> {
+	const rows = await directusGet(
+		"/items/news_items?fields=id,title,full_title,start_date&sort=-start_date&limit=" + LIST_LIMIT,
+		fetchFn,
+	);
+	return rows as DirectusNewsListItem[];
+}
+
+/** A `pager_items` row as the Pager Message picker lists it. */
+export interface DirectusPagerListItem {
+	id: number;
+	message: string;
+	provider?: string | null;
+	recipient_id?: string | null;
+	start_date?: string | null;
+}
+
+/** Distinct filter values (issue #560) — every `provider` seen in `pager_items`. */
+export async function fetchDirectusPagerProviders(fetchFn: typeof fetch = fetch): Promise<string[]> {
+	const rows = (await directusGet(
+		"/items/pager_items?aggregate[countDistinct]=provider&groupBy=provider",
+		fetchFn,
+	)) as Array<{ provider?: string | null }>;
+	return rows.map((r) => r.provider).filter((p): p is string => !!p).sort();
+}
+
+/**
+ * `pager_items` rows matching the picker's server-side filters — `provider`
+ * is an exact match (a pop-up of known values), `recipient`/`message` are
+ * substring matches, mirroring PagerDecoder.tsx's own filter bar. Any omitted
+ * filter is unconstrained.
+ */
+export async function fetchDirectusPagerList(
+	filters: { provider?: string; recipient?: string; message?: string },
+	fetchFn: typeof fetch = fetch,
+): Promise<DirectusPagerListItem[]> {
+	const params = new URLSearchParams();
+	params.set("fields", "id,message,provider,recipient_id,start_date");
+	params.set("sort", "-start_date");
+	params.set("limit", String(LIST_LIMIT));
+	if (filters.provider) params.set("filter[provider][_eq]", filters.provider);
+	if (filters.recipient) params.set("filter[recipient_id][_icontains]", filters.recipient);
+	if (filters.message) params.set("filter[message][_icontains]", filters.message);
+	const rows = await directusGet(`/items/pager_items?${params.toString()}`, fetchFn);
+	return rows as DirectusPagerListItem[];
 }

--- a/packages/frontend/src/Applications/HyperCard/extensions/editorMetadata.test.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/editorMetadata.test.ts
@@ -35,11 +35,6 @@ describe("registerHyperCardEditorMetadata", () => {
 		]);
 		expect(keys("directusNews")).toEqual(["itemId", "showImage", "showDate"]);
 		expect(keys("directusFlightMap")).toContain("trailMultiplier");
-		expect(
-			getHyperCardPartEditorMeta("directusMultiview")?.optionsSchema?.find(
-				(f) => f.key === "videos",
-			)?.kind,
-		).toBe("json");
 	});
 
 	it("registers the setDateTime command builder fields", () => {
@@ -56,5 +51,22 @@ describe("registerHyperCardEditorMetadata", () => {
 		expect(field?.kind).toBe("picker");
 		expect(field?.pickerId).toBe("radioTrafficClip");
 		expect(getHyperCardOptionPicker("radioTrafficClip")).toBeDefined();
+	});
+
+	// Issue #560 — every id/array field that used to be a bare num/text/json
+	// input now opens a picker instead, one per Directus-backed embed type.
+	it.each([
+		["directusVideo", "channelId", "tvClip"],
+		["directusMultiview", "videos", "tvMultiviewVideos"],
+		["directusNews", "itemId", "newsItem"],
+		["directusPager", "itemId", "pagerMessage"],
+		["directusWeatherStation", "station", "weatherStation"],
+		["directusFlightMap", "flight", "flightMap"],
+	])("registers a picker for %s's %s field", (type, key, pickerId) => {
+		registerHyperCardEditorMetadata();
+		const field = getHyperCardPartEditorMeta(type)?.optionsSchema?.find((f) => f.key === key);
+		expect(field?.kind).toBe("picker");
+		expect(field?.pickerId).toBe(pickerId);
+		expect(getHyperCardOptionPicker(pickerId)).toBeDefined();
 	});
 });

--- a/packages/frontend/src/Applications/HyperCard/extensions/editorMetadata.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/editorMetadata.ts
@@ -10,7 +10,13 @@ import {
 	registerHyperCardPartEditorMeta,
 	registerHyperCardOptionPicker,
 } from "classicy";
+import { FlightMapPicker } from "./FlightMapPicker";
+import { NewsItemPicker } from "./NewsItemPicker";
+import { PagerMessagePicker } from "./PagerMessagePicker";
 import { RadioTrafficClipPicker } from "./RadioTrafficClipPicker";
+import { TVClipPicker } from "./TVClipPicker";
+import { TVMultiviewPicker } from "./TVMultiviewPicker";
+import { WeatherStationPicker } from "./WeatherStationPicker";
 
 const text = (key: string, label: string): HCOptionField => ({ key, label, kind: "text" });
 const num = (key: string, label: string): HCOptionField => ({ key, label, kind: "number" });
@@ -29,6 +35,12 @@ const picker = (key: string, label: string, pickerId: string): HCOptionField => 
 
 export function registerHyperCardEditorMetadata(): void {
 	registerHyperCardOptionPicker("radioTrafficClip", RadioTrafficClipPicker);
+	registerHyperCardOptionPicker("tvClip", TVClipPicker);
+	registerHyperCardOptionPicker("tvMultiviewVideos", TVMultiviewPicker);
+	registerHyperCardOptionPicker("newsItem", NewsItemPicker);
+	registerHyperCardOptionPicker("pagerMessage", PagerMessagePicker);
+	registerHyperCardOptionPicker("weatherStation", WeatherStationPicker);
+	registerHyperCardOptionPicker("flightMap", FlightMapPicker);
 
 	registerHyperCardPartEditorMeta("directusAudio", {
 		label: "Audio Clip",
@@ -43,7 +55,7 @@ export function registerHyperCardEditorMetadata(): void {
 		defaultSize: [320, 180],
 		defaultOptions: { controls: true },
 		optionsSchema: [
-			num("channelId", "TV channel id"),
+			picker("channelId", "TV channel(s)", "tvClip"),
 			text("url", "Direct HLS URL"),
 			text("start", "Start (offset or wall clock)"),
 			text("end", "End (offset or wall clock)"),
@@ -61,14 +73,14 @@ export function registerHyperCardEditorMetadata(): void {
 		optionsSchema: [
 			text("audio", "Audio (solo | all | mute)"),
 			num("columns", "Columns (blank = auto)"),
-			{ key: "videos", label: "Videos", kind: "json" },
+			picker("videos", "Videos", "tvMultiviewVideos"),
 		],
 	});
 	registerHyperCardPartEditorMeta("directusNews", {
 		label: "News Item",
 		defaultSize: [280, 160],
 		optionsSchema: [
-			text("itemId", "News item id (or variable)"),
+			picker("itemId", "News item(s)", "newsItem"),
 			check("showImage", "Show image", true),
 			check("showDate", "Show date", true),
 		],
@@ -76,18 +88,18 @@ export function registerHyperCardEditorMetadata(): void {
 	registerHyperCardPartEditorMeta("directusPager", {
 		label: "Pager Message",
 		defaultSize: [280, 120],
-		optionsSchema: [text("itemId", "Pager item id (or variable)")],
+		optionsSchema: [picker("itemId", "Pager message(s)", "pagerMessage")],
 	});
 	registerHyperCardPartEditorMeta("directusWeatherStation", {
 		label: "Weather Station",
 		defaultSize: [260, 300],
-		optionsSchema: [text("station", "ICAO station id")],
+		optionsSchema: [picker("station", "Station(s)", "weatherStation")],
 	});
 	registerHyperCardPartEditorMeta("directusFlightMap", {
 		label: "Flight Map",
 		defaultSize: [404, 300],
 		optionsSchema: [
-			text("flight", "Flight (or variable)"),
+			picker("flight", "Flight(s)", "flightMap"),
 			check("notablesOnly", "Notable flights only"),
 			check("darkMap", "Dark map"),
 			text("mapStyle", "Map style"),

--- a/packages/frontend/src/Applications/HyperCard/extensions/useDirectusItem.test.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/useDirectusItem.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveItemId } from "./useDirectusItem";
+import { resolveItemId, resolveItemIds } from "./useDirectusItem";
 
 const identity = (e: string) => e;
 
@@ -19,5 +19,33 @@ describe("resolveItemId", () => {
 	it("is undefined when nothing usable is set", () => {
 		expect(resolveItemId(undefined, "", identity)).toBeUndefined();
 		expect(resolveItemId("", "", identity)).toBeUndefined();
+	});
+});
+
+describe("resolveItemIds", () => {
+	it("resolves every entry of an array option, each through the expression engine", () => {
+		expect(resolveItemIds([1, "clip", 3], "", (e) => (e === "clip" ? "2" : e))).toEqual(["1", "2", "3"]);
+	});
+
+	it("wraps a single legacy scalar option into a one-entry list", () => {
+		expect(resolveItemIds(42, "", identity)).toEqual(["42"]);
+	});
+
+	it("drops non-string/number array entries and entries that resolve empty", () => {
+		expect(resolveItemIds([1, null, "", 2], "", identity)).toEqual(["1", "2"]);
+	});
+
+	it("falls back to the field value as a single-entry list when the option is empty", () => {
+		expect(resolveItemIds(undefined, "7", identity)).toEqual(["7"]);
+		expect(resolveItemIds([], "7", identity)).toEqual(["7"]);
+	});
+
+	it("is an empty list when nothing usable is set", () => {
+		expect(resolveItemIds(undefined, "", identity)).toEqual([]);
+		expect(resolveItemIds([], "", identity)).toEqual([]);
+	});
+
+	it("prefers the option array over the field value even when non-empty", () => {
+		expect(resolveItemIds([3], "9", identity)).toEqual(["3"]);
 	});
 });

--- a/packages/frontend/src/Applications/HyperCard/extensions/useDirectusItem.ts
+++ b/packages/frontend/src/Applications/HyperCard/extensions/useDirectusItem.ts
@@ -4,6 +4,11 @@ import { useEffect, useState } from "react";
 // audio/video parts predate this and inline their own copy; new single-item
 // parts use these helpers instead of duplicating the fetch/abort/load-state
 // dance.
+//
+// `resolveItemIds` (issue #560) generalizes `resolveItemId` to the array-
+// valued option every picker-backed field now stores; it's option-resolution
+// plumbing rather than a fetch, so the weather-station and flight-map parts
+// use it too even though they don't otherwise touch this module's fetch hook.
 
 /**
  * Resolve an embed's item id from its authored option (passed through the stack
@@ -19,6 +24,32 @@ export function resolveItemId(
 	if (raw === undefined || raw === "") return undefined;
 	const resolved = resolve(String(raw)).trim();
 	return resolved === "" ? undefined : resolved;
+}
+
+/**
+ * The array-aware counterpart to {@link resolveItemId} — resolves a HyperCard
+ * option that now stores an array (or, for a not-yet-resaved legacy part, a
+ * single scalar) into an ordered list of ids, each run through the stack
+ * expression engine so any entry may still reference a variable/field. An
+ * empty/missing option falls back to the part's own field `value` as a
+ * single-entry list, exactly like `resolveItemId`'s own fallback, so an
+ * unconfigured legacy part bound to a field keeps working unchanged.
+ */
+export function resolveItemIds(
+	optionIds: unknown,
+	value: string,
+	resolve: (expr: string) => string,
+): string[] {
+	const raw: (string | number)[] = Array.isArray(optionIds)
+		? optionIds.filter((v): v is string | number => typeof v === "string" || typeof v === "number")
+		: typeof optionIds === "string" || typeof optionIds === "number"
+			? [optionIds]
+			: [];
+	if (raw.length === 0) {
+		const fallback = resolveItemId(undefined, value, resolve);
+		return fallback === undefined ? [] : [fallback];
+	}
+	return raw.map((r) => resolve(String(r)).trim()).filter((r) => r !== "");
 }
 
 export type ItemLoadState<T> =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
         version: 18.1.3
       classicy:
         specifier: latest
-        version: 0.77.5(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/dlv@1.1.5)(@types/react@19.2.18)(immer@11.1.17)(react-dom@19.2.8(react@19.2.8))(react-player@3.4.0(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zustand@5.0.15(@types/react@19.2.18)(immer@11.1.17)(react@19.2.8))
+        version: 0.78.1(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/dlv@1.1.5)(@types/react@19.2.18)(immer@11.1.17)(react-dom@19.2.8(react@19.2.8))(react-player@3.4.0(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zustand@5.0.15(@types/react@19.2.18)(immer@11.1.17)(react@19.2.8))
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -943,8 +943,8 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
-  classicy@0.77.5:
-    resolution: {integrity: sha512-Iw522cz0jxw66JheTv2AB1DvRo93l6mOL0Kdb3PD+0oJU9gtEz9j+PnboffhNMbTmIgQ4iBCXea2ja6Ejnnj/Q==}
+  classicy@0.78.1:
+    resolution: {integrity: sha512-cUsQ7vCiWAZalPZex6g1NnS6fUxEQ3Z9mjhQodEwkI2WY+J2x1PZOhasGxxHpsYlpZo7g4Ge5wB3z5TGTikIuA==}
     peerDependencies:
       '@tanstack/react-table': ^8.21.3
       immer: ^11.1.8
@@ -2449,7 +2449,7 @@ snapshots:
       readdirp: 5.1.1
     optional: true
 
-  classicy@0.77.5(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/dlv@1.1.5)(@types/react@19.2.18)(immer@11.1.17)(react-dom@19.2.8(react@19.2.8))(react-player@3.4.0(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zustand@5.0.15(@types/react@19.2.18)(immer@11.1.17)(react@19.2.8)):
+  classicy@0.78.1(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/dlv@1.1.5)(@types/react@19.2.18)(immer@11.1.17)(react-dom@19.2.8(react@19.2.8))(react-player@3.4.0(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zustand@5.0.15(@types/react@19.2.18)(immer@11.1.17)(react@19.2.8)):
     dependencies:
       '@analytics/google-tag-manager': 0.6.0
       '@noble/hashes': 2.4.0


### PR DESCRIPTION
## Summary
- Adds a shared `HyperCardItemPicker` window (search box + checkbox list + Confirm/Cancel, modeled on `RadioTraffic/TagPickerWindow.tsx`) and a `HyperCardOptionPickerField` shell, registered per field via classicy's `registerHyperCardOptionPicker`.
- Adds six concrete pickers — `TVClipPicker`, `TVMultiviewPicker`, `NewsItemPicker`, `PagerMessagePicker`, `WeatherStationPicker`, `FlightMapPicker` — each with its own data source and filter bar (network pop-up for TV, provider/recipient for pager, notable-only checkbox for flights).
- Widens `directusVideo.channelId`, `directusNews.itemId`, `directusPager.itemId`, `directusWeatherStation.station`, `directusFlightMap.flight` from a scalar to an array end-to-end (a bare legacy scalar is still accepted); the corresponding `Directus*Part.tsx` components render a grid/list of N tiles instead of one when more than one id is selected. `directusMultiview.videos` already stored/rendered an array — its new picker just manages each tile's `channelId`, preserving other per-tile settings.
- Per the approved plan's resolved open questions: all six fields use `selectionMode="multi"` and store arrays (Option B), and Weather Station / Flight Map filter against the *live* on-screen stations/positions from `MediaStreamContext`, not historical/replay data.

## Test plan
- [x] `pnpm --filter @rt911/frontend exec tsc -b`
- [x] `pnpm --filter @rt911/frontend run lint` (oxlint — pre-existing warnings only, no new errors)
- [x] `pnpm --filter @rt911/frontend exec vitest run` — 310 files / 3455 tests passing
- New/updated tests: `HyperCardItemPicker.test.tsx`, one test file per new picker, `directusCollections.test.ts` (list/search fetchers), `useDirectusItem.test.ts` (`resolveItemIds`), `editorMetadata.test.ts` (picker registration/schema), and a multi-item + empty-array case added to each `Directus*Part.test.tsx`.

Fixes #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)