### PR TITLE
Radio Traffic: show Transcript tab on tape-tier items with a transcript

### DIFF
--- a/packages/frontend/src/Applications/RadioTraffic/CardTabBar.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/CardTabBar.tsx
@@ -73,6 +73,20 @@ export function visibleCardTabs(meta: ItemMeta | undefined): readonly CardTab[] 
 	return CARD_TABS.filter((tab) => tab.available?.(meta) ?? true);
 }
 
+/**
+ * The 2-tab strip a `tier:tape` item with a transcript gets (issue #574) —
+ * Details and Transcript are the only two of the six that vary card to card
+ * on a tape's own terms: Summary/Parties/Mentions/Source still have nothing
+ * to switch to on one long continuous recording (issue #565's reasoning
+ * stands for those four), but a transcript changes with the recording
+ * exactly the way Details does. Filters the item's own `visibleCardTabs`
+ * result rather than re-deriving from `CARD_TABS` directly, so a tab
+ * `available` has already ruled out for this item stays ruled out here too.
+ */
+export function tapeCardTabs(tabs: readonly CardTab[]): readonly CardTab[] {
+	return tabs.filter((tab) => tab.id === "details" || tab.id === "transcript");
+}
+
 interface CardTabBarProps {
 	tabs: readonly CardTab[];
 	active: string;

--- a/packages/frontend/src/Applications/RadioTraffic/TrafficCard.test.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/TrafficCard.test.tsx
@@ -758,8 +758,12 @@ describe("TrafficCard tabs", () => {
 });
 
 describe("TrafficCard tape tier (issue #565)", () => {
-	it("renders Details' own content with no tab strip for a tier:tape item", () => {
+	it("renders Details' own content with no tab strip for a tier:tape item with no transcript", () => {
+		// Issue #574: the no-tab-strip bypass is now gated on subtitles, not tier
+		// alone — makeItem()'s fixture default sets subtitles, so this case has to
+		// override it to keep exercising #565's original, transcript-less path.
 		const { queryByRole, container } = renderCard({
+			item: makeItem({ subtitles: undefined }),
 			meta: makeMeta({
 				tags: [{ tag: "tier:tape", namespace: "tier", value: "Tape" }],
 			}),
@@ -782,6 +786,25 @@ describe("TrafficCard tape tier (issue #565)", () => {
 	it("still shows the tab strip for an item with no tier tag at all", () => {
 		const { getAllByRole } = renderCard({ meta: makeMeta() });
 		expect(getAllByRole("tab")).toHaveLength(6);
+	});
+});
+
+describe("TrafficCard tape tier with transcript (issue #574)", () => {
+	it("shows a 2-tab strip (Details, Transcript) for a tier:tape item with a transcript", () => {
+		const { getAllByRole, getByRole, container } = renderCard({
+			// makeItem()'s default already sets subtitles — spelled out here so the
+			// case reads as deliberate rather than accidental.
+			item: makeItem({ subtitles: "https://files.example/clip.srt" }),
+			meta: makeMeta({
+				tags: [{ tag: "tier:tape", namespace: "tier", value: "Tape" }],
+			}),
+		});
+		const tabs = getAllByRole("tab");
+		expect(tabs.map((tab) => tab.textContent)).toEqual(["Details", "Transcript"]);
+		expect(container.querySelector('[data-tab="details"]')).not.toBeNull();
+
+		fireEvent.click(getByRole("tab", { name: "Transcript" }));
+		expect(container.querySelector('[data-tab="transcript"]')).not.toBeNull();
 	});
 });
 

--- a/packages/frontend/src/Applications/RadioTraffic/TrafficCard.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/TrafficCard.tsx
@@ -47,7 +47,7 @@ import {
 } from "./audioCoordinator";
 import { type Badge, badgeFor, countdownFor, type Lane } from "./cardStatus";
 import { isSilentAt } from "./silence";
-import { CARD_TABS, CardTabBar, visibleCardTabs } from "./CardTabBar";
+import { CARD_TABS, CardTabBar, tapeCardTabs, visibleCardTabs } from "./CardTabBar";
 import { isTapeTier } from "./tagFilter";
 import { DetailsTab } from "./tabs/DetailsTab";
 import { itemTiming } from "./tabs/itemTiming";
@@ -391,13 +391,21 @@ const TrafficCardImpl: React.FC<TrafficCardProps> = ({
 	// that genuinely does depend on the item fall back to Details with Details
 	// highlighted instead of showing a panel with nothing selected.
 	const tabs = useMemo(() => visibleCardTabs(meta), [meta]);
-	const panel = tabs.find((tab) => tab.id === active) ?? tabs[0];
-	// Issue #565: a tape is one long continuous recording — the tab strip
-	// (Details, Summary, Mentions, ...) offers nothing to switch between, so it
-	// is skipped entirely in favor of Details' content alone, bypassing the
-	// tab-selection state above rather than pinning `active` to "details" (which
-	// would still render a CardTabBar with one, meaningless, button on it).
 	const tape = isTapeTier(meta);
+	// `item.subtitles` is the same field TranscriptTab itself fetches from —
+	// a missing one means no transcript exists for this clip at all, not a
+	// gap in the pipeline (see TranscriptTab.tsx).
+	const hasTranscript = Boolean(item.subtitles);
+	// Issue #565, amended by #574: a tier:tape item is one long continuous
+	// recording, so Summary/Parties/Mentions/Source have nothing to switch to
+	// — that reasoning still holds. What #574 changes is Transcript: a tape
+	// WITH one now gets a 2-tab strip (Details, Transcript) through the same
+	// tabs.find lookup tier:clip already uses below; a tape with none keeps
+	// #565's original bypass — DetailsTab's own content rendered bare, with
+	// no tab strip and no tab-selection state involved at all.
+	const tapeBare = tape && !hasTranscript;
+	const displayTabs = tape && hasTranscript ? tapeCardTabs(tabs) : tabs;
+	const panel = displayTabs.find((tab) => tab.id === active) ?? displayTabs[0];
 
 	// The existing panel switch, plus Story 045's touch signal alongside it —
 	// see onTabSelect above.
@@ -554,11 +562,11 @@ const TrafficCardImpl: React.FC<TrafficCardProps> = ({
 			</div>
 
 			<div className={styles.rtCardTabs}>
-				{!tape && (
-					<CardTabBar tabs={tabs} active={panel.id} onSelect={handleTabSelect} />
+				{!tapeBare && (
+					<CardTabBar tabs={displayTabs} active={panel.id} onSelect={handleTabSelect} />
 				)}
 				<div className={styles.rtCardPanel}>
-					{tape ? (
+					{tapeBare ? (
 						<DetailsTab item={item} meta={meta} tzOffsetHours={tzOffsetHours} />
 					) : (
 						<panel.Panel


### PR DESCRIPTION
## Summary
- Issue #565 made `tier:tape` RadioTraffic cards bypass `CardTabBar` entirely, always rendering `DetailsTab`'s content bare with no tab strip at all, regardless of whether the item has a transcript.
- This gates that bypass on transcript availability (`item.subtitles`, the same field `TranscriptTab` already fetches from) instead of tier alone:
  - `tier:tape` **without** `item.subtitles` → unchanged: bare `DetailsTab`, no tab strip (#565's original behavior stands).
  - `tier:tape` **with** `item.subtitles` → a 2-tab strip (Details, Transcript), routed through the same `tabs.find(...)` lookup `tier:clip` already uses. Only 2 tabs, not the full 6 — Summary/Parties/Mentions/Source still have nothing to switch to on one long continuous recording, so #565's reasoning holds for those four; only Transcript actually changes with a transcript present.
- Added a small `tapeCardTabs` helper in `CardTabBar.tsx` to keep the tab-list construction out of `TrafficCard.tsx`.

Fixes #574

## Test plan
- [x] `pnpm --filter @rt911/frontend exec vitest run src/Applications/RadioTraffic/TrafficCard.test.tsx` — 71 passed
- [x] `pnpm test` (full frontend suite) — 310 files / 3464 tests passed
- [x] `pnpm lint` — no new warnings or errors (oxlint output unchanged in kind, all pre-existing `only-export-components` style warnings)
- [x] `pnpm build` (`tsc -b && vite build`) — succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)