### PR TITLE
Radio Tuner: Help Balloon countdown for upcoming stations

### DIFF
--- a/packages/frontend/src/Applications/RadioTraffic/LaneSmallPlayer.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/LaneSmallPlayer.tsx
@@ -23,9 +23,9 @@
 
 import type React from "react";
 import type { ItemMeta, MediaItem } from "../../Providers/MediaStream/MediaStreamContext";
+import { countdownFor } from "../radio-core/countdownFormat";
 import Marquee from "../radio-core/marquee";
 import { useHorizontalOverflow } from "../radio-core/useHorizontalOverflow";
-import { countdownFor } from "./cardStatus";
 import styles from "./laneSmallPlayer.module.scss";
 import { durationSecondsLabel, startLabel } from "./smallPlayerLabels";
 import { itemTiming } from "./tabs/itemTiming";
@@ -77,8 +77,9 @@ export const LaneSmallPlayer: React.FC<LaneSmallPlayerProps> = ({
 
 	/**
 	 * Time remaining until this clip's `start_date` — "59s" under a minute,
-	 * "MM:SS" beyond it, "HH:MM:SS" from an hour out (cardStatus.countdownFor,
-	 * the same rendering the UPCOMING lane's full-card badge already uses).
+	 * "MM:SS" beyond it, "HH:MM:SS" from an hour out (radio-core's
+	 * countdownFor, the same rendering the UPCOMING lane's full-card badge
+	 * already uses).
 	 * Dropped once the start has passed rather than pinned at "0s": a LIVE or
 	 * PREVIOUS clip's collapsed player has nothing left to count down to, same
 	 * as the `start`/`duration`/`link` lines above are each dropped when the

--- a/packages/frontend/src/Applications/RadioTraffic/TrafficCard.tsx
+++ b/packages/frontend/src/Applications/RadioTraffic/TrafficCard.tsx
@@ -35,6 +35,7 @@ import {
 	useSyncExternalStore,
 } from "react";
 import type { ItemMeta, MediaItem } from "../../Providers/MediaStream/MediaStreamContext";
+import { countdownFor } from "../radio-core/countdownFormat";
 import { PeaksWaveform } from "../radio-core/PeaksWaveform";
 import { calcSeekSeconds } from "../radio-core/stationGrouping";
 import {
@@ -45,7 +46,7 @@ import {
 	subscribe,
 	unfollowClock,
 } from "./audioCoordinator";
-import { type Badge, badgeFor, countdownFor, type Lane } from "./cardStatus";
+import { type Badge, badgeFor, type Lane } from "./cardStatus";
 import { isSilentAt } from "./silence";
 import { CARD_TABS, CardTabBar, tapeCardTabs, visibleCardTabs } from "./CardTabBar";
 import { isTapeTier } from "./tagFilter";

--- a/packages/frontend/src/Applications/RadioTraffic/cardStatus.test.ts
+++ b/packages/frontend/src/Applications/RadioTraffic/cardStatus.test.ts
@@ -4,7 +4,6 @@ import { groupStations, previousSegments } from "../radio-core/stationGrouping";
 import {
 	type Badge,
 	badgeFor,
-	countdownFor,
 	historyPool,
 	laneFor,
 	rememberItems,
@@ -105,54 +104,8 @@ describe("laneFor", () => {
 	});
 });
 
-describe("countdownFor", () => {
-	const clip = item({ start_date: "2001-09-11T13:00:00.000Z" });
-
-	it("reads as bare seconds under a minute", () => {
-		expect(countdownFor(clip, t("2001-09-11T12:59:56.000Z"))).toBe("4s");
-		expect(countdownFor(clip, t("2001-09-11T12:59:01.000Z"))).toBe("59s");
-	});
-
-	it("reads as MM:SS from one minute out", () => {
-		expect(countdownFor(clip, t("2001-09-11T12:59:00.000Z"))).toBe("01:00");
-		expect(countdownFor(clip, t("2001-09-11T12:56:47.000Z"))).toBe("03:13");
-	});
-
-	it("rounds up so it reaches zero exactly at the start, never early", () => {
-		expect(countdownFor(clip, t("2001-09-11T12:59:59.500Z"))).toBe("1s");
-		expect(countdownFor(clip, t("2001-09-11T13:00:00.000Z"))).toBe("0s");
-	});
-
-	it("clamps at zero once the start has passed", () => {
-		expect(countdownFor(clip, t("2001-09-11T13:04:00.000Z"))).toBe("0s");
-	});
-
-	it("stays MM:SS right up to the last second under an hour", () => {
-		// 59:59 is the widest the two-field form ever gets. One second later the
-		// form has to change, so this is the assertion that pins where.
-		expect(countdownFor(clip, t("2001-09-11T12:00:01.000Z"))).toBe("59:59");
-	});
-
-	it("grows an hours field at exactly 60 minutes", () => {
-		// The bug: countdownLabel's minutes field is unbounded, so this read
-		// "60:00" — indistinguishable at a glance from a minute past the hour.
-		expect(countdownFor(clip, t("2001-09-11T12:00:00.000Z"))).toBe("01:00:00");
-	});
-
-	it("reads as HH:MM:SS for multi-hour waits", () => {
-		expect(countdownFor(clip, t("2001-09-11T11:30:00.000Z"))).toBe("01:30:00");
-		expect(countdownFor(clip, t("2001-09-11T10:59:47.000Z"))).toBe("02:00:13");
-		// The 8h18m tape in the corpus is the longest wait the app can show.
-		expect(countdownFor(clip, t("2001-09-11T04:42:00.000Z"))).toBe("08:18:00");
-	});
-
-	it("zero-pads minutes and seconds in both forms", () => {
-		// Field widths that move as the clock runs down would reflow the header's
-		// subject a character at a time, once a second.
-		expect(countdownFor(clip, t("2001-09-11T12:57:05.000Z"))).toBe("02:55");
-		expect(countdownFor(clip, t("2001-09-11T11:57:05.000Z"))).toBe("01:02:55");
-	});
-});
+// countdownFor's own tests moved to radio-core/countdownFormat.test.ts
+// alongside the implementation (story: shared with RadioTuner's balloon help).
 
 describe("badgeFor", () => {
 	const live = {

--- a/packages/frontend/src/Applications/RadioTraffic/cardStatus.ts
+++ b/packages/frontend/src/Applications/RadioTraffic/cardStatus.ts
@@ -11,7 +11,6 @@
 import type { MediaItem } from "../../Providers/MediaStream/MediaStreamContext";
 import {
 	activeSegments,
-	countdownLabel,
 	groupStations,
 	upcomingSegments,
 } from "../radio-core/stationGrouping";
@@ -49,14 +48,6 @@ export type Badge =
 const DRIFT_ENTER_MS = 3_000;
 const DRIFT_EXIT_MS = 1_000;
 
-/** Below a minute the countdown drops the MM: prefix ("4s", not "00:04"). */
-const COUNTDOWN_SHORT_FORM_SECONDS = 60;
-
-/** From an hour out the countdown grows an HH field, so 90 minutes is not "90:00". */
-const SECONDS_PER_HOUR = 3_600;
-
-const pad2 = (value: number): string => String(value).padStart(2, "0");
-
 /**
  * The lane `item` belongs to at `nowMs`.
  *
@@ -83,35 +74,6 @@ export function laneFor(item: MediaItem, nowMs: number): Lane {
 	return "previous";
 }
 
-/**
- * Countdown text for an UPCOMING card: "4s" inside the last minute, "03:13"
- * beyond it, "01:30:00" from an hour out.
- *
- * The *rounding* is radio-core's countdownLabel unchanged — the card and the
- * scanner's Coming Up list agree up to the whole second, hitting zero exactly at
- * the start instant and never a tick early — but the *rendering* is this
- * module's. countdownLabel is unbounded in its minutes field, so an item two
- * hours out reads "120:00" there: correct arithmetic, but a card badge that
- * makes a listener divide by 60 in their head, and one that reads as a
- * plausible-but-wrong "1:20" at a glance. Hours are split off here rather than
- * in radio-core because ten other consumers already agree on that MM:SS form
- * and none of them asked for this.
- */
-export function countdownFor(item: MediaItem, nowMs: number): string {
-	const [minutes, seconds] = countdownLabel(item, nowMs).split(":").map(Number);
-	const total = minutes * 60 + seconds;
-
-	if (total < COUNTDOWN_SHORT_FORM_SECONDS) return `${total}s`;
-	if (total < SECONDS_PER_HOUR) {
-		return `${pad2(Math.floor(total / 60))}:${pad2(total % 60)}`;
-	}
-	// Every field is two digits, so the badge's width never moves as the clock
-	// runs down and the header's subject never reflows a character at a time.
-	const hours = Math.floor(total / SECONDS_PER_HOUR);
-	const rest = total % SECONDS_PER_HOUR;
-	return `${pad2(hours)}:${pad2(Math.floor(rest / 60))}:${pad2(rest % 60)}`;
-}
-
 export interface BadgeArgs {
 	lane: Lane;
 	/** Where the virtual clock says the audio should be: calcSeekSeconds(item, now) * 1000. */
@@ -122,7 +84,7 @@ export interface BadgeArgs {
 	seeking: boolean;
 	/** The listener started this clip themselves (as opposed to it following the clock). */
 	userPlaying: boolean;
-	/** UPCOMING only: the text from countdownFor(). */
+	/** UPCOMING only: the text from radio-core's countdownFor(). */
 	countdown?: string;
 	/**
 	 * What this same card's badge read last tick, or undefined on the first one.

--- a/packages/frontend/src/Applications/RadioTuner/RadioTuner.test.tsx
+++ b/packages/frontend/src/Applications/RadioTuner/RadioTuner.test.tsx
@@ -179,6 +179,17 @@ vi.mock("classicy", () => ({
 			{children}
 		</button>
 	),
+	ClassicyBalloonHelp: ({
+		content,
+		children,
+	}: {
+		content?: string;
+		children?: React.ReactNode;
+	}) => (
+		<div data-balloon-content={content}>
+			{children}
+		</div>
+	),
 	ClassicyIcons: {
 		applications: { radio: { app: "radio.png" } },
 		controlPanels: { soundManager: { sound33: "sound.png" } },
@@ -245,6 +256,8 @@ function renderTuner(
 		item(2, "WCBS", "2001-09-11T12:30:00.000Z"),
 		item(3, "ATC", "2001-09-11T12:30:00.000Z"),
 	],
+	upcomingItems: MediaItem[] = [],
+	audioSources: string[] = ["WINS", "WCBS", "ATC"],
 ): void {
 	mockAppData.current = data;
 	const ctx: Partial<MediaStreamContextValue> = {
@@ -252,13 +265,13 @@ function renderTuner(
 		mp3History: [],
 		sources: {
 			video: [],
-			audio: ["WINS", "WCBS", "ATC"],
+			audio: audioSources,
 			pager: [],
 			usenet: [],
 		},
 		subscribeMp3: () => {},
 		unsubscribeMp3: () => {},
-		getUpcomingMp3Items: () => [],
+		getUpcomingMp3Items: () => upcomingItems,
 	};
 	render(
 		<MediaStreamContext.Provider value={ctx as MediaStreamContextValue}>
@@ -371,6 +384,72 @@ describe("RadioTuner station logo", () => {
 		const logo = screen.getByAltText("WINS") as HTMLImageElement;
 		expect(logo.className).toContain("rsDisplayLogo");
 		expect(logo.className).not.toContain("rsDisplayLogoOffline");
+	});
+});
+
+describe("RadioTuner upcoming countdown", () => {
+	afterEach(() => {
+		mockDispatch.mockClear();
+		stationPlayerProps.current = null;
+		cleanup();
+	});
+
+	// The mocked useClassicyDateTime reports the clock as paused, so
+	// RadioTuner's fine clock (getNowMs) contributes zero real-time elapsed —
+	// nowMs is pinned to 2001-09-11T12:40:00.000Z for every test in this file.
+
+	it("shows a Starts-in balloon over an upcoming station's strip button, and none over an on-air one", () => {
+		renderTuner(
+			{},
+			[item(1, "WINS", "2001-09-11T12:30:00.000Z")],
+			[item(4, "WOR", "2001-09-11T12:41:04.000Z")],
+			["WINS", "WOR"],
+		);
+
+		// WOR has nothing on air yet but one queued item 64s out — its strip
+		// button should sit inside a balloon reading the formatted countdown.
+		const worLabel = screen.getByText("WOR");
+		const worBalloon = worLabel.closest("[data-balloon-content]");
+		expect(worBalloon).not.toBeNull();
+		expect(worBalloon?.getAttribute("data-balloon-content")).toBe(
+			"Starts in 01:04",
+		);
+
+		// WINS is on-air (active by default) — its strip button label carries
+		// no balloon at all.
+		const winsStripLabel = screen
+			.getAllByText("WINS")
+			.find((el) => el.className.includes("rsStationSource"));
+		expect(winsStripLabel).toBeDefined();
+		expect(winsStripLabel?.closest("[data-balloon-content]")).toBeNull();
+	});
+
+	it("shows no balloon over an offline station's strip button", () => {
+		// WCBS is in the source list but carries neither an active nor an
+		// upcoming item — offline, not upcoming, so no balloon at all.
+		renderTuner(
+			{},
+			[item(1, "WINS", "2001-09-11T12:30:00.000Z")],
+			[],
+			["WINS", "WCBS"],
+		);
+		const wcbsLabel = screen.getByText("WCBS");
+		expect(wcbsLabel.closest("[data-balloon-content]")).toBeNull();
+	});
+
+	it("shows a countdown line under the logo when the active station is upcoming", () => {
+		renderTuner(
+			{},
+			[],
+			[item(4, "WOR", "2001-09-11T12:41:04.000Z")],
+			["WOR"],
+		);
+		expect(screen.getByText("Starts in 01:04")).toBeTruthy();
+	});
+
+	it("shows no countdown line under the logo when the active station is on-air", () => {
+		renderTuner();
+		expect(screen.queryByText(/Starts in/)).toBeNull();
 	});
 });
 

--- a/packages/frontend/src/Applications/RadioTuner/RadioTuner.tsx
+++ b/packages/frontend/src/Applications/RadioTuner/RadioTuner.tsx
@@ -1,5 +1,6 @@
 import {
     ClassicyApp,
+    ClassicyBalloonHelp,
     ClassicyButton,
     ClassicyIcons,
     ClassicyWindow,
@@ -25,6 +26,7 @@ import { MediaStreamContext } from "../../Providers/MediaStream/MediaStreamConte
 import type { MediaItem } from "../../Providers/MediaStream/MediaStreamContext";
 import { trackAppToggle } from "../../openreplay";
 import { isAudioBlocked, subscribeAudioBlocked } from "../radio-core/audioBlocked";
+import { countdownFor } from "../radio-core/countdownFormat";
 // import { NowPlayingList } from "./NowPlayingList";
 import {
     effectiveMutedIds,
@@ -48,6 +50,7 @@ import {
     sortStationsByStatusAndLabel,
     stationLogo,
     stationStatus,
+    upcomingSegments,
 } from "../radio-core/stationGrouping";
 import { useStationLogos } from "../radio-core/stationLogos";
 import "./RadioTunerContext";
@@ -318,6 +321,19 @@ export const RadioTuner: React.FC<RadioTunerProps> = () => {
         [activeStationObj, upcomingItems, nowMs],
     );
 
+    // "Starts in <countdown>" shown under the logo while the tuned station is
+    // scheduled but not yet on air — the same next-item lookup and formatter
+    // the strip's balloon help uses, so the two always agree.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: nowMs is the clock dep
+    const activeUpcomingCountdown = useMemo(() => {
+        if (!activeStationObj) return null;
+        if (stationStatus(activeStationObj, upcomingItems, nowMs) !== "upcoming") {
+            return null;
+        }
+        const next = upcomingSegments(activeStationObj, upcomingItems, nowMs, 1)[0];
+        return next ? countdownFor(next, nowMs) : null;
+    }, [activeStationObj, upcomingItems, nowMs]);
+
     // The active station's in-window segments — shared by the now-playing
     // list, the solo lifecycle, and the effective-mute derivation.
     // biome-ignore lint/correctness/useExhaustiveDependencies: nowMs is the clock dep
@@ -425,6 +441,11 @@ export const RadioTuner: React.FC<RadioTunerProps> = () => {
                                             {activeStationObj.label}
                                         </p>
                                     )}
+                                    {activeUpcomingCountdown && (
+                                        <p className={styles.rsDisplayCountdown}>
+                                            Starts in {activeUpcomingCountdown}
+                                        </p>
+                                    )}
                                     {/* <NowPlayingList
                                         segments={playingSegments}
                                         mutedItems={mutedItems}
@@ -468,9 +489,13 @@ export const RadioTuner: React.FC<RadioTunerProps> = () => {
                         <div className={styles.rsStationStrip}>
                             {stripStations.map((station) => {
                                 const isActive = station.key === activeStation;
-                                return (
+                                const status = stationStatus(
+                                    station,
+                                    upcomingItems,
+                                    nowMs,
+                                );
+                                const button = (
                                     <ClassicyButton
-                                        key={station.key}
                                         depressed={isActive}
                                         onClickFunc={() =>
                                             setActiveStation(station.key)
@@ -478,13 +503,38 @@ export const RadioTuner: React.FC<RadioTunerProps> = () => {
                                     >
                                         <StationButtonContent
                                             label={station.label}
-                                            status={stationStatus(
-                                                station,
-                                                upcomingItems,
-                                                nowMs,
-                                            )}
+                                            status={status}
                                         />
                                     </ClassicyButton>
+                                );
+                                if (status !== "upcoming") {
+                                    return (
+                                        <div key={station.key}>{button}</div>
+                                    );
+                                }
+                                // The strip re-sorts every tick (nowMs), so the
+                                // next item is looked up fresh rather than
+                                // carried from stripStations — a station one
+                                // clip away from going on-air still needs an
+                                // accurate countdown up to its last second.
+                                const next = upcomingSegments(
+                                    station,
+                                    upcomingItems,
+                                    nowMs,
+                                    1,
+                                )[0];
+                                if (!next) {
+                                    return (
+                                        <div key={station.key}>{button}</div>
+                                    );
+                                }
+                                return (
+                                    <ClassicyBalloonHelp
+                                        key={station.key}
+                                        content={`Starts in ${countdownFor(next, nowMs)}`}
+                                    >
+                                        {button}
+                                    </ClassicyBalloonHelp>
                                 );
                             })}
                         </div>

--- a/packages/frontend/src/Applications/radio-core/countdownFormat.test.ts
+++ b/packages/frontend/src/Applications/radio-core/countdownFormat.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import type { MediaItem } from "../../Providers/MediaStream/MediaStreamContext";
+import { countdownFor } from "./countdownFormat";
+
+const t = (iso: string) => new Date(iso).getTime();
+
+// Minimal MediaItem factory — only the fields the helper reads matter. Same
+// shape as stationGrouping.test.ts, deliberately.
+function item(over: Partial<MediaItem>): MediaItem {
+	return {
+		id: 0,
+		title: "t",
+		full_title: "t",
+		start_date: "2001-09-11T13:00:00.000Z",
+		url: "u",
+		format: "mp3",
+		approved: 1,
+		mute: 0,
+		volume: 1,
+		jump: 0,
+		trim: 0,
+		...over,
+	};
+}
+
+describe("countdownFor", () => {
+	const clip = item({ start_date: "2001-09-11T13:00:00.000Z" });
+
+	it("reads as bare seconds under a minute", () => {
+		expect(countdownFor(clip, t("2001-09-11T12:59:56.000Z"))).toBe("4s");
+		expect(countdownFor(clip, t("2001-09-11T12:59:01.000Z"))).toBe("59s");
+	});
+
+	it("reads as MM:SS from one minute out", () => {
+		expect(countdownFor(clip, t("2001-09-11T12:59:00.000Z"))).toBe("01:00");
+		expect(countdownFor(clip, t("2001-09-11T12:56:47.000Z"))).toBe("03:13");
+	});
+
+	it("rounds up so it reaches zero exactly at the start, never early", () => {
+		expect(countdownFor(clip, t("2001-09-11T12:59:59.500Z"))).toBe("1s");
+		expect(countdownFor(clip, t("2001-09-11T13:00:00.000Z"))).toBe("0s");
+	});
+
+	it("clamps at zero once the start has passed", () => {
+		expect(countdownFor(clip, t("2001-09-11T13:04:00.000Z"))).toBe("0s");
+	});
+
+	it("stays MM:SS right up to the last second under an hour", () => {
+		// 59:59 is the widest the two-field form ever gets. One second later the
+		// form has to change, so this is the assertion that pins where.
+		expect(countdownFor(clip, t("2001-09-11T12:00:01.000Z"))).toBe("59:59");
+	});
+
+	it("grows an hours field at exactly 60 minutes", () => {
+		// The bug: countdownLabel's minutes field is unbounded, so this read
+		// "60:00" — indistinguishable at a glance from a minute past the hour.
+		expect(countdownFor(clip, t("2001-09-11T12:00:00.000Z"))).toBe("01:00:00");
+	});
+
+	it("reads as HH:MM:SS for multi-hour waits", () => {
+		expect(countdownFor(clip, t("2001-09-11T11:30:00.000Z"))).toBe("01:30:00");
+		expect(countdownFor(clip, t("2001-09-11T10:59:47.000Z"))).toBe("02:00:13");
+		// The 8h18m tape in the corpus is the longest wait the app can show.
+		expect(countdownFor(clip, t("2001-09-11T04:42:00.000Z"))).toBe("08:18:00");
+	});
+
+	it("zero-pads minutes and seconds in both forms", () => {
+		// Field widths that move as the clock runs down would reflow the header's
+		// subject a character at a time, once a second.
+		expect(countdownFor(clip, t("2001-09-11T12:57:05.000Z"))).toBe("02:55");
+		expect(countdownFor(clip, t("2001-09-11T11:57:05.000Z"))).toBe("01:02:55");
+	});
+});

--- a/packages/frontend/src/Applications/radio-core/countdownFormat.ts
+++ b/packages/frontend/src/Applications/radio-core/countdownFormat.ts
@@ -1,0 +1,46 @@
+// Shared "how long until this starts" formatter.
+//
+// Lives in radio-core (not RadioTraffic, where it was first written) because
+// RadioTuner's station-strip balloon and under-logo countdown need the exact
+// same variable-width rendering RadioTraffic's upcoming-lane badge already
+// uses — two implementations of the same rounding/field-width rules would
+// drift the instant one of them got a bug fix the other didn't.
+
+import type { MediaItem } from "../../Providers/MediaStream/MediaStreamContext";
+import { countdownLabel } from "./stationGrouping";
+
+/** Below a minute the countdown drops the MM: prefix ("4s", not "00:04"). */
+const COUNTDOWN_SHORT_FORM_SECONDS = 60;
+
+/** From an hour out the countdown grows an HH field, so 90 minutes is not "90:00". */
+const SECONDS_PER_HOUR = 3_600;
+
+const pad2 = (value: number): string => String(value).padStart(2, "0");
+
+/**
+ * Countdown text for an item that hasn't started yet: "4s" inside the last
+ * minute, "03:13" beyond it, "01:30:00" from an hour out.
+ *
+ * The *rounding* is radio-core's countdownLabel unchanged — every consumer
+ * agrees up to the whole second, hitting zero exactly at the start instant
+ * and never a tick early — but the *rendering* is this module's. countdownLabel
+ * is unbounded in its minutes field, so an item two hours out reads "120:00"
+ * there: correct arithmetic, but a badge that makes a listener divide by 60 in
+ * their head, and one that reads as a plausible-but-wrong "1:20" at a glance.
+ * Hours are split off here rather than in stationGrouping because ten other
+ * consumers already agree on that MM:SS form and none of them asked for this.
+ */
+export function countdownFor(item: MediaItem, nowMs: number): string {
+	const [minutes, seconds] = countdownLabel(item, nowMs).split(":").map(Number);
+	const total = minutes * 60 + seconds;
+
+	if (total < COUNTDOWN_SHORT_FORM_SECONDS) return `${total}s`;
+	if (total < SECONDS_PER_HOUR) {
+		return `${pad2(Math.floor(total / 60))}:${pad2(total % 60)}`;
+	}
+	// Every field is two digits, so the badge's width never moves as the clock
+	// runs down and the header's subject never reflows a character at a time.
+	const hours = Math.floor(total / SECONDS_PER_HOUR);
+	const rest = total % SECONDS_PER_HOUR;
+	return `${pad2(hours)}:${pad2(Math.floor(rest / 60))}:${pad2(rest % 60)}`;
+}

--- a/packages/frontend/src/Applications/radio-core/radio.module.scss
+++ b/packages/frontend/src/Applications/radio-core/radio.module.scss
@@ -92,6 +92,17 @@
   opacity: 0.55;
 }
 
+// "Starts in <countdown>", shown under the logo/call-sign only while the
+// tuned station is upcoming — same tabular-nums treatment as the scanner's
+// rsCountdown so the digits don't jitter the line width as they tick down.
+.rsDisplayCountdown {
+  font-family: var(--ui-font);
+  font-size: calc(var(--ui-font-size) * 0.85);
+  color: var(--color-theme-02);
+  font-variant-numeric: tabular-nums;
+  margin: 0;
+}
+
 .rsDisplayTitle {
   font-family: var(--ui-font);
   font-size: calc(var(--ui-font-size) * 1.5);
@@ -135,12 +146,22 @@
   background-color: var(--color-system-03);
   padding: calc(var(--window-padding-size));
 
+  // Every station is one flex item — either the ClassicyButton directly, or a
+  // wrapping <div> (a plain key holder for on-air/offline stations, or
+  // ClassicyBalloonHelp's own inline-block anchor for upcoming ones). Both
+  // wrapper forms must refuse to shrink exactly like a bare button already
+  // did, or `overflow-x: auto` here (which drops the flex item's automatic
+  // minimum size to 0) would let only the wrapped stations squash below their
+  // content on a crowded strip.
+  > * {
+    flex-shrink: 0;
+  }
+
   // Stations are ClassicyButtons. The pressed/active and selected look comes
   // from the button's own `depressed` state; here we only size each one for
   // the horizontal strip — the light/label layout lives on the
   // .rsStationBtnContent wrapper inside (StationButtonContent).
   :global(.classicyButton) {
-    flex-shrink: 0;
     height: 90%;
     min-width: 8em;
     display: flex;


### PR DESCRIPTION
## Summary
- Wraps upcoming station-strip buttons in `ClassicyBalloonHelp`, showing "Starts in <countdown>" on hover.
- Shows the same countdown under the logo when the tuned/active station is upcoming.
- Lifts RadioTraffic's variable-width `countdownFor` formatter ("4s" / "03:13" / "01:30:00") into `radio-core/countdownFormat.ts` so RadioTuner and RadioTraffic share one implementation, per the approved plan's amendment.

Fixes #576

## Test plan
- [x] `vitest run` targeted: `RadioTuner.test.tsx`, `countdownFormat.test.ts`, `cardStatus.test.ts` (62 passed)
- [x] `pnpm test` full suite (3468 passed)
- [x] `pnpm lint` (no new warnings/errors)
- [x] `pnpm build` (`tsc -b && vite build`, clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)